### PR TITLE
fix(deploy): use project-directory for compose identity

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,7 +33,10 @@ resolve_compose_workdir() {
 }
 
 docker_compose() {
-    docker compose -p "$COMPOSE_PROJECT_NAME" "$@"
+    docker compose \
+        --project-directory "$COMPOSE_WORKDIR" \
+        -p "$COMPOSE_PROJECT_NAME" \
+        "$@"
 }
 
 notify() {
@@ -76,21 +79,13 @@ trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
 
 COMPOSE_WORKDIR="$(resolve_compose_workdir)"
 
-if [ "$COMPOSE_WORKDIR" != "$DEPLOY_DIR" ] && [ ! -e "$COMPOSE_WORKDIR" ]; then
-    mkdir -p "$(dirname "$COMPOSE_WORKDIR")"
-    ln -s "$DEPLOY_DIR" "$COMPOSE_WORKDIR"
-fi
-
 cd "$DEPLOY_DIR"
 git config --global --add safe.directory "$DEPLOY_DIR"
-git config --global --add safe.directory "$COMPOSE_WORKDIR"
 
 notify 16776960 "Deploy Started" "Pulling latest changes and rebuilding..."
 
 log "Pulling latest changes..."
 git pull origin main
-
-cd "$COMPOSE_WORKDIR"
 
 log "Pulling images..."
 if ! docker_compose pull bot backend frontend nginx; then


### PR DESCRIPTION
## Summary
- run compose commands with explicit `--project-directory "$COMPOSE_WORKDIR"`
- keep `-p lucky` project pinning while avoiding symlink creation under `/home`
- ensure webhook-side compose actions target the same stack identity labels as host-run compose

## Validation
- `bash -n scripts/deploy.sh`
- compose identity check inside webhook container:
  - `docker compose --project-directory /home/luk-server/Lucky -p lucky ps`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker Compose deployment invocation with explicit project directory specification
  * Removed symlink creation logic between working and deployment directories
  * Streamlined deployment script execution with simplified directory management for image operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->