### PR TITLE
fix(backend): stabilize redis startup and auth health contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   conflicts during webhook-driven deploys
 - Deploy lock handling now recovers stale `/tmp/lucky-deploy.lock` directories
   (PID-aware) after interrupted deploys instead of blocking all future runs
+- Backend startup now attempts to connect the shared Redis client before serving
+  requests, while continuing with fallback behavior if Redis is unavailable
+
+### Added
+
+- New auth readiness endpoint: `GET /api/health/auth-config` returning
+  `status`, auth/runtime flags, and deploy-safe warnings for OAuth/session
+  validation
 
 ## [2.6.6] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ packages/
 - Rate limiting (API 100/min, auth 20/15min, write 30/min)
 - Centralized error handling (AppError + asyncHandler + errorHandler)
 - Request logging middleware
+- Auth readiness health contract at `GET /api/health/auth-config`
 - 421 tests (361 backend + 60 frontend), 96% statement coverage
 
 ## Quick Start

--- a/packages/backend/src/bootstrap.ts
+++ b/packages/backend/src/bootstrap.ts
@@ -1,0 +1,32 @@
+import { ensureEnvironment } from '@lucky/shared/config'
+import { redisClient } from '@lucky/shared/services'
+import {
+    initializeSentry,
+    setupErrorHandlers,
+    warnLog,
+} from '@lucky/shared/utils'
+import { startWebApp } from './server'
+
+export async function bootstrapBackend(): Promise<void> {
+    await ensureEnvironment()
+    setupErrorHandlers()
+    initializeSentry()
+
+    try {
+        const connected = await redisClient.connect()
+        if (!connected) {
+            warnLog({
+                message:
+                    'Redis shared client unavailable. Backend starting with fallback behavior.',
+            })
+        }
+    } catch (error) {
+        warnLog({
+            message:
+                'Redis shared client connection failed. Backend starting with fallback behavior.',
+            error,
+        })
+    }
+
+    startWebApp()
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,15 +1,14 @@
-import { ensureEnvironment } from '@lucky/shared/config'
-import { setupErrorHandlers, initializeSentry } from '@lucky/shared/utils'
-import { startWebApp } from './server'
+import { errorLog } from '@lucky/shared/utils'
+import { bootstrapBackend } from './bootstrap'
 
 async function main(): Promise<void> {
-    await ensureEnvironment()
-    setupErrorHandlers()
-    initializeSentry()
-    startWebApp()
+    await bootstrapBackend()
 }
 
 main().catch((err: unknown) => {
-    console.error('Failed to start backend:', err)
+    errorLog({
+        message: 'Failed to start backend:',
+        error: err,
+    })
     process.exit(1)
 })

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -1,5 +1,7 @@
 import type { Express, Request, Response } from 'express'
 import { redisClient } from '@lucky/shared/services'
+import { getFrontendOrigins } from '../utils/frontendOrigin'
+import { getOAuthRedirectUri } from '../utils/oauthRedirectUri'
 
 export function setupHealthRoutes(app: Express): void {
     app.get('/api/health', (_req: Request, res: Response) => {
@@ -18,6 +20,57 @@ export function setupHealthRoutes(app: Express): void {
                 ...metrics,
                 hitRate: `${(metrics.hitRate * 100).toFixed(1)}%`,
             },
+        })
+    })
+
+    app.get('/api/health/auth-config', (req: Request, res: Response) => {
+        const redirectUri = getOAuthRedirectUri(req)
+        const frontendOrigins = getFrontendOrigins()
+        const clientIdConfigured = Boolean(process.env.CLIENT_ID?.trim())
+        const sessionSecretConfigured = Boolean(
+            process.env.WEBAPP_SESSION_SECRET?.trim(),
+        )
+        const redisHealthy = redisClient.isHealthy()
+
+        const warnings: string[] = []
+
+        if (!clientIdConfigured) {
+            warnings.push('CLIENT_ID not configured')
+        }
+
+        if (!sessionSecretConfigured) {
+            warnings.push('WEBAPP_SESSION_SECRET not configured')
+        }
+
+        if (!redisHealthy) {
+            warnings.push('Redis is not healthy for shared services')
+        }
+
+        try {
+            const parsedRedirectUri = new URL(redirectUri)
+            if (parsedRedirectUri.pathname !== '/api/auth/callback') {
+                warnings.push(
+                    'OAuth callback path should be /api/auth/callback',
+                )
+            }
+        } catch {
+            warnings.push('OAuth redirect URI is invalid')
+        }
+
+        if (frontendOrigins.length === 0) {
+            warnings.push('No WEBAPP_FRONTEND_URL origins configured')
+        }
+
+        res.json({
+            status: warnings.length === 0 ? 'ok' : 'degraded',
+            auth: {
+                redirectUri,
+                frontendOrigins,
+                clientIdConfigured,
+                sessionSecretConfigured,
+                redisHealthy,
+            },
+            warnings,
         })
     })
 }

