### PR TITLE
feat(bot): improve /music health triage diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added repo-local OpenCode guardrail plugins, verification/install helper
   scripts, and the `opencode-lucky-workflows` project skill for Lucky Codex
   sessions on local and `server-do-luk`.
+- Enhanced `/music health` diagnostics output for operator triage with resolver
+  source/cache visibility, repeat-mode labels, watchdog recovery timestamps,
+  and actionable recovery steps.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -487,7 +487,11 @@ Set `UNLEASH_URL` and `UNLEASH_API_TOKEN` for Unleash, or use `FEATURE_DOWNLOAD_
 ## Slash Commands
 
 ### Music
-`/play` `/pause` `/resume` `/skip` `/stop` `/queue` `/volume` `/seek` `/lyrics` `/shuffle` `/repeat` `/clear` `/remove` `/move` `/jump` `/history` `/songinfo` `/autoplay`
+`/play` `/pause` `/resume` `/skip` `/stop` `/queue` `/volume` `/seek` `/lyrics` `/shuffle` `/repeat` `/clear` `/remove` `/move` `/jump` `/history` `/songinfo` `/autoplay` `/music health`
+
+`/music health` provides operator diagnostics for queue state, resolver source/cache
+signals, provider cooldown/score status, watchdog recovery state, snapshot
+availability, and actionable recovery next steps.
 
 ### Download
 `/download` `/download-audio` `/download-video`

--- a/packages/bot/src/functions/music/commands/music.spec.ts
+++ b/packages/bot/src/functions/music/commands/music.spec.ts
@@ -184,4 +184,103 @@ describe('music command', () => {
             }),
         )
     })
+
+    it('includes resolver diagnostics and actionable next steps', async () => {
+        getAllStatusesMock.mockReturnValue({
+            youtube: {
+                provider: 'youtube',
+                score: 0.4,
+                cooldownUntil: 1000,
+                consecutiveFailures: 3,
+            },
+        })
+        getGuildStateMock.mockReturnValue({
+            timeoutMs: 25000,
+            lastRecoveryAction: 'failed',
+            lastActivityAt: 0,
+            lastRecoveryAt: 0,
+        })
+        getSnapshotMock.mockResolvedValue(null)
+        resolveGuildQueueMock.mockReturnValue({
+            queue: null,
+            source: 'miss',
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 2,
+                cacheSampleKeys: ['guild-9', 'guild-3'],
+            },
+        })
+
+        await musicCommand.execute({
+            client: createClient(),
+            interaction: createInteraction(),
+        } as any)
+
+        expect(createEmbedMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fields: expect.arrayContaining([
+                    expect.objectContaining({ name: 'Resolver diagnostics' }),
+                    expect.objectContaining({ name: 'Actionable next steps' }),
+                ]),
+            }),
+        )
+
+        const payload = createEmbedMock.mock.calls.at(-1)?.[0] as {
+            fields: Array<{ name: string; value: string }>
+        }
+        const actionField = payload.fields.find(
+            (field) => field.name === 'Actionable next steps',
+        )
+        const resolverField = payload.fields.find(
+            (field) => field.name === 'Resolver diagnostics',
+        )
+
+        expect(actionField?.value).toContain('/play')
+        expect(actionField?.value).toContain('/session save')
+        expect(actionField?.value).toContain('Providers on cooldown')
+        expect(resolverField?.value).toContain('Source: miss')
+        expect(resolverField?.value).toContain('Cache size: 2')
+        expect(resolverField?.value).toContain('guild-9, guild-3')
+    })
+
+    it('formats repeat mode label and watchdog recovery timestamp', async () => {
+        const queue = {
+            node: { isPlaying: () => false },
+            tracks: { size: 1 },
+            repeatMode: 3,
+        }
+        resolveGuildQueueMock.mockReturnValue({
+            queue,
+            source: 'cache.id',
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 1,
+                cacheSampleKeys: ['guild-1'],
+            },
+        })
+        getGuildStateMock.mockReturnValue({
+            timeoutMs: 25000,
+            lastRecoveryAction: 'play_next',
+            lastActivityAt: 10,
+            lastRecoveryAt: 20,
+        })
+
+        await musicCommand.execute({
+            client: createClient(queue),
+            interaction: createInteraction(),
+        } as any)
+
+        const payload = createEmbedMock.mock.calls.at(-1)?.[0] as {
+            fields: Array<{ name: string; value: string }>
+        }
+        const queueField = payload.fields.find(
+            (field) => field.name === 'Queue state',
+        )
+        const watchdogField = payload.fields.find(
+            (field) => field.name === 'Watchdog',
+        )
+
+        expect(queueField?.value).toContain('Repeat mode: autoplay')
+        expect(watchdogField?.value).toContain('Last recovery at:')
+    })
 })

--- a/packages/bot/src/functions/music/commands/music.ts
+++ b/packages/bot/src/functions/music/commands/music.ts
@@ -13,16 +13,107 @@ import { providerHealthService } from '../../../utils/music/search/providerHealt
 import { musicWatchdogService } from '../../../utils/music/watchdog'
 import { musicSessionSnapshotService } from '../../../utils/music/sessionSnapshots'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import type { ProviderStatus } from '../../../utils/music/search/providerHealth'
+import type { GuildQueue } from 'discord-player'
+import type { QueueResolutionResult } from '../../../utils/music/queueResolver'
+import type { WatchdogGuildState } from '../../../utils/music/watchdog'
 
-function formatProviderHealth(): string {
-    const statuses = providerHealthService.getAllStatuses()
-    const ordered = Object.values(statuses).sort((a, b) => b.score - a.score)
+function formatProviderHealth(statuses: ProviderStatus[]): string {
+    if (statuses.length === 0) {
+        return 'No provider status data collected yet.'
+    }
+
+    const ordered = [...statuses].sort((a, b) => b.score - a.score)
     return ordered
         .map((status) => {
             const health = status.cooldownUntil ? 'cooldown' : 'ready'
-            return `• ${status.provider}: ${(status.score * 100).toFixed(0)}% (${health}, failures: ${status.consecutiveFailures})`
+            const score = (status.score * 100).toFixed(0)
+            const failures = status.consecutiveFailures
+            return `• ${status.provider}: ${score}% (${health}, failures: ${failures})`
         })
         .join('\n')
+}
+
+function formatRepeatMode(mode: number): string {
+    if (mode === 1) return 'track'
+    if (mode === 2) return 'queue'
+    if (mode === 3) return 'autoplay'
+    return 'off'
+}
+
+function formatTime(value: number | null): string {
+    return value ? new Date(value).toISOString() : 'never'
+}
+
+function formatQueueState(queue: GuildQueue | null): string {
+    if (!queue) return 'No active queue'
+
+    return [
+        `Playing: ${queue.node.isPlaying() ? 'yes' : 'no'}`,
+        `Tracks in queue: ${queue.tracks.size}`,
+        `Repeat mode: ${formatRepeatMode(queue.repeatMode)}`,
+    ].join('\n')
+}
+
+function formatResolverDiagnostics(resolution: QueueResolutionResult): string {
+    const { source, diagnostics } = resolution
+    const keys =
+        diagnostics.cacheSampleKeys.length > 0
+            ? diagnostics.cacheSampleKeys.join(', ')
+            : 'none'
+
+    return `Source: ${source}\nCache size: ${diagnostics.cacheSize}\nCache keys: ${keys}`
+}
+
+function buildActionableSteps({
+    queue,
+    providers,
+    watchdog,
+    hasSnapshot,
+}: {
+    queue: GuildQueue | null
+    providers: ProviderStatus[]
+    watchdog: WatchdogGuildState
+    hasSnapshot: boolean
+}): string {
+    const steps: string[] = []
+
+    if (!queue) {
+        steps.push('• No queue active: run /play to prime playback.')
+    }
+
+    const cooldownCount = providers.filter(
+        (provider) => provider.cooldownUntil !== null,
+    ).length
+    if (providers.length > 0 && cooldownCount === providers.length) {
+        steps.push(
+            '• Providers on cooldown: wait for recovery or switch query source.',
+        )
+    } else if (cooldownCount > 0) {
+        steps.push(
+            '• Some providers degraded: retry with healthy sources first.',
+        )
+    }
+
+    if (watchdog.lastRecoveryAction === 'failed') {
+        steps.push(
+            '• Last watchdog recovery failed: run /skip or /play to recover manually.',
+        )
+    }
+
+    if (!hasSnapshot) {
+        steps.push(
+            '• No snapshot saved: run /session save before bot restarts.',
+        )
+    }
+
+    if (steps.length === 0) {
+        steps.push(
+            '• Music subsystem looks healthy. No operator action required.',
+        )
+    }
+
+    return steps.join('\n')
 }
 
 export default new Command({
@@ -67,12 +158,18 @@ export default new Command({
             return
         }
 
-        const { queue } = resolveGuildQueue(client, guildId)
-        const queueState = queue
-            ? `Playing: ${queue.node.isPlaying() ? 'yes' : 'no'}\nTracks in queue: ${queue.tracks.size}\nRepeat mode: ${queue.repeatMode}`
-            : 'No active queue'
+        const resolution = resolveGuildQueue(client, guildId)
+        const { queue } = resolution
+        const queueState = formatQueueState(queue)
         const watchdog = musicWatchdogService.getGuildState(guildId)
         const snapshot = await musicSessionSnapshotService.getSnapshot(guildId)
+        const providers = Object.values(providerHealthService.getAllStatuses())
+        const actions = buildActionableSteps({
+            queue,
+            providers,
+            watchdog,
+            hasSnapshot: Boolean(snapshot),
+        })
 
         const embed = createEmbed({
             title: `${EMOJIS.INFO} Music Health`,
@@ -85,19 +182,38 @@ export default new Command({
                 },
                 {
                     name: 'Provider health',
-                    value: formatProviderHealth(),
+                    value: formatProviderHealth(providers),
                     inline: false,
                 },
                 {
                     name: 'Watchdog',
-                    value: `Timeout: ${watchdog.timeoutMs}ms\nLast recovery: ${watchdog.lastRecoveryAction}\nLast activity: ${watchdog.lastActivityAt ? new Date(watchdog.lastActivityAt).toISOString() : 'never'}`,
+                    value: [
+                        `Timeout: ${watchdog.timeoutMs}ms`,
+                        `Last recovery: ${watchdog.lastRecoveryAction}`,
+                        `Last recovery at: ${formatTime(watchdog.lastRecoveryAt)}`,
+                        `Last activity: ${formatTime(watchdog.lastActivityAt)}`,
+                    ].join('\n'),
+                    inline: false,
+                },
+                {
+                    name: 'Resolver diagnostics',
+                    value: formatResolverDiagnostics(resolution),
                     inline: false,
                 },
                 {
                     name: 'Session snapshot',
                     value: snapshot
-                        ? `Snapshot: ${snapshot.sessionSnapshotId}\nSaved at: ${new Date(snapshot.savedAt).toISOString()}\nUpcoming tracks: ${snapshot.upcomingTracks.length}`
+                        ? [
+                              `Snapshot: ${snapshot.sessionSnapshotId}`,
+                              `Saved at: ${new Date(snapshot.savedAt).toISOString()}`,
+                              `Upcoming tracks: ${snapshot.upcomingTracks.length}`,
+                          ].join('\n')
                         : 'No snapshot saved',
+                    inline: false,
+                },
+                {
+                    name: 'Actionable next steps',
+                    value: actions,
                     inline: false,
                 },
             ],


### PR DESCRIPTION
## Summary
- deliver `#223` slice 1 by hardening `/music health` operator output only
- keep scope focused on diagnostics/readiness messaging (no watchdog/cooldown/snapshot restore feature bundling)
- add targeted command tests and docs/changelog updates

