### PR TITLE
fix(ci): retry oauth deploy smoke checks during rollout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,13 +128,13 @@ jobs:
                       body=$(echo "$response" | sed '$d')
 
                       if [ "$http_code" = "200" ]; then
-                          HEALTH_BODY="$body" node -e '
+                          if HEALTH_BODY="$body" node -e '
                             const body = process.env.HEALTH_BODY ?? "";
                             let parsed;
                             try {
                               parsed = JSON.parse(body);
                             } catch {
-                              console.error("::error::auth-config returned invalid JSON");
+                              console.log("auth-config returned invalid JSON");
                               process.exit(1);
                             }
 
@@ -164,25 +164,27 @@ jobs:
                               !callbackPathOk ||
                               !authorizePreviewOk
                             ) {
-                              console.error(
-                                `::error::OAuth auth-config smoke check failed (status=${status}, warnings=${warnings.length}, clientId=${clientId}, clientIdConfigured=${clientIdConfigured}, sessionSecretConfigured=${sessionSecretConfigured}, redisHealthy=${redisHealthy}, callbackPathOk=${callbackPathOk}, authorizePreviewOk=${authorizePreviewOk})`,
+                              console.log(
+                                `auth-config contract not ready (status=${status}, warnings=${warnings.length}, clientId=${clientId}, clientIdConfigured=${clientIdConfigured}, sessionSecretConfigured=${sessionSecretConfigured}, redisHealthy=${redisHealthy}, callbackPathOk=${callbackPathOk}, authorizePreviewOk=${authorizePreviewOk})`,
                               );
                               if (warnings.length > 0) {
-                                console.error(`::error::Warnings: ${warnings.join(" | ")}`);
+                                console.log(`warnings: ${warnings.join(" | ")}`);
                               }
                               process.exit(1);
                             }
 
-                            console.log("==> OAuth auth-config smoke check passed");
-                          '
-                          exit 0
+                            console.log("OAuth auth-config contract ready");
+                          '; then
+                              echo "==> OAuth auth-config smoke check passed"
+                              exit 0
+                          fi
                       fi
 
                       echo "Service not ready yet at $health_url (HTTP $http_code). Waiting 10s..."
                       sleep 10
                   done
 
-                  echo "::error::Timed out waiting for health endpoint to become available"
+                  echo "::error::Timed out waiting for OAuth auth-config contract"
                   exit 1
 
             - name: OAuth redirect contract smoke check
@@ -199,63 +201,61 @@ jobs:
 
                   echo "==> Running OAuth redirect contract smoke check: $auth_url"
 
-                  headers_file="$(mktemp)"
-                  http_code="$(curl -sS -o /dev/null -D "$headers_file" --max-time 20 "$auth_url" -w "%{http_code}" || true)"
+                  for attempt in $(seq 1 18); do
+                    echo "Attempt ${attempt}/18..."
+                    headers_file="$(mktemp)"
+                    http_code="$(curl -sS -o /dev/null -D "$headers_file" --max-time 20 "$auth_url" -w "%{http_code}" || true)"
 
-                  if [ "$http_code" != "302" ]; then
-                    echo "::error::Expected /api/auth/discord to return 302, got $http_code"
-                    cat "$headers_file"
+                    if [ "$http_code" = "302" ]; then
+                      location_header="$(awk 'BEGIN{IGNORECASE=1} /^location: /{print $2}' "$headers_file" | tr -d '\r')"
+                      if [ -n "$location_header" ] && OAUTH_LOCATION="$location_header" \
+                      EXPECTED_CLIENT_ID="$expected_client_id" \
+                      EXPECTED_REDIRECT_URI="$expected_redirect_uri" \
+                      node -e '
+                        const location = process.env.OAUTH_LOCATION ?? "";
+                        const expectedClientId = process.env.EXPECTED_CLIENT_ID ?? "";
+                        const expectedRedirectUri = process.env.EXPECTED_REDIRECT_URI ?? "";
+
+                        const parsed = new URL(location);
+                        const actualClientId = parsed.searchParams.get("client_id") ?? "";
+                        const actualRedirectUri = parsed.searchParams.get("redirect_uri") ?? "";
+                        const isDiscordHost = parsed.hostname === "discord.com";
+                        const isAuthorizePath = parsed.pathname.endsWith("/oauth2/authorize");
+
+                        if (!isDiscordHost || !isAuthorizePath) {
+                          console.log(
+                            `OAuth location host/path not ready: ${parsed.hostname}${parsed.pathname}`,
+                          );
+                          process.exit(1);
+                        }
+
+                        if (actualClientId !== expectedClientId) {
+                          console.log(
+                            `OAuth client_id not ready (expected=${expectedClientId}, actual=${actualClientId})`,
+                          );
+                          process.exit(1);
+                        }
+
+                        if (actualRedirectUri !== expectedRedirectUri) {
+                          console.log(
+                            `OAuth redirect_uri not ready (expected=${expectedRedirectUri}, actual=${actualRedirectUri})`,
+                          );
+                          process.exit(1);
+                        }
+                      '; then
+                        rm -f "$headers_file"
+                        echo "==> OAuth redirect contract smoke check passed"
+                        exit 0
+                      fi
+                    fi
+
                     rm -f "$headers_file"
-                    exit 1
-                  fi
+                    echo "OAuth redirect contract not ready yet (HTTP $http_code). Waiting 10s..."
+                    sleep 10
+                  done
 
-                  location_header="$(awk 'BEGIN{IGNORECASE=1} /^location: /{print $2}' "$headers_file" | tr -d '\r')"
-                  if [ -z "$location_header" ]; then
-                    echo "::error::Missing Location header from /api/auth/discord"
-                    cat "$headers_file"
-                    rm -f "$headers_file"
-                    exit 1
-                  fi
-
-                  OAUTH_LOCATION="$location_header" \
-                  EXPECTED_CLIENT_ID="$expected_client_id" \
-                  EXPECTED_REDIRECT_URI="$expected_redirect_uri" \
-                  node -e '
-                    const location = process.env.OAUTH_LOCATION ?? "";
-                    const expectedClientId = process.env.EXPECTED_CLIENT_ID ?? "";
-                    const expectedRedirectUri = process.env.EXPECTED_REDIRECT_URI ?? "";
-
-                    const parsed = new URL(location);
-                    const actualClientId = parsed.searchParams.get("client_id") ?? "";
-                    const actualRedirectUri = parsed.searchParams.get("redirect_uri") ?? "";
-                    const isDiscordHost = parsed.hostname === "discord.com";
-                    const isAuthorizePath = parsed.pathname.endsWith("/oauth2/authorize");
-
-                    if (!isDiscordHost || !isAuthorizePath) {
-                      console.error(
-                        `::error::Invalid OAuth location target host/path: ${parsed.hostname}${parsed.pathname}`,
-                      );
-                      process.exit(1);
-                    }
-
-                    if (actualClientId !== expectedClientId) {
-                      console.error(
-                        `::error::OAuth client_id mismatch (expected=${expectedClientId}, actual=${actualClientId})`,
-                      );
-                      process.exit(1);
-                    }
-
-                    if (actualRedirectUri !== expectedRedirectUri) {
-                      console.error(
-                        `::error::OAuth redirect_uri mismatch (expected=${expectedRedirectUri}, actual=${actualRedirectUri})`,
-                      );
-                      process.exit(1);
-                    }
-
-                    console.log("==> OAuth redirect contract smoke check passed");
-                  '
-
-                  rm -f "$headers_file"
+                  echo "::error::Timed out waiting for OAuth redirect contract"
+                  exit 1
 
             - name: Notify failure
               if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Deploy workflow OAuth smoke gates now retry contract validation during rollout
+  (auth-config and `/api/auth/discord`) instead of failing immediately when
+  checking a still-updating backend
+
 ## [2.6.8] - 2026-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Deploy workflow smoke checks now require `GET /api/health/auth-config` to return
 Deploy workflow now also validates the `/api/auth/discord` redirect contract:
 `302` to Discord authorize URL with expected `client_id` and same-origin
 `redirect_uri=https://lucky.lucassantana.tech/api/auth/callback`.
+Both deploy smoke checks now retry during rollout until the new backend
+containers are serving the expected contract.
 
 Vercel note: `vercel.json` runs `npm run db:generate` before `build:shared` and `build:frontend` to ensure Prisma generated client files are present during cloud builds.
 For hosted frontend deployments, set `VITE_API_BASE_URL` to your backend API origin


### PR DESCRIPTION
## Summary
- make auth-config deploy smoke gate retry contract validation until rollout is ready
- make `/api/auth/discord` contract gate retry until expected 302/client_id/redirect_uri is live
- prevent false-negative deploy failures during backend container replacement window

## Verification
- python yaml parse for `.github/workflows/deploy.yml`
- npm run lint
- npm run type:check
- npm run test --workspace=packages/backend -- tests/integration/routes/health.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Deploy workflow now retries OAuth contract validation during rollout instead of failing immediately when the backend is still updating, improving deployment reliability and reducing false-positive failures.
  * Enhanced health check messaging and error feedback for improved visibility into deployment readiness status and rollout progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->