### PR TITLE
chore(release): prepare v2.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.8] - 2026-03-10
+
 ### Fixed
 
 - Auth config health response now includes non-secret OAuth diagnostics

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.7",
+    "version": "2.6.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.7",
+            "version": "2.6.8",
             "license": "ISC",
             "workspaces": [
                 "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.7",
+    "version": "2.6.8",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary\n- cut release v2.6.8 from merged OAuth redirect contract hotfix\n- bump root version to 2.6.8\n- move Unreleased notes into 2.6.8 changelog section\n\n## Verification\n- npm run lint\n- npm run type:check\n- npm run test