--- a/packages/backend/tests/integration/routes/health.test.ts
+++ b/packages/backend/tests/integration/routes/health.test.ts
@@ -13,6 +13,12 @@ describe('Health Routes Integration', () => {
         app = express()
         setupHealthRoutes(app)
         jest.clearAllMocks()
+        process.env.CLIENT_ID = 'test-client-id'
+        process.env.WEBAPP_SESSION_SECRET = 'test-session-secret'
+        process.env.WEBAPP_FRONTEND_URL =
+            'https://lucky.lucassantana.tech,https://lukbot.vercel.app'
+        process.env.WEBAPP_REDIRECT_URI =
+            'https://lucky.lucassantana.tech/api/auth/callback'
     })
 
     describe('GET /api/health', () => {
@@ -96,6 +102,59 @@ describe('Health Routes Integration', () => {
                 .expect(200)
 
             expect(response.body.redis).toBe(false)
+        })
+    })
+
+    describe('GET /api/health/auth-config', () => {
+        test('should return ok auth-config status when required values are present', async () => {
+            mockRedis.isHealthy.mockReturnValue(true)
+
+            const response = await request(app)
+                .get('/api/health/auth-config')
+                .expect(200)
+
+            expect(response.body).toEqual({
+                status: 'ok',
+                auth: {
+                    redirectUri:
+                        'https://lucky.lucassantana.tech/api/auth/callback',
+                    frontendOrigins: [
+                        'https://lucky.lucassantana.tech',
+                        'https://lukbot.vercel.app',
+                    ],
+                    clientIdConfigured: true,
+                    sessionSecretConfigured: true,
+                    redisHealthy: true,
+                },
+                warnings: [],
+            })
+        })
+
+        test('should return degraded status with warnings when required values are missing', async () => {
+            mockRedis.isHealthy.mockReturnValue(false)
+            process.env.CLIENT_ID = ''
+            process.env.WEBAPP_SESSION_SECRET = ''
+            process.env.WEBAPP_REDIRECT_URI =
+                'http://localhost:3000/auth/callback'
+
+            const response = await request(app)
+                .get('/api/health/auth-config')
+                .expect(200)
+
+            expect(response.body.status).toBe('degraded')
+            expect(response.body.auth.clientIdConfigured).toBe(false)
+            expect(response.body.auth.sessionSecretConfigured).toBe(false)
+            expect(response.body.auth.redisHealthy).toBe(false)
+            expect(response.body.auth.redirectUri).toBe(
+                'http://localhost:3000/api/auth/callback',
+            )
+            expect(response.body.warnings).toContain('CLIENT_ID not configured')
+            expect(response.body.warnings).toContain(
+                'WEBAPP_SESSION_SECRET not configured',
+            )
+            expect(response.body.warnings).toContain(
+                'Redis is not healthy for shared services',
+            )
         })
     })
 })

