### PR TITLE
fix: canonicalize Last.fm connect URL host in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bot `/lastfm link` now prioritizes absolute `WEBAPP_BACKEND_URL` for connect
   URL host generation (fallback: `WEBAPP_REDIRECT_URI` origin), preventing
   stale legacy domains from appearing in user-facing link embeds (PR #163)
+- Bot `/lastfm link` now rejects legacy `nexus.lucassantana.tech` and non-HTTP(S)
+  origins during connect URL generation, preventing stale/bad origins from
+  leaking into production link embeds when env values drift
 - `/api/health/auth-config` now accepts forwarded request-origin fallback when
   `WEBAPP_BACKEND_URL` is unset, preventing false degraded deploy-gate failures
   while keeping OAuth callback path and origin validation active

--- a/README.md
+++ b/README.md
@@ -283,7 +283,9 @@ When `WEBAPP_BACKEND_URL` is temporarily missing, `/api/health/auth-config`
 now validates OAuth origin against the current request origin fallback so deploy
 smoke checks can confirm live routing contract correctly.
 Bot `/lastfm link` URLs prioritize `WEBAPP_BACKEND_URL` and fall back to the
-origin of `WEBAPP_REDIRECT_URI` when backend URL is not set.
+origin of `WEBAPP_REDIRECT_URI` when backend URL is not set. Legacy
+`nexus.lucassantana.tech` origins and non-HTTP(S) origins are rejected for
+link generation to prevent stale or invalid production URLs.
 
 Discord Developer Portal URL mapping for this deployment:
 
@@ -313,9 +315,9 @@ See `.env.example` for all available options. Key variables:
 | `REDIS_HOST` | No | Redis host (default: localhost) |
 | `WEBAPP_ENABLED` | No | Enable web dashboard (default: false) |
 | `WEBAPP_SESSION_SECRET` | No | Session encryption key |
-| `WEBAPP_REDIRECT_URI` | No | Explicit Discord OAuth callback URL (must match Discord app settings); fallback origin source for Last.fm connect links when backend URL is unset |
+| `WEBAPP_REDIRECT_URI` | No | Explicit Discord OAuth callback URL (must match Discord app settings); fallback origin source for Last.fm connect links when backend URL is unset (production canonical: `https://lucky.lucassantana.tech/api/auth/callback`) |
 | `WEBAPP_EXPECTED_CLIENT_ID` | No | Expected Discord app client id for `/api/health/auth-config` mismatch detection |
-| `WEBAPP_BACKEND_URL` | No | Public backend/API origin used as canonical host for backend links and bot Last.fm connect links (must be an absolute URL) |
+| `WEBAPP_BACKEND_URL` | No | Public backend/API origin used as canonical host for backend links and bot Last.fm connect links (must be an absolute HTTP(S) URL; production canonical: `https://lucky-api.lucassantana.tech`) |
 | `CLIENT_SECRET` | No | Discord OAuth secret (for dashboard) |
 | `SENTRY_DSN` | No | Error tracking |
 

--- a/packages/bot/src/functions/general/commands/lastfm.spec.ts
+++ b/packages/bot/src/functions/general/commands/lastfm.spec.ts
@@ -88,6 +88,33 @@ describe('lastfm command link generation', () => {
         expect(url).not.toContain('//api/lastfm/connect')
     })
 
+    it('ignores legacy nexus WEBAPP_BACKEND_URL and falls back to WEBAPP_REDIRECT_URI origin', async () => {
+        process.env.WEBAPP_BACKEND_URL = 'https://nexus.lucassantana.tech'
+        process.env.WEBAPP_REDIRECT_URI =
+            'https://lucky.lucassantana.tech/api/auth/callback'
+
+        await lastfmCommand.execute({
+            interaction: createInteraction('link'),
+        } as any)
+
+        const url = getConnectUrlFromEmbed()
+        expect(url).toContain('https://lucky.lucassantana.tech/api/lastfm/connect')
+        expect(url).not.toContain('nexus.lucassantana.tech')
+    })
+
+    it('ignores non-http WEBAPP_BACKEND_URL and falls back to WEBAPP_REDIRECT_URI origin', async () => {
+        process.env.WEBAPP_BACKEND_URL = 'ftp://lucky-api.lucassantana.tech'
+        process.env.WEBAPP_REDIRECT_URI =
+            'https://lucky.lucassantana.tech/api/auth/callback'
+
+        await lastfmCommand.execute({
+            interaction: createInteraction('link'),
+        } as any)
+
+        const url = getConnectUrlFromEmbed()
+        expect(url).toContain('https://lucky.lucassantana.tech/api/lastfm/connect')
+    })
+
     it('falls back to WEBAPP_REDIRECT_URI and normalizes /api/auth/callback', async () => {
         process.env.WEBAPP_REDIRECT_URI =
             'https://lucky.lucassantana.tech/api/auth/callback'
@@ -120,6 +147,24 @@ describe('lastfm command link generation', () => {
         expect(errorEmbedMock).toHaveBeenCalledWith(
             'Cannot generate link',
             expect.stringContaining('WEBAPP_BACKEND_URL'),
+        )
+    })
+
+    it('returns configuration error when WEBAPP_REDIRECT_URI still points to legacy nexus host', async () => {
+        process.env.WEBAPP_REDIRECT_URI =
+            'https://nexus.lucassantana.tech/api/auth/callback'
+
+        await lastfmCommand.execute({
+            interaction: createInteraction('link'),
+        } as any)
+
+        expect(errorEmbedMock).toHaveBeenCalledWith(
+            'Cannot generate link',
+            expect.stringContaining('WEBAPP_BACKEND_URL'),
+        )
+        expect(successEmbedMock).not.toHaveBeenCalledWith(
+            'Connect your Last.fm account',
+            expect.any(String),
         )
     })
 

--- a/packages/bot/src/functions/general/commands/lastfm.ts
+++ b/packages/bot/src/functions/general/commands/lastfm.ts
@@ -19,7 +19,11 @@ function getAbsoluteOrigin(rawUrl?: string): string | null {
     const value = rawUrl?.trim()
     if (!value) return null
     try {
-        return new URL(value).origin
+        const parsed = new URL(value)
+        const isHttp = parsed.protocol === 'http:' || parsed.protocol === 'https:'
+        if (!isHttp) return null
+        if (parsed.hostname.toLowerCase() === 'nexus.lucassantana.tech') return null
+        return parsed.origin
     } catch {
         return null
     }


### PR DESCRIPTION
## Summary
- harden `/lastfm link` URL origin validation to accept only HTTP(S)
- reject legacy `nexus.lucassantana.tech` origins in link generation
- add regression tests for stale/invalid origin fallbacks
- document canonical production contract for `WEBAPP_BACKEND_URL` and `WEBAPP_REDIRECT_URI`

## Verification
- `npm run test --workspace=packages/bot -- packages/bot/src/functions/general/commands/lastfm.spec.ts`
- `npm run test --workspace=packages/bot -- lastfm`
- `npm run type:check --workspace=packages/bot`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Last.fm link generation to reject invalid and legacy origins, preventing malformed URLs from appearing in production environments.

* **Documentation**
  * Updated OAuth origin fallback behavior documentation and environment variable descriptions for improved clarity on production URL requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->