### PR TITLE
chore: enable Codex-first OpenCode setup

### DIFF
--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package.json
+bun.lock
+.gitignore

--- a/.opencode/skills/backend-express
+++ b/.opencode/skills/backend-express
@@ -1,0 +1,1 @@
+../../.cursor/skills/backend-express

--- a/.opencode/skills/brainstorming
+++ b/.opencode/skills/brainstorming
@@ -1,0 +1,1 @@
+../../.agent-skills/brainstorming

--- a/.opencode/skills/database-migration
+++ b/.opencode/skills/database-migration
@@ -1,0 +1,1 @@
+../../.agent-skills/database-migration

--- a/.opencode/skills/discord-commands
+++ b/.opencode/skills/discord-commands
@@ -1,0 +1,1 @@
+../../.cursor/skills/discord-commands

--- a/.opencode/skills/e2e-playwright
+++ b/.opencode/skills/e2e-playwright
@@ -1,0 +1,1 @@
+../../.cursor/skills/e2e-playwright

--- a/.opencode/skills/event-handlers
+++ b/.opencode/skills/event-handlers
@@ -1,0 +1,1 @@
+../../.cursor/skills/event-handlers

--- a/.opencode/skills/frontend-react-vite
+++ b/.opencode/skills/frontend-react-vite
@@ -1,0 +1,1 @@
+../../.cursor/skills/frontend-react-vite

--- a/.opencode/skills/lucky-docker-dev
+++ b/.opencode/skills/lucky-docker-dev
@@ -1,0 +1,1 @@
+../../.cursor/skills/lucky-docker-dev

--- a/.opencode/skills/management-features
+++ b/.opencode/skills/management-features
@@ -1,0 +1,1 @@
+../../.cursor/skills/management-features

--- a/.opencode/skills/mcp-docs-search
+++ b/.opencode/skills/mcp-docs-search
@@ -1,0 +1,1 @@
+../../.cursor/skills/mcp-docs-search

--- a/.opencode/skills/moderation-automod
+++ b/.opencode/skills/moderation-automod
@@ -1,0 +1,1 @@
+../../.cursor/skills/moderation-automod

--- a/.opencode/skills/music-queue-player
+++ b/.opencode/skills/music-queue-player
@@ -1,0 +1,1 @@
+../../.cursor/skills/music-queue-player

--- a/.opencode/skills/nodejs-backend-patterns
+++ b/.opencode/skills/nodejs-backend-patterns
@@ -1,0 +1,1 @@
+../../.agent-skills/nodejs-backend-patterns

--- a/.opencode/skills/prisma-redis-lucky
+++ b/.opencode/skills/prisma-redis-lucky
@@ -1,0 +1,1 @@
+../../.cursor/skills/prisma-redis-lucky

--- a/.opencode/skills/requesting-code-review
+++ b/.opencode/skills/requesting-code-review
@@ -1,0 +1,1 @@
+../../.agent-skills/requesting-code-review

--- a/.opencode/skills/systematic-debugging
+++ b/.opencode/skills/systematic-debugging
@@ -1,0 +1,1 @@
+../../.agent-skills/systematic-debugging

--- a/.opencode/skills/test-driven-development
+++ b/.opencode/skills/test-driven-development
@@ -1,0 +1,1 @@
+../../.agent-skills/test-driven-development

--- a/.opencode/skills/testing-lucky
+++ b/.opencode/skills/testing-lucky
@@ -1,0 +1,1 @@
+../../.cursor/skills/testing-lucky

--- a/.opencode/skills/typescript-advanced-types
+++ b/.opencode/skills/typescript-advanced-types
@@ -1,0 +1,1 @@
+../../.agent-skills/typescript-advanced-types

--- a/.opencode/skills/vercel-react-best-practices
+++ b/.opencode/skills/vercel-react-best-practices
@@ -1,0 +1,1 @@
+../../.agent-skills/vercel-react-best-practices

--- a/.opencode/skills/verification-before-completion
+++ b/.opencode/skills/verification-before-completion
@@ -1,0 +1,1 @@
+../../.agent-skills/verification-before-completion

