### PR TITLE
chore(release): prepare v2.6.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.15] - 2026-03-14
+
 ### Added
 
 - Added project CI triage skill
@@ -17,13 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for `Transport closed` auth/transport remediation workflows.
 - Expanded CI triage skill with deterministic required-vs-informational status
   classification and explicit ruleset-mismatch handling.
-- Hardened GitHub MCP recovery runbook with protocol-compatibility detection
-  (framed vs line-delimited stdio), wrapper-based runtime auth alignment for
-  Codex, and local MCP config integrity checks for related server entries
-  (`filesystem`, `fetch`, `playwright`).
-
-### Added
-
 - Added repo-local OpenCode guardrail plugins, verification/install helper
   scripts, and the `opencode-lucky-workflows` project skill for Lucky Codex
   sessions on local and `server-do-luk`.
@@ -33,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened GitHub MCP recovery runbook with protocol-compatibility detection
+  (framed vs line-delimited stdio), wrapper-based runtime auth alignment for
+  Codex, and local MCP config integrity checks for related server entries
+  (`filesystem`, `fetch`, `playwright`).
 - Bot music stability hotfix: `/autoplay` now acknowledges interactions before
   queue replenishment work, preventing Discord command timeout responses.
 - Added fail-safe Discord Player error/debug handling (`player.events.on` and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.14",
+    "version": "2.6.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.14",
+            "version": "2.6.15",
             "license": "ISC",
             "workspaces": [
                 "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.14",
+    "version": "2.6.15",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- bump root version to `2.6.15`
- roll current release notes into `CHANGELOG.md`
- keep `Unreleased` ready for the next cycle

## Included release highlights
- deploy OAuth 429-tolerance behavior from #233
- CI/MCP recovery skills updates from #234 and #239
- dependency queue + moderate audit-chain cleanup from merged prior cycle

## Verification
- release metadata update only (no runtime code changes)
