### PR TITLE
fix: align oauth redirect callback with frontend canonical host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,13 +146,13 @@ SEARCH_RETRY_DELAY=5000
 # WEBAPP_PORT=3000
 # WEBAPP_FRONTEND_URL=http://localhost:5173
 # WEBAPP_BACKEND_URL=http://localhost:3000
-# WEBAPP_REDIRECT_URI=http://localhost:3000/api/auth/callback
+# WEBAPP_REDIRECT_URI=http://localhost:5173/api/auth/callback
 # DEVELOPER_USER_IDS=your_discord_user_id
 #
 # Production / Cloudflare Tunnel
 # WEBAPP_FRONTEND_URL=https://lucky.lucassantana.tech
 # WEBAPP_BACKEND_URL=https://lucky-api.lucassantana.tech
-# WEBAPP_REDIRECT_URI=https://lucky-api.lucassantana.tech/api/auth/callback
+# WEBAPP_REDIRECT_URI=https://lucky.lucassantana.tech/api/auth/callback
 # WEBAPP_EXPECTED_CLIENT_ID=962198089161134131
 # WEBAPP_SESSION_SECRET=generate-a-random-64-char-string
 # POSTGRES_PASSWORD=change-me-in-production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,9 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Features dashboard loading now classifies fetch failures as
   `auth|forbidden|network|upstream` and exposes retry/re-auth actions instead
   of silent fallback when catalog/global/server toggle fetches fail
-- OAuth callback resolution now prioritizes `WEBAPP_BACKEND_URL` in production
-  (fallback: `WEBAPP_REDIRECT_URI`) so `/api/auth/discord` and
-  `/api/health/auth-config` stay aligned with split-origin API deployments.
+- OAuth callback resolution now keeps `WEBAPP_REDIRECT_URI` as canonical in
+  production (no `WEBAPP_BACKEND_URL` override), restoring deploy OAuth smoke
+  contract and frontend-host callback consistency.
 - Local Prisma bootstrap now pins explicit config path
   (`--config prisma/prisma.config.ts`) across `db:*` scripts, and
   `db:migrate` now includes a guarded fallback for the known fresh-db legacy

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Deploy workflow smoke checks now require `GET /api/health/auth-config` to return
 `status=ok` with no warnings (including healthy Redis/auth-session flags).
 Deploy workflow now also validates the `/api/auth/discord` redirect contract:
 `302` to Discord authorize URL with expected `client_id` and same-origin
-`redirect_uri=https://lucky-api.lucassantana.tech/api/auth/callback`.
+`redirect_uri=https://lucky.lucassantana.tech/api/auth/callback`.
 Both deploy smoke checks now retry during rollout until the new backend
 containers are serving the expected contract.
 Deploy webhook rollout now starts `postgres`/`redis`, runs
@@ -295,15 +295,14 @@ When `WEBAPP_FRONTEND_URL` includes multiple origins, use comma-separated values
 accepts all configured entries while Last.fm redirects use the first origin.
 Set `WEBAPP_REDIRECT_URI` to the exact Discord OAuth callback URL registered in the
 Discord Developer Portal (example:
-`https://lucky-api.lucassantana.tech/api/auth/callback`).
+`https://lucky.lucassantana.tech/api/auth/callback`).
 Set `WEBAPP_EXPECTED_CLIENT_ID` to the production Discord app id to make
 `/api/health/auth-config` return `degraded` on credential drift.
 Set `WEBAPP_BACKEND_URL` to your public backend/API origin when you expose API routes
 through a dedicated host. Use an absolute URL (for example,
 `https://lucky-api.lucassantana.tech`).
-In production, OAuth callback generation now prioritizes `WEBAPP_BACKEND_URL`
-(`.../api/auth/callback`) and falls back to `WEBAPP_REDIRECT_URI` when backend
-URL is not set.
+OAuth callback generation now uses `WEBAPP_REDIRECT_URI` as canonical callback
+source and only falls back to request-derived callback URLs when it is unset.
 Bot `/lastfm link` URLs prioritize `WEBAPP_BACKEND_URL` and fall back to the
 origin of `WEBAPP_REDIRECT_URI` when backend URL is not set. Legacy
 `nexus.lucassantana.tech` origins and non-HTTP(S) origins are rejected for
@@ -337,9 +336,9 @@ See `.env.example` for all available options. Key variables:
 | `REDIS_HOST` | No | Redis host (default: localhost) |
 | `WEBAPP_ENABLED` | No | Enable web dashboard (default: false) |
 | `WEBAPP_SESSION_SECRET` | No | Session encryption key |