--- a/.opencode/skills/web-design-guidelines
+++ b/.opencode/skills/web-design-guidelines
@@ -1,0 +1,1 @@
+../../.agent-skills/web-design-guidelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added repo-local OpenCode project configuration (`opencode.jsonc`) plus
+  helper scripts to sync global/project OpenCode skills and attach a local
+  OpenCode client to the `server-do-luk` Lucky workspace over SSH
+
+### Changed
+
+- Documented the OpenCode config split between repo-local files and host-local
+  `~/.config/opencode/opencode.jsonc`, keeping authenticated MCP credentials out
+  of git while standardizing Codex-first Lucky sessions on OpenCode
+- Standardized the `server-do-luk` OpenCode serve path to bind on
+  `127.0.0.1:4096` from `/home/luk-server/Lucky`, so SSH attach no longer
+  depends on an invalid positional path argument to `opencode serve`
+
 ### Fixed
 
 - Bot music stability hotfix: `/autoplay` now acknowledges interactions before

--- a/README.md
+++ b/README.md
@@ -215,6 +215,38 @@ type-check, full build, backend + bot + frontend tests, and `audit:high`.
 Playwright stays separate under `npm run test:e2e` as a smoke/regression lane
 instead of running on every local verify cycle.
 
+### OpenCode + Codex
+
+Lucky now includes repo-local OpenCode support for Codex sessions:
+
+```bash
+./scripts/opencode-sync-global-skills.sh
+./scripts/opencode-sync-project-skills.sh
+opencode /Users/lucassantana/Desenvolvimento/Lucky
+```
+
+- Project instructions load from `AGENTS.md`.
+- Project-only skills are exposed through `opencode.jsonc` and
+  `.opencode/skills`.
+- Global/OpenAI/Codex defaults live in host-local OpenCode config under
+  `~/.config/opencode/opencode.jsonc`.
+- Global OpenCode skill bridges are rebuilt under `~/.opencode/skills/agents`
+  and `~/.opencode/skills/codex`.
+
+For remote Lucky work on `server-do-luk`:
+
+```bash
+./scripts/opencode-sync-server-do-luk-skills.sh
+./scripts/opencode-attach-server-do-luk.sh
+```
+
+- The remote OpenCode server binds to `127.0.0.1` only.
+- If `server-do-luk` does not already have OpenAI provider auth, refresh it on
+  that host with `opencode providers login -p openai`.
+- Host-local secrets and MCP credentials stay outside the repo.
+- `server-do-luk` uses a portable MCP core (`serena`, `context7`) plus the
+  synced global Codex/Lucky skills.
+
 For dependency security maintenance, run:
 
 ```bash

--- a/docs/MCP_SETUP.md
+++ b/docs/MCP_SETUP.md
@@ -99,3 +99,121 @@ Project-level Cursor Hooks are in **`.cursor/hooks.json`** (and scripts in `.cur
 For guidance on when to use which MCP tools and how AI agents should work on this repo, see [AGENTS.md](../AGENTS.md) at the project root. It maps MCPs (filesystem, GitHub, Context7, Tavily, Playwright, etc.) to tasks and references Cursor rules, **subagents** (`.cursor/rules/subagent-*.mdc`), **skills** (`.cursor/skills/`), and **commands** (`.cursor/COMMANDS.md` for verify, E2E, DB, deploy, specialist workflows).
 
 **Superpowers (Codex):** Superpowers are installed at `~/.codex/superpowers`. To use a skill in Cursor chat or in a prompt, run `~/.codex/superpowers/.codex/superpowers-codex use-skill <skill-name>` with a real skill name (e.g. `superpowers:brainstorming`, `superpowers:test-driven-development`). See the “Superpowers (Codex)” section in AGENTS.md for the full skill list and agent behavior.
