### PR TITLE
fix(auth): resolve OAuth callback on same origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,9 +146,9 @@ SEARCH_RETRY_DELAY=5000
 # DEVELOPER_USER_IDS=your_discord_user_id
 #
 # Production / Cloudflare Tunnel
-# WEBAPP_FRONTEND_URL=https://lucky.lucassantana.tech
+# WEBAPP_FRONTEND_URL=https://lucky.lucassantana.tech,https://lukbot.vercel.app
 # WEBAPP_BACKEND_URL=https://lucky-api.lucassantana.tech
-# WEBAPP_REDIRECT_URI=https://lucky-api.lucassantana.tech/api/auth/callback
+# WEBAPP_REDIRECT_URI=https://lucky.lucassantana.tech/api/auth/callback
 # WEBAPP_SESSION_SECRET=generate-a-random-64-char-string
 # POSTGRES_PASSWORD=change-me-in-production
 # NGINX_PORT=8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Frontend lint now uses ESLint flat config (`packages/frontend/eslint.config.js`) so TypeScript/TSX parsing works correctly with ESLint 10
 - CI quality gates now run package-level lint commands for frontend and backend, matching local verification workflow
-- OAuth authorize/callback now canonicalize to the API-domain callback in production via `WEBAPP_BACKEND_URL`, preventing Discord `redirect_uri inválido` mismatches
+- OAuth authorize/callback now resolves callback URI with same-origin precedence (`session` -> `WEBAPP_REDIRECT_URI` -> forwarded host), preventing split-session landing loops
 - Added `/auth/callback` compatibility alias and callback-path normalization so legacy `/auth/callback` values still resolve to `/api/auth/callback`
 - Backend server now enables `trust proxy` in production so secure session cookies are correctly issued behind nginx/Cloudflare
 - Backend CORS now accepts configured origins plus `*.lucassantana.tech` and `*.luk-homeserver.com.br` hosts for dashboard/API split-domain setups
 - Backend auth/Last.fm redirect targets now use the primary frontend origin when `WEBAPP_FRONTEND_URL` contains multiple comma-separated domains
-- Frontend API client now auto-resolves hosted API base to `lucky-api.lucassantana.tech` or `api.luk-homeserver.com.br` when `VITE_API_BASE_URL` is not set
 - Backend OAuth session persistence now uses a connect-redis v9 compatibility adapter for ioredis clients, preventing callback save failures
 - Frontend API inference now uses same-origin `/api` for `*.lucassantana.tech` to keep OAuth/session requests on one browser origin
 - Nginx now normalizes `X-Forwarded-Proto` from edge headers (defaulting to `https`) so secure dashboard session cookies are emitted behind Cloudflare Tunnel
