### PR TITLE
chore(skills): add MCP GitHub recovery workflow

### DIFF
--- a/.cursor/skills/lucky-ci-gate-recovery/SKILL.md
+++ b/.cursor/skills/lucky-ci-gate-recovery/SKILL.md
@@ -22,25 +22,35 @@ gh api repos/"$REPO_SLUG"/rulesets \
   --jq '.[] | select(.enforcement=="active") | .rules[]? | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
 ```
 
-2. Inspect PR status using required checks only:
+2. Build a required-vs-informational status matrix:
+
+```bash
+PR=<PR#>
+gh pr view "$PR" --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | {name: .name, conclusion: (.conclusion // "PENDING"), status: (.status // "UNKNOWN")}'
+```
+
+3. Inspect required checks only:
 
 ```bash
 gh pr checks <PR#> --required
 ```
 
-3. Classify failure bucket:
+4. Classify failure bucket:
 
 - `token-permission`: secret/project access mismatch
 - `quality-gate`: coverage/duplication/new-code thresholds
 - `workflow-runtime`: action/runtime failure
+- `ruleset-mismatch`: required context name differs from workflow-reported check
 
-4. Apply minimal fix in this order:
+5. Apply minimal fix in this order:
 
-- CI contract mismatch first
+- Ruleset/context mismatch first
+- CI contract mismatch second
 - then branch drift/rebase
 - then quality/test deltas
 
-5. Merge safety:
+6. Merge safety:
 
 ```bash
 SHA=$(gh pr view <PR#> --json headRefOid --jq .headRefOid)
@@ -52,6 +62,12 @@ gh pr merge <PR#> --squash --match-head-commit "$SHA"
 - Non-Dependabot runs: Sonar token required and enforced
 - Dependabot runs without token: scanner path must skip as success
 - Required status names must remain stable with ruleset contexts
+
+## Deterministic status policy
+
+- Only statuses listed in required checks gate merge decisions.
+- Pending informational checks (for example CodeRabbit/preview providers) are not blockers unless explicitly listed in the active ruleset.
+- If a required status is missing entirely, treat as `ruleset-mismatch` until context names are reconciled.
 
 ## Post-merge smoke contract
 

--- a/.cursor/skills/mcp-github-recovery/SKILL.md
+++ b/.cursor/skills/mcp-github-recovery/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mcp-github-recovery
+description: Use when user-GitHub MCP tools fail with transport/auth errors and Lucky needs MCP-first GitHub operations restored.
+---
+
+# MCP GitHub Recovery (Lucky)
+
+## When to use
+
+- `github/*` MCP tools return `Transport closed`
+- MCP GitHub requests fail while `gh` CLI still works
+- Lucky workflow requires MCP-first issue/PR automation (`#224`)
+
+## Recovery sequence
+
+1. Verify failure signature:
+
+```bash
+gh issue list --limit 1 >/dev/null
+```
+
+Then run MCP GitHub list calls. If MCP fails but `gh` succeeds, continue.
+
+2. Validate local Codex GitHub MCP config:
+
+```bash
+python3 - <<'PY'
+import pathlib, tomllib
+p = pathlib.Path.home()/'.codex'/'config.toml'
+cfg = tomllib.loads(p.read_text())
+s = cfg.get('mcp_servers', {}).get('github', {})
+print('command=', s.get('command'))
+print('args=', s.get('args'))
+print('env_keys=', list((s.get('env') or {}).keys()))
+PY
+```
+
+3. Refresh GitHub token wiring from active `gh` auth:
+
+```bash
+export GH_TOKEN_VALUE="$(gh auth token)"
+python3 - <<'PY'
+import os, pathlib, re
+p = pathlib.Path.home()/'.codex'/'config.toml'
+text = p.read_text()
+token = os.environ['GH_TOKEN_VALUE']
+text, n = re.subn(
+    r'(?m)^(GITHUB_PERSONAL_ACCESS_TOKEN\\s*=\\s*\")[^\"]*(\"\\s*)$',
+    r'\\1' + token + r'\\2',
+    text,
+)
+if n != 1:
+    raise SystemExit(f'Expected 1 token entry, found {n}')
+p.write_text(text)
+print('updated')
+PY
+```
+
+4. Re-run MCP GitHub calls:
+
+- list PRs
+- list issues
+- read issue details
+
+5. If still failing, document as environment/server instability and use `gh` as operational fallback until fixed.
+
+## Close criteria (`#224`)
+
+- MCP GitHub list PRs works
+- MCP GitHub list issues works
+- MCP GitHub issue-read works
+- Issue comment includes root cause and evidence

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ At the start of every session:
 | Embed builder, custom commands, auto-messages     | `management-features`    |
 | Unit tests, Jest ESM mocks, fixing disabled tests | `testing-lucky`          |
 | CI gate triage and required-check recovery        | `lucky-ci-gate-recovery` |
+| Recover GitHub MCP transport/auth failures        | `mcp-github-recovery`    |
 
 ### Ecosystem skills (`.agent-skills/` — from skills.sh)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added project CI triage skill
   `.cursor/skills/lucky-ci-gate-recovery/SKILL.md` and linked it in
   `AGENTS.md` for required-check/ruleset recovery workflows.
+- Added project MCP GitHub recovery skill
+  `.cursor/skills/mcp-github-recovery/SKILL.md` and linked it in `AGENTS.md`
+  for `Transport closed` auth/transport remediation workflows.
+- Expanded CI triage skill with deterministic required-vs-informational status
+  classification and explicit ruleset-mismatch handling.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ non-blocking success path when secrets are unavailable.
 The Sonar workflow uses `SonarSource/sonarqube-scan-action@v7`.
 For CI triage on Lucky, use the project skill:
 `.cursor/skills/lucky-ci-gate-recovery/SKILL.md`.
+For GitHub MCP transport/auth failures (`Transport closed`), use:
+`.cursor/skills/mcp-github-recovery/SKILL.md` before switching to `gh` fallback.
 Bundle-size PR checks export `YOUTUBE_DL_SKIP_DOWNLOAD=true` to keep
 `youtube-dl-exec` postinstall deterministic under GitHub API rate limits.
 


### PR DESCRIPTION
## Summary
- add project skill `mcp-github-recovery` for GitHub MCP transport/auth failure handling
- harden `lucky-ci-gate-recovery` with required-vs-informational check policy
- link the new MCP recovery workflow in AGENTS/README/CHANGELOG

## Context
- Incident follow-up for issue #224 (MCP GitHub currently returns `Transport closed`)
- includes sanitized security cleanup references for leaked token handling

## Validation
- local lint-staged hooks passed on commit
- GitHub auth restored for gh operations
- MCP GitHub still failing and tracked on #224


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery workflow to diagnose and resolve GitHub MCP transport and authentication failures, including token refresh and reconfiguration steps.
  * Enhanced CI triage skill with deterministic status classification, ruleset-mismatch detection, and improved failure categorization.

* **Documentation**
  * Updated README with guidance for GitHub MCP transport failures and recovery workflow reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->