### PR TITLE
fix(deploy): resolve compose workdir for webhook runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Deploy webhook script now pins `COMPOSE_PROJECT_NAME=lucky` so webhook-driven
-  rollouts do not fail with container-name conflicts when executed from `/repo`
+- Deploy webhook script now pins `COMPOSE_PROJECT_NAME=lucky` and auto-resolves
+  the live compose working directory so webhook rollouts executed from `/repo`
+  target the existing stack instead of failing on container-name conflicts
 
 ## [2.6.6] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ npm run deploy:homelab
 ```
 
 Triggers the GitHub `Deploy to Homelab` workflow, waits for completion, and shows failed logs.
-Webhook deployments force `COMPOSE_PROJECT_NAME=lucky` to avoid container-name
-conflicts when the repo is mounted under `/repo` on the homelab host.
+Webhook deployments pin `COMPOSE_PROJECT_NAME=lucky` and resolve the active
+compose working directory, so runs from `/repo` target the existing homelab stack.
 
 Vercel note: `vercel.json` runs `npm run db:generate` before `build:shared` and `build:frontend` to ensure Prisma generated client files are present during cloud builds.
 For hosted frontend deployments, set `VITE_API_BASE_URL` to your backend API origin

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,6 +13,25 @@ export COMPOSE_PROJECT_NAME
 
 log() { echo "$LOG_PREFIX $(date '+%H:%M:%S') $1"; }
 
+resolve_compose_workdir() {
+    if [ -n "${COMPOSE_WORKDIR:-}" ]; then
+        echo "$COMPOSE_WORKDIR"
+        return
+    fi
+
+    local existing_workdir
+    existing_workdir=$(docker inspect lucky-backend \
+        --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' \
+        2>/dev/null || true)
+
+    if [ -n "$existing_workdir" ]; then
+        echo "$existing_workdir"
+        return
+    fi
+
+    echo "$DEPLOY_DIR"
+}
+
 notify() {
     local color="$1" title="$2" desc="$3"
     [ -z "$DISCORD_WEBHOOK" ] && return
@@ -51,13 +70,23 @@ if ! mkdir "$LOCK_DIR" 2>/dev/null; then
 fi
 trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
 
+COMPOSE_WORKDIR="$(resolve_compose_workdir)"
+
+if [ "$COMPOSE_WORKDIR" != "$DEPLOY_DIR" ] && [ ! -e "$COMPOSE_WORKDIR" ]; then
+    mkdir -p "$(dirname "$COMPOSE_WORKDIR")"
+    ln -s "$DEPLOY_DIR" "$COMPOSE_WORKDIR"
+fi
+
 cd "$DEPLOY_DIR"
 git config --global --add safe.directory "$DEPLOY_DIR"
+git config --global --add safe.directory "$COMPOSE_WORKDIR"
 
 notify 16776960 "Deploy Started" "Pulling latest changes and rebuilding..."
 
 log "Pulling latest changes..."
 git pull origin main
+
+cd "$COMPOSE_WORKDIR"
 
 log "Pulling images..."
 if ! docker compose pull bot backend frontend nginx; then


### PR DESCRIPTION
## Summary
- keep webhook deploys on compose project `lucky`
- auto-detect active compose working dir from running stack labels
- create a path alias when webhook runtime (`/repo`) differs from live working dir, so compose targets the existing stack containers
- update README and CHANGELOG deployment notes

## Validation
- `bash -n scripts/deploy.sh`
- checked webhook failures and confirmed root cause from compose working-dir mismatch
- prepared follow-up deploy verification after merge
