### PR TITLE
chore(release): v2.6.11

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,7 +152,7 @@ SEARCH_RETRY_DELAY=5000
 # Production / Cloudflare Tunnel
 # WEBAPP_FRONTEND_URL=https://lucky.lucassantana.tech,https://lukbot.vercel.app
 # WEBAPP_BACKEND_URL=https://lucky-api.lucassantana.tech
-# WEBAPP_REDIRECT_URI=https://lucky-api.lucassantana.tech/api/auth/callback
+# WEBAPP_REDIRECT_URI=https://lucky.lucassantana.tech/api/auth/callback
 # WEBAPP_EXPECTED_CLIENT_ID=962198089161134131
 # WEBAPP_SESSION_SECRET=generate-a-random-64-char-string
 # POSTGRES_PASSWORD=change-me-in-production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `automod` categories
 - Command directory loading now ignores `*.spec.*` and `*.test.*` modules so
   test files are never registered as slash commands
-=======
 - Dashboard guild authorization now tolerates per-guild context failures
   instead of dropping the full `/api/guilds` response when one guild fails
 - Discord guild permission parsing now supports payload drift
@@ -111,6 +110,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   require `view` and mutating requests require `manage`
 - Bot Jest config now maps relative `.js` imports to source modules during test
   execution, matching the ESM build import style
+
+## [2.6.11] - 2026-03-12
+
+### Fixed
+
+- Docker publish reliability in CI images: npm cache mounts are now isolated per
+  stage with locked sharing, and `npm ci` failures are no longer masked by
+  cache-verify fallback logic.
+- Dashboard/server visibility stabilization from PR #169 is now on `main`,
+  including resilient guild authorization handling, safer Discord permissions
+  parsing, server selector error-state clarity, and authenticated `/servers`
+  access.
+- Backlog merge completion for PRs #163, #168, #164, and #169 in the same
+  cycle.
+
+### Changed
+
+- OAuth callback policy for production docs is now explicitly frontend-host
+  canonical (`https://lucky.lucassantana.tech/api/auth/callback`) for Discord
+  portal alignment in this release cycle.
+
+### Verification
+
+- `docker build -f Dockerfile --target production-backend .`
+- `docker build -f Dockerfile --target production-bot .`
+- `docker build -f Dockerfile.frontend .`
+- `npm run test --workspace=packages/backend -- tests/unit/services/DiscordOAuthService.test.ts tests/unit/services/GuildAccessService.test.ts`
+- `npm run test --workspace=packages/frontend -- src/stores/guildStore.test.ts src/hooks/useGuildSelection.test.tsx src/App.authRoutes.test.tsx src/components/Layout/Sidebar.test.tsx src/pages/ServersPage.test.tsx src/pages/DashboardOverview.test.tsx`
+- `CI=1 npm run test:e2e --workspace=packages/frontend -- tests/e2e/dashboard-page.spec.ts tests/e2e/servers-page.spec.ts tests/e2e/layout-navigation.spec.ts`
+- `npm run lint --workspace=packages/frontend`
+- `npm run type:check --workspace=packages/frontend`
 
 ## [2.6.10] - 2026-03-11
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Deploy workflow smoke checks now require `GET /api/health/auth-config` to return
 `status=ok` with no warnings (including healthy Redis/auth-session flags).
 Deploy workflow now also validates the `/api/auth/discord` redirect contract:
 `302` to Discord authorize URL with expected `client_id` and same-origin
-`redirect_uri=https://lucky-api.lucassantana.tech/api/auth/callback`.
+`redirect_uri=https://lucky.lucassantana.tech/api/auth/callback`.
 Both deploy smoke checks now retry during rollout until the new backend
 containers are serving the expected contract.
 
@@ -201,7 +201,8 @@ When `WEBAPP_FRONTEND_URL` includes multiple origins, use comma-separated values
 (example: `https://lucky.lucassantana.tech,https://lukbot.vercel.app`); backend CORS
 accepts all configured entries while OAuth/Last.fm redirects use the first origin.
 Set `WEBAPP_REDIRECT_URI` to the exact Discord OAuth callback URL registered in the
-Discord Developer Portal (example: `https://lucky-api.lucassantana.tech/api/auth/callback`).
+Discord Developer Portal (example: `https://lucky.lucassantana.tech/api/auth/callback`).
+For this release cycle, keep the frontend-host callback as canonical in Discord.
 Set `WEBAPP_EXPECTED_CLIENT_ID` to the production Discord app id to make
 `/api/health/auth-config` return `degraded` on credential drift.
 Set `WEBAPP_BACKEND_URL` to your public backend/API origin when you expose API routes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.10",
+    "version": "2.6.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.10",
+            "version": "2.6.11",
             "license": "ISC",
             "workspaces": [
                 "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.10",
+    "version": "2.6.11",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- bump root version to `2.6.11`
- publish release notes for Docker publish recovery + backlog merge cycle
- align OAuth callback documentation/env examples to frontend-host canonical policy

## Included Cycle Scope
- Docker publish cache integrity hotfix (PR #172)
- Backlog merges on main: #163, #168, #164, #169

## Verification
- npm run lint --workspace=packages/frontend
- npm run type:check --workspace=packages/frontend
- npm audit --audit-level=high
