### PR TITLE
fix(ci): tolerate oauth 429 rate-limits during deploy smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -268,11 +268,23 @@ jobs:
                   expected_client_id="$configured_expected_client_id"
 
                   echo "==> Running OAuth redirect contract smoke check: $auth_url"
+                  rate_limited_count=0
+                  non_rate_limited_attempts=0
 
                   for attempt in $(seq 1 18); do
                     echo "Attempt ${attempt}/18..."
                     headers_file="$(mktemp)"
                     http_code="$(curl -sS -o /dev/null -D "$headers_file" --max-time 20 "$auth_url" -w "%{http_code}" || true)"
+
+                    if [ "$http_code" = "429" ]; then
+                      rate_limited_count=$((rate_limited_count + 1))
+                      rm -f "$headers_file"
+                      echo "OAuth redirect contract check is rate-limited (429). Waiting 10s..."
+                      sleep 10
+                      continue
+                    fi
+
+                    non_rate_limited_attempts=$((non_rate_limited_attempts + 1))
 
                     if [ "$http_code" = "302" ]; then
                       location_header="$(awk 'BEGIN{IGNORECASE=1} /^location: /{print $2}' "$headers_file" | tr -d '\r')"
@@ -322,7 +334,13 @@ jobs:
                     sleep 10
                   done
 
+                  if [ "$non_rate_limited_attempts" -eq 0 ] && [ "$rate_limited_count" -gt 0 ]; then
+                    echo "::warning::OAuth redirect contract check hit sustained Discord rate limiting (429) across all retries; treating as non-blocking after auth-config contract pass."
+                    exit 0
+                  fi
+
                   echo "::error::Timed out waiting for OAuth redirect contract"
+                  echo "::error::OAuth redirect smoke summary: non_rate_limited_attempts=$non_rate_limited_attempts, rate_limited_count=$rate_limited_count"
                   exit 1
 
             - name: Notify failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-Dependabot runs fail fast if the token is missing.
 - Upgraded SonarCloud GitHub Action to `SonarSource/sonarqube-scan-action@v7`
   to keep workflow compatibility current.
+- Deploy OAuth redirect smoke now treats sustained `429` rate-limit responses
+  as warning-only (after auth-config contract passes), preventing false-negative
+  homelab deploy failures caused by Discord OAuth endpoint throttling.
 
 ## [2.6.14] - 2026-03-14
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ SonarCloud workflow policy is token-aware: non-Dependabot runs fail fast when
 `SONAR_TOKEN` is missing, while Dependabot PRs skip the Sonar scan step as a
 non-blocking success path when secrets are unavailable.
 The Sonar workflow uses `SonarSource/sonarqube-scan-action@v7`.
+For CI triage on Lucky, use the project skill:
+`.cursor/skills/lucky-ci-gate-recovery/SKILL.md`.
 Bundle-size PR checks export `YOUTUBE_DL_SKIP_DOWNLOAD=true` to keep
 `youtube-dl-exec` postinstall deterministic under GitHub API rate limits.
 
@@ -287,6 +289,9 @@ Deploy workflow now also validates the `/api/auth/discord` redirect contract:
 `redirect_uri=https://lucky.lucassantana.tech/api/auth/callback`.
 Both deploy smoke checks now retry during rollout until the new backend
 containers are serving the expected contract.
+If OAuth redirect smoke receives only Discord rate-limit responses (`429`)
+across all retries, deploy now emits a warning and proceeds after auth-config
+contract success, instead of failing the rollout as a false negative.
 Deploy webhook rollout now starts `postgres`/`redis`, runs
 `prisma migrate deploy`, and executes a `guild_role_grants` relation preflight
 before service rollout to fail fast on schema drift.


### PR DESCRIPTION
## Summary
- update deploy OAuth redirect smoke loop to track `429` responses explicitly
- keep strict contract validation for non-429 responses
- treat sustained all-429 retries as warning-only after auth-config contract already passed
- add README/CHANGELOG notes for the new deploy smoke behavior

## Why
Mainline deploy run `23091086295` failed after 18 retries with HTTP 429 from `/api/auth/discord`, even though auth-config contract was healthy. This is an external rate-limit false negative, not a contract regression.

## Verification
- inspected failing run logs and confirmed repeated `429` responses during OAuth redirect smoke step
- updated retry/fail logic in `.github/workflows/deploy.yml`

## Refs
- follow-up for failed run: https://github.com/LucasSantana-Dev/Lucky/actions/runs/23091086295


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved OAuth redirect smoke test resilience by handling rate-limit responses (HTTP 429) during deployment checks. Rate-limited attempts now trigger a warning instead of failing the deployment, preventing false negatives caused by Discord throttling while maintaining validation of the auth-config contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->