### PR TITLE
fix(dashboard): restore server list by resolving bot membership in backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bot `/autoplay` command now resolves guild queue from player node cache when
   direct node lookup misses, preventing false `No music queue found` errors
   while a track is actively playing
+- Dashboard guild listing now resolves bot membership through a backend Discord
+  API fallback when the bot client cache is unavailable, restoring server
+  visibility for split-process deployments
 
 ## [2.6.9] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ See `.env.example` for all available options. Key variables:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `DISCORD_TOKEN` | Yes | Discord bot token |
+| `DISCORD_TOKEN` | Yes | Discord bot token (bot runtime + backend guild membership checks) |
 | `CLIENT_ID` | Yes | Discord application client ID |
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
 | `REDIS_HOST` | No | Redis host (default: localhost) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
                 condition: service_healthy
         environment:
             - NODE_ENV=production
+            - DISCORD_TOKEN=${DISCORD_TOKEN}
             - CLIENT_ID=${CLIENT_ID}
             - CLIENT_SECRET=${CLIENT_SECRET}
             - DATABASE_URL=postgresql://discordbot:${POSTGRES_PASSWORD:-discordbot123}@postgres:5432/discordbot

--- a/packages/backend/src/services/GuildService.ts
+++ b/packages/backend/src/services/GuildService.ts
@@ -3,9 +3,12 @@ import { discordOAuthService, type DiscordGuild } from './DiscordOAuthService'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 
 let botClient: Client | null = null
