### PR TITLE
chore(release): prepare v2.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.7] - 2026-03-10
+
 ### Fixed
 
 - Deploy webhook script now pins `COMPOSE_PROJECT_NAME=lucky` and auto-resolves

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.6",
+    "version": "2.6.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.6",
+            "version": "2.6.7",
             "license": "ISC",
             "workspaces": [
                 "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.6",
+    "version": "2.6.7",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- cut release `v2.6.7` from current `Unreleased` changes
- bump root package version from `2.6.6` to `2.6.7`
- publish changelog section `## [2.6.7] - 2026-03-10`

## Changes
- `package.json`: `version` -> `2.6.7`
- `package-lock.json`: lockfile version metadata aligned to `2.6.7`
- `CHANGELOG.md`:
  - keep `Unreleased` placeholder
  - move current unreleased notes into `2.6.7`

## Verification
- `npm run lint`
- `npm run type:check`
- `npm test`

All commands passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deploy webhook script now correctly targets the intended stack and prevents container-name conflicts during rollouts.

* **Chores**
  * Version bumped to 2.6.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->