### PR TITLE
ci(sonarcloud): make dependabot runs token-aware

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,6 +10,8 @@ jobs:
     sonarcloud:
         name: SonarCloud Scan
         runs-on: ubuntu-latest
+        env:
+            SONAR_TOKEN_PRESENT: ${{ secrets.SONAR_TOKEN != '' }}
 
         steps:
             - name: Checkout code
@@ -47,7 +49,20 @@ jobs:
               run: npm run test --workspace=packages/frontend -- --coverage --coverage.reporter=lcov --coverage.reporter=text
               continue-on-error: true
 
+            - name: Validate Sonar token policy
+              if: env.SONAR_TOKEN_PRESENT != 'true' && github.actor != 'dependabot[bot]'
+              run: |
+                  echo "::error::SONAR_TOKEN is required for non-Dependabot runs."
+                  exit 1
+
+            - name: Skip Sonar scan for Dependabot without token
+              if: env.SONAR_TOKEN_PRESENT != 'true' && github.actor == 'dependabot[bot]'
+              run: |
+                  echo "SONAR_TOKEN is unavailable for Dependabot context."
+                  echo "Skipping SonarCloud scan as a non-blocking success path."
+
             - name: SonarCloud Scan
+              if: env.SONAR_TOKEN_PRESENT == 'true'
               uses: SonarSource/sonarqube-scan-action@v6
               env:
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved queue-miss guidance after runtime restarts: music commands now
   return explicit recovery text directing users to start a fresh queue with
   `/play`.
+- SonarCloud CI is now Dependabot-safe: scans run only when `SONAR_TOKEN` is
+  present, Dependabot PRs skip scan as success when token is unavailable, and
+  non-Dependabot runs fail fast if the token is missing.
 
 ## [2.6.14] - 2026-03-14
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ verification in CI or local checks.
 Sonar main-gate reliability checks are strict on new code: use deterministic
 string sorting (`localeCompare`), keyboard-accessible UI interactions for
 clickable controls, and bounded parsing logic for user-facing text handling.
+SonarCloud workflow policy is token-aware: non-Dependabot runs fail fast when
+`SONAR_TOKEN` is missing, while Dependabot PRs skip the Sonar scan step as a
+non-blocking success path when secrets are unavailable.
 Bundle-size PR checks export `YOUTUBE_DL_SKIP_DOWNLOAD=true` to keep
 `youtube-dl-exec` postinstall deterministic under GitHub API rate limits.
 


### PR DESCRIPTION
## Summary
- add explicit Sonar token policy in `sonarcloud.yml`
- fail fast for non-Dependabot runs when `SONAR_TOKEN` is missing
- skip Sonar scan as success for Dependabot PRs when token is unavailable
- document the policy in README and CHANGELOG

## Why
Dependabot workflow PRs were failing the `SonarCloud Scan` job when secrets were unavailable (`Project not found` + missing token context), blocking routine dependency maintenance.

## Refs
- Closes #228
