### PR TITLE
fix(auth): detect oauth client id drift in auth health

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,6 +153,7 @@ SEARCH_RETRY_DELAY=5000
 # WEBAPP_FRONTEND_URL=https://lucky.lucassantana.tech,https://lukbot.vercel.app
 # WEBAPP_BACKEND_URL=https://lucky-api.lucassantana.tech
 # WEBAPP_REDIRECT_URI=https://lucky.lucassantana.tech/api/auth/callback
+# WEBAPP_EXPECTED_CLIENT_ID=962198089161134131
 # WEBAPP_SESSION_SECRET=generate-a-random-64-char-string
 # POSTGRES_PASSWORD=change-me-in-production
 # NGINX_PORT=8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deploy workflow OAuth smoke gates now retry contract validation during rollout
   (auth-config and `/api/auth/discord`) instead of failing immediately when
   checking a still-updating backend
+- Auth config health now marks `degraded` when `CLIENT_ID` differs from the
+  expected production app id (`WEBAPP_EXPECTED_CLIENT_ID`, with production
+  fallback) to detect Discord OAuth credential drift
 
 ## [2.6.8] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ When `WEBAPP_FRONTEND_URL` includes multiple origins, use comma-separated values
 accepts all configured entries while OAuth/Last.fm redirects use the first origin.
 Set `WEBAPP_REDIRECT_URI` to the exact Discord OAuth callback URL registered in the
 Discord Developer Portal (example: `https://lucky.lucassantana.tech/api/auth/callback`).
+Set `WEBAPP_EXPECTED_CLIENT_ID` to the production Discord app id to make
+`/api/health/auth-config` return `degraded` on credential drift.
 Set `WEBAPP_BACKEND_URL` to your public backend/API origin when you expose API routes
 through a dedicated host.
 
@@ -175,6 +177,7 @@ See `.env.example` for all available options. Key variables:
 | `WEBAPP_ENABLED` | No | Enable web dashboard (default: false) |
 | `WEBAPP_SESSION_SECRET` | No | Session encryption key |
 | `WEBAPP_REDIRECT_URI` | No | Explicit Discord OAuth callback URL (must match Discord app settings) |
+| `WEBAPP_EXPECTED_CLIENT_ID` | No | Expected Discord app client id for `/api/health/auth-config` mismatch detection |
 | `WEBAPP_BACKEND_URL` | No | Public backend/API origin used by backend links that must target the API host |
 | `CLIENT_SECRET` | No | Discord OAuth secret (for dashboard) |
 | `SENTRY_DSN` | No | Error tracking |

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -4,6 +4,8 @@ import { getFrontendOrigins } from '../utils/frontendOrigin'
 import { getOAuthRedirectUri } from '../utils/oauthRedirectUri'
 import { buildAuthConfigHealth } from '../utils/authHealth'
 