@@ -55,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Backend lint scripts now include scoped guardrails for legacy strict-rule debt files and expose `npm run lint:full --workspace=packages/backend` for full debt tracking (follow-up: #136)
-- Added `WEBAPP_BACKEND_URL` env propagation in Docker compose stacks and updated OAuth setup docs/examples to use API-domain callback URLs in production
+- Added `WEBAPP_BACKEND_URL` env propagation in Docker compose stacks and updated OAuth setup docs/examples to use same-origin callback URLs in production
 - Added root npm deploy shortcuts: `npm run deploy:remote` and `npm run deploy:homelab`
 - `scripts/deploy-remote.sh` now targets workflow file `deploy.yml` and waits for the dispatch run more reliably
 - `scripts/deploy-remote.sh` now always prints failed GitHub Actions logs before exiting

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ When `WEBAPP_FRONTEND_URL` includes multiple origins, use comma-separated values
 (example: `https://lucky.lucassantana.tech,https://lukbot.vercel.app`); backend CORS
 accepts all configured entries while OAuth/Last.fm redirects use the first origin.
 Set `WEBAPP_REDIRECT_URI` to the exact Discord OAuth callback URL registered in the
-Discord Developer Portal (example: `https://lucky-api.lucassantana.tech/api/auth/callback`).
-Set `WEBAPP_BACKEND_URL` to your public backend/API origin so production OAuth always
-builds callback URLs on the API domain.
+Discord Developer Portal (example: `https://lucky.lucassantana.tech/api/auth/callback`).
+Set `WEBAPP_BACKEND_URL` to your public backend/API origin when you expose API routes
+through a dedicated host.
 
 ## Environment Variables
 
@@ -161,7 +161,7 @@ See `.env.example` for all available options. Key variables:
 | `WEBAPP_ENABLED` | No | Enable web dashboard (default: false) |
 | `WEBAPP_SESSION_SECRET` | No | Session encryption key |
 | `WEBAPP_REDIRECT_URI` | No | Explicit Discord OAuth callback URL (must match Discord app settings) |
-| `WEBAPP_BACKEND_URL` | No | Public backend/API origin used to canonicalize OAuth callbacks in production |
+| `WEBAPP_BACKEND_URL` | No | Public backend/API origin used by backend links that must target the API host |
 | `CLIENT_SECRET` | No | Discord OAuth secret (for dashboard) |
 | `SENTRY_DSN` | No | Error tracking |
 

--- a/docs/CLOUDFLARE_TUNNEL_SETUP.md
+++ b/docs/CLOUDFLARE_TUNNEL_SETUP.md
@@ -137,13 +137,13 @@ WEBAPP_PORT=3000
 # Public URL of the web app (Cloudflare Tunnel / custom domain)
 WEBAPP_FRONTEND_URL=https://app.yourdomain.com
 WEBAPP_BACKEND_URL=https://api.yourdomain.com
-WEBAPP_REDIRECT_URI=https://api.yourdomain.com/api/auth/callback
+WEBAPP_REDIRECT_URI=https://app.yourdomain.com/api/auth/callback
 ```
 
 Discord OAuth2 redirect URI must match exactly:
 
 1. In [Discord Developer Portal](https://discord.com/developers/applications) → your app → **OAuth2** → **Redirects**, add:
-   `https://api.yourdomain.com/api/auth/callback`
+   `https://app.yourdomain.com/api/auth/callback`
 2. Use the same value for `WEBAPP_REDIRECT_URI`.
 
 See [WEBAPP_SETUP.md](WEBAPP_SETUP.md) and [DISCORD_OAUTH2_SETUP.md](DISCORD_OAUTH2_SETUP.md) for full OAuth and session configuration.
@@ -225,7 +225,7 @@ Important: `localhost` in a container means the container itself. If `cloudflare
 3. Point a hostname (e.g. `app.yourdomain.com`) to the tunnel and set ingress to `http://localhost:WEBAPP_PORT`.
 4. Set `WEBAPP_FRONTEND_URL=https://app.yourdomain.com`,
    `WEBAPP_BACKEND_URL=https://api.yourdomain.com`, and
-   `WEBAPP_REDIRECT_URI=https://api.yourdomain.com/api/auth/callback`.
+   `WEBAPP_REDIRECT_URI=https://app.yourdomain.com/api/auth/callback`.
 5. Add the same callback URL in the Discord Developer Portal.
 
 After that, the bot frontend is served over HTTPS at your custom domain via Cloudflare Tunnel and DNS.

--- a/docs/WEBAPP_SETUP.md
+++ b/docs/WEBAPP_SETUP.md
@@ -85,7 +85,7 @@ VITE_API_BASE_URL=https://api.yourdomain.com/api
 - **CLIENT_SECRET**: Your Discord application's Client Secret (keep this secure!)
 - **WEBAPP_REDIRECT_URI**: The callback URL registered in Discord OAuth2 settings. Must match exactly.
 - **WEBAPP_FRONTEND_URL**: The frontend application URL (used for OAuth redirects after authentication)
-- **WEBAPP_BACKEND_URL**: Public backend/API origin used to canonicalize OAuth callback URLs in production
+- **WEBAPP_BACKEND_URL**: Public backend/API origin used for API links when backend is exposed on a dedicated host
 - **WEBAPP_SESSION_SECRET**: A random secret string for signing session cookies (use a strong random value)
 - **DEVELOPER_USER_IDS**: Comma-separated list of Discord user IDs with developer access
 
@@ -101,7 +101,7 @@ VITE_API_BASE_URL=https://api.yourdomain.com/api
 
 1. In the "Redirects" section, add your callback URL:
     - Development: `http://localhost:3000/api/auth/callback`
-    - Production: `https://api.yourdomain.com/api/auth/callback`
+    - Production: `https://app.yourdomain.com/api/auth/callback`
 2. Save changes
 
 ### Step 3: Get Credentials
@@ -241,8 +241,8 @@ The Express server automatically serves the built frontend in production mode (`
 For production, ensure:
 
 - `WEBAPP_FRONTEND_URL` points to your production frontend URL
-- `WEBAPP_BACKEND_URL` points to your production backend/API URL
-- `WEBAPP_REDIRECT_URI` matches your production callback URL on the API domain
+- `WEBAPP_BACKEND_URL` points to your production backend/API URL (if separate host is used)
+- `WEBAPP_REDIRECT_URI` matches your production callback URL on the web app origin
 - `WEBAPP_SESSION_SECRET` is a strong random value
 - `NODE_ENV=production` for secure cookies
 
@@ -275,7 +275,7 @@ If OAuth isn't working:
 
 - Verify `CLIENT_ID` and `CLIENT_SECRET` are correct
 - Check `WEBAPP_REDIRECT_URI` matches Discord OAuth settings exactly
-- Check `WEBAPP_BACKEND_URL` matches the backend/API public origin
+- Check `WEBAPP_BACKEND_URL` matches the backend/API public origin when configured
 - Ensure redirect URI is whitelisted in Discord Developer Portal
 - Check browser console for CORS errors
 - Verify `WEBAPP_FRONTEND_URL` is set correctly

--- a/packages/backend/src/utils/oauthRedirectUri.ts
+++ b/packages/backend/src/utils/oauthRedirectUri.ts
@@ -1,8 +1,5 @@
 import type { Request } from 'express'
 
-const CANONICAL_PRODUCTION_REDIRECT_URI =
-    'https://lucky-api.lucassantana.tech/api/auth/callback'
-
 const getForwardedHeader = (
     req: Request,
     headerName: string,
@@ -27,36 +24,13 @@ const normalizeCallbackPath = (redirectUri?: string): string | undefined => {
     }
 }
 
-const isLegacyProductionFrontendRedirect = (redirectUri: string): boolean => {
-    try {
-        const parsed = new URL(redirectUri)
-        return (
-            parsed.hostname === 'lucky.lucassantana.tech' &&
-            (parsed.pathname === '/api/auth/callback' ||
-                parsed.pathname === '/auth/callback')
-        )
-    } catch {
-        return false
-    }
-}
-
-const getCanonicalProductionRedirectUri = (): string => {
-    const backendUrl = process.env.WEBAPP_BACKEND_URL
-    if (!backendUrl) {
-        return CANONICAL_PRODUCTION_REDIRECT_URI
-    }
-
-    try {
-        return new URL('/api/auth/callback', backendUrl).toString()
-    } catch {
-        return CANONICAL_PRODUCTION_REDIRECT_URI
-    }
-}
-
 const buildRequestRedirectUri = (req: Request): string => {
     const forwardedProto = getForwardedHeader(req, 'x-forwarded-proto')
     const forwardedHost = getForwardedHeader(req, 'x-forwarded-host')
-    const protocol = forwardedProto ?? req.protocol ?? 'http'
+    const protocol =
+        process.env.NODE_ENV === 'production'
+            ? 'https'
+            : (forwardedProto ?? req.protocol ?? 'http')
     const host =
         forwardedHost ??
         req.get('host') ??
@@ -69,19 +43,9 @@ export function getOAuthRedirectUri(
     req: Request,
     sessionRedirectUri?: string,
 ): string {
-    const resolvedRedirectUri =
+    return (
         normalizeCallbackPath(sessionRedirectUri) ??
         normalizeCallbackPath(process.env.WEBAPP_REDIRECT_URI) ??
-        (process.env.NODE_ENV === 'production'
-            ? getCanonicalProductionRedirectUri()
-            : buildRequestRedirectUri(req))
-
-    if (
-        process.env.NODE_ENV === 'production' &&
-        isLegacyProductionFrontendRedirect(resolvedRedirectUri)
-    ) {
-        return getCanonicalProductionRedirectUri()
-    }
-
-    return resolvedRedirectUri
+        buildRequestRedirectUri(req)
+    )
 }

--- a/packages/backend/tests/integration/routes/auth.test.ts
+++ b/packages/backend/tests/integration/routes/auth.test.ts
@@ -97,7 +97,7 @@ describe('Auth Routes Integration', () => {
             }
         })
 
-        test('should use canonical API callback in production when env is unset', async () => {
+        test('should derive callback from forwarded host in production when env is unset', async () => {
             const originalRedirectUri = process.env.WEBAPP_REDIRECT_URI
             const originalNodeEnv = process.env.NODE_ENV
             delete process.env.WEBAPP_REDIRECT_URI
@@ -112,7 +112,7 @@ describe('Auth Routes Integration', () => {
 
                 expect(response.headers.location).toContain(
                     encodeURIComponent(
-                        'https://lucky-api.lucassantana.tech/api/auth/callback',
+                        'https://lucky.lucassantana.tech/api/auth/callback',
                     ),
                 )
             } finally {
@@ -196,7 +196,7 @@ describe('Auth Routes Integration', () => {
             }
         })
 
-        test('should enforce canonical callback and secure cookie in production', async () => {
+        test('should enforce same-origin callback and secure cookie in production', async () => {
             const originalNodeEnv = process.env.NODE_ENV
             const originalRedirectUri = process.env.WEBAPP_REDIRECT_URI
             const originalBackendUrl = process.env.WEBAPP_BACKEND_URL
@@ -204,8 +204,6 @@ describe('Auth Routes Integration', () => {
             process.env.NODE_ENV = 'production'
             process.env.WEBAPP_REDIRECT_URI =
                 'https://lucky.lucassantana.tech/api/auth/callback'
-            process.env.WEBAPP_BACKEND_URL =
-                'https://lucky-api.lucassantana.tech'
 
             const productionApp = express()
             productionApp.set('trust proxy', 1)
@@ -220,7 +218,7 @@ describe('Auth Routes Integration', () => {
 
             expect(response.headers.location).toContain(
                 encodeURIComponent(
-                    'https://lucky-api.lucassantana.tech/api/auth/callback',
+                    'https://lucky.lucassantana.tech/api/auth/callback',
                 ),
             )
 

--- a/packages/backend/tests/unit/utils/oauthRedirectUri.test.ts
+++ b/packages/backend/tests/unit/utils/oauthRedirectUri.test.ts
@@ -2,9 +2,6 @@ import type { Request } from 'express'
 import { beforeEach, afterEach, describe, expect, test } from '@jest/globals'
 import { getOAuthRedirectUri } from '../../../src/utils/oauthRedirectUri'
 
-const CANONICAL_PRODUCTION_CALLBACK =
-    'https://lucky-api.lucassantana.tech/api/auth/callback'
-
 function createRequest(
     headers: Record<string, string> = {},
     protocol = 'http',
@@ -24,7 +21,8 @@ describe('getOAuthRedirectUri', () => {
 
     beforeEach(() => {
         process.env.NODE_ENV = 'test'
-        process.env.WEBAPP_REDIRECT_URI = 'http://localhost:3000/api/auth/callback'
+        process.env.WEBAPP_REDIRECT_URI =
+            'http://localhost:3000/api/auth/callback'
     })
 
     afterEach(() => {
@@ -59,7 +57,7 @@ describe('getOAuthRedirectUri', () => {
         expect(uri).toBe('https://api.example.com/api/auth/callback')
     })
 
-    test('should use canonical callback in production when env is unset', () => {
+    test('should derive callback from forwarded host in production when env is unset', () => {
         process.env.NODE_ENV = 'production'
         delete process.env.WEBAPP_REDIRECT_URI
 
@@ -70,17 +68,17 @@ describe('getOAuthRedirectUri', () => {
             }),
         )
 
-        expect(uri).toBe(CANONICAL_PRODUCTION_CALLBACK)
+        expect(uri).toBe('https://lucky.lucassantana.tech/api/auth/callback')
     })
 
-    test('should normalize legacy production frontend callback from env', () => {
+    test('should normalize legacy /auth/callback from env', () => {
         process.env.NODE_ENV = 'production'
         process.env.WEBAPP_REDIRECT_URI =
-            'https://lucky.lucassantana.tech/api/auth/callback'
+            'https://lucky.lucassantana.tech/auth/callback'
 
         const uri = getOAuthRedirectUri(createRequest())
 
-        expect(uri).toBe(CANONICAL_PRODUCTION_CALLBACK)
+        expect(uri).toBe('https://lucky.lucassantana.tech/api/auth/callback')
     })
 
     test('should use forwarded host in non-production when env is unset', () => {


### PR DESCRIPTION
## Summary
- remove production hard-force to `lucky-api` callback host
- keep callback resolution precedence as `session -> WEBAPP_REDIRECT_URI -> request-derived host`
- keep callback-path normalization from `/auth/callback` to `/api/auth/callback`
- align env/docs examples to same-origin OAuth callback strategy
- update auth redirect unit/integration tests to enforce same-origin behavior

## Validation
- npm run test --workspace=packages/backend -- --runInBand tests/unit/utils/oauthRedirectUri.test.ts
- npm run test --workspace=packages/backend -- --runInBand tests/integration/routes/auth.test.ts
- npm run test --workspace=packages/frontend -- src/services/apiBase.test.ts
- npm run type:check --workspace=packages/backend
- npm run lint --workspace=packages/backend
- npm run lint --workspace=packages/frontend