+
+## OpenCode
+
+Lucky now ships repo-local OpenCode configuration in `opencode.jsonc`.
+
+### Config split
+
+- Repo-local: `opencode.jsonc`
+  - project instructions
+  - Lucky project skill bridge under `.opencode/skills`
+  - portable MCP entries that are safe to share in git
+- Host-local: `~/.config/opencode/opencode.jsonc`
+  - default Codex model/agent
+  - host-bound MCP commands
+  - any authenticated MCP headers or OAuth state
+
+Do not put secrets in repo-local OpenCode files.
+
+### Project skill bridge
+
+Rebuild the Lucky project skill bridge with:
+
+```bash
+./scripts/opencode-sync-project-skills.sh
+```
+
+This mirrors:
+
+- `.cursor/skills`
+- `.agent-skills`
+
+into `.opencode/skills` using symlinks, with `.cursor/skills` taking precedence
+when names collide.
+
+### Global skill bridge
+
+Rebuild the explicit host-local OpenCode skill bridge with:
+
+```bash
+./scripts/opencode-sync-global-skills.sh
+```
+
+This creates:
+
+- `~/.opencode/skills/agents` from `~/.agents/skills`
+- `~/.opencode/skills/codex` from Codex-only skills under `~/.codex/skills`
+
+The host-local OpenCode config then points to those bridge directories instead
+of relying on implicit discovery.
+
+### Local OpenCode launch
+
+From the Lucky repo:
+
+```bash
+opencode .
+```
+
+Expected behavior:
+
+- OpenCode uses `openai/gpt-5.3-codex` from host-local config.
+- Lucky project instructions come from `AGENTS.md`.
+- Lucky project skills load from `.opencode/skills`.
+
+### `server-do-luk` remote attach
+
+Sync global skills to the remote host:
+
+```bash
+./scripts/opencode-sync-server-do-luk-skills.sh
+```
+
+Attach to the remote Lucky workspace through SSH:
+
+```bash
+./scripts/opencode-attach-server-do-luk.sh
+```
+
+The attach helper:
+
+- ensures the remote OpenCode server is running in `/home/luk-server/Lucky`
+- keeps the remote server on `127.0.0.1` only
+- opens an SSH local port forward
+- runs `opencode attach` against the forwarded endpoint
+
+The remote helper script is:
+
+```bash
+~/.local/bin/opencode-lucky-serve
+```
+
+It changes into `/home/luk-server/Lucky` and starts:
+
+```bash
+~/.opencode/bin/opencode serve --hostname 127.0.0.1 --port 4096
+```
+
+### Remote cloudflared-style host config expectations
+
+`server-do-luk` host-local OpenCode config should include:
+
+- default model `openai/gpt-5.3-codex`
+- primary coding agent `codex-primary`
+- remote skill paths:
+  - `/home/luk-server/.opencode/skills/agents`
+  - `/home/luk-server/.opencode/skills/codex`
+  - `/home/luk-server/Lucky/.cursor/skills`
+  - `/home/luk-server/Lucky/.opencode/skills`
+- portable MCP core:
+  - `serena`
+  - `context7`
+
+Credentialed MCP servers should stay disabled until their auth is configured on
+that host. If `openai/gpt-5.3-codex` is unavailable on `server-do-luk`, run:
+
+```bash
+opencode providers login -p openai
+```

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"],
+  "skills": {
+    "paths": [".opencode/skills"]
+  },
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "enabled": true,
+      "timeout": 10000
+    },
+    "stitch": {
+      "type": "remote",
+      "url": "https://stitch.googleapis.com/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "supabase": {
+      "type": "remote",
+      "url": "https://mcp.supabase.com/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "gmail": {
+      "type": "remote",
+      "url": "https://gmail.mcp.claude.com/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "google-calendar": {
+      "type": "remote",
+      "url": "https://gcal.mcp.claude.com/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "linear": {
+      "type": "remote",
+      "url": "https://mcp.linear.app/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "mcp-gateway": {
+      "type": "remote",
+      "url": "https://stormmcp.ai/gateway/a0fd0056-dfd5-49bd-85d7-e19ba7e65bd0/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "vercel": {
+      "type": "remote",
+      "url": "https://mcp.vercel.com",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "jam": {
+      "type": "remote",
+      "url": "https://mcp.jam.dev/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "cloudflare": {
+      "type": "remote",
+      "url": "https://bindings.mcp.cloudflare.com/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "sentry": {
+      "type": "remote",
+      "url": "https://mcp.sentry.dev/mcp",
+      "enabled": false,
+      "timeout": 10000
+    },
+    "huggingface": {
+      "type": "remote",
+      "url": "https://huggingface.co/mcp?login&gradio=none",
+      "enabled": false,
+      "timeout": 10000
+    }
+  }
+}

