### PR TITLE
fix(e2e): stabilize features loading-state route mock

### DIFF
--- a/packages/frontend/tests/e2e/features-page.spec.ts
+++ b/packages/frontend/tests/e2e/features-page.spec.ts
@@ -104,19 +104,25 @@ test.describe('Features Page', () => {
     })
 
     test('shows loading states during data fetch', async ({ page }) => {
+        await page.unroute('**/api/features')
         await page.route('**/api/features', async (route) => {
-            await page.waitForTimeout(1000)
-            await route.continue()
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 1000)
+            })
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ features: MOCK_FEATURES }),
+            })
         })
 
         await navigateToFeatures(page)
 
         const skeleton = page
-            .locator('[class*="skeleton"], [class*="Skeleton"]')
+            .locator('.animate-pulse.bg-lucky-bg-tertiary')
             .first()
-        const isVisible = await skeleton
-            .isVisible({ timeout: 2000 })
-            .catch(() => false)
+        await expect(skeleton).toBeVisible({ timeout: 2000 })
+        await waitForFeatures(page)
     })
 
     test('shows toast notifications on toggle success', async ({ page }) => {


### PR DESCRIPTION
## Summary
- fix flaky Playwright test for Features loading state
- replace `page.waitForTimeout` inside `page.route` callback with deterministic delayed `route.fulfill`
- assert the real skeleton selector from Features page and wait for data load completion

## Why
The previous test could finish while a route callback was still running, causing:
- `page.waitForTimeout: Test ended`

## Validation
- `npm run lint`
- `npm run type:check`
- `npm run test --workspace=packages/backend`
- `npm run test --workspace=packages/bot`
- `npm run test --workspace=packages/frontend`
- `npm run test:e2e --workspace=packages/frontend -- tests/e2e/features-page.spec.ts --grep "shows loading states during data fetch"`
- `npm run test:e2e --workspace=packages/frontend`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test reliability for loading state verification with improved API mock handling and more specific element selectors for better test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->