### PR TITLE
chore: remediate high security advisories (undici/flatted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Security dependency remediation: upgraded transitive `undici` and `flatted`
-  via workspace-aware lockfile refresh to clear `npm audit --audit-level=high`
-  findings on `main`
+- Security high/critical dependency remediation: pinned transitive overrides
+  to `undici >=7.24.0` and `flatted >=3.4.0` to clear current high advisories;
+  moderate findings remain tracked for a dedicated follow-up cycle.
 - GitGuardian incident hardening: removed hardcoded compose PostgreSQL password
   fallbacks, enforced secret-managed expected client-id checks in deploy OAuth
   smoke validation, and replaced secret-like literals in test/example fixtures

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ npm run lint --workspace=packages/backend
 npm run type:check      # TypeScript validation
 npm run test            # Backend tests (Jest)
 npm run test:coverage   # With coverage report
+npm run audit:high      # Dependency audit (high/critical gate)
 npm run format          # Prettier
 npm audit --audit-level=high
 ```
@@ -207,6 +208,10 @@ For dependency security maintenance, run:
 npm update undici flatted --workspaces --include-workspace-root
 npm audit --audit-level=high
 ```
+
+Security remediation policy: each hardening cycle clears high/critical
+findings first with minimal dependency blast radius; moderate findings are
+tracked in `docs/DEPENDENCY_UPDATES.md` for follow-up cycles.
 
 ### Local Database Bootstrap
 

--- a/docs/DEPENDENCY_UPDATES.md
+++ b/docs/DEPENDENCY_UPDATES.md
@@ -2,7 +2,9 @@
 
 Phased plan for updating Lucky dependencies. Run each phase on a branch; verify build, type-check, tests, and `npm run audit:critical` before merging.
 
-**Plan status:** Phase 1, Phase 2 (2a–2d), and Phase 3 are complete. Ongoing: re-run `npm audit` / `audit:critical` when upstreams release fixes; retry Zod 4 when `@hookform/resolvers` supports it.
+**Plan status:** Phase 1, Phase 2 (2a–2d), and Phase 3 are complete. Current
+security cycle (`chore/security-high-remediation`) is scoped to high/critical
+findings only; moderate findings remain tracked for follow-up.
 
 ## Current stack summary
 
@@ -84,18 +86,24 @@ Do these only after Phase 1 is merged and stable.
 
 ## Phase 3: Transitive / security (track only; no force-downgrade)
 
-**Known audit issues (last updated: after Phase 2d; 32 vulnerabilities: 12 low, 14 moderate, 6 high):**
+**Known audit issues (baseline before high/critical hotfix: 10 moderate, 2 high, 0 critical):**
 
 - **@smithy/config-resolver** (via @infisical/sdk): Override `@smithy/config-resolver@>=4.4.0` was tried; incompatible with AWS SDK v3 chain (SDK v3 uses @smithy v3). Wait for @infisical/sdk to upgrade to an AWS SDK that pulls @smithy v4+.
 - **hono** (via prisma): pinned via root override to `>=4.12.7`.
 - **lodash** (via chevrotain → @mrleebo/prisma-ast): Prisma/ecosystem updates may resolve; no override unless patched.
 - **tar** (via tooling): pinned via root override to `>=7.5.11`.
 - **file-type** (via transitive media tooling): pinned via root override to `>=21.3.1`.
-- **undici** (via discord.js, youtubei.js): Same; keep discord.js and youtubei.js at latest 14.x / 16.x and track releases.
+- **undici** (via discord.js, youtubei.js): high advisories are mitigated in
+  this cycle via root override `undici >=7.24.0`; keep discord.js and
+  youtubei.js updated to reduce long-term override reliance.
+- **flatted** (via eslint flat-cache): high advisory is mitigated in this
+  cycle via root override `flatted >=3.4.0`; remove override once upstream
+  minimums include patched ranges.
 
 **Actions:**
 
-- Re-run `npm audit` and `npm run audit:critical` after Phase 1 and after any major upgrade.
+- Re-run `npm audit` and `npm run audit:high` after this high/critical cycle
+  and after any major upgrade.
 - Add `overrides` in root `package.json` only when a specific patch is required and safe. Do **not** override `@smithy/config-resolver` to v4+ while @infisical/sdk uses AWS SDK v3 (incompatible). Test thoroughly.
 - Document remaining known high/critical in this file or in a short “Known vulnerabilities” section and update when upstream fixes land.
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "overrides": {
         "fast-xml-parser": ">=4.5.4",
         "tar": ">=7.5.11",
-        "undici": ">=6.23.0",
+        "undici": ">=7.24.0",
+        "flatted": ">=3.4.0",
         "@smithy/config-resolver": ">=4.4.10",
         "@aws-sdk/client-sso": ">=3.726.0",
         "@hono/node-server": ">=1.19.10",


### PR DESCRIPTION
## Summary
- Remediate current high/critical npm audit findings in a scoped dependency-only PR.
- Enforce patched transitive versions via root overrides.
- Keep scope focused on high/critical; moderate findings remain tracked for a later cycle.

## Changes
- package.json
  - overrides.undici -> >=7.24.0
  - add overrides.flatted -> >=3.4.0
- package-lock.json
  - lockfile re-resolved to apply patched ranges
- CHANGELOG.md
  - add security remediation entry
- README.md + docs/DEPENDENCY_UPDATES.md
  - document high/critical-only remediation policy and deferred moderate follow-up

## Security Evidence
### Before
- npm audit --audit-level=high --json
  - high: 2, critical: 0
  - affected: undici, flatted

### After
- npm audit --audit-level=high --json
  - high: 0, critical: 0
  - remaining: moderate: 10

### Version Resolution
- undici@7.24.1
- flatted@3.4.1

## Verification
- npm run lint
- npm run type:check
- npm run build
- npm run test --workspace=packages/backend
- npm run test --workspace=packages/frontend
- npm run test --workspace=packages/bot -- --runInBand

All commands passed locally.