--- a/packages/backend/tests/setup.ts
+++ b/packages/backend/tests/setup.ts
@@ -226,6 +226,7 @@ jest.mock('@lucky/shared/utils/database/prismaClient', () => ({
 
 jest.mock('@lucky/shared/services', () => ({
     redisClient: {
+        connect: jest.fn(() => Promise.resolve(true)),
         isHealthy: jest.fn(() => true),
         get: jest.fn(),
         set: jest.fn(),

--- a/packages/backend/tests/unit/bootstrap.test.ts
+++ b/packages/backend/tests/unit/bootstrap.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { redisClient } from '@lucky/shared/services'
+import { ensureEnvironment } from '@lucky/shared/config'
+import {
+    initializeSentry,
+    setupErrorHandlers,
+    warnLog,
+} from '@lucky/shared/utils'
+import { bootstrapBackend } from '../../src/bootstrap'
+import { startWebApp } from '../../src/server'
+
+jest.mock('@lucky/shared/config', () => ({
+    ensureEnvironment: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    initializeSentry: jest.fn(),
+    setupErrorHandlers: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    redisClient: {
+        connect: jest.fn(),
+    },
+}))
+
+jest.mock('../../src/server', () => ({
+    startWebApp: jest.fn(),
+}))
+
+describe('Backend Bootstrap', () => {
+    const mockRedis = redisClient as jest.Mocked<typeof redisClient>
+    const mockEnsureEnvironment = ensureEnvironment as jest.MockedFunction<
+        typeof ensureEnvironment
+    >
+    const mockSetupErrorHandlers = setupErrorHandlers as jest.MockedFunction<
+        typeof setupErrorHandlers
+    >
+    const mockInitializeSentry = initializeSentry as jest.MockedFunction<
+        typeof initializeSentry
+    >
+    const mockWarnLog = warnLog as jest.MockedFunction<typeof warnLog>
+    const mockStartWebApp = startWebApp as jest.MockedFunction<
+        typeof startWebApp
+    >
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockEnsureEnvironment.mockResolvedValue(process.env)
+        mockRedis.connect.mockResolvedValue(true)
+    })
+
+    test('connects redis before starting backend server', async () => {
+        await bootstrapBackend()
+
+        expect(mockEnsureEnvironment).toHaveBeenCalledTimes(1)
+        expect(mockSetupErrorHandlers).toHaveBeenCalledTimes(1)
+        expect(mockInitializeSentry).toHaveBeenCalledTimes(1)
+        expect(mockRedis.connect).toHaveBeenCalledTimes(1)
+        expect(mockStartWebApp).toHaveBeenCalledTimes(1)
+    })
+
+    test('continues startup when redis connect returns false', async () => {
+        mockRedis.connect.mockResolvedValue(false)
+
+        await bootstrapBackend()
+
+        expect(mockWarnLog).toHaveBeenCalledTimes(1)
+        expect(mockStartWebApp).toHaveBeenCalledTimes(1)
+    })
+
+    test('continues startup when redis connect throws', async () => {
+        mockRedis.connect.mockRejectedValue(new Error('redis down'))
+
+        await bootstrapBackend()
+
+        expect(mockWarnLog).toHaveBeenCalledTimes(1)
+        expect(mockStartWebApp).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Summary
- add backend bootstrap flow that attempts shared Redis connect before serving requests
- keep backend startup resilient by continuing with fallback behavior when Redis connect fails
- add `GET /api/health/auth-config` for deploy-safe OAuth/session readiness validation
- add unit/integration tests for bootstrap Redis connect behavior and auth-config health response

## Verification
- npm run test --workspace=packages/backend -- tests/unit/bootstrap.test.ts tests/integration/routes/health.test.ts --runInBand
- npm run test --workspace=packages/backend -- tests/integration/routes/auth.test.ts --runInBand
- npm run type:check --workspace=packages/backend
- npm run lint --workspace=packages/backend
- npm run test --workspace=packages/backend -- --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health check endpoint providing real-time auth configuration status, including OAuth redirect URI and session validation details.

* **Improvements**
  * Backend startup now attempts Redis client initialization with graceful fallback if unavailable.
  * Enhanced error logging with structured diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->