### PR TITLE
fix(auth): harden oauth redirect contract checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,50 +133,129 @@ jobs:
                             let parsed;
                             try {
                               parsed = JSON.parse(body);
-                        } catch {
-                          console.error("::error::auth-config returned invalid JSON");
-                          process.exit(1);
-                        }
+                            } catch {
+                              console.error("::error::auth-config returned invalid JSON");
+                              process.exit(1);
+                            }
 
                             const status = parsed?.status ?? "unknown";
                             const auth = parsed?.auth ?? {};
-                            const hasLegacyDomain = Boolean(parsed?.auth?.hasLegacyDomain);
                             const warnings = Array.isArray(parsed?.warnings) ? parsed.warnings : [];
+                            const clientId = typeof auth?.clientId === "string" ? auth.clientId : "";
                             const clientIdConfigured = auth?.clientIdConfigured === true;
                             const sessionSecretConfigured = auth?.sessionSecretConfigured === true;
                             const redisHealthy = auth?.redisHealthy === true;
                             const redirectUri = typeof auth?.redirectUri === "string" ? auth.redirectUri : "";
+                            const authorizeUrlPreview = typeof auth?.authorizeUrlPreview === "string"
+                              ? auth.authorizeUrlPreview
+                              : "";
                             const callbackPathOk = redirectUri.includes("/api/auth/callback");
+                            const authorizePreviewOk = authorizeUrlPreview.includes(
+                              "discord.com/api/oauth2/authorize",
+                            );
 
                             if (
                               status !== "ok" ||
-                              hasLegacyDomain ||
                               warnings.length > 0 ||
+                              clientId.length === 0 ||
                               !clientIdConfigured ||
                               !sessionSecretConfigured ||
                               !redisHealthy ||
-                              !callbackPathOk
+                              !callbackPathOk ||
+                              !authorizePreviewOk
                             ) {
                               console.error(
-                                `::error::OAuth auth-config smoke check failed (status=${status}, hasLegacyDomain=${hasLegacyDomain}, warnings=${warnings.length}, clientIdConfigured=${clientIdConfigured}, sessionSecretConfigured=${sessionSecretConfigured}, redisHealthy=${redisHealthy}, callbackPathOk=${callbackPathOk})`,
+                                `::error::OAuth auth-config smoke check failed (status=${status}, warnings=${warnings.length}, clientId=${clientId}, clientIdConfigured=${clientIdConfigured}, sessionSecretConfigured=${sessionSecretConfigured}, redisHealthy=${redisHealthy}, callbackPathOk=${callbackPathOk}, authorizePreviewOk=${authorizePreviewOk})`,
                               );
                               if (warnings.length > 0) {
                                 console.error(`::error::Warnings: ${warnings.join(" | ")}`);
                               }
                               process.exit(1);
-                        }
+                            }
 
-                        console.log("==> OAuth auth-config smoke check passed");
-                      '
-                      exit 0
-                    fi
+                            console.log("==> OAuth auth-config smoke check passed");
+                          '
+                          exit 0
+                      fi
 
-                    echo "Service not ready yet at $health_url (HTTP $http_code). Waiting 10s..."
-                    sleep 10
+                      echo "Service not ready yet at $health_url (HTTP $http_code). Waiting 10s..."
+                      sleep 10
                   done
 
                   echo "::error::Timed out waiting for health endpoint to become available"
                   exit 1
