### PR TITLE
fix(deploy): pin prisma config for webhook migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pinned webhook-driven `prisma migrate deploy` and `prisma migrate status`
+  calls to `prisma/prisma.config.ts` so homelab deploys keep `DATABASE_URL`
+  resolution when run from the webhook container.
+
 ## [2.6.15] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -371,6 +371,9 @@ contract success, instead of failing the rollout as a false negative.
 Deploy webhook rollout now starts `postgres`/`redis`, runs
 `prisma migrate deploy`, and executes a `guild_role_grants` relation preflight
 before service rollout to fail fast on schema drift.
+When those Prisma migration commands run from the webhook container, they must
+pin `prisma/prisma.config.ts` (and `prisma/schema.prisma`) explicitly so the
+deploy path keeps `DATABASE_URL` resolution deterministic.
 CLOUDFLARED tunnel restarts now mount config from `CLOUDFLARED_CONFIG_DIR`
 instead of shell `$HOME`; use a canonical host path like
 `/home/luk-server/.cloudflared` to avoid deploy-context mount drift.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -286,14 +286,16 @@ log "Starting database services..."
 docker_compose up -d postgres redis
 
 log "Running database migrations..."
-if ! docker_compose run --rm --no-deps backend sh -lc "npx prisma migrate deploy"; then
+if ! docker_compose run --rm --no-deps backend \
+    sh -lc "npx prisma migrate deploy --config prisma/prisma.config.ts --schema prisma/schema.prisma"; then
     log "ERROR: prisma migrate deploy failed (migration execution error)"
     notify 16711680 "Deploy Failed" "Database migration failed"
     exit 1
 fi
 
 log "Checking migration status..."
-if ! docker_compose run --rm --no-deps backend sh -lc "npx prisma migrate status"; then
+if ! docker_compose run --rm --no-deps backend \
+    sh -lc "npx prisma migrate status --config prisma/prisma.config.ts --schema prisma/schema.prisma"; then
     log "ERROR: prisma migrate status failed (migration drift/history mismatch)"
     notify 16711680 "Deploy Failed" "Database migration status guard failed"
     exit 1


### PR DESCRIPTION
## Summary
- pin webhook-driven Prisma migrate commands to `prisma/prisma.config.ts`
- keep homelab deploys deterministic when the webhook container invokes one-off backend migrations
- document the deploy-specific Prisma requirement

## Verification
- `bash -n scripts/deploy.sh`
- reproduced the failure on `server-do-luk` from the webhook container path
- reran the same migrate commands successfully after pinning the config path in the host hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved DATABASE_URL resolution inconsistencies during Prisma migrations initiated from the webhook container, ensuring stable behavior across deployments.

* **Documentation**
  * Updated CHANGELOG and README with configuration requirements and guidance for webhook-driven database migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->