-| `WEBAPP_REDIRECT_URI` | No | Explicit Discord OAuth callback URL (must match Discord app settings); fallback callback source when `WEBAPP_BACKEND_URL` is unset |
+| `WEBAPP_REDIRECT_URI` | No | Explicit Discord OAuth callback URL (must match Discord app settings and deploy smoke contract) |
 | `WEBAPP_EXPECTED_CLIENT_ID` | No | Expected Discord app client id for `/api/health/auth-config` mismatch detection |
-| `WEBAPP_BACKEND_URL` | No | Public backend/API origin used as canonical host for backend links and bot Last.fm connect links (must be an absolute HTTP(S) URL; production canonical: `https://lucky-api.lucassantana.tech`) |
+| `WEBAPP_BACKEND_URL` | No | Public backend/API origin used for backend links and bot Last.fm connect links (must be an absolute HTTP(S) URL; recommended: `https://lucky-api.lucassantana.tech`) |
 | `CLIENT_SECRET` | No | Discord OAuth secret (for dashboard) |
 | `SENTRY_DSN` | No | Error tracking |
 

--- a/docs/WEBAPP_SETUP.md
+++ b/docs/WEBAPP_SETUP.md
@@ -57,7 +57,7 @@ Add these to your `.env` file:
 # Discord OAuth2 Configuration
 CLIENT_ID=your_discord_client_id
 CLIENT_SECRET=your_discord_client_secret
-WEBAPP_REDIRECT_URI=http://localhost:3000/api/auth/callback
+WEBAPP_REDIRECT_URI=http://localhost:5173/api/auth/callback
 
 # Web Application Configuration
 WEBAPP_ENABLED=true
@@ -100,7 +100,7 @@ VITE_API_BASE_URL=https://api.yourdomain.com/api
 ### Step 2: Configure OAuth2 Redirect URI
 
 1. In the "Redirects" section, add your callback URL:
-    - Development: `http://localhost:3000/api/auth/callback`
+    - Development: `http://localhost:5173/api/auth/callback`
     - Production: `https://your-frontend-domain.com/api/auth/callback`
 2. Save changes
 

--- a/packages/backend/src/utils/oauthRedirectUri.ts
+++ b/packages/backend/src/utils/oauthRedirectUri.ts
@@ -1,5 +1,4 @@
 import type { Request } from 'express'
-import { getFrontendOrigins } from './frontendOrigin'
 
 const getForwardedHeader = (
     req: Request,
@@ -25,29 +24,6 @@ const normalizeCallbackPath = (redirectUri?: string): string | undefined => {
     }
 }
 