+
+            - name: OAuth redirect contract smoke check
+              env:
+                  WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+              run: |
+                  set -euo pipefail
+
+                  expected_client_id="962198089161134131"
+                  expected_redirect_uri="https://lucky.lucassantana.tech/api/auth/callback"
+
+                  base_url=$(node -e 'const u = new URL(process.env.WEBHOOK_URL); console.log(`${u.protocol}//${u.host}`)')
+                  auth_url="${base_url}/api/auth/discord"
+
+                  echo "==> Running OAuth redirect contract smoke check: $auth_url"
+
+                  headers_file="$(mktemp)"
+                  http_code="$(curl -sS -o /dev/null -D "$headers_file" --max-time 20 "$auth_url" -w "%{http_code}" || true)"
+
+                  if [ "$http_code" != "302" ]; then
+                    echo "::error::Expected /api/auth/discord to return 302, got $http_code"
+                    cat "$headers_file"
+                    rm -f "$headers_file"
+                    exit 1
+                  fi
+
+                  location_header="$(awk 'BEGIN{IGNORECASE=1} /^location: /{print $2}' "$headers_file" | tr -d '\r')"
+                  if [ -z "$location_header" ]; then
+                    echo "::error::Missing Location header from /api/auth/discord"
+                    cat "$headers_file"
+                    rm -f "$headers_file"
+                    exit 1
+                  fi
+
+                  OAUTH_LOCATION="$location_header" \
+                  EXPECTED_CLIENT_ID="$expected_client_id" \
+                  EXPECTED_REDIRECT_URI="$expected_redirect_uri" \
+                  node -e '
+                    const location = process.env.OAUTH_LOCATION ?? "";
+                    const expectedClientId = process.env.EXPECTED_CLIENT_ID ?? "";
+                    const expectedRedirectUri = process.env.EXPECTED_REDIRECT_URI ?? "";
+
+                    const parsed = new URL(location);
+                    const actualClientId = parsed.searchParams.get("client_id") ?? "";
+                    const actualRedirectUri = parsed.searchParams.get("redirect_uri") ?? "";
+                    const isDiscordHost = parsed.hostname === "discord.com";
+                    const isAuthorizePath = parsed.pathname.endsWith("/oauth2/authorize");
+
+                    if (!isDiscordHost || !isAuthorizePath) {
+                      console.error(
+                        `::error::Invalid OAuth location target host/path: ${parsed.hostname}${parsed.pathname}`,
+                      );
+                      process.exit(1);
+                    }
+
+                    if (actualClientId !== expectedClientId) {
+                      console.error(
+                        `::error::OAuth client_id mismatch (expected=${expectedClientId}, actual=${actualClientId})`,
+                      );
+                      process.exit(1);
+                    }
+
+                    if (actualRedirectUri !== expectedRedirectUri) {
+                      console.error(
+                        `::error::OAuth redirect_uri mismatch (expected=${expectedRedirectUri}, actual=${actualRedirectUri})`,
+                      );
+                      process.exit(1);
+                    }
+
+                    console.log("==> OAuth redirect contract smoke check passed");
+                  '
+
+                  rm -f "$headers_file"
 
             - name: Notify failure
               if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Auth config health response now includes non-secret OAuth diagnostics
+  (`auth.clientId`, `auth.authorizeUrlPreview`) and marks `degraded` when the
+  OAuth redirect origin does not match configured frontend origins
+- Deploy workflow now enforces OAuth redirect contract validation on
+  `/api/auth/discord` (HTTP 302, expected Discord `client_id`, expected
+  `redirect_uri`) before treating deploy as successful
+
 ## [2.6.7] - 2026-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ packages/
 - Centralized error handling (AppError + asyncHandler + errorHandler)
 - Request logging middleware
 - Auth readiness health contract at `GET /api/health/auth-config`
+  (includes `clientId` and generated `authorizeUrlPreview`, without secrets)
 - 421 tests (361 backend + 60 frontend), 96% statement coverage
 
 ## Quick Start
@@ -141,6 +142,9 @@ The webhook container now executes deploy commands from
 Interrupted deploys now auto-recover stale lock directories on the next run.
 Deploy workflow smoke checks now require `GET /api/health/auth-config` to return
 `status=ok` with no warnings (including healthy Redis/auth-session flags).
+Deploy workflow now also validates the `/api/auth/discord` redirect contract:
+`302` to Discord authorize URL with expected `client_id` and same-origin
+`redirect_uri=https://lucky.lucassantana.tech/api/auth/callback`.
 
 Vercel note: `vercel.json` runs `npm run db:generate` before `build:shared` and `build:frontend` to ensure Prisma generated client files are present during cloud builds.
 For hosted frontend deployments, set `VITE_API_BASE_URL` to your backend API origin

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from 'express'
 import { redisClient } from '@lucky/shared/services'
 import { getFrontendOrigins } from '../utils/frontendOrigin'
 import { getOAuthRedirectUri } from '../utils/oauthRedirectUri'
