### PR TITLE
chore(release): v2.6.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added backend automation API routes under
   `/api/guilds/:guildId/automation/*` for manifest CRUD, run execution, status,
   and cutover operations
-- Added `scripts/verify-shared-exports.mjs` to validate deep `@lucky/shared`
-  service import paths used by backend startup
-- Added `scripts/homelab-diagnostics.sh` for sanitized deploy incident triage on
-  `server-do-luk` (container state, backend logs, auth checks)
 
 - Added `docs/BOT_COMMAND_ROADMAP_BENCHMARKS.md` with a benchmark-driven Lucky
   command roadmap (Dyno, Rythm, Loritta, MEE6, Carl-bot references), prioritized
@@ -126,9 +122,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Criativaria `/serversetup` now uses explicit upsert client typings for
   auto-message, embed template, and custom command operations, preventing
   stale shared declaration drift from breaking bot typecheck resolution.
-- Production backend crash-loop caused by `ERR_PACKAGE_PATH_NOT_EXPORTED` is
-  fixed by exposing wildcard `@lucky/shared/services/*` subpath exports used by
-  backend deep imports.
 
 ### Changed
 
@@ -156,8 +149,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   convergent plans
 - Shared guild automation lock flow now uses Redis token-based distributed locks
   (`SET NX PX` + safe token release) instead of in-memory instance-local locks
+
+## [2.6.13] - 2026-03-12
+
+### Added
+
+- Added `scripts/verify-shared-exports.mjs` to validate deep `@lucky/shared`
+  service import paths used by backend startup.
+- Added `scripts/homelab-diagnostics.sh` for sanitized deploy incident triage on
+  `server-do-luk` (container state, backend logs, auth checks).
+
+### Fixed
+
+- Production backend crash-loop caused by `ERR_PACKAGE_PATH_NOT_EXPORTED` is
+  fixed by exposing wildcard `@lucky/shared/services/*` subpath exports used by
+  backend deep imports.
+
+### Changed
+
 - CI Quality Gates now verify shared deep exports after `build:shared` using
   `npm run verify:shared-exports` to prevent regressions before deploy.
+
+### Verification
+
+- `npm run build:shared`
+- `node --input-type=module -e "import('@lucky/shared/services/guildAutomation/manifestSchema')"`
+- `npm run type:check --workspace=packages/backend`
+- `npm run test --workspace=packages/backend -- tests/integration/routes/guildAutomation.test.ts`
 
 ## [2.6.12] - 2026-03-12
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ packages/
   - Primitives: `Shell`, `SectionHeader`, `EmptyState`, `StatTile`,
     `ActionPanel` in `packages/frontend/src/components/ui`
 