--- a/scripts/opencode-attach-server-do-luk.sh
+++ b/scripts/opencode-attach-server-do-luk.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+remote_host="${1:-server-do-luk}"
+remote_dir="${OPENCODE_REMOTE_DIR:-/home/luk-server/Lucky}"
+remote_serve_cmd="${OPENCODE_REMOTE_SERVE_CMD:-\$HOME/.local/bin/opencode-lucky-serve}"
+remote_port="${OPENCODE_REMOTE_PORT:-4096}"
+local_port="${OPENCODE_LOCAL_PORT:-4096}"
+local_bin="${OPENCODE_LOCAL_BIN:-$HOME/.opencode/bin/opencode}"
+ssh_args=(
+  -o ExitOnForwardFailure=yes
+  -o ServerAliveInterval=30
+  -o ServerAliveCountMax=3
+)
+
+ssh "$remote_host" "bash -lc '
+  set -euo pipefail
+  if [[ ! -x $remote_serve_cmd ]]; then
+    echo \"Missing OpenCode serve helper at $remote_serve_cmd\" >&2
+    exit 1
+  fi
+  if ! ss -ltnH | awk '\''{print \$4}'\'' | grep -qx \"127.0.0.1:$remote_port\"; then
+    mkdir -p \"\$HOME/.local/share/opencode\"
+    nohup $remote_serve_cmd \
+      >\"\$HOME/.local/share/opencode/lucky-serve.log\" 2>&1 &
+    for _ in 1 2 3 4 5; do
+      sleep 1
+      if ss -ltnH | awk '\''{print \$4}'\'' | grep -qx \"127.0.0.1:$remote_port\"; then
+        break
+      fi
+    done
+  fi
+  if ! ss -ltnH | awk '\''{print \$4}'\'' | grep -qx \"127.0.0.1:$remote_port\"; then
+    echo \"OpenCode server did not start on 127.0.0.1:$remote_port\" >&2
+    exit 1
+  fi
+'"
+
+ssh "${ssh_args[@]}" -N -L "${local_port}:127.0.0.1:${remote_port}" "$remote_host" &
+tunnel_pid=$!
+
+cleanup() {
+  if kill -0 "$tunnel_pid" >/dev/null 2>&1; then
+    kill "$tunnel_pid"
+    wait "$tunnel_pid" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+sleep 1
+"$local_bin" attach "http://127.0.0.1:${local_port}" --dir "$remote_dir"

--- a/scripts/opencode-sync-global-skills.sh
+++ b/scripts/opencode-sync-global-skills.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dest_root="${OPENCODE_GLOBAL_SKILLS_DIR:-$HOME/.opencode/skills}"
+agents_dest="$dest_root/agents"
+codex_dest="$dest_root/codex"
+agents_src="$HOME/.agents/skills"
+codex_src="$HOME/.codex/skills"
+
+python3 - "$dest_root" "$agents_dest" "$codex_dest" <<'PY'
+import pathlib
+import shutil
+import sys
+
+root = pathlib.Path(sys.argv[1])
+root.mkdir(parents=True, exist_ok=True)
+
+for child in root.iterdir():
+    if child.name in {"agents", "codex"}:
+        continue
+    if child.is_symlink() or child.is_file():
+        child.unlink()
+    elif child.is_dir():
+        shutil.rmtree(child)
+
+for raw in sys.argv[2:]:
+    path = pathlib.Path(raw)
+    path.mkdir(parents=True, exist_ok=True)
+    for child in path.iterdir():
+        if child.is_symlink() or child.is_file():
+            child.unlink()
+        elif child.is_dir():
+            shutil.rmtree(child)
+PY
+
+relative_path() {
+  python3 - "$1" "$2" <<'PY'
+import os
+import sys
+
+print(os.path.relpath(sys.argv[2], sys.argv[1]))
+PY
+}
+
+link_dir() {
+  local dest_dir="$1"
+  local source_dir="$2"
+  local skill_name="$3"
+  local target="$dest_dir/$skill_name"
+
+  [[ -e "$target" ]] && return 0
+  ln -s "$(relative_path "$dest_dir" "$source_dir")" "$target"
+}
+
+if [[ -d "$agents_src" ]]; then
+  while IFS= read -r skill_dir; do
+    link_dir "$agents_dest" "$skill_dir" "$(basename "$skill_dir")"
+  done < <(find "$agents_src" -mindepth 1 -maxdepth 1 -type d | sort)
+fi
+
+if [[ -d "$codex_src" ]]; then
+  while IFS= read -r skill_file; do
+    skill_dir="$(dirname "$skill_file")"
+    skill_name="$(basename "$skill_dir")"
+
+    if [[ -e "$agents_dest/$skill_name" ]]; then
+      continue
+    fi
+
+    link_dir "$codex_dest" "$skill_dir" "$skill_name"
+  done < <(find "$codex_src" -name SKILL.md | sort)
+fi

--- a/scripts/opencode-sync-project-skills.sh
+++ b/scripts/opencode-sync-project-skills.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dest_dir="$repo_root/.opencode/skills"
+
+python3 - "$dest_dir" <<'PY'
+import pathlib
+import shutil
+import sys
+
+dest = pathlib.Path(sys.argv[1])
+dest.mkdir(parents=True, exist_ok=True)
+
+for child in dest.iterdir():
+    if child.is_symlink() or child.is_file():
+        child.unlink()
+    elif child.is_dir():
+        shutil.rmtree(child)
+PY
+
+link_skill() {
+  local source_dir="$1"
+  local skill_name="$2"
+  local target="$dest_dir/$skill_name"
+
+  if [[ -e "$target" ]]; then
+    return 0
+  fi
+
+  local relative_target
+  relative_target="$(python3 - "$dest_dir" "$source_dir" <<'PY'
+import os
+import sys
+
+print(os.path.relpath(sys.argv[2], sys.argv[1]))
+PY
+)"
+
+  ln -s "$relative_target" "$target"
+}
+
+for base_dir in "$repo_root/.cursor/skills" "$repo_root/.agent-skills"; do
+  if [[ ! -d "$base_dir" ]]; then
+    continue
+  fi
+
+  while IFS= read -r skill_dir; do
+    link_skill "$skill_dir" "$(basename "$skill_dir")"
+  done < <(find "$base_dir" -mindepth 1 -maxdepth 1 -type d | sort)
+done