+const DISCORD_API_BASE_URL = 'https://discord.com/api/v10'
+const BOT_GUILD_CACHE_TTL_MS = 60_000
 
 export function setBotClient(client: Client | null): void {
     botClient = client
+    guildService.clearBotGuildCache()
 }
 
 function getClient(): Client | null {
@@ -18,8 +21,110 @@ export interface GuildWithBotStatus extends DiscordGuild {
 }
 
 class GuildService {
+    private botGuildIdsCache: {
+        guildIds: Set<string>
+        expiresAt: number
+    } | null = null
+
+    private botGuildIdsInFlight: Promise<Set<string> | null> | null = null
+
     private getBotClient(): Client | null {
         return getClient()
+    }
+
+    clearBotGuildCache(): void {
+        this.botGuildIdsCache = null
+        this.botGuildIdsInFlight = null
+    }
+
+    private getBotToken(): string | null {
+        const token = process.env.DISCORD_TOKEN?.trim()
+        return token && token.length > 0 ? token : null
+    }
+
+    private async fetchBotGuildIds(token: string): Promise<Set<string> | null> {
+        try {
+            const response = await fetch(
+                `${DISCORD_API_BASE_URL}/users/@me/guilds`,
+                {
+                    headers: {
+                        Authorization: `Bot ${token}`,
+                    },
+                },
+            )
+
+            if (!response.ok) {
+                const responseBody = await response.text()
+                errorLog({
+                    message: 'Failed to fetch bot guilds from Discord API',
+                    data: {
+                        status: response.status,
+                        responseBody,
+                    },
+                })
+                return null
+            }
+
+            const payload = (await response.json()) as unknown
+            if (!Array.isArray(payload)) {
+                errorLog({
+                    message: 'Invalid bot guild payload from Discord API',
+                })
+                return null
+            }
+
+            const guildIds = new Set<string>()
+            for (const item of payload) {
+                if (
+                    typeof item === 'object' &&
+                    item !== null &&
+                    typeof (item as { id?: unknown }).id === 'string'
+                ) {
+                    guildIds.add((item as { id: string }).id)
+                }
+            }
+
+            this.botGuildIdsCache = {
+                guildIds,
+                expiresAt: Date.now() + BOT_GUILD_CACHE_TTL_MS,
+            }
+
+            debugLog({
+                message: 'Fetched bot guild ids from Discord API',
+                data: { guildCount: guildIds.size },
+            })
+
+            return guildIds
+        } catch (error) {
+            errorLog({
+                message: 'Error fetching bot guild ids from Discord API',
+                error,
+            })
+            return null
+        }
+    }
+
+    private async getBotGuildIds(): Promise<Set<string> | null> {
+        const token = this.getBotToken()
+        if (!token) {
+            this.clearBotGuildCache()
+            return null
+        }
+
+        const now = Date.now()
+        if (this.botGuildIdsCache && this.botGuildIdsCache.expiresAt > now) {
+            return this.botGuildIdsCache.guildIds
+        }
+
+        if (this.botGuildIdsInFlight) {
+            return this.botGuildIdsInFlight
+        }
+
+        this.botGuildIdsInFlight = this.fetchBotGuildIds(token).finally(() => {
+            this.botGuildIdsInFlight = null
+        })
+
+        return this.botGuildIdsInFlight
     }
 
     async getUserGuilds(accessToken: string): Promise<DiscordGuild[]> {
@@ -74,8 +179,12 @@ class GuildService {
     async enrichGuildsWithBotStatus(
         guilds: DiscordGuild[],
     ): Promise<GuildWithBotStatus[]> {
+        const botGuildIds = await this.getBotGuildIds()
+
         return guilds.map((guild) => {
-            const hasBot = this.checkBotInGuild(guild.id)
+            const hasBot =
+                this.checkBotInGuild(guild.id) ||
+                (botGuildIds?.has(guild.id) ?? false)
             const botInviteUrl = hasBot
                 ? undefined
                 : this.generateBotInviteUrl(guild.id)

--- a/packages/backend/tests/unit/services/GuildService.test.ts
+++ b/packages/backend/tests/unit/services/GuildService.test.ts
@@ -1,4 +1,11 @@
-import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import {
+    describe,
+    test,
+    expect,
+    beforeEach,
+    afterEach,
+    jest,
+} from '@jest/globals'
 import { guildService, setBotClient } from '../../../src/services/GuildService'
 import { discordOAuthService } from '../../../src/services/DiscordOAuthService'
 import {
@@ -6,6 +13,8 @@ import {
     MOCK_TOKEN_RESPONSE,
 } from '../../fixtures/mock-data'
 import type { Client, Guild } from 'discord.js'
+
+const originalFetch = global.fetch
 
 jest.mock('../../../src/services/DiscordOAuthService', () => ({
     discordOAuthService: {
@@ -15,9 +24,23 @@ jest.mock('../../../src/services/DiscordOAuthService', () => ({
 }))
 
 describe('GuildService', () => {
+    let originalDiscordToken: string | undefined
+
     beforeEach(() => {
         jest.clearAllMocks()
         setBotClient(null)
+        originalDiscordToken = process.env.DISCORD_TOKEN
+        delete process.env.DISCORD_TOKEN
+        global.fetch = originalFetch
+    })
+
+    afterEach(() => {
+        if (originalDiscordToken === undefined) {
+            delete process.env.DISCORD_TOKEN
+        } else {
+            process.env.DISCORD_TOKEN = originalDiscordToken
+        }
+        global.fetch = originalFetch
     })
 
     describe('getUserGuilds', () => {
@@ -157,6 +180,63 @@ describe('GuildService', () => {
             expect(result[0].botInviteUrl).toBeUndefined()
             expect(result[1].hasBot).toBe(false)
             expect(result[1].botInviteUrl).toBeDefined()
+        })
+
+        test('should use Discord API fallback when bot client is unavailable', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: true,
+                json: async () => [{ id: '111111111111111111' }],
+            } as never) as unknown as typeof fetch
+
+            const result =
+                await guildService.enrichGuildsWithBotStatus(
+                    MOCK_DISCORD_GUILDS,
+                )
+
+            expect(result[0].hasBot).toBe(true)
+            expect(result[0].botInviteUrl).toBeUndefined()
+            expect(result[1].hasBot).toBe(false)
+            expect(result[1].botInviteUrl).toBeDefined()
+            expect(global.fetch).toHaveBeenCalledWith(
+                'https://discord.com/api/v10/users/@me/guilds',
+                expect.objectContaining({
+                    headers: { Authorization: 'Bot test-bot-token' },
+                }),
+            )
+        })
+
+        test('should keep processing guilds when Discord API fallback fails', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: false,
+                status: 500,
+                text: async () => 'discord api unavailable',
+            } as never) as unknown as typeof fetch
+
+            const result =
+                await guildService.enrichGuildsWithBotStatus(
+                    MOCK_DISCORD_GUILDS,
+                )
+
+            expect(result[0].hasBot).toBe(false)
+            expect(result[1].hasBot).toBe(false)
+            expect(result[0].botInviteUrl).toBeDefined()
+            expect(result[1].botInviteUrl).toBeDefined()
+        })
+
+        test('should cache Discord API fallback guild ids for short periods', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            const fetchMock = jest.fn().mockResolvedValue({
+                ok: true,
+                json: async () => [{ id: '111111111111111111' }],
+            } as never)
+            global.fetch = fetchMock as unknown as typeof fetch
+
+            await guildService.enrichGuildsWithBotStatus(MOCK_DISCORD_GUILDS)
+            await guildService.enrichGuildsWithBotStatus(MOCK_DISCORD_GUILDS)
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
         })
 
         test('should set botInviteUrl when bot is not in guild', async () => {

--- a/packages/frontend/src/components/Layout/Sidebar.test.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.test.tsx
@@ -195,4 +195,43 @@ describe('Sidebar', () => {
             expect(screen.queryByText('Another Server')).not.toBeInTheDocument()
         })
     })
+
+    test('shows invite guidance when user has admin guilds without Lucky', async () => {
+        const noBotGuilds: Guild[] = [
+            { ...mockGuild, botAdded: false },
+            { ...mockGuild2, botAdded: false },
+        ]
+
+        vi.mocked(useGuildStore).mockReturnValue({
+            guilds: noBotGuilds,
+            selectedGuild: null,
+            selectedGuildId: null,
+            isLoading: false,
+            serverSettings: null,
+            serverListing: null,
+            fetchGuilds: vi.fn(),
+            selectGuild: mockSelectGuild,
+            setSelectedGuild: vi.fn(),
+            updateServerSettings: vi.fn(),
+            updateServerListing: vi.fn(),
+        })
+
+        const user = userEvent.setup()
+        renderSidebar()
+
+        await user.click(
+            screen.getByRole('button', { name: /select a server/i }),
+        )
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('No servers with Lucky yet'),
+            ).toBeInTheDocument()
+            expect(
+                screen.getByText(
+                    'Invite Lucky to one of your servers from the Dashboard.',
+                ),
+            ).toBeInTheDocument()
+        })
+    })
 })

--- a/packages/frontend/src/components/Layout/Sidebar.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.tsx
@@ -174,8 +174,18 @@ function Sidebar() {
                             >
                                 <ScrollArea className='max-h-48'>
                                     {botGuilds.length === 0 ? (
-                                        <div className='px-3 py-4 text-sm text-lucky-text-tertiary text-center'>
-                                            No servers with bot
+                                        <div className='px-3 py-4 text-center space-y-1'>
+                                            <p className='text-sm text-lucky-text-tertiary'>
+                                                {guilds.length > 0
+                                                    ? 'No servers with Lucky yet'
+                                                    : 'No admin servers found'}
+                                            </p>
+                                            {guilds.length > 0 && (
+                                                <p className='text-xs text-lucky-text-tertiary'>
+                                                    Invite Lucky to one of your
+                                                    servers from the Dashboard.
+                                                </p>
+                                            )}
                                         </div>
                                     ) : (
                                         botGuilds.map((guild) => (


### PR DESCRIPTION
## Summary
Restores dashboard server visibility when backend and bot run in separate processes by making bot membership detection topology-safe.

## Changes
- Keep in-process Discord client cache check when available.
- Add backend fallback that fetches bot guild IDs via Discord API (DISCORD_TOKEN) with short TTL cache and in-flight dedupe.
- Use fallback in guild enrichment so /api/guilds keeps authoritative hasBot even without injected bot client.
- Add backend env propagation for DISCORD_TOKEN in Docker compose and docs.
- Improve sidebar empty state messaging with explicit invite guidance when user has guilds but bot is not present.

## API/Behavior
- No breaking changes.
- /api/guilds response contract unchanged.

## Validation
- npm run test --workspace=packages/backend -- tests/unit/services/GuildService.test.ts tests/integration/routes/guilds.test.ts
- npm run test --workspace=packages/frontend -- src/components/Layout/Sidebar.test.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed dashboard guild listing to reliably display servers even when the bot client cache is unavailable, improving visibility for split-process deployments.

* **UI Improvements**
  * Enhanced sidebar messaging with context-aware guidance when no servers have Lucky installed, clearly directing users to invite the bot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->