-### Latest Release (`v2.6.12`)
-- Stabilized dashboard/runtime behavior across shell routes (guild re-sync,
-  RBAC-aware visibility, identity fallback chain).
-- Refreshed E2E contracts and visual baselines for redesigned pages.
-- Removed Deezer integration (`discord-player-deezer`) and switched Opus runtime
-  to `opusscript`.
-- Security override floor updates: `tar>=7.5.11`, `hono>=4.12.7`,
-  `file-type>=21.3.1`.
+### Latest Release (`v2.6.13`)
+- Fixed production backend crash-loop caused by
+  `ERR_PACKAGE_PATH_NOT_EXPORTED` on shared deep imports.
+- Added wildcard shared exports for `@lucky/shared/services/*` to keep backend
+  runtime imports stable.
+- Added CI regression guard (`npm run verify:shared-exports`) after
+  `build:shared`.
+- Added homelab diagnostics helper (`scripts/homelab-diagnostics.sh`) for fast
+  deploy smoke incident triage.
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.12",
+    "version": "2.6.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.12",
+            "version": "2.6.13",
             "license": "ISC",
             "workspaces": [
                 "packages/*"
@@ -2761,7 +2761,7 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
             "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@chevrotain/gast": "10.5.0",
@@ -2773,7 +2773,7 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
             "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@chevrotain/types": "10.5.0",
@@ -2784,14 +2784,14 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
             "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@chevrotain/utils": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
             "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@commitlint/cli": {
@@ -3379,14 +3379,14 @@
             "version": "0.3.15",
             "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
             "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@electric-sql/pglite-socket": {
             "version": "0.0.20",
             "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
             "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "pglite-server": "dist/scripts/server.js"
@@ -3399,7 +3399,7 @@
             "version": "0.2.20",
             "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
             "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@electric-sql/pglite": "0.3.15"
@@ -4085,7 +4085,7 @@
             "version": "1.19.11",
             "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
             "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18.14.1"
@@ -4938,7 +4938,7 @@
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
             "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chevrotain": "^10.5.0",
@@ -6005,7 +6005,7 @@
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.4.2.tgz",
             "integrity": "sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "c12": "3.1.0",
@@ -6024,7 +6024,7 @@
             "version": "0.20.0",
             "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
             "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@electric-sql/pglite": "0.3.15",
@@ -6059,7 +6059,7 @@
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.4.2.tgz",
             "integrity": "sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -6073,14 +6073,14 @@
             "version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
             "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919.tgz",
             "integrity": "sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
             "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "7.4.2"
@@ -6090,7 +6090,7 @@
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.4.2.tgz",
             "integrity": "sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "7.4.2",
@@ -6102,7 +6102,7 @@
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
             "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "7.4.2"
@@ -6112,7 +6112,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
             "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "7.2.0"
@@ -6122,7 +6122,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
             "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/instrumentation": {
@@ -6170,14 +6170,14 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
             "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/studio-core": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.13.1.tgz",
             "integrity": "sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@types/react": "^18.0.0 || ^19.0.0",
@@ -9804,7 +9804,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@standard-schema/utils": {
@@ -9885,7 +9885,7 @@
             "version": "1.15.18",
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.18.tgz",
             "integrity": "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10094,14 +10094,14 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@swc/types": {
             "version": "0.1.25",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
             "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -10991,7 +10991,7 @@
             "version": "19.2.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -11001,7 +11001,7 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -12311,7 +12311,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
             "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0"
@@ -13087,7 +13087,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
             "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.3",
@@ -13116,7 +13116,7 @@
             "version": "16.6.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
             "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -13339,7 +13339,7 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
             "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@chevrotain/cst-dts-gen": "10.5.0",
@@ -13385,7 +13385,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
             "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "consola": "^3.2.3"
@@ -13618,7 +13618,7 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
             "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/connect-redis": {
@@ -13930,7 +13930,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/dargs": {
@@ -14081,7 +14081,7 @@
             "version": "7.1.5",
             "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
             "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=16.0.0"
@@ -14114,7 +14114,7 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
             "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/delayed-stream": {
@@ -14158,7 +14158,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
             "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/detect-libc": {
@@ -14713,7 +14713,7 @@
             "version": "3.18.4",
             "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
             "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
@@ -14751,7 +14751,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
             "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14"
@@ -15474,7 +15474,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
             "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/ext-list": {
@@ -15508,7 +15508,7 @@
             "version": "3.23.2",
             "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
             "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -15531,7 +15531,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
             "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -15924,7 +15924,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
             "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cross-spawn": "^7.0.6",
@@ -15941,7 +15941,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -16129,7 +16129,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
             "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-property": "^1.0.2"
@@ -16202,7 +16202,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
             "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/get-proto": {
@@ -16235,7 +16235,7 @@
             "version": "4.13.6",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
             "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -16248,7 +16248,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
             "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.1.6",
@@ -16473,14 +16473,14 @@
             "version": "3.1.12",
             "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
             "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/graphmatch": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
             "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/handlebars": {
@@ -16600,7 +16600,7 @@
             "version": "4.12.7",
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
             "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -16713,7 +16713,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
             "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/http2-wrapper": {
@@ -17076,7 +17076,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
             "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/is-stream": {
@@ -18518,7 +18518,7 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -19068,7 +19068,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
             "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -19182,7 +19182,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
             "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/lowercase-keys": {
@@ -19212,7 +19212,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
             "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "bun": ">=1.0.0",
@@ -19260,20 +19260,6 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
-            }
-        },
-        "node_modules/magicast": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-            "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.25.4",
-                "@babel/types": "^7.25.4",
-                "source-map-js": "^1.2.0"
             }
         },
         "node_modules/make-asynchronous": {
@@ -19778,7 +19764,7 @@
             "version": "3.15.3",
             "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
             "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "aws-ssl-profiles": "^1.1.1",
@@ -19799,7 +19785,7 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -19827,7 +19813,7 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
             "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lru.min": "^1.1.0"
@@ -19840,7 +19826,7 @@
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -19938,7 +19924,7 @@
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
             "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/node-fetch/node_modules/tr46": {
@@ -20069,7 +20055,7 @@
             "version": "0.6.5",
             "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
             "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.2.0",
@@ -20087,7 +20073,7 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
             "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/object-assign": {
@@ -20126,7 +20112,7 @@
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
             "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/on-finished": {
@@ -20469,7 +20455,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
             "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/pg": {
@@ -20680,7 +20666,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
             "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "confbox": "^0.2.2",
@@ -20767,7 +20753,7 @@
             "version": "8.5.8",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
             "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -20850,7 +20836,7 @@
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
             "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Unlicense",
             "engines": {
                 "node": ">=12"
@@ -20959,7 +20945,7 @@
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.4.2.tgz",
             "integrity": "sha512-2bP8Ruww3Q95Z2eH4Yqh4KAENRsj/SxbdknIVBfd6DmjPwmpsC4OVFMLOeHt6tM3Amh8ebjvstrUz3V/hOe1dA==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -21011,7 +20997,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
             "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -21023,7 +21009,7 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -21189,7 +21175,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
             "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "defu": "^6.1.4",
@@ -21493,14 +21479,14 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
             "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/remeda": {
             "version": "2.33.4",
             "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
             "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/remeda"
@@ -21572,7 +21558,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -21889,7 +21875,7 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
             "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/serve-static": {
             "version": "2.2.1",
@@ -22225,7 +22211,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "devOptional": true,
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -22330,7 +22316,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
             "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -22397,7 +22383,7 @@
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
             "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/streamx": {
@@ -22863,6 +22849,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
             "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/tailwindcss-animate": {
@@ -23105,7 +23092,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
             "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -23407,7 +23394,7 @@
             "version": "4.21.0",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.27.0",
@@ -23888,7 +23875,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
             "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "typescript": ">=5"
@@ -24548,7 +24535,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
             "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "grammex": "^3.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.12",
+    "version": "2.6.13",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- bump version to `2.6.13`
- publish release notes for the backend crash recovery hotfix
- update README latest release section

## Included in this release
- shared exports hotfix for `@lucky/shared/services/*`
- CI regression guard `verify:shared-exports`
- homelab diagnostics script/runbook additions

## Verification
- `npm run build:shared`
- `node --input-type=module -e "import('@lucky/shared/services/guildAutomation/manifestSchema')"`
- `npm run type:check --workspace=packages/backend`
- `npm run test --workspace=packages/backend -- tests/integration/routes/guildAutomation.test.ts`
- `npm run verify:shared-exports`
