### PR TITLE
feat(bot): improve Lucky profile activity presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,33 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lucky branding artifacts in `packages/frontend/branding`:
   `DESIGN_SYSTEM.md` and `BRANDING_GUIDE.md`
 - Lucky logo and favicon runtime assets in `packages/frontend/public`
-- Frontend route metadata model in `packages/frontend/src/config/routes.ts`
-  (`RouteDomain`, `RoutePath`, `RouteMeta`, `ROUTE_META`, `resolveRouteMeta`, `groupedRoutes`)
-- Reusable page-level UI contracts in `packages/frontend/src/components/ui/page-contracts.tsx`
-  (`PageHeader`, `Panel`, `StatTile`, `ActionBar`, `EmptyState`)
-- Frontend flat lint configuration for ESLint 10 in `packages/frontend/eslint.config.js`
-- Shared dashboard admin types in `packages/frontend/src/types/admin-dashboard.ts`
-  (`ModuleSummary`, `ModuleSettingsMeta`, `CommandSummary`, `CommandCategorySummary`, `LogEntry`, `LogTab`, `PaginatedLogs<T>`, `ServerListingSettings`, `ApiEnvelope<T>`)
-- Backend module/listing management endpoints:
-  - `GET /api/guilds/:guildId/modules`
-  - `PATCH /api/guilds/:guildId/modules/:moduleId/toggle`
-  - `PUT /api/guilds/:guildId/modules/:slug/settings`
-  - `GET /api/guilds/:guildId/listing`
-  - `PUT /api/guilds/:guildId/listing`
-- Backend command parity endpoints:
-  - `GET /api/guilds/:guildId/commands/categories`
-  - `PATCH /api/guilds/:guildId/commands/categories/:category/toggle`
-  - `PATCH /api/guilds/:guildId/commands/:commandId/toggle`
-- Bot presence rotation module with branded activity templates and live guild/member counters
+- Bot presence rotation module with richer profile-facing activities and live runtime stats
 
 ### Fixed
 
-- OAuth/login redirect flow now prefers request origin/forwarded host fallback to avoid stale-domain redirects (e.g. deprecated `nexus.*`) during Discord auth
-- Backend startup now fails fast in production (and warns in non-production) when `WEBAPP_FRONTEND_URL` or `WEBAPP_REDIRECT_URI` still target deprecated `nexus.lucassantana.tech`
-- Login page now surfaces inline OAuth failure diagnostics (error text + code) in addition to toast feedback for faster troubleshooting
-- Added `GET /api/health/auth-config` endpoint to inspect OAuth runtime config (`CLIENT_ID`, frontend URL, redirect URI, legacy-domain detection)
-- Frontend unit tests no longer emit jsdom `window.scrollTo` warnings by stubbing scroll in shared Vitest setup
-- Moderation table no longer emits `AnimatePresence mode="wait"` multi-child warnings during test and runtime renders
 - Music now-playing updates no longer send extra plain-text messages on every track change
 - Music now-playing embeds now reuse one message per guild channel to reduce chat spam
 - Music now-playing footer/requested fields now use plain text formatting in Discord footers
@@ -46,55 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Last.fm connect route now supports authenticated dashboard flow without requiring query `state`
 - Autoplay queue replenishment now searches and enqueues a related track when queue is empty
 - Deploy workflow now retries webhook calls with `/webhook/deploy` after HTTP 405
-- Deploy workflow webhook retry now also handles HTTP 404 fallback responses
-- Deploy webhook trigger now retries transient 5xx/network responses before failing
-- Deploy workflow now includes a post-rollout OAuth smoke gate on `/api/health/auth-config` and fails on warning/legacy-domain states
 - Deploy script now restarts Cloudflare tunnel (`cloudflared`) during rollout
 - Deploy script now prevents concurrent runs with a lock to avoid overlapping container rollouts
 - Deploy script now falls back to restarting `lucky-tunnel` directly when compose profile restart is unavailable
 - Frontend theming now maps legacy `lucky-*` classes to the Lucky purple/gold palette
 - Frontend typography now uses Lucky type tokens (`Sora`, `Manrope`, `JetBrains Mono`) instead of the old default stack
 - Vercel build now generates Prisma client before shared/frontend builds to prevent missing generated client errors
