### PR TITLE
chore(deps): bump SonarSource/sonarqube-scan-action to v7

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -63,6 +63,6 @@ jobs:
 
             - name: SonarCloud Scan
               if: env.SONAR_TOKEN_PRESENT == 'true'
-              uses: SonarSource/sonarqube-scan-action@v6
+              uses: SonarSource/sonarqube-scan-action@v7
               env:
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SonarCloud CI is now Dependabot-safe: scans run only when `SONAR_TOKEN` is
   present, Dependabot PRs skip scan as success when token is unavailable, and
   non-Dependabot runs fail fast if the token is missing.
+- Upgraded SonarCloud GitHub Action to `SonarSource/sonarqube-scan-action@v7`
+  to keep workflow compatibility current.
 
 ## [2.6.14] - 2026-03-14
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ clickable controls, and bounded parsing logic for user-facing text handling.
 SonarCloud workflow policy is token-aware: non-Dependabot runs fail fast when
 `SONAR_TOKEN` is missing, while Dependabot PRs skip the Sonar scan step as a
 non-blocking success path when secrets are unavailable.
+The Sonar workflow uses `SonarSource/sonarqube-scan-action@v7`.
 Bundle-size PR checks export `YOUTUBE_DL_SKIP_DOWNLOAD=true` to keep
 `youtube-dl-exec` postinstall deterministic under GitHub API rate limits.
 


### PR DESCRIPTION
## Summary
- bump `SonarSource/sonarqube-scan-action` from `v6` to `v7`
- keep the existing token-aware Dependabot Sonar policy intact
- document the update in README and CHANGELOG

## Context
Dependabot PR #214 could not be auto-updated due merge conflicts. This PR is a clean replacement from latest `main`.

## Refs
- Supersedes #214