+import { buildAuthConfigHealth } from '../utils/authHealth'
 
 export function setupHealthRoutes(app: Express): void {
     app.get('/api/health', (_req: Request, res: Response) => {
@@ -26,51 +27,20 @@ export function setupHealthRoutes(app: Express): void {
     app.get('/api/health/auth-config', (req: Request, res: Response) => {
         const redirectUri = getOAuthRedirectUri(req)
         const frontendOrigins = getFrontendOrigins()
-        const clientIdConfigured = Boolean(process.env.CLIENT_ID?.trim())
+        const clientId = process.env.CLIENT_ID?.trim() ?? ''
         const sessionSecretConfigured = Boolean(
             process.env.WEBAPP_SESSION_SECRET?.trim(),
         )
         const redisHealthy = redisClient.isHealthy()
 
-        const warnings: string[] = []
-
-        if (!clientIdConfigured) {
-            warnings.push('CLIENT_ID not configured')
-        }
-
-        if (!sessionSecretConfigured) {
-            warnings.push('WEBAPP_SESSION_SECRET not configured')
-        }
-
-        if (!redisHealthy) {
-            warnings.push('Redis is not healthy for shared services')
-        }
-
-        try {
-            const parsedRedirectUri = new URL(redirectUri)
-            if (parsedRedirectUri.pathname !== '/api/auth/callback') {
-                warnings.push(
-                    'OAuth callback path should be /api/auth/callback',
-                )
-            }
-        } catch {
-            warnings.push('OAuth redirect URI is invalid')
-        }
-
-        if (frontendOrigins.length === 0) {
-            warnings.push('No WEBAPP_FRONTEND_URL origins configured')
-        }
-
-        res.json({
-            status: warnings.length === 0 ? 'ok' : 'degraded',
-            auth: {
-                redirectUri,
-                frontendOrigins,
-                clientIdConfigured,
-                sessionSecretConfigured,
-                redisHealthy,
-            },
-            warnings,
+        const healthResponse = buildAuthConfigHealth({
+            clientId,
+            redirectUri,
+            frontendOrigins,
+            sessionSecretConfigured,
+            redisHealthy,
         })
+
+        res.json(healthResponse)
     })
 }

--- a/packages/backend/src/utils/authHealth.ts
+++ b/packages/backend/src/utils/authHealth.ts
@@ -1,0 +1,123 @@
+interface AuthConfigHealthInput {
+    clientId: string
+    redirectUri: string
+    frontendOrigins: string[]
+    sessionSecretConfigured: boolean
+    redisHealthy: boolean
+}
+
+interface AuthConfigHealthResponse {
+    status: 'ok' | 'degraded'
+    auth: {
+        clientId: string
+        redirectUri: string
+        frontendOrigins: string[]
+        clientIdConfigured: boolean
+        sessionSecretConfigured: boolean
+        redisHealthy: boolean
+        authorizeUrlPreview: string
+    }
+    warnings: string[]
+}
+
+const DISCORD_AUTHORIZE_BASE = 'https://discord.com/api/oauth2/authorize'
+const OAUTH_SCOPE = 'identify guilds'
+
+const getConfiguredFrontendOrigins = (
+    frontendOrigins: string[],
+): Set<string> => {
+    const normalizedOrigins = frontendOrigins
+        .map((origin) => {
+            try {
+                return new URL(origin).origin
+            } catch {
+                return ''
+            }
+        })
+        .filter((origin) => origin.length > 0)
+
+    return new Set(normalizedOrigins)
+}
+
+export function buildAuthorizeUrlPreview(
+    clientId: string,
+    redirectUri: string,
+): string {
+    if (!clientId) {
+        return ''
+    }
+
+    const query = new URLSearchParams({
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: OAUTH_SCOPE,
+    })
+
+    return `${DISCORD_AUTHORIZE_BASE}?${query.toString().replace(/\+/g, '%20')}`
+}
+
+export function buildAuthConfigHealth({
+    clientId,
+    redirectUri,
+    frontendOrigins,
+    sessionSecretConfigured,
+    redisHealthy,
+}: AuthConfigHealthInput): AuthConfigHealthResponse {
+    const warnings: string[] = []
+    const clientIdConfigured = clientId.length > 0
+
+    if (!clientIdConfigured) {
+        warnings.push('CLIENT_ID not configured')
+    }
+
+    if (!sessionSecretConfigured) {
+        warnings.push('WEBAPP_SESSION_SECRET not configured')
+    }
+
+    if (!redisHealthy) {
+        warnings.push('Redis is not healthy for shared services')
+    }
+
+    if (frontendOrigins.length === 0) {
+        warnings.push('No WEBAPP_FRONTEND_URL origins configured')
+    }
+
+    try {
+        const parsedRedirectUri = new URL(redirectUri)
+
+        if (parsedRedirectUri.pathname !== '/api/auth/callback') {
+            warnings.push('OAuth callback path should be /api/auth/callback')
+        }
+
+        if (frontendOrigins.length > 0) {
+            const configuredOrigins =
+                getConfiguredFrontendOrigins(frontendOrigins)
+
+            if (!configuredOrigins.has(parsedRedirectUri.origin)) {
+                warnings.push(
+                    'OAuth redirect origin is not in WEBAPP_FRONTEND_URL',
+                )
+            }
+        }
+    } catch {
+        warnings.push('OAuth redirect URI is invalid')
+    }
+
+    return {
+        status: warnings.length === 0 ? 'ok' : 'degraded',
+        auth: {
+            clientId,
+            redirectUri,
+            frontendOrigins,
+            clientIdConfigured,
+            sessionSecretConfigured,
+            redisHealthy,
+            authorizeUrlPreview: buildAuthorizeUrlPreview(
+                clientId,
+                redirectUri,
+            ),
+        },
+        warnings,
+    }
+}

--- a/packages/backend/tests/integration/routes/auth.test.ts
+++ b/packages/backend/tests/integration/routes/auth.test.ts
@@ -62,15 +62,15 @@ describe('Auth Routes Integration', () => {
                 .get('/api/auth/discord')
                 .expect(302)
 
-            expect(response.headers.location).toContain(
-                'discord.com/api/oauth2/authorize',
-            )
-            expect(response.headers.location).toContain(
-                'client_id=test-client-id',
-            )
-            expect(response.headers.location).toContain('response_type=code')
-            expect(response.headers.location).toContain(
-                'scope=identify%20guilds',
+            const location = response.headers.location
+            expect(location).toContain('discord.com/api/oauth2/authorize')
+
+            const url = new URL(location)
+            expect(url.searchParams.get('client_id')).toBe('test-client-id')
+            expect(url.searchParams.get('response_type')).toBe('code')
+            expect(url.searchParams.get('scope')).toBe('identify guilds')
+            expect(url.searchParams.get('redirect_uri')).toBe(
+                'http://localhost:3000/api/auth/callback',
             )
         })
 

--- a/packages/backend/tests/integration/routes/health.test.ts
+++ b/packages/backend/tests/integration/routes/health.test.ts
@@ -116,6 +116,7 @@ describe('Health Routes Integration', () => {
             expect(response.body).toEqual({
                 status: 'ok',
                 auth: {
+                    clientId: 'test-client-id',
                     redirectUri:
                         'https://lucky.lucassantana.tech/api/auth/callback',
                     frontendOrigins: [
@@ -125,9 +126,15 @@ describe('Health Routes Integration', () => {
                     clientIdConfigured: true,
                     sessionSecretConfigured: true,
                     redisHealthy: true,
+                    authorizeUrlPreview:
+                        'https://discord.com/api/oauth2/authorize?client_id=test-client-id&redirect_uri=https%3A%2F%2Flucky.lucassantana.tech%2Fapi%2Fauth%2Fcallback&response_type=code&scope=identify%20guilds',
                 },
                 warnings: [],
             })
+            expect(response.body.auth.clientSecret).toBeUndefined()
+            expect(response.body.auth.authorizeUrlPreview).not.toContain(
+                'client_secret=',
+            )
         })
 
         test('should return degraded status with warnings when required values are missing', async () => {
@@ -142,18 +149,35 @@ describe('Health Routes Integration', () => {
                 .expect(200)
 
             expect(response.body.status).toBe('degraded')
+            expect(response.body.auth.clientId).toBe('')
             expect(response.body.auth.clientIdConfigured).toBe(false)
             expect(response.body.auth.sessionSecretConfigured).toBe(false)
             expect(response.body.auth.redisHealthy).toBe(false)
             expect(response.body.auth.redirectUri).toBe(
                 'http://localhost:3000/api/auth/callback',
             )
+            expect(response.body.auth.authorizeUrlPreview).toBe('')
             expect(response.body.warnings).toContain('CLIENT_ID not configured')
             expect(response.body.warnings).toContain(
                 'WEBAPP_SESSION_SECRET not configured',
             )
             expect(response.body.warnings).toContain(
                 'Redis is not healthy for shared services',
+            )
+        })
+
+        test('should return degraded when redirect origin does not match configured frontend origins', async () => {
+            mockRedis.isHealthy.mockReturnValue(true)
+            process.env.WEBAPP_REDIRECT_URI =
+                'https://other.lucassantana.tech/api/auth/callback'
+
+            const response = await request(app)
+                .get('/api/health/auth-config')
+                .expect(200)
+
+            expect(response.body.status).toBe('degraded')
+            expect(response.body.warnings).toContain(
+                'OAuth redirect origin is not in WEBAPP_FRONTEND_URL',
             )
         })
     })

--- a/packages/backend/tests/unit/utils/authHealth.test.ts
+++ b/packages/backend/tests/unit/utils/authHealth.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from '@jest/globals'
+import {
+    buildAuthConfigHealth,
+    buildAuthorizeUrlPreview,
+} from '../../../src/utils/authHealth'
+
+describe('authHealth utils', () => {
+    describe('buildAuthorizeUrlPreview', () => {
+        test('builds encoded Discord authorize URL', () => {
+            const preview = buildAuthorizeUrlPreview(
+                '962198089161134131',
+                'https://lucky.lucassantana.tech/api/auth/callback',
+            )
+
+            expect(preview).toBe(
+                'https://discord.com/api/oauth2/authorize?client_id=962198089161134131&redirect_uri=https%3A%2F%2Flucky.lucassantana.tech%2Fapi%2Fauth%2Fcallback&response_type=code&scope=identify%20guilds',
+            )
+        })
+
+        test('returns empty preview when client id is missing', () => {
+            expect(
+                buildAuthorizeUrlPreview(
+                    '',
+                    'https://lucky.lucassantana.tech/api/auth/callback',
+                ),
+            ).toBe('')
+        })
+    })
+
+    describe('buildAuthConfigHealth', () => {
+        test('returns ok when redirect contract matches frontend origins', () => {
+            const response = buildAuthConfigHealth({
+                clientId: '962198089161134131',
+                redirectUri:
+                    'https://lucky.lucassantana.tech/api/auth/callback',
+                frontendOrigins: [
+                    'https://lucky.lucassantana.tech',
+                    'https://lukbot.vercel.app',
+                ],
+                sessionSecretConfigured: true,
+                redisHealthy: true,
+            })
+
+            expect(response.status).toBe('ok')
+            expect(response.auth.clientId).toBe('962198089161134131')
+            expect(response.auth.authorizeUrlPreview).toContain(
+                'client_id=962198089161134131',
+            )
+            expect(response.warnings).toEqual([])
+        })
+
+        test('returns degraded when redirect uri origin is outside frontend origins', () => {
+            const response = buildAuthConfigHealth({
+                clientId: '962198089161134131',
+                redirectUri: 'https://app.otherdomain.com/api/auth/callback',
+                frontendOrigins: ['https://lucky.lucassantana.tech'],
+                sessionSecretConfigured: true,
+                redisHealthy: true,
+            })
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain(
+                'OAuth redirect origin is not in WEBAPP_FRONTEND_URL',
+            )
+        })
+
+        test('returns degraded when callback path is not the API callback path', () => {
+            const response = buildAuthConfigHealth({
+                clientId: '962198089161134131',
+                redirectUri: 'https://lucky.lucassantana.tech/auth/callback',
+                frontendOrigins: ['https://lucky.lucassantana.tech'],
+                sessionSecretConfigured: true,
+                redisHealthy: true,
+            })
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain(
+                'OAuth callback path should be /api/auth/callback',
+            )
+        })
+    })
+})


### PR DESCRIPTION
## Summary
- add auth-config diagnostics (`clientId`, `authorizeUrlPreview`) without exposing secrets
- mark auth-config degraded when redirect origin is outside configured frontend origins
- harden deploy workflow with OAuth redirect contract smoke validation on `/api/auth/discord`
- add/adjust backend unit+integration tests for health/auth redirect behavior

## Verification
- `npm run lint`
- `npm run type:check`
- `npm run build`
- `npm run test`
- `npm run test --workspace=packages/backend -- tests/unit/utils/authHealth.test.ts tests/integration/routes/health.test.ts tests/integration/routes/auth.test.ts`

## Notes
- Discord Developer Portal redirect list still needs to include exactly: `https://lucky.lucassantana.tech/api/auth/callback` for client `962198089161134131`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * OAuth configuration diagnostics improved: health endpoint now includes client configuration information and detects mismatched redirect origins, returning degraded status when misconfiguration is detected.
  * Deploy process now validates OAuth redirect contracts to ensure proper configuration before deployment.

* **Documentation**
  * Updated health endpoint and deploy workflow documentation with new validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->