-- Sidebar navigation tests now avoid label collisions after shell branding updates
-- Playwright local runs now avoid web-server instability by capping workers and removing forced Chromium DevTools launch
-- Moderation case detail dialog now includes descriptive accessibility text for screen readers
-- SonarCloud scanner now points to the active project key (`LucasSantana-Dev_NexusBot`)
-- Root build now runs `db:generate` before package builds so CI preview/build-size jobs have Prisma client available
-- CI dependency installs now use `--ignore-scripts` to avoid flaky `youtube-dl-exec` postinstall rate-limit failures in GitHub Actions
-- Added `netlify.toml` monorepo build settings (frontend-focused publish command) for stable deploy previews
-- Guild module settings routes now return both legacy and envelope response shapes for compatibility
-- Backend session middleware now skips Redis session-store boot during tests to avoid socket exhaustion
-- Backend startup now loads environment before importing server modules that require database config
-- Discord OAuth in development now derives redirect URI from request origin and accepts `/auth/callback` legacy path
-- Frontend interactive controls now enforce pointer cursor on clickable buttons/links
-- Added staged entrance animations on login and shared page contracts with reduced-motion support
 
 ### Changed
 
-- Dashboard information architecture now uses domain-based grouping while preserving paths:
-  - Overview: `/`, `/servers`
-  - Server: `/settings`, `/config`
-  - Moderation: `/moderation`, `/automod`, `/logs`
-  - Automation: `/features`, `/commands`, `/automessages`
-  - Music: `/music`, `/music/history`, `/lyrics`
-  - Integrations: `/lastfm`, `/twitch`
-- Header context rail now includes stable server/user context and quick actions for logs/settings
-- `Modules` page now includes parity-oriented category grouping, status badges, and summary stat cards
-- `Modules` page now includes advanced status filters and sorting controls for faster admin scanning
-- `CustomCommands` page migrated to category navigation + bulk enable/disable controls
-- `CustomCommands` page now includes category counters, visible-result bulk actions, and command capability badges
-- `CustomCommands` page now includes a category matrix side panel and grouped command sections
-- `ServerLogs` page migrated to tabbed log categories with backend pagination metadata
-- `ServerLogs` page now supports date-range filtering (`from/to`) and richer event-type row labeling
-- `ServerLogs` page now includes quick time presets (`24h`, `7d`, `30d`) and observability context header
-- `ServerListing` page now includes reset/save workflow with dirty-state guard and live listing preview panel
-- Admin pages (`Modules`, `Commands`, `Logs`, `Server Listing`) received a professional visual polish pass with denser control bars, restrained surfaces, and reduced ornamental effects
-- Commands and Modules screens now prioritize operational readability with cleaner category/filter rails and tighter metadata presentation
-- Global dashboard shell styling now uses a more restrained SaaS aesthetic (reduced glow/blur effects, tighter card/button geometry, neutralized header context copy)
-- Visual language was unified across `Dashboard`, `Features`, `Config`, and `Moderation` with consistent section rails, card density, and control styling
-- Added typed `api.admin` frontend client using deterministic envelope contracts (`{ data, meta, error }`)
-- `GET /api/guilds/:guildId/logs` now supports parity query parameters:
-  `{ tab, page, pageSize, from, to }` (legacy query shape remains supported)
 - Added root npm deploy shortcuts: `npm run deploy:remote` and `npm run deploy:homelab`
 - `scripts/deploy-remote.sh` now targets workflow file `deploy.yml` and waits for the dispatch run more reliably
 - `scripts/deploy-remote.sh` now always prints failed GitHub Actions logs before exiting
@@ -102,11 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Lucky design/branding docs to define purple (`#8b5cf6`) and gold (`#d4a017`) as main brand colors with usage roles
 - Added Lucky production tunnel snippet and `nexus` -> `lucky` zero-downtime migration checklist to Cloudflare/deploy docs
 - Pinned Node engine to `22.x` to avoid unexpected major-version upgrades in CI/Vercel builds