## Behavior changes
- `/music health` now includes:
  - `Resolver diagnostics` field (queue source + cache diagnostics)
  - `Actionable next steps` field with concrete operator actions
  - human-readable repeat mode labels (`off|track|queue|autoplay`)
  - watchdog `Last recovery at` timestamp
- existing fields are preserved (`Queue state`, `Provider health`, `Watchdog`, `Session snapshot`)

## Docs
- README music command list now includes `/music health` with diagnostics description
- CHANGELOG unreleased updated with the new diagnostics behavior

## Verification
- `npm run test --workspace=packages/bot -- src/functions/music/commands/music.spec.ts` ✅
- `npm run test --workspace=packages/bot` ✅ (59 suites, 333 tests)
- `npm run type:check --workspace=packages/bot` ✅
- `npm run build --workspace=packages/bot` ✅
- `npm run lint` ⚠️ local-only failure from unrelated `.opencode/plugins/*` paths in root/worktree scan; not touched in this PR

## Tracking
- Refs #223
- Remaining wave-1 slices opened as child issues: #241, #242, #243


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `/music health` command with expanded diagnostics for operator triage, including resolver source/cache visibility, repeat-mode labels, watchdog recovery timestamps, and actionable recovery steps.

* **Documentation**
  * Added `/music health` command documentation describing available diagnostic output and recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->