### PR TITLE
fix(deploy): align webhook working directory with homelab stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deploy webhook script now pins `COMPOSE_PROJECT_NAME=lucky` and auto-resolves
   the live compose working directory so webhook rollouts executed from `/repo`
   target the existing stack instead of failing on container-name conflicts
+- Webhook service now runs deploy commands from `/home/luk-server/Lucky` so
+  compose metadata matches the homelab stack and avoids container recreation
+  conflicts during webhook-driven deploys
 
 ## [2.6.6] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ npm run deploy:homelab
 Triggers the GitHub `Deploy to Homelab` workflow, waits for completion, and shows failed logs.
 Webhook deployments pin `COMPOSE_PROJECT_NAME=lucky` and resolve the active
 compose working directory, so runs from `/repo` target the existing homelab stack.
+The webhook container now executes deploy commands from
+`/home/luk-server/Lucky` to match the live compose stack metadata.
 
 Vercel note: `vercel.json` runs `npm run db:generate` before `build:shared` and `build:frontend` to ensure Prisma generated client files are present during cloud builds.
 For hosted frontend deployments, set `VITE_API_BASE_URL` to your backend API origin

--- a/deploy/hooks.json
+++ b/deploy/hooks.json
@@ -2,7 +2,7 @@
     {
         "id": "deploy",
         "execute-command": "/scripts/deploy.sh",
-        "command-working-directory": "/repo",
+        "command-working-directory": "/home/luk-server/Lucky",
         "response-message": "Deploy triggered",
         "pass-arguments-to-command": [
             {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,13 +178,13 @@ services:
         environment:
             - DEPLOY_WEBHOOK_SECRET=${DEPLOY_WEBHOOK_SECRET}
             - DISCORD_DEPLOY_WEBHOOK=${DISCORD_DEPLOY_WEBHOOK:-}
-            - DEPLOY_DIR=/repo
+            - DEPLOY_DIR=/home/luk-server/Lucky
         volumes:
             - ./deploy/hooks.json:/etc/webhook/hooks.json:ro
             - ./scripts/deploy.sh:/scripts/deploy.sh:ro
-            - .:/repo
+            - .:/home/luk-server/Lucky
             - /var/run/docker.sock:/var/run/docker.sock
-        working_dir: /repo
+        working_dir: /home/luk-server/Lucky
         networks:
             - lucky-network
         logging:


### PR DESCRIPTION
## Summary
- move webhook command working directory from `/repo` to `/home/luk-server/Lucky`
- align webhook container bind mount + `DEPLOY_DIR` + `working_dir` with the live homelab compose metadata path
- keep docs/changelog aligned with deploy behavior

## Why
Current webhook deploys still fail with container-name conflicts because compose metadata is tied to `/home/luk-server/Lucky/docker-compose.yml` while webhook runs from `/repo`.

## Validation
- `jq . deploy/hooks.json`
- verified live webhook failures show compose identity mismatch symptoms in container logs