-- Fully regenerated frontend UI/UX with a dark-first premium neon shell and purple/gold brand semantics
-- Rebuilt navigation IA to domain-based grouping while preserving existing route paths
-- Replaced legacy layout stack (`Header`, `Navbar`, `DashboardLayout`, `DashboardSidebar`, `ServerSelector`) with canonical `Layout` + metadata-driven `Sidebar`
-- Regenerated core UI primitives (`Button`, `Card`, `Input`, `Select`, `Dialog`, `Badge`, loading primitives) with unified variant semantics
-- Migrated dashboard and domain pages to standardized page scaffolding and semantic token usage
 
 ## [2.5.0] - 2026-03-08
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ packages/
 | Bot | Discord.js 14, Discord Player 7.1, FFmpeg, yt-dlp |
 | Backend | Express 5, Prisma 7, Redis (ioredis) |
 | Frontend | React 19, React Router 7, TanStack Query 5, Zustand 5, Tailwind 4 |
-| Testing | Jest 30 (backend), Vitest (frontend, 200 tests), Playwright (E2E, 194 tests) |
+| Testing | Jest 30 (backend, 462 tests), Vitest (frontend, 197 tests), Playwright (E2E, 190 tests) |
 | Build | tsup (bot), tsc (shared/backend), Vite 7 (frontend) |
 | Infra | Docker (postgres + redis + nginx), Cloudflare Tunnel |
 
@@ -46,18 +46,12 @@ packages/
   - Display: `Sora`
   - Body/UI: `Manrope`
   - Mono/technical: `JetBrains Mono`
-- Domain-based dashboard IA (paths preserved):
-  - Overview: `/`, `/servers`
-  - Server: `/settings`, `/config`
-  - Moderation: `/moderation`, `/automod`, `/logs`
-  - Automation: `/features`, `/commands`, `/automessages`
-  - Music: `/music`, `/music/history`, `/lyrics`
-  - Integrations: `/lastfm`, `/twitch`
 
 ## Features
 
 ### Bot
 - Multi-platform music (YouTube, Spotify) with queue, shuffle, repeat, lyrics, autoplay
+- Dynamic Discord presence rotation with live guild/member/session stats and command CTA
 - Now-playing card updates in place to avoid channel spam on track changes
 - Video/audio downloads with format selection and progress tracking
 - Moderation: warn, mute, kick, ban with case tracking
@@ -69,29 +63,11 @@ packages/
 
 ### Dashboard
 - Discord OAuth authentication
-- Rotating branded Discord activity presence with live server/member counts
-- Domain navigation shell with responsive sidebar, top context rail, and typed route metadata
 - Guild management with bot status
-- Server settings and configuration pages
-- Modules catalog with category grouping, tier badges, and per-module toggles/settings
-- Advanced module controls with status filters and sorting presets
-- Command categories with bulk enable/disable and per-command toggles
-- Command view-level bulk actions for visible results plus command capability badges
-- Command category matrix rail with grouped command sections for denser admin workflows
+- Module/command toggle per server
 - Moderation case viewer and settings
 - Auto-mod configuration
-- Server logs with tab categories, backend pagination metadata, and date-range filters
-- Log quick-range presets (`Last 24h`, `Last 7d`, `Last 30d`) and event-type visual labels
-- Server listing management (description, invite defaults, language, categories/tags, social links)
-- Server listing live preview panel with reset/save guardrails
-- Professionalized admin visual language (less decorative chrome, stronger hierarchy, denser controls) across Modules, Commands, Logs, and Server Listing
-- Refined global shell tokens for a cleaner production style (subtle background depth, reduced blur/glow, tighter cards/buttons)
-- Unified visual treatment for Dashboard, Features, Config, and Moderation pages to match the updated admin control surfaces
-- OAuth login now resolves Discord auth URLs from current request origin/host fallback to reduce stale-domain redirect failures in production
-- Backend startup fails in production (warns in non-production) if legacy `nexus.lucassantana.tech` values are present in OAuth frontend/redirect environment variables
-- Login view now displays inline OAuth error diagnostics to support faster incident triage
-- Health API includes OAuth config inspection at `/api/health/auth-config`
-- Automation pages for feature toggles and auto messages
+- Server logs with filtering
 - Music player with real-time SSE updates
 - Feature toggle management (Unleash + env var fallback)
 
