### PR TITLE
fix(backend): enforce frontend-host OAuth callback canonicalization

### DIFF
--- a/packages/backend/src/utils/oauthRedirectUri.ts
+++ b/packages/backend/src/utils/oauthRedirectUri.ts
@@ -25,29 +25,6 @@ const normalizeCallbackPath = (redirectUri?: string): string | undefined => {
     }
 }
 
-const resolveBackendCallbackUri = (): string | undefined => {
-    const backendUrl = process.env.WEBAPP_BACKEND_URL?.trim()
-    if (!backendUrl) return undefined
-
-    try {
-        const parsed = new URL(backendUrl)
-        parsed.pathname = '/api/auth/callback'
-        parsed.search = ''
-        parsed.hash = ''
-        return parsed.toString()
-    } catch {
-        return undefined
-    }
-}
-
-const isPublicOrigin = (origin: string): boolean => {
-    return (
-        !origin.includes('localhost') &&
-        !origin.includes('127.0.0.1') &&
-        !origin.includes('0.0.0.0')
-    )
-}
-
 const buildRequestRedirectUri = (req: Request): string => {
     const forwardedProto = getForwardedHeader(req, 'x-forwarded-proto')
     const forwardedHost = getForwardedHeader(req, 'x-forwarded-host')
@@ -63,17 +40,35 @@ const buildRequestRedirectUri = (req: Request): string => {
     return `${protocol}://${host}/api/auth/callback`
 }
 
-const resolveEnvRedirectUri = (req: Request): string | undefined => {
+const resolvePrimaryFrontendCallbackUri = (): string | undefined => {
+    const frontendOrigin = getFrontendOrigins().find((origin) => {
+        try {
+            new URL(origin)
+            return true
+        } catch {
+            return false
+        }
+    })
+
+    if (!frontendOrigin) return undefined
+
+    try {
+        const parsed = new URL(frontendOrigin)
+        parsed.pathname = '/api/auth/callback'
+        parsed.search = ''
+        parsed.hash = ''
+        return parsed.toString()
+    } catch {
+        return undefined
+    }
+}
+
+const resolveEnvRedirectUri = (): string | undefined => {
     const normalized = normalizeCallbackPath(process.env.WEBAPP_REDIRECT_URI)
     if (!normalized) return undefined
 
     if (process.env.NODE_ENV !== 'production') {
         return normalized
-    }
-
-    const backendCallback = resolveBackendCallbackUri()
-    if (backendCallback) {
-        return backendCallback
     }
 
     try {
@@ -88,14 +83,13 @@ const resolveEnvRedirectUri = (req: Request): string | undefined => {
             }),
         )
 
-        const requestCallback = buildRequestRedirectUri(req)
-        const requestOrigin = new URL(requestCallback).origin
+        if (frontendOrigins.has(parsedRedirect.origin)) {
+            return normalized
+        }
 
-        if (
-            frontendOrigins.has(parsedRedirect.origin) &&
-            isPublicOrigin(requestOrigin)
-        ) {
-            return requestCallback
+        const primaryFrontendCallback = resolvePrimaryFrontendCallbackUri()
+        if (primaryFrontendCallback) {
+            return primaryFrontendCallback
         }
     } catch {
         return undefined
@@ -115,15 +109,8 @@ export function getOAuthRedirectUri(
         return normalizedSessionRedirectUri
     }
 
-    if (process.env.NODE_ENV === 'production') {
-        const backendCallback = resolveBackendCallbackUri()
-        if (backendCallback) {
-            return backendCallback
-        }
-    }
-
     return (
-        resolveEnvRedirectUri(req) ??
+        resolveEnvRedirectUri() ??
         normalizeCallbackPath(process.env.WEBAPP_REDIRECT_URI) ??
         buildRequestRedirectUri(req)
     )

--- a/packages/backend/tests/integration/routes/auth.test.ts
+++ b/packages/backend/tests/integration/routes/auth.test.ts
@@ -200,12 +200,14 @@ describe('Auth Routes Integration', () => {
             const originalNodeEnv = process.env.NODE_ENV
             const originalRedirectUri = process.env.WEBAPP_REDIRECT_URI
             const originalBackendUrl = process.env.WEBAPP_BACKEND_URL
+            const originalFrontendUrl = process.env.WEBAPP_FRONTEND_URL
 
             process.env.NODE_ENV = 'production'
             process.env.WEBAPP_REDIRECT_URI =
-                'https://lucky.lucassantana.tech/api/auth/callback'
+                'https://lucky-api.lucassantana.tech/api/auth/callback'
             process.env.WEBAPP_BACKEND_URL =
                 'https://lucky-api.lucassantana.tech'
+            process.env.WEBAPP_FRONTEND_URL = 'https://lucky.lucassantana.tech'
 
             const productionApp = express()
             productionApp.set('trust proxy', 1)
@@ -220,7 +222,7 @@ describe('Auth Routes Integration', () => {
 
             expect(response.headers.location).toContain(
                 encodeURIComponent(
-                    'https://lucky-api.lucassantana.tech/api/auth/callback',
+                    'https://lucky.lucassantana.tech/api/auth/callback',
                 ),
             )
 
@@ -239,6 +241,11 @@ describe('Auth Routes Integration', () => {
                 process.env.WEBAPP_BACKEND_URL = originalBackendUrl
             } else {
                 delete process.env.WEBAPP_BACKEND_URL
+            }
+            if (originalFrontendUrl) {
+                process.env.WEBAPP_FRONTEND_URL = originalFrontendUrl
+            } else {
+                delete process.env.WEBAPP_FRONTEND_URL
             }
         })
     })

--- a/packages/backend/tests/integration/routes/health.test.ts
+++ b/packages/backend/tests/integration/routes/health.test.ts
@@ -18,7 +18,7 @@ describe('Health Routes Integration', () => {
         process.env.WEBAPP_FRONTEND_URL =
             'https://lucky.lucassantana.tech,https://lukbot.vercel.app'
         process.env.WEBAPP_REDIRECT_URI =
-            'https://lucky-api.lucassantana.tech/api/auth/callback'
+            'https://lucky.lucassantana.tech/api/auth/callback'
         process.env.WEBAPP_BACKEND_URL = 'https://lucky-api.lucassantana.tech'
         delete process.env.WEBAPP_EXPECTED_CLIENT_ID
     })
@@ -120,7 +120,7 @@ describe('Health Routes Integration', () => {
                 auth: {
                     clientId: 'test-client-id',
                     redirectUri:
-                        'https://lucky-api.lucassantana.tech/api/auth/callback',
+                        'https://lucky.lucassantana.tech/api/auth/callback',
                     frontendOrigins: [
                         'https://lucky.lucassantana.tech',
                         'https://lukbot.vercel.app',
@@ -129,7 +129,7 @@ describe('Health Routes Integration', () => {
                     sessionSecretConfigured: true,
                     redisHealthy: true,
                     authorizeUrlPreview:
-                        'https://discord.com/api/oauth2/authorize?client_id=test-client-id&redirect_uri=https%3A%2F%2Flucky-api.lucassantana.tech%2Fapi%2Fauth%2Fcallback&response_type=code&scope=identify%20guilds',
+                        'https://discord.com/api/oauth2/authorize?client_id=test-client-id&redirect_uri=https%3A%2F%2Flucky.lucassantana.tech%2Fapi%2Fauth%2Fcallback&response_type=code&scope=identify%20guilds',
                 },
                 warnings: [],
             })
@@ -198,7 +198,7 @@ describe('Health Routes Integration', () => {
             )
         })
 
-        test('should return ok when backend origin comes from forwarded request headers', async () => {
+        test('should keep frontend callback canonical when request hits backend origin', async () => {
             mockRedis.isHealthy.mockReturnValue(true)
             process.env.NODE_ENV = 'production'
             delete process.env.WEBAPP_BACKEND_URL
@@ -216,7 +216,7 @@ describe('Health Routes Integration', () => {
             expect(response.body.warnings).toEqual([])
             expect(response.body.status).toBe('ok')
             expect(response.body.auth.redirectUri).toBe(
-                'https://lucky-api.lucassantana.tech/api/auth/callback',
+                'https://lucky.lucassantana.tech/api/auth/callback',
             )
         })
     })

--- a/packages/backend/tests/unit/utils/oauthRedirectUri.test.ts
+++ b/packages/backend/tests/unit/utils/oauthRedirectUri.test.ts
@@ -91,26 +91,28 @@ describe('getOAuthRedirectUri', () => {
         process.env.NODE_ENV = 'production'
         process.env.WEBAPP_REDIRECT_URI =
             'https://lucky.lucassantana.tech/auth/callback'
+        process.env.WEBAPP_FRONTEND_URL = 'https://lucky.lucassantana.tech'
 
         const uri = getOAuthRedirectUri(createRequest())
 
         expect(uri).toBe('https://lucky.lucassantana.tech/api/auth/callback')
     })
 
-    test('should enforce API-domain callback in production when WEBAPP_BACKEND_URL is set', () => {
+    test('should keep frontend callback in production when WEBAPP_BACKEND_URL is set', () => {
         process.env.NODE_ENV = 'production'
         process.env.WEBAPP_REDIRECT_URI =
             'https://lucky.lucassantana.tech/api/auth/callback'
+        process.env.WEBAPP_FRONTEND_URL = 'https://lucky.lucassantana.tech'
         process.env.WEBAPP_BACKEND_URL = 'https://lucky-api.lucassantana.tech'
 
         const uri = getOAuthRedirectUri(createRequest())
 
         expect(uri).toBe(
-            'https://lucky-api.lucassantana.tech/api/auth/callback',
+            'https://lucky.lucassantana.tech/api/auth/callback',
         )
     })
 
-    test('should prefer request host callback in production when env callback is legacy frontend origin', () => {
+    test('should not switch callback host from configured frontend origin', () => {
         process.env.NODE_ENV = 'production'
         process.env.WEBAPP_REDIRECT_URI =
             'https://lucky.lucassantana.tech/api/auth/callback'
@@ -124,8 +126,20 @@ describe('getOAuthRedirectUri', () => {
         )
 
         expect(uri).toBe(
-            'https://lucky-api.lucassantana.tech/api/auth/callback',
+            'https://lucky.lucassantana.tech/api/auth/callback',
         )
+    })
+
+    test('should normalize legacy api-host callback to primary frontend origin in production', () => {
+        process.env.NODE_ENV = 'production'
+        process.env.WEBAPP_REDIRECT_URI =
+            'https://lucky-api.lucassantana.tech/api/auth/callback'
+        process.env.WEBAPP_FRONTEND_URL =
+            'https://lucky.lucassantana.tech,https://lukbot.vercel.app'
+
+        const uri = getOAuthRedirectUri(createRequest())
+
+        expect(uri).toBe('https://lucky.lucassantana.tech/api/auth/callback')
     })
 
     test('should use forwarded host in non-production when env is unset', () => {


### PR DESCRIPTION
## Summary
- keep production OAuth redirect URI canonical on frontend origin (`https://lucky.lucassantana.tech/api/auth/callback`)
- prevent callback host drift to backend/request host when `WEBAPP_REDIRECT_URI` is legacy API-domain
- align auth/health integration and unit tests with frontend-host callback contract

## Root cause
- OAuth redirect resolution still allowed production callback to remain API-domain in some env/header combinations, which broke deploy smoke checks expecting frontend-host callback canonical policy.

## Changes
- updated callback resolution in `oauthRedirectUri` to:
  - normalize legacy callback path
  - prefer session callback if present
  - canonicalize production callback to primary frontend origin when configured redirect origin is outside frontend origins
  - use request-derived callback only as final fallback
- updated backend tests for auth and health routes to assert frontend-host canonical behavior in production

## Verification
- `npm run test --workspace=packages/backend -- oauthRedirectUri`
- `npm run test --workspace=packages/backend -- auth.test.ts`
- `npm run test --workspace=packages/backend -- health.test.ts`

## Notes
- `npm run lint --workspace=packages/backend` currently fails on pre-existing unrelated route typing issues in this baseline.
- `npm run type:check --workspace=packages/backend` currently fails on pre-existing monorepo build/type baseline issues unrelated to this change.
