### PR TITLE
feat(bot): provider health cooldown enforcement (wave1 slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Provider fallback ordering in search now sorts by health score so degraded
+  providers are deprioritized before hitting their cooldown threshold, and
+  on-cooldown providers are skipped entirely (`engineManager.ts`).
+- `isAvailable()` now self-heals by clearing `cooldownUntil` in-place when the
+  expiry timestamp has passed, so `/music health` no longer shows stale
+  cooldown values for recovered providers.
+
 ### Fixed
 
 - Made music watchdog recovery deterministic after disconnects by waiting for

--- a/packages/bot/src/utils/music/search/engineManager.spec.ts
+++ b/packages/bot/src/utils/music/search/engineManager.spec.ts
@@ -20,11 +20,15 @@ jest.mock('../youtubeErrorHandler', () => ({
     logYouTubeError: (...args: unknown[]) => logYouTubeErrorMock(...args),
 }))
 
+const getOrderedProvidersMock = jest.fn()
+
 jest.mock('./providerHealth', () => ({
     providerHealthService: {
         isAvailable: (...args: unknown[]) => isAvailableMock(...args),
         recordSuccess: (...args: unknown[]) => recordSuccessMock(...args),
         recordFailure: (...args: unknown[]) => recordFailureMock(...args),
+        getOrderedProviders: (...args: unknown[]) =>
+            getOrderedProvidersMock(...args),
     },
     providerFromQueryType: (...args: unknown[]) =>
         providerFromQueryTypeMock(...args),
@@ -34,6 +38,7 @@ describe('SearchEngineManager', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         isAvailableMock.mockReturnValue(true)
+        getOrderedProvidersMock.mockImplementation((providers: string[]) => providers)
         providerFromQueryTypeMock.mockImplementation((engine: QueryType) => {
             if (engine === QueryType.YOUTUBE_SEARCH) return 'youtube'
             if (engine === QueryType.AUTO) return 'youtube'
@@ -151,6 +156,52 @@ describe('SearchEngineManager', () => {
             result: { tracks: [{ title: 'C' }] },
             attempts: 2,
         })
+    })
+
+    it('sorts fallback providers by health score via getOrderedProviders', async () => {
+        // spotify degraded so getOrderedProviders puts soundcloud first
+        getOrderedProvidersMock.mockReturnValue(['soundcloud', 'spotify'])
+        const player = {
+            search: jest
+                .fn()
+                .mockResolvedValueOnce({ tracks: [] }) // youtube (preferred) fails
+                .mockResolvedValueOnce({ tracks: [{ title: 'SC track' }] }), // soundcloud succeeds
+        }
+        const manager = new SearchEngineManager(player as any)
+
+        const result = await manager.performSearch({
+            query: 'degraded fallback test',
+            requestedBy: { id: 'user-1' } as any,
+            preferredEngine: QueryType.YOUTUBE_SEARCH,
+            enableFallbacks: true,
+        })
+
+        expect(getOrderedProvidersMock).toHaveBeenCalled()
+        expect(result.success).toBe(true)
+        expect(result.usedFallback).toBe(true)
+        expect(result.attempts).toBe(2)
+    })
+
+    it('skips on-cooldown fallback providers and uses remaining healthy ones', async () => {
+        // getOrderedProviders returns only soundcloud (spotify on cooldown)
+        getOrderedProvidersMock.mockReturnValue(['soundcloud'])
+        const player = {
+            search: jest
+                .fn()
+                .mockResolvedValueOnce({ tracks: [] }) // youtube fails
+                .mockResolvedValueOnce({ tracks: [{ title: 'SC' }] }), // soundcloud ok
+        }
+        const manager = new SearchEngineManager(player as any)
+
+        const result = await manager.performSearch({
+            query: 'cooldown skip test',
+            requestedBy: { id: 'user-1' } as any,
+            preferredEngine: QueryType.YOUTUBE_SEARCH,
+            enableFallbacks: true,
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.attempts).toBe(2)
     })
 
     it('returns failure details after max retry exhaustion', async () => {

--- a/packages/bot/src/utils/music/search/engineManager.ts
+++ b/packages/bot/src/utils/music/search/engineManager.ts
@@ -51,15 +51,22 @@ export class SearchEngineManager {
             return attempts
         }
 
-        for (const fallback of FALLBACK_ATTEMPTS) {
-            if (
-                attempts.some(
+        const remainingFallbacks = FALLBACK_ATTEMPTS.filter(
+            (fallback) =>
+                !attempts.some(
                     (candidate) => candidate.provider === fallback.provider,
-                )
-            ) {
-                continue
-            }
-            attempts.push(fallback)
+                ),
+        )
+
+        const orderedProviders = providerHealthService.getOrderedProviders(
+            remainingFallbacks.map((f) => f.provider),
+        )
+
+        for (const provider of orderedProviders) {
+            const fallback = remainingFallbacks.find(
+                (f) => f.provider === provider,
+            )
+            if (fallback) attempts.push(fallback)
         }
 
         return attempts

--- a/packages/bot/src/utils/music/search/providerHealth.spec.ts
+++ b/packages/bot/src/utils/music/search/providerHealth.spec.ts
@@ -98,6 +98,88 @@ describe('ProviderHealthService', () => {
     })
 })
 
+describe('ProviderHealthService cooldown boundary conditions', () => {
+    it('clears cooldownUntil in-place when expiry is reached on isAvailable call', () => {
+        const service = new ProviderHealthService({
+            cooldownMs: 1_000,
+            failureThreshold: 1,
+        })
+        const now = 5_000
+
+        service.recordFailure('youtube', now, 'fail')
+        expect(service.isAvailable('youtube', now + 500)).toBe(false)
+        // Cooldown still set before expiry
+        expect(service.getStatus('youtube').cooldownUntil).not.toBeNull()
+
+        // At expiry boundary, isAvailable clears cooldownUntil in-place
+        expect(service.isAvailable('youtube', now + 1_000)).toBe(true)
+        expect(service.getStatus('youtube').cooldownUntil).toBeNull()
+    })
+
+    it('deprioritizes degraded-but-available provider relative to healthy one', () => {
+        const service = new ProviderHealthService({
+            cooldownMs: 10_000,
+            failureThreshold: 3,
+            failurePenalty: 0.3,
+        })
+        const now = 1_000
+
+        // Degrade spotify (score: 0.7) but not yet in cooldown
+        service.recordFailure('spotify', now, 'partial fail')
+        // youtube untouched (score: 1.0)
+
+        const ordered = service.getOrderedProviders(
+            ['spotify', 'youtube'],
+            now + 100,
+        )
+        expect(ordered[0]).toBe('youtube')
+        expect(ordered[1]).toBe('spotify')
+    })
+
+    it('excludes on-cooldown providers while ordering remaining by score', () => {
+        const service = new ProviderHealthService({
+            cooldownMs: 5_000,
+            failureThreshold: 1,
+            failurePenalty: 0.4,
+        })
+        const now = 1_000
+
+        // soundcloud goes into cooldown
+        service.recordFailure('soundcloud', now, 'fail')
+        // spotify degraded but available
+        service.recordFailure('spotify', now, 'degraded')
+        service.recordSuccess('spotify', now)
+        // youtube healthy
+        service.recordSuccess('youtube', now)
+
+        const ordered = service.getOrderedProviders(
+            ['soundcloud', 'spotify', 'youtube'],
+            now + 100,
+        )
+
+        expect(ordered).not.toContain('soundcloud')
+        expect(ordered[0]).toBe('youtube')
+    })
+
+    it('returns empty array when all providers are on cooldown', () => {
+        const service = new ProviderHealthService({
+            cooldownMs: 60_000,
+            failureThreshold: 1,
+        })
+        const now = 1_000
+
+        service.recordFailure('youtube', now)
+        service.recordFailure('spotify', now)
+        service.recordFailure('soundcloud', now)
+
+        const ordered = service.getOrderedProviders(
+            ['youtube', 'spotify', 'soundcloud'],
+            now + 100,
+        )
+        expect(ordered).toHaveLength(0)
+    })
+})
+
 describe('provider mappers', () => {
     it('maps query types to providers', () => {
         expect(providerFromQueryType('youtubeSearch' as any)).toBe('youtube')

--- a/packages/bot/src/utils/music/search/providerHealth.ts
+++ b/packages/bot/src/utils/music/search/providerHealth.ts
@@ -98,7 +98,11 @@ export class ProviderHealthService {
     isAvailable(provider: MusicProvider, now = Date.now()): boolean {
         const status = this.ensure(provider)
         if (status.cooldownUntil === null) return true
-        return now >= status.cooldownUntil
+        if (now >= status.cooldownUntil) {
+            status.cooldownUntil = null
+            return true
+        }
+        return false
     }
 
     getStatus(provider: MusicProvider): ProviderStatus {


### PR DESCRIPTION
## Summary

Tightens provider cooldown scoring and enforcement in search fallback
ordering. Closes #242, part of #223.

## Changes

### `engineManager.ts` — Score-ordered fallback selection
`buildAttempts()` now calls `providerHealthService.getOrderedProviders()`
to sort fallback candidates by health score before building the attempt
list. Degraded-but-available providers (score < 1.0) are tried after
healthier ones; on-cooldown providers are excluded entirely by
`getOrderedProviders`'s `isAvailable` filter.

**Before:** `FALLBACK_ATTEMPTS` always iterated `youtube → spotify →
soundcloud`, regardless of each provider's current health score.

**After:** Fallbacks are ordered by descending health score at call time,
so a degraded Spotify (score 0.6) is tried after a healthy SoundCloud
(score 1.0), and a cooldown-active provider is skipped completely.

### `providerHealth.ts` — Self-healing `isAvailable()`
`isAvailable()` now clears `cooldownUntil` in-place when the expiry
timestamp has passed. Previously the field remained non-null until
`recordSuccess()` was called, causing `/music health` to display stale
cooldown timestamps for providers that had already recovered.

## Tests

Added 4 targeted boundary tests in `providerHealth.spec.ts`:
- Cooldown expiry self-heals `cooldownUntil` to `null` at boundary
- Degraded-but-available provider is ordered after healthy one
- On-cooldown provider is excluded from ordered results
- All-providers-cooldown returns empty array

Added 2 `engineManager.spec.ts` tests:
- Score-based ordering is used when `getOrderedProviders` deprioritizes degraded provider
- On-cooldown provider is skipped, next healthy provider is used

## Acceptance

- [x] Cooldown behavior is deterministic and test-covered (18 tests pass)
- [x] CHANGELOG updated
- [x] PR references #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Provider fallback ordering now prioritizes healthy providers by sorting based on health scores, deprioritizing degraded providers and skipping those on cooldown.

* **Bug Fixes**
  * Health status display no longer shows stale cooldown values for recovered providers; cooldown timers are now automatically cleared when expiry passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->