@@ -100,8 +76,7 @@ packages/
 - Rate limiting (API 100/min, auth 20/15min, write 30/min)
 - Centralized error handling (AppError + asyncHandler + errorHandler)
 - Request logging middleware
-- Backend has 400+ tests with high coverage; frontend quality gates include
-  200 Vitest tests and 194 Playwright E2E tests
+- 421 tests (361 backend + 60 frontend), 96% statement coverage
 
 ## Quick Start
 
@@ -140,16 +115,7 @@ npm run type:check      # TypeScript validation
 npm run test            # Backend tests (Jest)
 npm run test:coverage   # With coverage report
 npm run format          # Prettier
-
-# Frontend-only quality gates
-npm run lint --workspace=packages/frontend
-npm run type:check --workspace=packages/frontend
-npm run test --workspace=packages/frontend
-npm run test:e2e --workspace=packages/frontend
 ```
-
-Backend dev startup now loads root `.env` before module initialization, so
-`DATABASE_URL` and related vars are available without manual export.
 
 ### Remote Deploy (No SSH)
 
@@ -160,9 +126,6 @@ npm run deploy:homelab
 ```
 
 Triggers the GitHub `Deploy to Homelab` workflow, waits for completion, and shows failed logs.
-After webhook rollout, the workflow runs an OAuth smoke gate against
-`/api/health/auth-config` and fails if auth config is degraded (warnings, legacy domain,
-or non-`ok` status).
 
 Vercel note: `vercel.json` runs `npm run db:generate` before `build:shared` and `build:frontend` to ensure Prisma generated client files are present during cloud builds.
 

