### PR TITLE
feat(bot): music watchdog auto-recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Made music watchdog recovery deterministic after disconnects by waiting for
+  voice reconnection before replay attempts, recording recovery detail for
+  failures/successes, and surfacing that detail in `/music health`.
+
 ## [2.6.16] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -495,9 +495,9 @@ Set `UNLEASH_URL` and `UNLEASH_API_TOKEN` for Unleash, or use `FEATURE_DOWNLOAD_
 ### Music
 `/play` `/pause` `/resume` `/skip` `/stop` `/queue` `/volume` `/seek` `/lyrics` `/shuffle` `/repeat` `/clear` `/remove` `/move` `/jump` `/history` `/songinfo` `/autoplay` `/music health`
 
-`/music health` provides operator diagnostics for queue state, resolver source/cache
-signals, provider cooldown/score status, watchdog recovery state, snapshot
-availability, and actionable recovery next steps.
+`/music health` provides operator diagnostics for queue state, resolver
+source/cache signals, provider cooldown/score status, watchdog recovery state
+and detail, snapshot availability, and actionable recovery next steps.
 
 ### Download
 `/download` `/download-audio` `/download-video`

--- a/packages/bot/src/functions/music/commands/music.spec.ts
+++ b/packages/bot/src/functions/music/commands/music.spec.ts
@@ -83,6 +83,8 @@ describe('music command', () => {
             timeoutMs: 25000,
             lastRecoveryAction: 'none',
             lastActivityAt: 0,
+            lastRecoveryAt: null,
+            lastRecoveryDetail: null,
         })
         getSnapshotMock.mockResolvedValue(null)
         resolveGuildQueueMock.mockReturnValue({
@@ -199,6 +201,7 @@ describe('music command', () => {
             lastRecoveryAction: 'failed',
             lastActivityAt: 0,
             lastRecoveryAt: 0,
+            lastRecoveryDetail: 'connection_not_ready_after_rejoin',
         })
         getSnapshotMock.mockResolvedValue(null)
         resolveGuildQueueMock.mockReturnValue({
@@ -241,6 +244,13 @@ describe('music command', () => {
         expect(resolverField?.value).toContain('Source: miss')
         expect(resolverField?.value).toContain('Cache size: 2')
         expect(resolverField?.value).toContain('guild-9, guild-3')
+
+        const watchdogField = payload.fields.find(
+            (field) => field.name === 'Watchdog',
+        )
+        expect(watchdogField?.value).toContain(
+            'Last recovery detail: connection_not_ready_after_rejoin',
+        )
     })
 
     it('formats repeat mode label and watchdog recovery timestamp', async () => {
@@ -263,6 +273,7 @@ describe('music command', () => {
             lastRecoveryAction: 'play_next',
             lastActivityAt: 10,
             lastRecoveryAt: 20,
+            lastRecoveryDetail: 'started_next_track',
         })
 
         await musicCommand.execute({
@@ -282,5 +293,8 @@ describe('music command', () => {
 
         expect(queueField?.value).toContain('Repeat mode: autoplay')
         expect(watchdogField?.value).toContain('Last recovery at:')
+        expect(watchdogField?.value).toContain(
+            'Last recovery detail: started_next_track',
+        )
     })
 })

--- a/packages/bot/src/functions/music/commands/music.ts
+++ b/packages/bot/src/functions/music/commands/music.ts
@@ -9,14 +9,20 @@ import {
 } from '../../../utils/general/embeds'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import { requireGuild } from '../../../utils/command/commandValidations'
-import { providerHealthService } from '../../../utils/music/search/providerHealth'
-import { musicWatchdogService } from '../../../utils/music/watchdog'
+import {
+    providerHealthService,
+    type ProviderStatus,
+} from '../../../utils/music/search/providerHealth'
+import {
+    musicWatchdogService,
+    type WatchdogGuildState,
+} from '../../../utils/music/watchdog'
 import { musicSessionSnapshotService } from '../../../utils/music/sessionSnapshots'
-import { resolveGuildQueue } from '../../../utils/music/queueResolver'
-import type { ProviderStatus } from '../../../utils/music/search/providerHealth'
+import {
+    resolveGuildQueue,
+    type QueueResolutionResult,
+} from '../../../utils/music/queueResolver'
 import type { GuildQueue } from 'discord-player'
-import type { QueueResolutionResult } from '../../../utils/music/queueResolver'
-import type { WatchdogGuildState } from '../../../utils/music/watchdog'
 
 function formatProviderHealth(statuses: ProviderStatus[]): string {
     if (statuses.length === 0) {
@@ -97,7 +103,11 @@ function buildActionableSteps({
 
     if (watchdog.lastRecoveryAction === 'failed') {
         steps.push(
-            '• Last watchdog recovery failed: run /skip or /play to recover manually.',
+            `• Last watchdog recovery failed${
+                watchdog.lastRecoveryDetail
+                    ? ` (${watchdog.lastRecoveryDetail})`
+                    : ''
+            }: run /skip or /play to recover manually.`,
         )
     }
 
@@ -190,6 +200,7 @@ export default new Command({
                     value: [
                         `Timeout: ${watchdog.timeoutMs}ms`,
                         `Last recovery: ${watchdog.lastRecoveryAction}`,
+                        `Last recovery detail: ${watchdog.lastRecoveryDetail ?? 'n/a'}`,
                         `Last recovery at: ${formatTime(watchdog.lastRecoveryAt)}`,
                         `Last activity: ${formatTime(watchdog.lastActivityAt)}`,
                     ].join('\n'),

--- a/packages/bot/src/utils/music/watchdog.spec.ts
+++ b/packages/bot/src/utils/music/watchdog.spec.ts
@@ -13,13 +13,22 @@ describe('MusicWatchdogService', () => {
     })
 
     it('attempts recovery when queue is stalled', async () => {
-        const rejoin = jest.fn()
+        const connection = {
+            state: { status: 'disconnected' },
+            rejoin: jest.fn(() => {
+                connection.state.status = 'ready'
+            }),
+        }
         const play = jest.fn().mockResolvedValue(undefined)
-        const service = new MusicWatchdogService({ timeoutMs: 1_000 })
+        const service = new MusicWatchdogService({
+            timeoutMs: 1_000,
+            recoveryWaitTimeoutMs: 500,
+            recoveryPollIntervalMs: 50,
+        })
         const queue = {
             guild: { id: 'guild-1' },
             currentTrack: { title: 'Song', url: 'https://example.com/song' },
-            connection: { state: { status: 'disconnected' }, rejoin },
+            connection,
             node: {
                 isPlaying: () => false,
                 play,
@@ -28,13 +37,15 @@ describe('MusicWatchdogService', () => {
         } as unknown as GuildQueue
 
         service.arm(queue)
-        jest.advanceTimersByTime(1_100)
-        await Promise.resolve()
+        await jest.advanceTimersByTimeAsync(1_100)
 
-        expect(rejoin).toHaveBeenCalledTimes(1)
+        expect(connection.rejoin).toHaveBeenCalledTimes(1)
         expect(play).toHaveBeenCalledTimes(1)
-        expect(service.getGuildState('guild-1').lastRecoveryAction).toBe(
-            'requeue_current',
+        expect(service.getGuildState('guild-1')).toEqual(
+            expect.objectContaining({
+                lastRecoveryAction: 'requeue_current',
+                lastRecoveryDetail: 'rejoined_and_requeued_current',
+            }),
         )
     })
 
@@ -54,10 +65,86 @@ describe('MusicWatchdogService', () => {
         } as unknown as GuildQueue
 
         service.arm(queue)
-        jest.advanceTimersByTime(1_100)
-        await Promise.resolve()
+        await jest.advanceTimersByTimeAsync(1_100)
 
         expect(rejoin).not.toHaveBeenCalled()
         expect(play).not.toHaveBeenCalled()
+    })
+
+    it('waits for the connection to become ready before replaying', async () => {
+        const connection = {
+            state: { status: 'disconnected' },
+            rejoin: jest.fn(() => {
+                setTimeout(() => {
+                    connection.state.status = 'ready'
+                }, 200)
+            }),
+        }
+        const play = jest.fn().mockResolvedValue(undefined)
+        const service = new MusicWatchdogService({
+            timeoutMs: 1_000,
+            recoveryWaitTimeoutMs: 500,
+            recoveryPollIntervalMs: 50,
+        })
+        const queue = {
+            guild: { id: 'guild-ready' },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection,
+            node: {
+                isPlaying: () => false,
+                play,
+            },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const recoveryPromise = service.checkAndRecover(queue)
+        jest.advanceTimersByTime(200)
+        await recoveryPromise
+
+        expect(connection.rejoin).toHaveBeenCalledTimes(1)
+        expect(play).toHaveBeenCalledTimes(1)
+        expect(service.getGuildState('guild-ready')).toEqual(
+            expect.objectContaining({
+                lastRecoveryAction: 'requeue_current',
+                lastRecoveryDetail: 'rejoined_and_requeued_current',
+            }),
+        )
+    })
+
+    it('fails deterministically when the connection stays disconnected', async () => {
+        const connection = {
+            state: { status: 'disconnected' },
+            rejoin: jest.fn(),
+        }
+        const play = jest.fn().mockResolvedValue(undefined)
+        const service = new MusicWatchdogService({
+            timeoutMs: 1_000,
+            recoveryWaitTimeoutMs: 300,
+            recoveryPollIntervalMs: 100,
+        })
+        const queue = {
+            guild: { id: 'guild-failed' },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection,
+            node: {
+                isPlaying: () => false,
+                play,
+            },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const recoveryPromise = service.checkAndRecover(queue)
+        jest.advanceTimersByTime(400)
+        const action = await recoveryPromise
+
+        expect(action).toBe('failed')
+        expect(connection.rejoin).toHaveBeenCalledTimes(1)
+        expect(play).not.toHaveBeenCalled()
+        expect(service.getGuildState('guild-failed')).toEqual(
+            expect.objectContaining({
+                lastRecoveryAction: 'failed',
+                lastRecoveryDetail: 'connection_not_ready_after_rejoin',
+            }),
+        )
     })
 })

--- a/packages/bot/src/utils/music/watchdog.ts
+++ b/packages/bot/src/utils/music/watchdog.ts
@@ -14,14 +14,19 @@ export type WatchdogGuildState = {
     lastActivityAt: number | null
     lastRecoveryAt: number | null
     lastRecoveryAction: RecoveryAction
+    lastRecoveryDetail: string | null
 }
 
 type MusicWatchdogOptions = {
     timeoutMs?: number
+    recoveryWaitTimeoutMs?: number
+    recoveryPollIntervalMs?: number
 }
 
 export class MusicWatchdogService {
     private readonly timeoutMs: number
+    private readonly recoveryWaitTimeoutMs: number
+    private readonly recoveryPollIntervalMs: number
     private readonly timers = new Map<string, ReturnType<typeof setTimeout>>()
     private readonly states = new Map<string, WatchdogGuildState>()
 
@@ -29,6 +34,12 @@ export class MusicWatchdogService {
         this.timeoutMs =
             options.timeoutMs ??
             parseInt(process.env.MUSIC_WATCHDOG_TIMEOUT_MS ?? '25000', 10)
+        this.recoveryWaitTimeoutMs =
+            options.recoveryWaitTimeoutMs ??
+            parseInt(process.env.MUSIC_WATCHDOG_RECOVERY_WAIT_MS ?? '1500', 10)
+        this.recoveryPollIntervalMs =
+            options.recoveryPollIntervalMs ??
+            parseInt(process.env.MUSIC_WATCHDOG_RECOVERY_POLL_MS ?? '100', 10)
     }
 
     private ensureState(guildId: string): WatchdogGuildState {
@@ -40,9 +51,34 @@ export class MusicWatchdogService {
             lastActivityAt: null,
             lastRecoveryAt: null,
             lastRecoveryAction: 'none',
+            lastRecoveryDetail: null,
         }
         this.states.set(guildId, created)
         return created
+    }
+
+    private async waitForConnectionReady(
+        connection: GuildQueue['connection'],
+    ): Promise<boolean> {
+        if (!connection) return true
+        if (this.isConnectionReady(connection)) return true
+
+        const deadline = Date.now() + this.recoveryWaitTimeoutMs
+        while (Date.now() < deadline) {
+            await new Promise((resolve) =>
+                setTimeout(resolve, this.recoveryPollIntervalMs),
+            )
+
+            if (this.isConnectionReady(connection)) {
+                return true
+            }
+        }
+
+        return this.isConnectionReady(connection)
+    }
+
+    private isConnectionReady(connection: GuildQueue['connection']): boolean {
+        return connection?.state?.status === 'ready'
     }
 
     touch(guildId: string, now = Date.now()): void {
@@ -75,25 +111,45 @@ export class MusicWatchdogService {
 
         if (queue.node.isPlaying()) {
             state.lastRecoveryAction = 'none'
+            state.lastRecoveryDetail = 'queue_playing'
             return 'none'
         }
 
         let action: RecoveryAction = 'none'
+        let detail = 'nothing_to_recover'
+        let didRejoin = false
         try {
             if (queue.connection?.state?.status !== 'ready') {
                 queue.connection?.rejoin?.()
-                action = 'rejoin'
+                didRejoin = true
+                const ready = await this.waitForConnectionReady(queue.connection)
+                if (!ready) {
+                    action = 'failed'
+                    detail = 'connection_not_ready_after_rejoin'
+                    state.lastRecoveryAction = action
+                    state.lastRecoveryDetail = detail
+                    state.lastRecoveryAt = Date.now()
+                    return action
+                }
             }
 
             if (queue.currentTrack) {
                 await queue.node.play()
                 action = 'requeue_current'
+                detail = didRejoin
+                    ? 'rejoined_and_requeued_current'
+                    : 'requeue_current'
             } else if (queue.tracks.size > 0) {
                 await queue.node.play()
                 action = 'play_next'
+                detail = 'started_next_track'
             }
         } catch (error) {
             action = 'failed'
+            detail =
+                error instanceof Error
+                    ? `recovery_failed:${error.message}`
+                    : `recovery_failed:${String(error)}`
             errorLog({
                 message: 'Music watchdog recovery failed',
                 error,
@@ -102,11 +158,12 @@ export class MusicWatchdogService {
         }
 
         state.lastRecoveryAction = action
+        state.lastRecoveryDetail = detail
         state.lastRecoveryAt = Date.now()
 
         debugLog({
             message: 'Music watchdog recovery result',
-            data: { guildId, action },
+            data: { guildId, action, detail },
         })
 
         return action


### PR DESCRIPTION
## Summary
- make watchdog recovery deterministic after disconnects and stalled playback
- record recovery detail for successful and failed recovery attempts
- surface recovery detail in `/music health`

Closes #241
Refs #223

## Changes
- wait for voice reconnection before replay attempts after `rejoin()`
- stop replay attempts when the voice connection never becomes ready
- expose `lastRecoveryDetail` in watchdog state and `/music health`
- add targeted success/failure watchdog tests and command diagnostics coverage
- update `README.md` and `CHANGELOG.md`

## Verification
- `npm run test --workspace=packages/bot -- src/utils/music/watchdog.spec.ts src/handlers/player/lifecycleHandlers.spec.ts src/functions/music/commands/music.spec.ts`
- `npx eslint src/utils/music/watchdog.ts src/functions/music/commands/music.ts -c ../../eslint.config.js` (from `packages/bot`)
- `npm run db:generate`

## Known unrelated local blockers
- `npx tsc --noEmit -p packages/bot/tsconfig.json` still fails in pre-existing automation files:
  - `packages/bot/src/functions/management/commands/guildconfig.ts:299`
  - `packages/bot/src/utils/guildAutomation/captureGuildState.ts:183`
  - `packages/bot/src/utils/guildAutomation/captureGuildState.ts:187`
  - `packages/bot/src/utils/guildAutomation/captureGuildState.ts:194`
- broader preflight/build also still hits pre-existing shared issues outside this slice:
  - `packages/shared/src/services/guildAutomation/service.ts:398`
  - `packages/shared/src/services/RoleManagementService/index.ts:134`
  - `packages/shared/src/services/TwitchNotificationService/index.ts:106`
