### PR TITLE
test(backend): backfill auth health coverage cases

### DIFF
--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -6,7 +6,7 @@ import { buildAuthConfigHealth } from '../utils/authHealth'
 
 const DEFAULT_PRODUCTION_CLIENT_ID = '962198089161134131'
 
-const getForwardedHeader = (
+export const getForwardedHeader = (
     req: Request,
     headerName: string,
 ): string | undefined => {
@@ -16,7 +16,7 @@ const getForwardedHeader = (
     return raw.split(',')[0].trim() || undefined
 }
 
-const resolveRequestOrigin = (req: Request): string | undefined => {
+export const resolveRequestOrigin = (req: Request): string | undefined => {
     const forwardedProtocol =
         req.get('x-forwarded-proto')?.split(',')[0].trim() ||
         getForwardedHeader(req, 'x-forwarded-proto')

--- a/packages/backend/tests/integration/routes/health.test.ts
+++ b/packages/backend/tests/integration/routes/health.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import request from 'supertest'
 import express from 'express'
-import { setupHealthRoutes } from '../../../src/routes/health'
+import {
+    setupHealthRoutes,
+    getForwardedHeader,
+    resolveRequestOrigin,
+} from '../../../src/routes/health'
 import { redisClient } from '@lucky/shared/services'
 
 const mockRedis = redisClient as jest.Mocked<typeof redisClient>
@@ -218,6 +222,48 @@ describe('Health Routes Integration', () => {
             expect(response.body.auth.redirectUri).toBe(
                 'https://lucky.lucassantana.tech/api/auth/callback',
             )
+        })
+    })
+
+    describe('health route origin helpers', () => {
+        test('reads first value from array-based forwarded headers', () => {
+            const req = {
+                headers: {
+                    'x-forwarded-host': ['api.example.com', 'fallback.example.com'],
+                },
+            } as any
+
+            expect(getForwardedHeader(req, 'x-forwarded-host')).toBe(
+                'api.example.com',
+            )
+        })
+
+        test('returns undefined when request host is unavailable', () => {
+            const req = {
+                headers: {},
+                protocol: 'https',
+                get: jest.fn((_header: string) => undefined),
+            } as any
+
+            expect(resolveRequestOrigin(req)).toBeUndefined()
+        })
+
+        test('returns undefined for malformed forwarded host values', () => {
+            const req = {
+                headers: {
+                    'x-forwarded-host': 'bad host',
+                    'x-forwarded-proto': 'https',
+                },
+                protocol: 'https',
+                get: jest.fn((header: string) => {
+                    if (header === 'x-forwarded-host') return 'bad host'
+                    if (header === 'x-forwarded-proto') return 'https'
+                    if (header === 'host') return undefined
+                    return undefined
+                }),
+            } as any
+
+            expect(resolveRequestOrigin(req)).toBeUndefined()
         })
     })
 })

--- a/packages/backend/tests/unit/utils/authHealth.test.ts
+++ b/packages/backend/tests/unit/utils/authHealth.test.ts
@@ -112,6 +112,56 @@ describe('authHealth utils', () => {
             )
         })
 
+        test('returns degraded when redirect uri is invalid', () => {
+            const response = buildAuthConfigHealth({
+                clientId: '962198089161134131',
+                redirectUri: 'not-a-valid-uri',
+                frontendOrigins: ['https://lucky.lucassantana.tech'],
+                backendOrigins: ['https://lucky-api.lucassantana.tech'],
+                sessionSecretConfigured: true,
+                redisHealthy: true,
+            })
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain('OAuth redirect URI is invalid')
+        })
+
+        test('returns degraded when no frontend, backend, or request origins are configured', () => {
+            const response = buildAuthConfigHealth({
+                clientId: '962198089161134131',
+                redirectUri:
+                    'https://lucky.lucassantana.tech/api/auth/callback',
+                frontendOrigins: [],
+                backendOrigins: [],
+                requestOrigin: undefined,
+                sessionSecretConfigured: true,
+                redisHealthy: true,
+            })
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain(
+                'No WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL origins configured',
+            )
+        })
+
+        test('ignores malformed configured origins and malformed request origin', () => {
+            const response = buildAuthConfigHealth({
+                clientId: '962198089161134131',
+                redirectUri:
+                    'https://lucky.lucassantana.tech/api/auth/callback',
+                frontendOrigins: ['not-an-origin'],
+                backendOrigins: ['still-not-an-origin'],
+                requestOrigin: 'bad-origin',
+                sessionSecretConfigured: true,
+                redisHealthy: true,
+            })
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain(
+                'OAuth redirect origin is not in WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL',
+            )
+        })
+
         test('returns degraded when client id differs from expected production app id', () => {
             const response = buildAuthConfigHealth({
                 clientId: '111111111111111111',


### PR DESCRIPTION
## Summary
- cherry-pick the missed coverage commit that landed after PR #175 merged
- increase branch coverage around auth-config health and request-origin helpers
- keep runtime behavior unchanged (test-focused follow-up)

## Changes
- export `getForwardedHeader` and `resolveRequestOrigin` from the health route module for direct helper tests
- add integration tests for forwarded header parsing and malformed/missing host paths
- add unit tests in `authHealth` for invalid redirect URL, missing origin configuration, and malformed origin normalization branches

## Verification
- `npm run db:generate`
- `npm run build --workspace=packages/shared`
- `npm run type:check --workspace=packages/backend`
- `npm run test --workspace=packages/backend -- tests/unit/utils/authHealth.test.ts tests/integration/routes/health.test.ts`
- `npm run test --workspace=packages/backend -- --ci --coverage`

## Context
PR #175 merged at commit `de757e9` before this test coverage commit was included. This PR backfills only that missing patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for request origin resolution and header forwarding validation.
  * Enhanced health checks to detect degraded status for invalid redirect URIs and malformed origin configurations.

* **Refactor**
  * Improved health route utilities for better reusability and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->