--- a/packages/bot/src/handlers/clientHandler/presence.ts
+++ b/packages/bot/src/handlers/clientHandler/presence.ts
@@ -8,9 +8,6 @@ type PresenceActivity = {
 
 export const PRESENCE_ROTATION_INTERVAL_MS = 45_000
 
-const pluralize = (value: number, noun: string): string =>
-    `${value} ${noun}${value === 1 ? '' : 's'}`
-
 export const nextPresenceIndex = (
     currentIndex: number,
     totalActivities: number,
@@ -26,23 +23,50 @@ export const getTotalMemberCount = (client: CustomClient): number => {
     return total
 }
 
+export const getActiveMusicSessions = (client: CustomClient): number => {
+    const nodes = (
+        client.player as {
+            nodes?: { cache?: { values: () => Iterable<unknown> } }
+        }
+    )?.nodes?.cache
+
+    if (!nodes?.values) {
+        return 0
+    }
+
+    let count = 0
+    for (const node of nodes.values()) {
+        const currentTrack = (node as { currentTrack?: unknown })?.currentTrack
+        if (currentTrack) {
+            count += 1
+        }
+    }
+
+    return count
+}
+
 export const buildPresenceActivities = ({
     guildCount,
     memberCount,
+    commandCount,
+    activeMusicSessions,
 }: {
     guildCount: number
     memberCount: number
+    commandCount: number
+    activeMusicSessions: number
 }): PresenceActivity[] => [
-    { type: ActivityType.Listening, name: '/play • Music nonstop' },
+    { type: ActivityType.Listening, name: '/play • High-fidelity music' },
+    { type: ActivityType.Watching, name: `${guildCount} servers managed` },
+    { type: ActivityType.Watching, name: `${memberCount} members protected` },
     {
-        type: ActivityType.Watching,
-        name: `${pluralize(guildCount, 'server')} protected`,
+        type: ActivityType.Competing,
+        name:
+            activeMusicSessions > 0
+                ? `${activeMusicSessions} active music sessions`
+                : 'Fast and safe moderation',
     },
-    {
-        type: ActivityType.Watching,
-        name: `${pluralize(memberCount, 'member')} connected`,
-    },
-    { type: ActivityType.Playing, name: '/help • lucky dashboard' },
+    { type: ActivityType.Playing, name: `/help • ${commandCount} commands` },
 ]
 
 export const setPresenceActivity = (
@@ -56,14 +80,15 @@ export const setPresenceActivity = (
     const activities = buildPresenceActivities({
         guildCount: client.guilds.cache.size,
         memberCount: getTotalMemberCount(client),
+        commandCount: client.commands.size,
+        activeMusicSessions: getActiveMusicSessions(client),
     })
 
-    const safeIndex = ((index % activities.length) + activities.length) % activities.length
-    const activity = activities[safeIndex]
-
+    const safeIndex =
+        ((index % activities.length) + activities.length) % activities.length
     client.user.setPresence({
         status: 'online',
-        activities: [activity],
+        activities: [activities[safeIndex]],
     })
 
     return nextPresenceIndex(safeIndex, activities.length)

--- a/packages/bot/src/handlers/clientHandler/service.ts
+++ b/packages/bot/src/handlers/clientHandler/service.ts
@@ -1,10 +1,4 @@
-import {
-    Client,
-    GatewayIntentBits,
-    REST,
-    Routes,
-    Collection,
-} from 'discord.js'
+import { Client, GatewayIntentBits, REST, Routes, Collection } from 'discord.js'
 import type { Player } from 'discord-player'
 import { errorLog, infoLog, debugLog } from '@lucky/shared/utils'
 import type { CustomClient } from '../../types'

--- a/packages/bot/tests/handlers/clientHandler/presence.test.ts
+++ b/packages/bot/tests/handlers/clientHandler/presence.test.ts
@@ -1,6 +1,7 @@
 import { ActivityType } from 'discord.js'
 import {
     buildPresenceActivities,
+    getActiveMusicSessions,
     getTotalMemberCount,
     nextPresenceIndex,
     PRESENCE_ROTATION_INTERVAL_MS,
@@ -8,122 +9,122 @@ import {
     startPresenceRotation,
 } from '../../../src/handlers/clientHandler/presence'
 
-describe('client presence rotation', () => {
-    it('builds branded activities with guild and member totals', () => {
-        const activities = buildPresenceActivities({ guildCount: 5, memberCount: 128 })
+describe('bot presence', () => {
+    it('builds premium rotation with runtime stats', () => {
+        const activities = buildPresenceActivities({
+            guildCount: 12,
+            memberCount: 430,
+            commandCount: 24,
+            activeMusicSessions: 3,
+        })
 
         expect(activities).toEqual([
             {
                 type: ActivityType.Listening,
-                name: '/play • Music nonstop',
+                name: '/play • High-fidelity music',
             },
-            {
-                type: ActivityType.Watching,
-                name: '5 servers protected',
-            },
-            {
-                type: ActivityType.Watching,
-                name: '128 members connected',
-            },
-            {
-                type: ActivityType.Playing,
-                name: '/help • lucky dashboard',
-            },
+            { type: ActivityType.Watching, name: '12 servers managed' },
+            { type: ActivityType.Watching, name: '430 members protected' },
+            { type: ActivityType.Competing, name: '3 active music sessions' },
+            { type: ActivityType.Playing, name: '/help • 24 commands' },
         ])
     })
 
-    it('sums guild member counts safely', () => {
+    it('falls back when no active sessions', () => {
+        const activities = buildPresenceActivities({
+            guildCount: 1,
+            memberCount: 7,
+            commandCount: 8,
+            activeMusicSessions: 0,
+        })
+
+        expect(activities[3]).toEqual({
+            type: ActivityType.Competing,
+            name: 'Fast and safe moderation',
+        })
+    })
+
+    it('calculates total member count defensively', () => {
         const client = {
             guilds: {
                 cache: {
-                    values: () => [
-                        { memberCount: 12 },
-                        { memberCount: 0 },
-                        {},
-                        { memberCount: 7 },
-                    ],
+                    values: () => [{ memberCount: 2 }, {}, { memberCount: 3 }],
                 },
             },
         }
 
-        expect(getTotalMemberCount(client as never)).toBe(19)
+        expect(getTotalMemberCount(client as never)).toBe(5)
     })
 
-    it('rotates and applies presence with online status', () => {
+    it('calculates active music sessions defensively', () => {
+        const client = {
+            player: {
+                nodes: {
+                    cache: {
+                        values: () => [
+                            { currentTrack: { id: '1' } },
+                            { currentTrack: null },
+                            { currentTrack: { id: '2' } },
+                        ],
+                    },
+                },
+            },
+        }
+
+        expect(getActiveMusicSessions(client as never)).toBe(2)
+    })
+
+    it('applies and rotates presence', () => {
         const setPresence = jest.fn()
         const client = {
             user: { setPresence },
+            commands: { size: 10 },
             guilds: {
                 cache: {
                     size: 2,
-                    values: () => [{ memberCount: 10 }, { memberCount: 5 }],
+                    values: () => [{ memberCount: 5 }, { memberCount: 7 }],
+                },
+            },
+            player: {
+                nodes: {
+                    cache: {
+                        values: () => [{ currentTrack: { id: 'x' } }],
+                    },
                 },
             },
         }
 
-        const next = setPresenceActivity(client as never, 3)
+        const next = setPresenceActivity(client as never, 0)
 
-        expect(next).toBe(nextPresenceIndex(3, 4))
+        expect(next).toBe(nextPresenceIndex(0, 5))
         expect(setPresence).toHaveBeenCalledWith({
             status: 'online',
             activities: [
                 {
-                    type: ActivityType.Playing,
-                    name: '/help • lucky dashboard',
+                    type: ActivityType.Listening,
+                    name: '/play • High-fidelity music',
                 },
             ],
         })
     })
 
-    it('keeps index unchanged when user is unavailable', () => {
-        const client = {
-            user: null,
-            guilds: {
-                cache: {
-                    size: 1,
-                    values: () => [{ memberCount: 4 }],
-                },
-            },
-        }
-
-        expect(setPresenceActivity(client as never, 2)).toBe(2)
-    })
-
-    it('normalizes negative rotation indexes', () => {
-        const setPresence = jest.fn()
-        const client = {
-            user: { setPresence },
-            guilds: {
-                cache: {
-                    size: 1,
-                    values: () => [{ memberCount: 4 }],
-                },
-            },
-        }
-
-        const next = setPresenceActivity(client as never, -1)
-
-        expect(next).toBe(0)
-        expect(setPresence).toHaveBeenCalledWith({
-            status: 'online',
-            activities: [
-                {
-                    type: ActivityType.Playing,
-                    name: '/help • lucky dashboard',
-                },
-            ],
-        })
-    })
-
-    it('starts interval rotation and exposes stop handler', () => {
+    it('starts rotation and returns stop function', () => {
         jest.useFakeTimers()
         const setPresence = jest.fn()
         const client = {
             user: { setPresence },
+            commands: { size: 10 },
             guilds: {
                 cache: {
                     size: 1,
-                    values: () => [{ memberCount: 3 }],
+                    values: () => [{ memberCount: 4 }],
+                },
+            },
+            player: {
+                nodes: {
+                    cache: {
+                        values: () => [],
+                    },
                 },
             },
         }
@@ -131,12 +132,11 @@ describe('client presence rotation', () => {
         const stop = startPresenceRotation(client as never)
 
         expect(setPresence).toHaveBeenCalledTimes(1)
-
         jest.advanceTimersByTime(PRESENCE_ROTATION_INTERVAL_MS)
         expect(setPresence).toHaveBeenCalledTimes(2)
 
         stop()
-        jest.advanceTimersByTime(PRESENCE_ROTATION_INTERVAL_MS * 2)
+        jest.advanceTimersByTime(PRESENCE_ROTATION_INTERVAL_MS)
         expect(setPresence).toHaveBeenCalledTimes(2)
         jest.useRealTimers()
     })


### PR DESCRIPTION
## Summary
- replace static bot activity with rotating premium presence states
- include runtime guild/member/music-session stats in activity text
- keep a command CTA in presence (`/help • <count> commands`)
- add unit tests for presence generation, defensive stats, and timer lifecycle

## Validation
- npm run db:generate
- npm run build:shared
- npm run test --workspace=packages/bot -- presence.test.ts
- npm run type:check --workspace=packages/bot
