### PR TITLE
chore(release): prepare v2.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.9] - 2026-03-10
+
 ### Fixed
 
 - Deploy workflow OAuth smoke gates now retry contract validation during rollout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.8",
+    "version": "2.6.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.8",
+            "version": "2.6.9",
             "license": "ISC",
             "workspaces": [
                 "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.8",
+    "version": "2.6.9",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- cut release `2.6.9`
- move Unreleased fixes into `## [2.6.9] - 2026-03-10` in CHANGELOG
- bump root/package-lock version to `2.6.9`

## Validation
- npm run lint
- npm run test --workspace=packages/backend -- tests/unit/utils/authHealth.test.ts tests/integration/routes/health.test.ts
