### PR TITLE
fix(deploy): pin compose project for webhook rollouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Deploy webhook script now pins `COMPOSE_PROJECT_NAME=lucky` so webhook-driven
+  rollouts do not fail with container-name conflicts when executed from `/repo`
+
 ## [2.6.6] - 2026-03-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ npm run deploy:homelab
 ```
 
 Triggers the GitHub `Deploy to Homelab` workflow, waits for completion, and shows failed logs.
+Webhook deployments force `COMPOSE_PROJECT_NAME=lucky` to avoid container-name
+conflicts when the repo is mounted under `/repo` on the homelab host.
 
 Vercel note: `vercel.json` runs `npm run db:generate` before `build:shared` and `build:frontend` to ensure Prisma generated client files are present during cloud builds.
 For hosted frontend deployments, set `VITE_API_BASE_URL` to your backend API origin

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,9 @@ DEPLOY_DIR="${DEPLOY_DIR:-/repo}"
 DISCORD_WEBHOOK="${DISCORD_DEPLOY_WEBHOOK:-}"
 LOG_PREFIX="[deploy]"
 LOCK_DIR="/tmp/lucky-deploy.lock"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-lucky}"
+
+export COMPOSE_PROJECT_NAME
 
 log() { echo "$LOG_PREFIX $(date '+%H:%M:%S') $1"; }
 


### PR DESCRIPTION
## Summary
- force `COMPOSE_PROJECT_NAME=lucky` in `scripts/deploy.sh`
- prevent webhook-triggered deploys from using project name `repo` when running inside `/repo`
- document behavior in README and CHANGELOG

## Validation
- `bash -n scripts/deploy.sh`
- webhook deploy executed on homelab without secret mismatch
- OAuth redirect smoke now returns same-origin callback