-const resolveBackendCallbackUri = (): string | undefined => {
-    const backendUrl = process.env.WEBAPP_BACKEND_URL?.trim()
-    if (!backendUrl) return undefined
-
-    try {
-        const parsed = new URL(backendUrl)
-        parsed.pathname = '/api/auth/callback'
-        parsed.search = ''
-        parsed.hash = ''
-        return parsed.toString()
-    } catch {
-        return undefined
-    }
-}
-
-const isPublicOrigin = (origin: string): boolean => {
-    return (
-        !origin.includes('localhost') &&
-        !origin.includes('127.0.0.1') &&
-        !origin.includes('0.0.0.0')
-    )
-}
-
 const buildRequestRedirectUri = (req: Request): string => {
     const forwardedProto = getForwardedHeader(req, 'x-forwarded-proto')
     const forwardedHost = getForwardedHeader(req, 'x-forwarded-host')
@@ -63,43 +39,9 @@ const buildRequestRedirectUri = (req: Request): string => {
     return `${protocol}://${host}/api/auth/callback`
 }
 
-const resolveEnvRedirectUri = (req: Request): string | undefined => {
+const resolveEnvRedirectUri = (): string | undefined => {
     const normalized = normalizeCallbackPath(process.env.WEBAPP_REDIRECT_URI)
     if (!normalized) return undefined
-
-    if (process.env.NODE_ENV !== 'production') {
-        return normalized
-    }
-
-    const backendCallback = resolveBackendCallbackUri()
-    if (backendCallback) {
-        return backendCallback
-    }
-
-    try {
-        const parsedRedirect = new URL(normalized)
-        const frontendOrigins = new Set(
-            getFrontendOrigins().map((origin) => {
-                try {
-                    return new URL(origin).origin
-                } catch {
-                    return ''
-                }
-            }),
-        )
-
-        const requestCallback = buildRequestRedirectUri(req)
-        const requestOrigin = new URL(requestCallback).origin
-
-        if (
-            frontendOrigins.has(parsedRedirect.origin) &&
-            isPublicOrigin(requestOrigin)
-        ) {
-            return requestCallback
-        }
-    } catch {
-        return undefined
-    }
 
     return normalized
 }
@@ -115,15 +57,8 @@ export function getOAuthRedirectUri(
         return normalizedSessionRedirectUri
     }
 
-    if (process.env.NODE_ENV === 'production') {
-        const backendCallback = resolveBackendCallbackUri()
-        if (backendCallback) {
-            return backendCallback
-        }
-    }
-
     return (
-        resolveEnvRedirectUri(req) ??
+        resolveEnvRedirectUri() ??
         normalizeCallbackPath(process.env.WEBAPP_REDIRECT_URI) ??
         buildRequestRedirectUri(req)
     )

--- a/packages/backend/tests/integration/routes/auth.test.ts
+++ b/packages/backend/tests/integration/routes/auth.test.ts
@@ -196,7 +196,7 @@ describe('Auth Routes Integration', () => {
             }
         })
 
-        test('should enforce backend callback and secure cookie in production', async () => {
+        test('should keep configured callback and secure cookie in production', async () => {
             const originalNodeEnv = process.env.NODE_ENV
             const originalRedirectUri = process.env.WEBAPP_REDIRECT_URI
             const originalBackendUrl = process.env.WEBAPP_BACKEND_URL
@@ -220,7 +220,7 @@ describe('Auth Routes Integration', () => {
 
             expect(response.headers.location).toContain(
                 encodeURIComponent(
-                    'https://lucky-api.lucassantana.tech/api/auth/callback',
+                    'https://lucky.lucassantana.tech/api/auth/callback',
                 ),
             )
 

--- a/packages/backend/tests/unit/utils/oauthRedirectUri.test.ts
+++ b/packages/backend/tests/unit/utils/oauthRedirectUri.test.ts
@@ -97,7 +97,7 @@ describe('getOAuthRedirectUri', () => {
         expect(uri).toBe('https://lucky.lucassantana.tech/api/auth/callback')
     })
 
-    test('should enforce API-domain callback in production when WEBAPP_BACKEND_URL is set', () => {
+    test('should keep configured callback when WEBAPP_BACKEND_URL is set', () => {
         process.env.NODE_ENV = 'production'
         process.env.WEBAPP_REDIRECT_URI =
             'https://lucky.lucassantana.tech/api/auth/callback'
@@ -105,12 +105,10 @@ describe('getOAuthRedirectUri', () => {
 
         const uri = getOAuthRedirectUri(createRequest())
 
-        expect(uri).toBe(
-            'https://lucky-api.lucassantana.tech/api/auth/callback',
-        )
+        expect(uri).toBe('https://lucky.lucassantana.tech/api/auth/callback')
     })
 
-    test('should prefer request host callback in production when env callback is legacy frontend origin', () => {
+    test('should not override configured callback with forwarded host in production', () => {
         process.env.NODE_ENV = 'production'
         process.env.WEBAPP_REDIRECT_URI =
             'https://lucky.lucassantana.tech/api/auth/callback'
@@ -123,9 +121,7 @@ describe('getOAuthRedirectUri', () => {
             }),
         )
 
-        expect(uri).toBe(
-            'https://lucky-api.lucassantana.tech/api/auth/callback',
-        )
+        expect(uri).toBe('https://lucky.lucassantana.tech/api/auth/callback')
     })
 
     test('should keep configured callback when frontend origins do not match redirect origin', () => {


### PR DESCRIPTION
## Summary
- remove production override that forced OAuth callback host to `WEBAPP_BACKEND_URL`
- keep `WEBAPP_REDIRECT_URI` as canonical callback source for `/api/auth/discord`
- sync docs/env examples to frontend-host callback policy

## Why
- `Deploy to Homelab` run `23062404328` failed on OAuth smoke because it expected:
  - `https://lucky.lucassantana.tech/api/auth/callback`
- backend emitted:
  - `https://lucky-api.lucassantana.tech/api/auth/callback`

## Changes
- backend redirect resolver now:
  - uses session callback when present
  - otherwise uses normalized `WEBAPP_REDIRECT_URI`
  - falls back to request-derived callback only when env callback is unset
- updated backend tests for the production callback behavior
- updated `README.md`, `docs/WEBAPP_SETUP.md`, and `.env.example` callback examples
- updated `CHANGELOG.md`

## Validation
- `npm run test --workspace=packages/backend -- tests/unit/utils/oauthRedirectUri.test.ts`
- `npm run test --workspace=packages/backend -- tests/integration/routes/auth.test.ts`
- `npm run lint --workspace=packages/backend`
- `npm run type:check --workspace=packages/backend`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth authentication by correcting redirect URIs to point to the frontend domain instead of the backend API domain in development and production environments.

* **Documentation**
  * Updated development setup guides and environment configuration examples with accurate OAuth redirect URI references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->