### PR TITLE
chore(skills): add Lucky CI gate recovery skill

### DIFF
--- a/.cursor/skills/lucky-ci-gate-recovery/SKILL.md
+++ b/.cursor/skills/lucky-ci-gate-recovery/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: lucky-ci-gate-recovery
+description: Use when Lucky PRs are blocked by required-check failures, especially SonarCloud or Dependabot CI contract mismatches.
+---
+
+# Lucky CI Gate Recovery
+
+## When to use
+
+- Required checks are blocking merge despite low-risk changes
+- Sonar checks fail only on Dependabot PRs
+- CI status appears contradictory (workflow pass + required status fail)
+- You need a deterministic merge-safety checklist before release
+
+## Required sequence
+
+1. Capture required checks from active ruleset:
+
+```bash
+REPO_SLUG=$(git remote get-url origin | sed 's#.*github.com[:/]\(.*\)\.git#\1#' | sed 's#.*github.com[:/]\(.*\)#\1#')
+gh api repos/"$REPO_SLUG"/rulesets \
+  --jq '.[] | select(.enforcement=="active") | .rules[]? | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+```
+
+2. Inspect PR status using required checks only:
+
+```bash
+gh pr checks <PR#> --required
+```
+
+3. Classify failure bucket:
+
+- `token-permission`: secret/project access mismatch
+- `quality-gate`: coverage/duplication/new-code thresholds
+- `workflow-runtime`: action/runtime failure
+
+4. Apply minimal fix in this order:
+
+- CI contract mismatch first
+- then branch drift/rebase
+- then quality/test deltas
+
+5. Merge safety:
+
+```bash
+SHA=$(gh pr view <PR#> --json headRefOid --jq .headRefOid)
+gh pr merge <PR#> --squash --match-head-commit "$SHA"
+```
+
+## Dependabot Sonar policy (Lucky)
+
+- Non-Dependabot runs: Sonar token required and enforced
+- Dependabot runs without token: scanner path must skip as success
+- Required status names must remain stable with ruleset contexts
+
+## Post-merge smoke contract
+
+```bash
+curl -i https://lucky-api.lucassantana.tech/api/health
+curl -i https://lucky-api.lucassantana.tech/api/health/auth-config
+curl -i https://lucky-api.lucassantana.tech/api/auth/discord
+```
+
+Expect:
+
+- `/api/health` => `200`
+- `/api/health/auth-config` => `status: ok`
+- `/api/auth/discord` => `302`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,20 +20,21 @@ At the start of every session:
 
 ### Project skills (`.cursor/skills/`)
 
-| Task                                              | Skill                 |
-| ------------------------------------------------- | --------------------- |
-| Add/change slash command                          | `discord-commands`    |
-| Play/queue/skip/volume, player lifecycle          | `music-queue-player`  |
-| Schema, migrations, DB/Redis in shared            | `prisma-redis-lucky`  |
-| Docker, compose, local run                        | `lucky-docker-dev`    |
-| Frontend (React, Vite, Tailwind)                  | `frontend-react-vite` |
-| Backend (Express API, routes, services)           | `backend-express`     |
-| E2E tests, Playwright, browser verification       | `e2e-playwright`      |
-| Docs lookup, web search, MCP usage                | `mcp-docs-search`     |
-| Moderation commands + AutoModService              | `moderation-automod`  |
-| Bot event wiring (messageCreate, memberAdd, etc.) | `event-handlers`      |
-| Embed builder, custom commands, auto-messages     | `management-features` |
-| Unit tests, Jest ESM mocks, fixing disabled tests | `testing-lucky`       |
+| Task                                              | Skill                    |
+| ------------------------------------------------- | ------------------------ |
+| Add/change slash command                          | `discord-commands`       |
+| Play/queue/skip/volume, player lifecycle          | `music-queue-player`     |
+| Schema, migrations, DB/Redis in shared            | `prisma-redis-lucky`     |
+| Docker, compose, local run                        | `lucky-docker-dev`       |
+| Frontend (React, Vite, Tailwind)                  | `frontend-react-vite`    |
+| Backend (Express API, routes, services)           | `backend-express`        |
+| E2E tests, Playwright, browser verification       | `e2e-playwright`         |
+| Docs lookup, web search, MCP usage                | `mcp-docs-search`        |
+| Moderation commands + AutoModService              | `moderation-automod`     |
+| Bot event wiring (messageCreate, memberAdd, etc.) | `event-handlers`         |
+| Embed builder, custom commands, auto-messages     | `management-features`    |
+| Unit tests, Jest ESM mocks, fixing disabled tests | `testing-lucky`          |
+| CI gate triage and required-check recovery        | `lucky-ci-gate-recovery` |
 
 ### Ecosystem skills (`.agent-skills/` — from skills.sh)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added project CI triage skill
+  `.cursor/skills/lucky-ci-gate-recovery/SKILL.md` and linked it in
+  `AGENTS.md` for required-check/ruleset recovery workflows.
+
 ### Fixed
 
 - Bot music stability hotfix: `/autoplay` now acknowledges interactions before
@@ -22,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-Dependabot runs fail fast if the token is missing.
 - Upgraded SonarCloud GitHub Action to `SonarSource/sonarqube-scan-action@v7`
   to keep workflow compatibility current.
+- Cleared the open Dependabot workflow queue by landing split updates:
+  `actions/checkout@v6`, `preactjs/compressed-size-action@v3`,
+  `actions/labeler@v6`, and Sonar scan action `v7` via replacement PR.
 - Deploy OAuth redirect smoke now treats sustained `429` rate-limit responses
   as warning-only (after auth-config contract passes), preventing false-negative
   homelab deploy failures caused by Discord OAuth endpoint throttling.


### PR DESCRIPTION
## Summary
- add repo-local skill `.cursor/skills/lucky-ci-gate-recovery/SKILL.md` for required-check and Sonar/Dependabot CI triage
- register the skill in `AGENTS.md`
- update `CHANGELOG.md` unreleased notes for skill addition and dependency queue closure

## Why
This packages the pending skills/docs work in a dedicated PR, isolated from deploy-runtime fixes.

## Verification
- npm run lint
- npm run type:check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added CI gate recovery guide with step-by-step instructions for Lucky PR workflows
  * Updated agents documentation to reference new CI triage skill

* **Chores**
  * Updated GitHub Actions and Sonar scan dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->