### PR TITLE
fix(auth): prevent frontend-host oauth 404 and normalize frontend origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Backend CORS now accepts configured origins plus `*.lucassantana.tech` and `*.luk-homeserver.com.br` hosts for dashboard/API split-domain setups
+- Backend auth/Last.fm redirect targets now use the primary frontend origin when `WEBAPP_FRONTEND_URL` contains multiple comma-separated domains
 - Frontend API client now auto-resolves hosted API base to `lucky-api.lucassantana.tech` or `api.luk-homeserver.com.br` when `VITE_API_BASE_URL` is not set
 - Deploy smoke check now falls back to `/api/health` when `/api/health/auth-config` is unavailable
 - Vercel routing no longer rewrites `/api/*` back to the same Lucky host, preventing `508 INFINITE_LOOP` on OAuth login
 - Frontend API base URL now supports `VITE_API_BASE_URL` for hosted deployments that use a separate backend origin
+- Vercel now forwards `/api/*` directly to `https://lucky-api.lucassantana.tech/api/*` to prevent frontend-host `404 NOT_FOUND` on OAuth/API routes
 - Deploy webhook trigger now uses strict curl connect/request timeouts to avoid long hangs in CI deploy jobs
 - Deploy webhook trigger now retries longer on 5xx/network failures, logs every attempt, and falls back to canonical `/webhook/deploy` path for all non-2xx responses
 - Music now-playing updates no longer send extra plain-text messages on every track change

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ For hosted frontend deployments, set `VITE_API_BASE_URL` to your backend API ori
 (example: `https://api.yourdomain.com/api`) to avoid auth/API loop misrouting.
 Without `VITE_API_BASE_URL`, frontend now auto-targets `lucky-api.lucassantana.tech` for
 `*.lucassantana.tech` hosts and `api.luk-homeserver.com.br` for `*.luk-homeserver.com.br`.
+When `WEBAPP_FRONTEND_URL` includes multiple origins, use comma-separated values
+(example: `https://lucky.lucassantana.tech,https://lukbot.vercel.app`); backend CORS
+accepts all configured entries while OAuth/Last.fm redirects use the first origin.
 
 ## Environment Variables
 

--- a/packages/backend/src/middleware/index.ts
+++ b/packages/backend/src/middleware/index.ts
@@ -5,17 +5,13 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { setupSessionMiddleware } from './session'
 import { requestLogger } from './requestLogger'
+import { getFrontendOrigins } from '../utils/frontendOrigin'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export function setupMiddleware(app: Express): void {
-    const frontendUrl =
-        process.env.WEBAPP_FRONTEND_URL ?? 'http://localhost:5173'
-    const configuredOrigins = frontendUrl
-        .split(',')
-        .map((origin) => origin.trim())
-        .filter((origin) => origin.length > 0)
+    const configuredOrigins = getFrontendOrigins()
 
     const isAllowedOrigin = (origin: string): boolean => {
         if (configuredOrigins.includes(origin)) {

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -6,9 +6,10 @@ import { asyncHandler } from '../middleware/asyncHandler'
 import { AppError } from '../errors/AppError'
 import { authLimiter } from '../middleware/rateLimit'
 import { handleOAuthCallback } from './authCallback'
+import { getPrimaryFrontendUrl } from '../utils/frontendOrigin'
 
 const getFrontendUrl = (): string => {
-    return process.env.WEBAPP_FRONTEND_URL ?? 'http://localhost:5173'
+    return getPrimaryFrontendUrl()
 }
 
 export function setupAuthRoutes(app: Express): void {

--- a/packages/backend/src/routes/authCallback.ts
+++ b/packages/backend/src/routes/authCallback.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import { discordOAuthService } from '../services/DiscordOAuthService'
 import { sessionService } from '../services/SessionService'
+import { getPrimaryFrontendUrl } from '../utils/frontendOrigin'
 
 export async function handleOAuthCallback(
     req: Request,
@@ -9,8 +10,7 @@ export async function handleOAuthCallback(
 ): Promise<void> {
     try {
         const { code, error } = req.query
-        const frontendUrl =
-            process.env.WEBAPP_FRONTEND_URL ?? 'http://localhost:5173'
+        const frontendUrl = getPrimaryFrontendUrl()
 
         if (error) {
             errorLog({ message: 'Discord OAuth error', data: { error } })
@@ -92,8 +92,7 @@ export async function handleOAuthCallback(
         res.redirect(`${frontendUrl}/?authenticated=true`)
     } catch (error) {
         errorLog({ message: 'Error in Discord OAuth callback:', error })
-        const frontendUrl =
-            process.env.WEBAPP_FRONTEND_URL ?? 'http://localhost:5173'
+        const frontendUrl = getPrimaryFrontendUrl()
         res.redirect(
             `${frontendUrl}/?error=auth_failed&message=authentication_error`,
         )

--- a/packages/backend/src/routes/lastfm.ts
+++ b/packages/backend/src/routes/lastfm.ts
@@ -11,6 +11,7 @@ import {
     requireAuth,
     type AuthenticatedRequest,
 } from '../middleware/auth'
+import { getPrimaryFrontendUrl } from '../utils/frontendOrigin'
 
 const LASTFM_STATE_COOKIE = 'lastfm_state'
 const STATE_MAX_AGE_SEC = 600
@@ -60,7 +61,7 @@ function decodeAndVerifyState(state: string, secret: string): string | null {
 }
 
 function getFrontendUrl(): string {
-    return process.env.WEBAPP_FRONTEND_URL ?? 'http://localhost:5173'
+    return getPrimaryFrontendUrl()
 }
 
 export function setupLastFmRoutes(app: Express): void {

--- a/packages/backend/src/utils/frontendOrigin.ts
+++ b/packages/backend/src/utils/frontendOrigin.ts
@@ -1,0 +1,15 @@
+const DEFAULT_FRONTEND_URL = 'http://localhost:5173'
+
+export function getFrontendOrigins(): string[] {
+    const configured = process.env.WEBAPP_FRONTEND_URL ?? DEFAULT_FRONTEND_URL
+    const origins = configured
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter((origin) => origin.length > 0)
+
+    return origins.length > 0 ? origins : [DEFAULT_FRONTEND_URL]
+}
+
+export function getPrimaryFrontendUrl(): string {
+    return getFrontendOrigins()[0]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,11 @@
     "buildCommand": "npm run db:generate && npm run build:shared && npm run build:frontend",
     "outputDirectory": "packages/frontend/dist",
     "installCommand": "npm ci",
-    "framework": "vite"
+    "framework": "vite",
+    "rewrites": [
+        {
+            "source": "/api/:path*",
+            "destination": "https://lucky-api.lucassantana.tech/api/:path*"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- add Vercel `/api/*` rewrite to backend API host to prevent frontend-host 404 during OAuth
- normalize backend frontend origin parsing using a shared helper
- use primary frontend origin for OAuth and Last.fm redirects when multiple origins are configured

## Validation
- `npm run test --workspace=packages/backend -- tests/integration/routes/auth.test.ts tests/integration/routes/lastfm.test.ts`

## Notes
- `api.lucky.lucassantana.tech` DNS/tunnel was configured, but TLS handshake is not available with current cert coverage; production API target remains `lucky-api.lucassantana.tech` for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved OAuth and Last.fm redirect failures when configuring multiple frontend domains; redirects now use the primary domain.
  * Fixed 404 errors on API requests by implementing proper forwarding to the backend API service.

* **Documentation**
  * Added guidance on configuring multiple frontend domains using comma-separated values and how each service handles multi-domain setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->