### PR TITLE
chore(repo): apply conservative hygiene cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ packages/*/package-lock.json
 .env.production
 .env.development
 .env.*.local
+.env.vercel.*
 *.env
 
 # AI Agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Backend lint no longer uses scoped ignore guardrails; strict lint now runs
   across the full backend package by default (issue #136 closure)
+- Repository hygiene now ignores local Vercel environment artifacts
+  (`.env.vercel.*`) and removes merged stale branches conservatively (merged
+  local + merged remote only)
 
 ## [2.6.6] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ See `.env.example` for all available options. Key variables:
 | `CLIENT_SECRET` | No | Discord OAuth secret (for dashboard) |
 | `SENTRY_DSN` | No | Error tracking |
 
+Local Vercel export files (`.env.vercel.*`) are treated as machine-local
+artifacts and are git-ignored by default.
+
 ### Feature Toggles
 
 Two-tier system: Unleash (optional) → env vars (`FEATURE_<NAME>=true|false`) → defaults.


### PR DESCRIPTION
## Summary
- add git ignore hygiene for local Vercel export env files (`.env.vercel.*`)
- perform conservative branch cleanup after merged PRs
- update docs/changelog to reflect repository hygiene policy

## Changes
- `.gitignore`
  - added `.env.vercel.*` so local Vercel env snapshots do not dirty the working tree
- `README.md`
  - documented that `.env.vercel.*` files are treated as local-only artifacts
- `CHANGELOG.md`
  - added Unreleased entry for hygiene updates
- conservative cleanup executed:
  - deleted merged local branch: `fix/api-host-fallback-nexus`
  - deleted merged remote stale branch: `chore/deps-zod-v4`

## Verification
- `npm run lint`
- `npm run type:check`
- `npm test`

All commands passed locally.