+const DEFAULT_PRODUCTION_CLIENT_ID = '962198089161134131'
+
 export function setupHealthRoutes(app: Express): void {
     app.get('/api/health', (_req: Request, res: Response) => {
         res.json({
@@ -28,6 +30,11 @@ export function setupHealthRoutes(app: Express): void {
         const redirectUri = getOAuthRedirectUri(req)
         const frontendOrigins = getFrontendOrigins()
         const clientId = process.env.CLIENT_ID?.trim() ?? ''
+        const expectedClientId =
+            process.env.WEBAPP_EXPECTED_CLIENT_ID?.trim() ??
+            (process.env.NODE_ENV === 'production'
+                ? DEFAULT_PRODUCTION_CLIENT_ID
+                : '')
         const sessionSecretConfigured = Boolean(
             process.env.WEBAPP_SESSION_SECRET?.trim(),
         )
@@ -39,6 +46,7 @@ export function setupHealthRoutes(app: Express): void {
             frontendOrigins,
             sessionSecretConfigured,
             redisHealthy,
+            expectedClientId,
         })
 
         res.json(healthResponse)

--- a/packages/backend/src/utils/authHealth.ts
+++ b/packages/backend/src/utils/authHealth.ts
@@ -4,6 +4,7 @@ interface AuthConfigHealthInput {
     frontendOrigins: string[]
     sessionSecretConfigured: boolean
     redisHealthy: boolean
+    expectedClientId?: string
 }
 
 interface AuthConfigHealthResponse {
@@ -63,12 +64,24 @@ export function buildAuthConfigHealth({
     frontendOrigins,
     sessionSecretConfigured,
     redisHealthy,
+    expectedClientId,
 }: AuthConfigHealthInput): AuthConfigHealthResponse {
     const warnings: string[] = []
     const clientIdConfigured = clientId.length > 0
+    const normalizedExpectedClientId = expectedClientId?.trim() ?? ''
 
     if (!clientIdConfigured) {
         warnings.push('CLIENT_ID not configured')
+    }
+
+    if (
+        normalizedExpectedClientId.length > 0 &&
+        clientIdConfigured &&
+        clientId !== normalizedExpectedClientId
+    ) {
+        warnings.push(
+            `CLIENT_ID does not match expected production app id (${normalizedExpectedClientId})`,
+        )
     }
 
     if (!sessionSecretConfigured) {

--- a/packages/backend/tests/integration/routes/health.test.ts
+++ b/packages/backend/tests/integration/routes/health.test.ts
@@ -19,6 +19,7 @@ describe('Health Routes Integration', () => {
             'https://lucky.lucassantana.tech,https://lukbot.vercel.app'
         process.env.WEBAPP_REDIRECT_URI =
             'https://lucky.lucassantana.tech/api/auth/callback'
+        delete process.env.WEBAPP_EXPECTED_CLIENT_ID
     })
 
     describe('GET /api/health', () => {
@@ -178,6 +179,21 @@ describe('Health Routes Integration', () => {
             expect(response.body.status).toBe('degraded')
             expect(response.body.warnings).toContain(
                 'OAuth redirect origin is not in WEBAPP_FRONTEND_URL',
+            )
+        })
+
+        test('should return degraded when CLIENT_ID differs from expected app id', async () => {
+            mockRedis.isHealthy.mockReturnValue(true)
+            process.env.CLIENT_ID = 'different-client-id'
+            process.env.WEBAPP_EXPECTED_CLIENT_ID = 'expected-client-id'
+
+            const response = await request(app)
+                .get('/api/health/auth-config')
+                .expect(200)
+
+            expect(response.body.status).toBe('degraded')
+            expect(response.body.warnings).toContain(
+                'CLIENT_ID does not match expected production app id (expected-client-id)',
             )
         })
     })

--- a/packages/backend/tests/unit/utils/authHealth.test.ts
+++ b/packages/backend/tests/unit/utils/authHealth.test.ts
@@ -78,5 +78,22 @@ describe('authHealth utils', () => {
                 'OAuth callback path should be /api/auth/callback',
             )
         })
+
+        test('returns degraded when client id differs from expected production app id', () => {
+            const response = buildAuthConfigHealth({
+                clientId: '111111111111111111',
+                expectedClientId: '962198089161134131',
+                redirectUri:
+                    'https://lucky.lucassantana.tech/api/auth/callback',
+                frontendOrigins: ['https://lucky.lucassantana.tech'],
+                sessionSecretConfigured: true,
+                redisHealthy: true,
+            })
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain(
+                'CLIENT_ID does not match expected production app id (962198089161134131)',
+            )
+        })
     })
 })


### PR DESCRIPTION
## Summary
- mark `/api/health/auth-config` as `degraded` when runtime `CLIENT_ID` differs from expected production app id
- support explicit `WEBAPP_EXPECTED_CLIENT_ID` env override with production fallback to `962198089161134131`
- add unit/integration coverage for client-id drift detection

## Validation
- npm run lint
- npm run build
- npm run type:check
- npm run test
