### PR TITLE
docs(roadmap): map Lucky command/features inspired by top Discord bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `docs/BOT_COMMAND_ROADMAP_BENCHMARKS.md` with a benchmark-driven Lucky
+  command roadmap (Dyno, Rythm, Loritta, MEE6, Carl-bot references), prioritized
+  matrix, and a one-command-per-PR rollout plan for the next 6 weeks
+
 ### Fixed
 
 - Bot `/autoplay` command now resolves guild queue from player node cache when

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Set `UNLEASH_URL` and `UNLEASH_API_TOKEN` for Unleash, or use `FEATURE_DOWNLOAD_
 ## Documentation
 
 - [Architecture](docs/ARCHITECTURE.md) — Package layout, entry points, adding new code
+- [Bot Command Roadmap](docs/BOT_COMMAND_ROADMAP_BENCHMARKS.md) — Benchmark-driven,
+  6-week command rollout plan inspired by top Discord bots
 - [CI/CD](docs/CI_CD.md) — Pipeline, pre-commit hooks, deploy workflow
 - [Testing](docs/TESTING.md) — Strategy, running tests, coverage
 - [Docker Setup](docs/WEBAPP_SETUP.md) — Web app configuration

--- a/docs/BOT_COMMAND_ROADMAP_BENCHMARKS.md
+++ b/docs/BOT_COMMAND_ROADMAP_BENCHMARKS.md
@@ -1,0 +1,74 @@
+# Lucky Command and Feature Roadmap (Benchmarked)
+
+This roadmap maps Lucky's next bot-first command/features against mature patterns from
+Dyno, Rythm, Loritta, MEE6, and Carl-bot. It is reliability-first and incremental.
+
+## Benchmark Sources
+
+- Dyno docs: https://docs.dyno.gg/en
+- Dyno listing (module surface): https://top.gg/bot/155149108183695360
+- Rythm commands: https://rythm.fm/docs/commands
+- Loritta listing/features: https://top.gg/bot/297153970613387264
+- MEE6 features: https://mee6.xyz/en/features
+- Carl-bot docs: https://docs.carl.gg/
+
+## Delivery Principles
+
+- Bot-first: slash commands and bot-side behavior first, dashboard support only when required.
+- Reliability-first: playback and moderation safety before growth features.
+- One command per PR: isolate blast radius and make CI/review/rollback simple.
+- No contract breaks: additive commands and metadata fields only.
+
+## Prioritized Command Matrix
+
+| Priority | Command/Feature                                   | Inspired by                          | User Value                                         | Complexity                | Dependencies                              | Acceptance Criteria                                                                       |
+| -------- | ------------------------------------------------- | ------------------------------------ | -------------------------------------------------- | ------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| P0       | `/music health`                                   | Dyno module diagnostics              | Faster incident triage for moderators              | S                         | Player state + provider metrics           | Reports queue state, provider status, last recovery action, and voice connection state    |
+| P0       | Music watchdog auto-recovery                      | Rythm reliability expectations       | Fewer dead/stalled sessions                        | M                         | Player lifecycle hooks + retry policy     | Stalled playback auto-recovers in >=95% simulated failure scenarios                       |
+| P0       | Provider health cooldown                          | Rythm multi-source behavior          | Avoids repeated source failures                    | M                         | Extractor telemetry + Redis TTL           | Failing provider enters cooldown and fallback provider succeeds without user intervention |
+| P0       | Queue snapshot restore                            | Dyno-style resiliency expectations   | Survives reconnect/restart without losing sessions | M                         | Redis persistence + queue serializer      | Queue restores after reconnect/restart with current track + next entries intact           |
+| P1       | `/recommendation feedback like                    | dislike`                             | Music bots with feedback loops                     | Better autoplay relevance | M                                         | Redis feedback store + recommendation pipeline                                            | Disliked tracks are not replayed during TTL window unless pool exhausted |
+| P1       | Recommendation diversity constraints              | Rythm autoplay depth                 | Reduces repetitive autoplay streaks                | M                         | Track history + dedupe windows            | No same-track repeats in cooldown and no near-duplicate artist streaks in normal pools    |
+| P1       | Recommendation reason tags (`why this`)           | Spotify-like explainability patterns | Builds trust in autoplay choices                   | S                         | Recommendation metadata + embed updates   | Now playing and queue output expose reason tags for recommended tracks                    |
+| P1       | `/queue rescue`                                   | Dyno utility module style            | One-shot recovery for broken queues                | S                         | Queue validator + recommendation fallback | Removes unplayable entries and refills queue when below threshold                         |
+| P2       | `/queue smartshuffle`                             | Rythm queue ergonomics               | Better shuffle flow for group listening            | M                         | Weighted randomizer + requester history   | Shuffle preserves energy flow and avoids same-user streaks above configured threshold     |
+| P2       | `/session save` and `/session restore`            | Event/session utility patterns       | Long listening sessions become reusable            | M                         | Redis snapshots + permission checks       | Saved session restore recreates queue order/metadata for authorized roles                 |
+| P2       | `/playlist collaborative`                         | Loritta/MEE6 community collaboration | Shared curation for communities                    | L                         | Per-user quota rules + queue policy       | Collaborative mode enforces contribution limits and keeps moderation controls             |
+| P2       | Moderation automation presets (`/automod preset`) | Dyno/Carl automod modules            | Faster secure setup for new servers                | M                         | AutoModService rule packs                 | Applying a preset creates validated rules for spam/link/mention abuse                     |
+| P2       | `/mod digest` weekly summary                      | Dyno moderation reporting            | Better moderation visibility                       | S                         | Case aggregation + scheduler              | Sends scheduled summary with top incidents and action counts                              |
+| P2       | Engagement utilities (`/starboard`, `/level`)     | MEE6/Loritta engagement layer        | Higher server retention                            | L                         | Message event pipeline + storage          | Commands expose leaderboard/state with role-safe configuration                            |
+
+## Next 6 Weeks (Locked Order)
+
+### Weeks 1-2: Reliability Core
+
+1. `/music health`
+2. Music watchdog auto-recovery
+3. Provider health cooldown
+4. Queue snapshot restore
+
+### Weeks 3-4: Autoplay Intelligence V2
+
+1. `/recommendation feedback like|dislike`
+2. Recommendation diversity constraints
+3. Recommendation reason tags
+4. `/queue rescue`
+
+### Weeks 5-6: High-Value UX
+
+1. `/queue smartshuffle`
+2. `/session save`
+3. `/session restore`
+4. `/playlist collaborative`
+
+## Rollout Guide (One Command per PR)
+
+For each roadmap item:
+
+1. Create one branch (`feature/<command-or-capability>` or `fix/<capability>`).
+2. Implement only that command/feature plus required tests.
+3. Update `README.md` and `CHANGELOG.md` in the same PR.
+4. Run package-targeted tests first, then monorepo lint/type-check/test gates.
+5. Merge only after required checks are green and code review findings are resolved.
+
+Recommended PR order follows the 6-week sequence above.


### PR DESCRIPTION
## Summary
Adds a benchmark-driven Lucky command/features roadmap inspired by top Discord bots, with explicit prioritization and rollout order.

## Changes
- New docs/BOT_COMMAND_ROADMAP_BENCHMARKS.md with:
  - benchmark references (Dyno, Rythm, Loritta, MEE6, Carl-bot)
  - prioritized command matrix (value, complexity, dependencies, acceptance criteria)
  - explicit 6-week sequence
  - one-command-per-PR rollout guidance
- README documentation index updated with roadmap entry.
- CHANGELOG updated under Unreleased.

## Scope
- Documentation-only PR.
- No API, command behavior, or type contract changes.

## Validation
- npx prettier --check README.md CHANGELOG.md docs/BOT_COMMAND_ROADMAP_BENCHMARKS.md
- External reference links sanity-checked.
