### PR TITLE
fix(auth): stop vercel oauth infinite loop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,8 @@ jobs:
                     curl -s -w "\n%{http_code}" \
                       -X POST \
                       -H "X-Webhook-Secret: $WEBHOOK_SECRET" \
-                      --max-time 300 \
+                      --connect-timeout 10 \
+                      --max-time 20 \
                       "$url"
                   }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Vercel routing no longer rewrites `/api/*` back to the same Lucky host, preventing `508 INFINITE_LOOP` on OAuth login
+- Frontend API base URL now supports `VITE_API_BASE_URL` for hosted deployments that use a separate backend origin
+- Deploy webhook trigger now uses strict curl connect/request timeouts to avoid long hangs in CI deploy jobs
 - Deploy webhook trigger now retries longer on 5xx/network failures, logs every attempt, and falls back to canonical `/webhook/deploy` path for all non-2xx responses
 - Music now-playing updates no longer send extra plain-text messages on every track change
 - Music now-playing embeds now reuse one message per guild channel to reduce chat spam

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ npm run deploy:homelab
 Triggers the GitHub `Deploy to Homelab` workflow, waits for completion, and shows failed logs.
 
 Vercel note: `vercel.json` runs `npm run db:generate` before `build:shared` and `build:frontend` to ensure Prisma generated client files are present during cloud builds.
+For hosted frontend deployments, set `VITE_API_BASE_URL` to your backend API origin
+(example: `https://api.yourdomain.com/api`) to avoid auth/API loop misrouting.
 
 ## Environment Variables
 

--- a/docs/WEBAPP_SETUP.md
+++ b/docs/WEBAPP_SETUP.md
@@ -69,6 +69,12 @@ WEBAPP_SESSION_SECRET=your_random_session_secret_here
 DEVELOPER_USER_IDS=user_id_1,user_id_2
 ```
 
+For hosted frontend builds (Vercel/Netlify), set frontend env:
+
+```env
+VITE_API_BASE_URL=https://api.yourdomain.com/api
+```
+
 ### Environment Variable Descriptions
 
 - **CLIENT_ID**: Your Discord application's Client ID from the [Discord Developer Portal](https://discord.com/developers/applications)

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -15,7 +15,11 @@ import { createModerationApi } from './moderationApi'
 import { createAutoModApi } from './automodApi'
 import { createLogsApi } from './logsApi'
 
-const API_BASE = '/api'
+const configuredApiBase = import.meta.env.VITE_API_BASE_URL?.trim()
+const API_BASE = (configuredApiBase && configuredApiBase.length > 0
+    ? configuredApiBase
+    : '/api'
+).replace(/\/+$/, '')
 
 interface BackendGuild {
     id: string

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_API_BASE_URL?: string
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,5 @@
     "buildCommand": "npm run db:generate && npm run build:shared && npm run build:frontend",
     "outputDirectory": "packages/frontend/dist",
     "installCommand": "npm ci",
-    "framework": "vite",
-    "rewrites": [
-        {
-            "source": "/api/:path*",
-            "destination": "https://lucky.lucassantana.tech/api/:path*"
-        }
-    ]
+    "framework": "vite"
 }


### PR DESCRIPTION
## Summary
- fix Vercel auth loop by removing self-referential `/api` rewrite that caused `508 INFINITE_LOOP`
- add frontend `VITE_API_BASE_URL` support so hosted frontend can target a dedicated backend API origin
- harden deploy webhook step with explicit curl connect/request timeouts to prevent long hangs
- document hosted frontend API base env in README and webapp setup docs

## Root Cause
`vercel.json` rewrote `/api/:path*` to `https://lucky.lucassantana.tech/api/:path*`.
When the same custom domain was attached to Vercel, auth requests looped through Vercel and returned `508 INFINITE_LOOP`.

## Validation
- `npm run type:check --workspace=packages/frontend`
- workflow YAML parse with `python3` + `yaml.safe_load`
- `npm run lint --workspace=packages/frontend` currently fails from existing repo-wide ESLint parser/config issues unrelated to this patch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Vercel routing issue that caused 508 INFINITE_LOOP errors on OAuth login.
  * Improved deploy webhook reliability with stricter timeout settings to prevent CI job hangs.
  * Music now-playing updates now reuse a single message per channel to reduce chat spam.

* **New Features**
  * Added configurable API base URL support for hosted frontend deployments via environment variable.

* **Documentation**
  * Added setup guidance for hosted frontend deployments to properly configure backend API routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->