### PR TITLE
fix(web): reduce guild-selection upstream call amplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guild auto-selection now picks the first server where Lucky is already added;
   when no server has Lucky installed, dashboard keeps no selected server and
   shows explicit selection guidance
+- Dashboard guild selection no longer performs eager `/api/guilds/:id` and
+  `/api/guilds/:id/listing` bootstrap requests, reducing duplicate upstream
+  dependency calls during route navigation
 - Frontend guild-fetch failures now preserve the current selected guild context
   to avoid abrupt resets across module pages during transient upstream errors
 - Backend startup now verifies `guild_role_grants` relation availability before

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ visit to `/servers` first.
 Guild auto-selection prioritizes the first server where Lucky is already added;
 if none are bot-added, the dashboard keeps no selected server and shows a clear
 selection/empty guidance state.
+Guild selection now loads only member-context bootstrap data and no longer
+triggers eager guild detail/listing fetches during route navigation.
 Server selector empty/error states are split:
 - `No accessible servers found` means authentication worked but no authorized
   guilds matched your access policy.

--- a/packages/frontend/src/stores/guildStore.test.ts
+++ b/packages/frontend/src/stores/guildStore.test.ts
@@ -38,15 +38,9 @@ const MANAGE_ACCESS = {
 
 type MeResponse = { data: GuildMemberContext }
 
-function setupSelectedGuildApiMocks(guildId: string, guild?: Guild) {
-    vi.mocked(api.guilds.get).mockResolvedValue({
-        data: { guild: guild ?? mockGuild({ id: guildId }) },
-    } as never)
+function setupSelectedGuildApiMocks(guildId: string) {
     vi.mocked(api.guilds.getSettings).mockResolvedValue({
         data: { settings: null },
-    } as never)
-    vi.mocked(api.guilds.getListing).mockResolvedValue({
-        data: { listing: null },
     } as never)
     vi.mocked(api.guilds.getMe).mockResolvedValue({
         data: {
@@ -73,7 +67,6 @@ describe('guildStore', () => {
             memberContext: null,
             memberContextLoading: false,
             serverSettings: null,
-            serverListing: null,
         })
         vi.clearAllMocks()
     })
@@ -108,6 +101,22 @@ describe('guildStore', () => {
             expect(useGuildStore.getState().selectedGuildId).toBe('2')
         })
 
+        test('should keep selected guild empty when user has no bot-added guild', async () => {
+            const guilds = [
+                mockGuild({ id: '1', botAdded: false }),
+                mockGuild({ id: '2', botAdded: false }),
+            ]
+
+            vi.mocked(api.guilds.list).mockResolvedValue({
+                data: { guilds },
+            } as never)
+
+            await useGuildStore.getState().fetchGuilds()
+
+            expect(useGuildStore.getState().selectedGuildId).toBeNull()
+            expect(vi.mocked(api.guilds.getMe)).not.toHaveBeenCalled()
+        })
+
         test('should reset on fetch error', async () => {
             vi.mocked(api.guilds.list).mockRejectedValue(
                 new Error('Network error'),
@@ -131,7 +140,7 @@ describe('guildStore', () => {
             vi.mocked(api.guilds.list).mockResolvedValue({
                 data: { guilds: [refreshedGuild] },
             } as never)
-            setupSelectedGuildApiMocks(refreshedGuild.id, refreshedGuild)
+            setupSelectedGuildApiMocks(refreshedGuild.id)
 
             await useGuildStore.getState().fetchGuilds()
 
@@ -158,9 +167,12 @@ describe('guildStore', () => {
             expect(useGuildStore.getState().selectedGuild).toBeNull()
             expect(useGuildStore.getState().selectedGuildId).toBeNull()
         })
-    test('should clear member context and settings when dependent calls fail', async () => {
-        const guild = mockGuild({ id: 'error-guild' })
-        vi.mocked(api.guilds.getMe).mockRejectedValue(new Error('me failed'))
+
+        test('should clear member context and settings when dependent calls fail', async () => {
+            const guild = mockGuild({ id: 'error-guild' })
+            vi.mocked(api.guilds.getMe).mockRejectedValue(
+                new Error('me failed'),
+            )
 
             useGuildStore.getState().selectGuild(guild)
 
@@ -195,6 +207,8 @@ describe('guildStore', () => {
             })
 
             expect(vi.mocked(api.guilds.getSettings)).not.toHaveBeenCalled()
+            expect(vi.mocked(api.guilds.get)).not.toHaveBeenCalled()
+            expect(vi.mocked(api.guilds.getListing)).not.toHaveBeenCalled()
         })
 
         test('should ignore stale async responses from previous selected guild', async () => {
@@ -251,12 +265,12 @@ describe('guildStore', () => {
             })
             await Promise.resolve()
 
-        const state = useGuildStore.getState()
-        expect(state.selectedGuildId).toBe(guildB.id)
-        expect(state.memberContext?.guildId).toBe(guildB.id)
-        expect(state.serverSettings).toBeNull()
+            const state = useGuildStore.getState()
+            expect(state.selectedGuildId).toBe(guildB.id)
+            expect(state.memberContext?.guildId).toBe(guildB.id)
+            expect(state.serverSettings).toBeNull()
+        })
     })
-})
 
     describe('updateServerSettings', () => {
         test('should merge partial settings', () => {

--- a/packages/frontend/src/stores/guildStore.ts
+++ b/packages/frontend/src/stores/guildStore.ts
@@ -3,7 +3,6 @@ import type {
     Guild,
     GuildMemberContext,
     ServerSettings,
-    ServerListing,
 } from '@/types'
 import { api } from '@/services/api'
 import { ApiError } from '@/services/ApiError'
@@ -30,48 +29,12 @@ interface GuildState {
     memberContext: GuildMemberContext | null
     memberContextLoading: boolean
     serverSettings: ServerSettings | null
-    serverListing: ServerListing | null
     fetchGuilds: (force?: boolean) => Promise<void>
     selectGuild: (guild: Guild | null) => void
     fetchMemberContext: (guildId: string) => Promise<void>
     setSelectedGuild: (guildId: string | null) => void
     getSelectedGuild: () => Guild | null
     updateServerSettings: (settings: Partial<ServerSettings>) => void
-    updateServerListing: (listing: Partial<ServerListing>) => void
-}
-
-function mergeGuild(guilds: Guild[], incoming: Guild): Guild[] {
-    return guilds.map((guild) =>
-        guild.id === incoming.id ? { ...guild, ...incoming } : guild,
-    )
-}
-
-function findGuildById(guilds: Guild[], guildId: string): Guild | null {
-    for (const guild of guilds) {
-        if (guild.id === guildId) {
-            return guild
-        }
-    }
-
-    return null
-}
-
-function mergeDetailedGuildState(
-    state: GuildState,
-    guildId: string,
-    detailedGuild: Guild,
-): Pick<GuildState, 'guilds' | 'selectedGuild'> | object {
-    if (state.selectedGuildId !== guildId) {
-        return {}
-    }
-
-    const mergedGuilds = mergeGuild(state.guilds, detailedGuild)
-    const selectedGuild = findGuildById(mergedGuilds, guildId) ?? detailedGuild
-
-    return {
-        guilds: mergedGuilds,
-        selectedGuild,
-    }
 }
 
 function classifyGuildLoadError(error: unknown): GuildLoadErrorState {
@@ -118,7 +81,6 @@ export const useGuildStore = create<GuildState>((set, get) => ({
     memberContext: null,
     memberContextLoading: false,
     serverSettings: null,
-    serverListing: null,
 
     fetchGuilds: async (force = false) => {
         if (!force && get().isLoading && guildFetchPromise) {
@@ -155,14 +117,14 @@ export const useGuildStore = create<GuildState>((set, get) => ({
                         memberContext: null,
                         memberContextLoading: false,
                         serverSettings: null,
-                        serverListing: null,
                     })
                 }
 
                 if (guilds.length > 0 && !selectedGuild) {
-                    const firstWithBot =
-                        guilds.find((guild) => guild.botAdded) ?? guilds[0]
-                    get().selectGuild(firstWithBot)
+                    const firstWithBot = guilds.find((guild) => guild.botAdded)
+                    if (firstWithBot) {
+                        get().selectGuild(firstWithBot)
+                    }
                 }
             } catch (error) {
                 set((state) => ({
@@ -172,7 +134,6 @@ export const useGuildStore = create<GuildState>((set, get) => ({
                     memberContext: state.memberContext,
                     memberContextLoading: false,
                     serverSettings: state.serverSettings,
-                    serverListing: state.serverListing,
                     guildLoadError: classifyGuildLoadError(error),
                     isLoading: false,
                     hasFetchedGuilds: true,
@@ -198,43 +159,13 @@ export const useGuildStore = create<GuildState>((set, get) => ({
             memberContext: null,
             memberContextLoading: Boolean(guild),
             serverSettings: null,
-            serverListing: null,
         })
 
         if (!guildId) {
             return
         }
 
-        const withCurrentGuild = <T extends object>(value: T): T | object => {
-            return get().selectedGuildId === guildId ? value : {}
-        }
-
-        get()
-            .fetchMemberContext(guildId)
-            .catch(() => {})
-
-        api.guilds
-            .get(guildId)
-            .then((response) => {
-                const detailedGuild = response.data.guild
-                set((state) =>
-                    mergeDetailedGuildState(state, guildId, detailedGuild),
-                )
-            })
-            .catch(() => {})
-
-        api.guilds
-            .getListing(guildId)
-            .then((response) => {
-                set(
-                    withCurrentGuild({
-                        serverListing: response.data.listing,
-                    }),
-                )
-            })
-            .catch(() => {
-                set(withCurrentGuild({ serverListing: null }))
-            })
+        void get().fetchMemberContext(guildId)
     },
 
     fetchMemberContext: async (guildId) => {
@@ -276,13 +207,6 @@ export const useGuildStore = create<GuildState>((set, get) => ({
         const current = get().serverSettings
         if (current) {
             set({ serverSettings: { ...current, ...settings } })
-        }
-    },
-
-    updateServerListing: (listing) => {
-        const current = get().serverListing
-        if (current) {
-            set({ serverListing: { ...current, ...listing } })
         }
     },
 }))


### PR DESCRIPTION
## Summary
- stop eager guild bootstrap calls ( and ) during generic guild selection
- enforce bot-only auto-selection behavior (no fallback selection when no  guild exists)
- keep member-context bootstrap fetch as the only selection-time dependency
- update README and CHANGELOG traceability notes

## Why
- reduces avoidable upstream dependency fan-out during route navigation
- aligns runtime behavior with documented dashboard selection rules
- prevents noisy/proxy-failing calls in E2E and production-like flows

## Validation
- 
> lucky-webapp@1.0.0 test
> vitest run src/stores/authStore.test.ts src/hooks/useFeatures.test.ts src/stores/guildStore.test.ts src/pages/Features.test.tsx src/pages/ServerSettings.test.tsx


 RUN  v4.0.18 /Users/lucassantana/Desenvolvimento/Lucky/packages/frontend

 ✓ src/stores/guildStore.test.ts (21 tests) 106ms
 ✓ src/pages/Features.test.tsx (5 tests) 28ms
 ✓ src/pages/ServerSettings.test.tsx (17 tests) 935ms

 Test Files  3 passed (3)
      Tests  43 passed (43)
   Start at  15:45:07
   Duration  1.90s (transform 271ms, setup 213ms, import 749ms, tests 1.07s, environment 1.28s)
- 
> lucky-webapp@1.0.0 test:e2e
> playwright test tests/e2e/dashboard-page.spec.ts tests/e2e/servers-page.spec.ts tests/e2e/layout-navigation.spec.ts



Running 30 tests using 6 workers

























[1A[2K[1/30] [chromium] › tests/e2e/dashboard-page.spec.ts:101:5 › Dashboard Page › navigates to servers page from empty state
[1A[2K[2/30] [chromium] › tests/e2e/dashboard-page.spec.ts:71:5 › Dashboard Page › selects different server from dropdown
[1A[2K[3/30] [chromium] › tests/e2e/dashboard-page.spec.ts:35:5 › Dashboard Page › displays No Server Selected state when no bot servers
[1A[2K[4/30] [chromium] › tests/e2e/dashboard-page.spec.ts:16:5 › Dashboard Page › auto-selects first server with bot when available
[1A[2K[5/30] [chromium] › tests/e2e/dashboard-page.spec.ts:129:5 › Dashboard Page › server grid displays correctly
[1A[2K[6/30] [chromium] › tests/e2e/dashboard-page.spec.ts:57:5 › Dashboard Page › server selector dropdown in header
[1A[2K[7/30] [chromium] › tests/e2e/dashboard-page.spec.ts:145:5 › Dashboard Page › server selection persists across navigation
[1A[2K[8/30] [chromium] › tests/e2e/dashboard-page.spec.ts:169:5 › Dashboard Page › shows loading states during server fetch
[1A[2K[9/30] [chromium] › tests/e2e/layout-navigation.spec.ts:11:5 › Layout and Navigation › sidebar displays correctly
[1A[2K[10/30] [chromium] › tests/e2e/layout-navigation.spec.ts:18:5 › Layout and Navigation › navigation items work
[1A[2K[11/30] [chromium] › tests/e2e/layout-navigation.spec.ts:32:5 › Layout and Navigation › active route highlighting
[1A[2K[12/30] [chromium] › tests/e2e/layout-navigation.spec.ts:40:5 › Layout and Navigation › user info in sidebar
[1A[2K[13/30] [chromium] › tests/e2e/layout-navigation.spec.ts:47:5 › Layout and Navigation › user avatar and username display
[1A[2K[14/30] [chromium] › tests/e2e/layout-navigation.spec.ts:59:5 › Layout and Navigation › logout functionality
[1A[2K[15/30] [chromium] › tests/e2e/layout-navigation.spec.ts:77:5 › Layout and Navigation › server selector dropdown in sidebar
[1A[2K[16/30] [chromium] › tests/e2e/layout-navigation.spec.ts:90:5 › Layout and Navigation › mobile menu toggle
[1A[2K[17/30] [chromium] › tests/e2e/layout-navigation.spec.ts:110:5 › Layout and Navigation › sidebar closes on mobile
[1A[2K[18/30] [chromium] › tests/e2e/layout-navigation.spec.ts:139:5 › Layout and Navigation › navigation redirects unauthenticated users
[1A[2K[19/30] [chromium] › tests/e2e/layout-navigation.spec.ts:153:5 › Layout and Navigation › Lucky branding in sidebar
[1A[2K[20/30] [chromium] › tests/e2e/servers-page.spec.ts:23:5 › Servers Page › displays user avatar and username
[1A[2K[21/30] [chromium] › tests/e2e/servers-page.spec.ts:38:5 › Servers Page › lists all user Discord servers
[1A[2K[22/30] [chromium] › tests/e2e/servers-page.spec.ts:48:5 › Servers Page › shows server cards with correct information
[1A[2K[23/30] [chromium] › tests/e2e/servers-page.spec.ts:58:5 › Servers Page › displays Bot Added badge for servers with bot
[1A[2K[24/30] [chromium] › tests/e2e/servers-page.spec.ts:69:5 › Servers Page › displays Not Added badge for servers without bot
[1A[2K[25/30] [chromium] › tests/e2e/servers-page.spec.ts:82:5 › Servers Page › Manage button navigates to dashboard for servers with bot
[1A[2K[26/30] [chromium] › tests/e2e/servers-page.spec.ts:99:5 › Servers Page › Add Bot button functionality for servers without bot
[1A[2K[27/30] [chromium] › tests/e2e/servers-page.spec.ts:116:5 › Servers Page › shows loading skeleton during data fetch
[1A[2K[28/30] [chromium] › tests/e2e/servers-page.spec.ts:140:5 › Servers Page › handles empty state when no servers available
[1A[2K[29/30] [chromium] › tests/e2e/servers-page.spec.ts:156:5 › Servers Page › handles error when API fails
[1A[2K[30/30] [chromium] › tests/e2e/servers-page.spec.ts:171:5 › Servers Page › displays server count correctly
[1A[2K  30 passed (11.4s)
- 
> lucky-bot@2.6.13 type:check
> npm run type:check --workspace=packages/shared && npm run type:check --workspace=packages/bot && npm run type:check --workspace=packages/backend && npm run type:check --workspace=packages/frontend


> @lucky/shared@1.0.0 type:check
> tsc --noEmit


> @lucky/bot@1.0.0 type:check
> npm run preflight && tsc --noEmit


> @lucky/bot@1.0.0 preflight
> npm --prefix ../.. run db:generate && npm --prefix ../.. run build:shared


> lucky-bot@2.6.13 db:generate
> DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres} prisma generate --config prisma/prisma.config.ts


✔ Generated Prisma Client (7.4.2) to ./packages/shared/src/generated/prisma in 84ms


> lucky-bot@2.6.13 build:shared
> npm run build --workspace=packages/shared


> @lucky/shared@1.0.0 build
> tsc -b --force && node add-js-extensions.js

Updated 53 files with .js extensions

> @lucky/backend@1.0.0 type:check
> tsc --noEmit


> lucky-webapp@1.0.0 type:check
> tsc --noEmit
- 
> lucky-bot@2.6.13 lint
> eslint . -c eslint.config.js
- 
> lucky-bot@2.6.13 build
> npm run db:generate && npm run build --workspace=packages/shared && npm run build --workspace=packages/bot && npm run build --workspace=packages/backend && npm run build --workspace=packages/frontend


> lucky-bot@2.6.13 db:generate
> DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres} prisma generate --config prisma/prisma.config.ts


✔ Generated Prisma Client (7.4.2) to ./packages/shared/src/generated/prisma in 78ms


> @lucky/shared@1.0.0 build
> tsc -b --force && node add-js-extensions.js

Updated 53 files with .js extensions

> @lucky/bot@1.0.0 build
> npm run preflight && tsc && node add-js-extensions.js


> @lucky/bot@1.0.0 preflight
> npm --prefix ../.. run db:generate && npm --prefix ../.. run build:shared


> lucky-bot@2.6.13 db:generate
> DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres} prisma generate --config prisma/prisma.config.ts


✔ Generated Prisma Client (7.4.2) to ./packages/shared/src/generated/prisma in 78ms


> lucky-bot@2.6.13 build:shared
> npm run build --workspace=packages/shared


> @lucky/shared@1.0.0 build
> tsc -b --force && node add-js-extensions.js

Updated 53 files with .js extensions
Updated 133 files with .js extensions

> @lucky/backend@1.0.0 build
> tsc && node add-js-extensions.js

Updated 32 files with .js extensions

> lucky-webapp@1.0.0 build
> tsc && vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 2520 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                0.81 kB │ gzip:   0.38 kB
dist/assets/index-uqKsDL2-.css                93.48 kB │ gzip:  14.38 kB
dist/assets/Skeleton-CgLGELLV.js               0.38 kB │ gzip:   0.30 kB │ map:     0.81 kB
dist/assets/usePageMetadata-BoSSoUOu.js        0.39 kB │ gzip:   0.29 kB │ map:     1.24 kB
dist/assets/Card-CnMZv2QT.js                   0.69 kB │ gzip:   0.45 kB │ map:     1.49 kB
dist/assets/input-Cuim_jyn.js                  0.79 kB │ gzip:   0.50 kB │ map:     1.34 kB
dist/assets/label-DH9d7jgK.js                  0.85 kB │ gzip:   0.54 kB │ map:     2.48 kB
dist/assets/badge-CfMThH7J.js                  0.96 kB │ gzip:   0.54 kB │ map:     1.88 kB
dist/assets/switch-CjWN7v8v.js                 1.22 kB │ gzip:   0.61 kB │ map:     1.88 kB
dist/assets/ActionPanel-T91uwRnQ.js            3.36 kB │ gzip:   0.66 kB │ map:     4.17 kB
dist/assets/zod-DPgK3k5h.js                    4.41 kB │ gzip:   1.58 kB │ map:    36.40 kB
dist/assets/PrivacyPolicy-BhkPj8v3.js          4.92 kB │ gzip:   0.98 kB │ map:     5.03 kB
dist/assets/TermsOfService-BcMk3kER.js         5.00 kB │ gzip:   1.02 kB │ map:     5.11 kB
dist/assets/select-BanLrs5C.js                 6.06 kB │ gzip:   1.40 kB │ map:    10.19 kB
dist/assets/CommandsConfig-CuOufs8p.js         7.39 kB │ gzip:   1.71 kB │ map:    13.10 kB
dist/assets/Lyrics-Cs205iES.js                 7.66 kB │ gzip:   1.54 kB │ map:    10.85 kB
dist/assets/Config-C7w4CvXy.js                 8.16 kB │ gzip:   1.90 kB │ map:     9.34 kB
dist/assets/MusicConfig-Cpe251s_.js           10.39 kB │ gzip:   1.95 kB │ map:    14.88 kB
dist/assets/TwitchNotifications-BTvQsMph.js   11.50 kB │ gzip:   2.38 kB │ map:    19.82 kB
dist/assets/LastFm-CYlefb6m.js                11.52 kB │ gzip:   2.06 kB │ map:    14.65 kB
dist/assets/AutoMessages-rqP2kJJ9.js          11.75 kB │ gzip:   1.95 kB │ map:    15.74 kB
dist/assets/CustomCommands-CUhuy9D_.js        12.22 kB │ gzip:   2.48 kB │ map:    19.92 kB
dist/assets/TrackHistory-BQNOM1vi.js          12.44 kB │ gzip:   2.23 kB │ map:    19.46 kB
dist/assets/Login-CUMnhDTZ.js                 12.93 kB │ gzip:   2.67 kB │ map:    16.12 kB
dist/assets/ModerationConfig-BgPrQWjR.js      13.64 kB │ gzip:   2.37 kB │ map:    21.66 kB
dist/assets/Features-D5RABRpH.js              13.97 kB │ gzip:   2.84 kB │ map:    28.17 kB
dist/assets/ServerLogs-C-GAp3tH.js            19.06 kB │ gzip:   3.42 kB │ map:    29.24 kB
dist/assets/DashboardOverview-dJypOKxz.js     19.27 kB │ gzip:   3.41 kB │ map:    31.51 kB
dist/assets/ServersPage-D_Je7l9G.js           20.09 kB │ gzip:   3.27 kB │ map:    28.44 kB
dist/assets/AutoMod-DhUvmuCZ.js               23.67 kB │ gzip:   3.83 kB │ map:    40.33 kB
dist/assets/ServerSettings-BSR5LUYF.js        30.04 kB │ gzip:   4.13 kB │ map:    49.20 kB
dist/assets/Moderation-D81jSSHh.js            30.20 kB │ gzip:   4.62 kB │ map:    47.30 kB
dist/assets/Music-CBM1PZKQ.js                 46.67 kB │ gzip:   7.44 kB │ map:    79.68 kB
dist/assets/vendor-react-DuuYX5aE.js          67.29 kB │ gzip:  22.71 kB │ map:   525.18 kB
dist/assets/vendor-forms-Badp0Yxz.js          77.55 kB │ gzip:  21.16 kB │ map:   385.34 kB
dist/assets/vendor-state-CfFXWCAs.js          78.15 kB │ gzip:  27.53 kB │ map:   345.59 kB
dist/assets/vendor-radix-DuH8V26s.js         115.68 kB │ gzip:  33.59 kB │ map:   598.32 kB
dist/assets/vendor-ui-DcxIDvYC.js            205.42 kB │ gzip:  66.11 kB │ map: 1,019.71 kB
dist/assets/index-DsInG8e8.js                429.45 kB │ gzip: 122.99 kB │ map: 1,759.37 kB
✓ built in 2.22s