### PR TITLE
fix(deploy): recover stale webhook deploy lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Webhook service now runs deploy commands from `/home/luk-server/Lucky` so
   compose metadata matches the homelab stack and avoids container recreation
   conflicts during webhook-driven deploys
+- Deploy lock handling now recovers stale `/tmp/lucky-deploy.lock` directories
+  (PID-aware) after interrupted deploys instead of blocking all future runs
 
 ## [2.6.6] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Webhook deployments pin `COMPOSE_PROJECT_NAME=lucky` and resolve the active
 compose working directory, so runs from `/repo` target the existing homelab stack.
 The webhook container now executes deploy commands from
 `/home/luk-server/Lucky` to match the live compose stack metadata.
+Interrupted deploys now auto-recover stale lock directories on the next run.
 
 Vercel note: `vercel.json` runs `npm run db:generate` before `build:shared` and `build:frontend` to ensure Prisma generated client files are present during cloud builds.
 For hosted frontend deployments, set `VITE_API_BASE_URL` to your backend API origin

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,7 @@ DEPLOY_DIR="${DEPLOY_DIR:-/repo}"
 DISCORD_WEBHOOK="${DISCORD_DEPLOY_WEBHOOK:-}"
 LOG_PREFIX="[deploy]"
 LOCK_DIR="/tmp/lucky-deploy.lock"
+LOCK_PID_FILE="$LOCK_DIR/pid"
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-lucky}"
 
 export COMPOSE_PROJECT_NAME
@@ -60,6 +61,27 @@ notify() {
         }" || true
 }
 
+acquire_lock() {
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        echo "$$" >"$LOCK_PID_FILE"
+        return 0
+    fi
+
+    local existing_pid=""
+    if [ -f "$LOCK_PID_FILE" ]; then
+        existing_pid=$(cat "$LOCK_PID_FILE" 2>/dev/null || true)
+    fi
+
+    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+        return 1
+    fi
+
+    rm -rf "$LOCK_DIR" 2>/dev/null || true
+    mkdir "$LOCK_DIR" 2>/dev/null || return 1
+    echo "$$" >"$LOCK_PID_FILE"
+    return 0
+}
+
 if [ -z "$EXPECTED_SECRET" ]; then
     log "ERROR: DEPLOY_WEBHOOK_SECRET not configured"
     exit 1
@@ -70,12 +92,12 @@ if [ "$RECEIVED_SECRET" != "$EXPECTED_SECRET" ]; then
     exit 1
 fi
 
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+if ! acquire_lock; then
     log "ERROR: another deploy is already running"
     notify 16711680 "Deploy Skipped" "Another deploy is already in progress"
     exit 1
 fi
-trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
 
 COMPOSE_WORKDIR="$(resolve_compose_workdir)"
 


### PR DESCRIPTION
## Summary
- add PID-aware lock acquisition to `scripts/deploy.sh`
- recover stale `/tmp/lucky-deploy.lock` directories left by interrupted deploys
- switch cleanup trap to `rm -rf` so lock metadata is always removed
- update README + CHANGELOG deploy notes

## Validation
- `bash -n scripts/deploy.sh`
- webhook logs confirmed stale lock condition (`another deploy is already running`) before this patch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deploy process now automatically recovers from stale locks left by interrupted deployments, allowing subsequent deployment attempts to proceed instead of being permanently blocked.

* **Documentation**
  * Updated documentation to clarify that interrupted deployments will automatically recover stale lock directories on the next run, improving reliability in remote deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->