--- a/scripts/opencode-sync-server-do-luk-skills.sh
+++ b/scripts/opencode-sync-server-do-luk-skills.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+remote_host="${1:-server-do-luk}"
+remote_opencode_dir="/home/luk-server/.opencode/skills"
+
+"$repo_root/scripts/opencode-sync-global-skills.sh"
+"$repo_root/scripts/opencode-sync-project-skills.sh"
+
+ssh "$remote_host" "mkdir -p '$remote_opencode_dir/agents' '$remote_opencode_dir/codex'"
+
+rsync -aL --delete "$HOME/.opencode/skills/agents/" \
+  "$remote_host:$remote_opencode_dir/agents/"
+
+rsync -aL --delete "$HOME/.opencode/skills/codex/" \
+  "$remote_host:$remote_opencode_dir/codex/"


### PR DESCRIPTION
## Summary
- add repo-local OpenCode config and Lucky project skill bridge
- add local/remote OpenCode helper scripts for skill sync and server-do-luk attach
- document the local vs host-local OpenCode split for Codex sessions

## Verification
- bash -n scripts/opencode-sync-global-skills.sh scripts/opencode-sync-project-skills.sh scripts/opencode-sync-server-do-luk-skills.sh scripts/opencode-attach-server-do-luk.sh
- opencode run --format json "Say only OK"
- opencode run --agent codex-primary --format json "Say only OK"
- opencode mcp list
- ssh server-do-luk: opencode run --format json "Say only OK"
- ssh server-do-luk: opencode mcp list
- validated SSH attach flow opens `/home/luk-server/Lucky` via `scripts/opencode-attach-server-do-luk.sh` under timeout capture