### PR TITLE
feat(bot): harden queue snapshot restore with staleness guard and double-restore prevention (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `MusicSessionSnapshotService.deleteSnapshot()` — explicit Redis delete after a
+  successful restore so the same snapshot is not re-applied on subsequent
+  connections (double-restore prevention).
+
 ### Changed
 
+- Session snapshot restore now prepends `currentTrack` to the restored queue so
+  the track that was playing at crash/disconnect time is also recovered, not
+  only upcoming tracks.
+- `restoreSnapshot()` now enforces a configurable `maxAgeMs` staleness guard
+  (default 30 minutes) and skips snapshots older than the threshold.
+- `lifecycleHandlers.ts` now reads the session-restore gate from
+  `ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED` instead of raw
+  `process.env`, aligning with the shared config source of truth.
+- `MusicSessionSnapshotService` constructor now uses
+  `ENVIRONMENT_CONFIG.SESSIONS.QUEUE_SESSION_TTL` as the default TTL so the
+  `QUEUE_SESSION_TTL` env var is respected at the singleton level.
 - Provider fallback ordering in search now sorts by health score so degraded
   providers are deprioritized before hitting their cooldown threshold, and
   on-cooldown providers are skipped entirely (`engineManager.ts`).

--- a/packages/bot/src/handlers/player/lifecycleHandlers.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.ts
@@ -1,5 +1,6 @@
 import type { GuildQueue } from 'discord-player'
 import { infoLog, debugLog } from '@lucky/shared/utils'
+import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 import { musicWatchdogService } from '../../utils/music/watchdog'
 import { musicSessionSnapshotService } from '../../utils/music/sessionSnapshots'
 import type { User } from 'discord.js'
@@ -29,7 +30,7 @@ export const setupLifecycleHandlers = (player: {
             })
         }
 
-        if (process.env.MUSIC_SESSION_RESTORE_ENABLED !== 'false') {
+        if (ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED) {
             const metadata = queue.metadata as
                 | { requestedBy?: User | null }
                 | undefined

--- a/packages/bot/src/utils/music/sessionSnapshots.spec.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.spec.ts
@@ -4,6 +4,7 @@ import { MusicSessionSnapshotService } from './sessionSnapshots'
 
 const getMock = jest.fn()
 const setexMock = jest.fn()
+const delMock = jest.fn()
 
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
@@ -14,6 +15,13 @@ jest.mock('@lucky/shared/services', () => ({
     redisClient: {
         get: (...args: unknown[]) => getMock(...args),
         setex: (...args: unknown[]) => setexMock(...args),
+        del: (...args: unknown[]) => delMock(...args),
+    },
+}))
+
+jest.mock('@lucky/shared/config', () => ({
+    ENVIRONMENT_CONFIG: {
+        SESSIONS: { QUEUE_SESSION_TTL: 7200 },
     },
 }))
 
@@ -53,6 +61,20 @@ describe('MusicSessionSnapshotService', () => {
         expect(setexMock.mock.calls[0]?.[0]).toContain('music:session:guild-1')
     })
 
+    it('returns null when queue is empty and does not write to redis', async () => {
+        const service = new MusicSessionSnapshotService(300)
+        const queue = {
+            guild: { id: 'guild-empty' },
+            currentTrack: null,
+            tracks: { toArray: () => [] },
+        } as unknown as GuildQueue
+
+        const result = await service.saveSnapshot(queue)
+
+        expect(result).toBeNull()
+        expect(setexMock).not.toHaveBeenCalled()
+    })
+
     it('restores tracks from snapshot by searching and adding to queue', async () => {
         const service = new MusicSessionSnapshotService(300)
         const snapshot = {
@@ -71,6 +93,7 @@ describe('MusicSessionSnapshotService', () => {
             ],
         }
         getMock.mockResolvedValue(JSON.stringify(snapshot))
+        delMock.mockResolvedValue(1)
 
         const addTrack = jest.fn()
         const queue = {
@@ -100,5 +123,201 @@ describe('MusicSessionSnapshotService', () => {
 
         expect(result.restoredCount).toBe(1)
         expect(addTrack).toHaveBeenCalledTimes(1)
+        // Snapshot must be cleared after restore (Gap 3 fix)
+        expect(delMock).toHaveBeenCalledWith('music:session:guild-2')
+    })
+
+    it('also restores currentTrack prepended to the queue (Gap 4 fix)', async () => {
+        const service = new MusicSessionSnapshotService(300)
+        const snapshot = {
+            sessionSnapshotId: 'snap-ct',
+            guildId: 'guild-ct',
+            savedAt: Date.now(),
+            currentTrack: {
+                title: 'Was Playing',
+                author: 'Artist A',
+                url: 'https://example.com/current',
+                duration: '3:00',
+                source: 'youtube',
+            },
+            upcomingTracks: [
+                {
+                    title: 'Next Up',
+                    author: 'Artist B',
+                    url: 'https://example.com/next',
+                    duration: '2:30',
+                    source: 'youtube',
+                },
+            ],
+        }
+        getMock.mockResolvedValue(JSON.stringify(snapshot))
+        delMock.mockResolvedValue(1)
+
+        const addTrack = jest.fn()
+        const queue = {
+            guild: { id: 'guild-ct' },
+            currentTrack: null,
+            tracks: { size: 0 },
+            addTrack,
+            node: {
+                isPlaying: () => false,
+                play: jest.fn().mockResolvedValue(undefined),
+            },
+            player: {
+                search: jest.fn().mockImplementation(async (query: unknown) => ({
+                    tracks: [
+                        {
+                            title: String(query).split(' ')[0],
+                            author: 'resolved',
+                            url: query,
+                            metadata: {},
+                        },
+                    ],
+                })),
+            },
+        } as unknown as GuildQueue
+
+        const result = await service.restoreSnapshot(queue)
+
+        // currentTrack + 1 upcoming = 2 tracks
+        expect(result.restoredCount).toBe(2)
+        expect(addTrack).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects snapshot older than maxAgeMs (Gap 2 staleness guard)', async () => {
+        const service = new MusicSessionSnapshotService(300)
+        const staleSnapshot = {
+            sessionSnapshotId: 'snap-stale',
+            guildId: 'guild-stale',
+            savedAt: Date.now() - 60 * 60 * 1_000, // 1 hour ago
+            currentTrack: null,
+            upcomingTracks: [
+                {
+                    title: 'Old Song',
+                    author: 'Old Artist',
+                    url: 'https://example.com/old',
+                    duration: '3:00',
+                    source: 'youtube',
+                },
+            ],
+        }
+        getMock.mockResolvedValue(JSON.stringify(staleSnapshot))
+
+        const addTrack = jest.fn()
+        const queue = {
+            guild: { id: 'guild-stale' },
+            currentTrack: null,
+            tracks: { size: 0 },
+            addTrack,
+            node: { isPlaying: () => false, play: jest.fn() },
+            player: { search: jest.fn() },
+        } as unknown as GuildQueue
+
+        // Use 30-min maxAge (default)
+        const result = await service.restoreSnapshot(queue, undefined, {
+            maxAgeMs: 30 * 60 * 1_000,
+        })
+
+        expect(result.restoredCount).toBe(0)
+        expect(result.sessionSnapshotId).toBeNull()
+        expect(addTrack).not.toHaveBeenCalled()
+        // Should NOT delete the stale snapshot (so TTL can still expire it naturally)
+        expect(delMock).not.toHaveBeenCalled()
+    })
+
+    it('accepts snapshot within maxAgeMs window', async () => {
+        const service = new MusicSessionSnapshotService(300)
+        const freshSnapshot = {
+            sessionSnapshotId: 'snap-fresh',
+            guildId: 'guild-fresh',
+            savedAt: Date.now() - 5 * 60 * 1_000, // 5 min ago
+            currentTrack: null,
+            upcomingTracks: [
+                {
+                    title: 'Fresh Song',
+                    author: 'Fresh Artist',
+                    url: 'https://example.com/fresh',
+                    duration: '3:00',
+                    source: 'youtube',
+                },
+            ],
+        }
+        getMock.mockResolvedValue(JSON.stringify(freshSnapshot))
+        delMock.mockResolvedValue(1)
+
+        const addTrack = jest.fn()
+        const queue = {
+            guild: { id: 'guild-fresh' },
+            currentTrack: null,
+            tracks: { size: 0 },
+            addTrack,
+            node: {
+                isPlaying: () => false,
+                play: jest.fn().mockResolvedValue(undefined),
+            },
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [{ title: 'Fresh Song', author: 'Fresh Artist', url: 'https://example.com/fresh', metadata: {} }],
+                }),
+            },
+        } as unknown as GuildQueue
+
+        const result = await service.restoreSnapshot(queue, undefined, {
+            maxAgeMs: 30 * 60 * 1_000,
+        })
+
+        expect(result.restoredCount).toBe(1)
+        expect(delMock).toHaveBeenCalledWith('music:session:guild-fresh')
+    })
+
+    it('returns early when queue already has tracks', async () => {
+        const service = new MusicSessionSnapshotService(300)
+        const queue = {
+            guild: { id: 'guild-busy' },
+            currentTrack: { title: 'Playing Now' },
+            tracks: { size: 2 },
+        } as unknown as GuildQueue
+
+        const result = await service.restoreSnapshot(queue)
+
+        expect(result.restoredCount).toBe(0)
+        expect(getMock).not.toHaveBeenCalled()
+    })
+
+    it('does not delete snapshot when no tracks are restored', async () => {
+        const service = new MusicSessionSnapshotService(300)
+        const snapshot = {
+            sessionSnapshotId: 'snap-noresult',
+            guildId: 'guild-noresult',
+            savedAt: Date.now(),
+            currentTrack: null,
+            upcomingTracks: [
+                {
+                    title: 'Ghost Track',
+                    author: 'Ghost',
+                    url: 'https://example.com/ghost',
+                    duration: '3:00',
+                    source: 'youtube',
+                },
+            ],
+        }
+        getMock.mockResolvedValue(JSON.stringify(snapshot))
+
+        const addTrack = jest.fn()
+        const queue = {
+            guild: { id: 'guild-noresult' },
+            currentTrack: null,
+            tracks: { size: 0 },
+            addTrack,
+            node: { isPlaying: () => false, play: jest.fn() },
+            player: {
+                search: jest.fn().mockResolvedValue({ tracks: [] }), // no results
+            },
+        } as unknown as GuildQueue
+
+        const result = await service.restoreSnapshot(queue)
+
+        expect(result.restoredCount).toBe(0)
+        expect(delMock).not.toHaveBeenCalled()
     })
 })

--- a/packages/bot/src/utils/music/sessionSnapshots.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.ts
@@ -4,6 +4,7 @@ import type { User } from 'discord.js'
 import { randomUUID } from 'crypto'
 import { redisClient } from '@lucky/shared/services'
 import { debugLog, errorLog } from '@lucky/shared/utils'
+import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 
 export type SnapshotTrack = {
     title: string
@@ -29,6 +30,9 @@ export type SnapshotRestoreResult = {
 }
 
 const MAX_SNAPSHOT_TRACKS = 25
+
+/** Maximum age in ms for a snapshot to be automatically restored (30 minutes). */
+const DEFAULT_MAX_SNAPSHOT_AGE_MS = 30 * 60 * 1_000
 
 type SearchOptions = {
     requestedBy?: User
@@ -74,7 +78,10 @@ function applySnapshotMetadata(
 }
 
 export class MusicSessionSnapshotService {
-    constructor(private readonly ttlSeconds = 7_200) {}
+    constructor(
+        private readonly ttlSeconds = ENVIRONMENT_CONFIG.SESSIONS.QUEUE_SESSION_TTL,
+        private readonly maxSnapshotAgeMs = DEFAULT_MAX_SNAPSHOT_AGE_MS,
+    ) {}
 
     private getKey(guildId: string): string {
         return `music:session:${guildId}`
@@ -137,9 +144,26 @@ export class MusicSessionSnapshotService {
         }
     }
 
+    /**
+     * Delete the snapshot for a guild from Redis.
+     * Called after a successful restore so the same snapshot is not re-applied
+     * on subsequent connections.
+     */
+    async deleteSnapshot(guildId: string): Promise<void> {
+        try {
+            await redisClient.del(this.getKey(guildId))
+        } catch (error) {
+            errorLog({
+                message: 'Failed to delete music session snapshot',
+                error,
+            })
+        }
+    }
+
     async restoreSnapshot(
         queue: GuildQueue,
         requestedBy?: User,
+        options: { maxAgeMs?: number } = {},
     ): Promise<SnapshotRestoreResult> {
         try {
             if (queue.currentTrack || queue.tracks.size > 0) {
@@ -151,13 +175,34 @@ export class MusicSessionSnapshotService {
                 return { restoredCount: 0, sessionSnapshotId: null }
             }
 
+            // Staleness guard: reject snapshots older than maxAgeMs.
+            const maxAge = options.maxAgeMs ?? this.maxSnapshotAgeMs
+            if (Date.now() - snapshot.savedAt > maxAge) {
+                debugLog({
+                    message: 'Music session snapshot is too old; skipping restore',
+                    data: {
+                        guildId: queue.guild.id,
+                        savedAt: snapshot.savedAt,
+                        ageMs: Date.now() - snapshot.savedAt,
+                        maxAgeMs: maxAge,
+                    },
+                })
+                return { restoredCount: 0, sessionSnapshotId: null }
+            }
+
             const searchOptions: SearchOptions = {
                 searchEngine: QueryType.AUTO,
                 ...(requestedBy ? { requestedBy } : {}),
             }
 
+            // Build ordered track list: currentTrack first so it replays from the top.
+            const tracksToRestore: SnapshotTrack[] = [
+                ...(snapshot.currentTrack ? [snapshot.currentTrack] : []),
+                ...snapshot.upcomingTracks,
+            ]
+
             let restoredCount = 0
-            for (const entry of snapshot.upcomingTracks) {
+            for (const entry of tracksToRestore) {
                 const query =
                     entry.url || `${entry.title} ${entry.author}`.trim()
                 const result = await queue.player.search(query, searchOptions)
@@ -173,8 +218,14 @@ export class MusicSessionSnapshotService {
                 restoredCount += 1
             }
 
-            if (restoredCount > 0 && !queue.node.isPlaying()) {
-                await queue.node.play()
+            if (restoredCount > 0) {
+                // Clear the snapshot after a successful restore so it cannot
+                // be applied again on the next connection event.
+                await this.deleteSnapshot(queue.guild.id)
+
+                if (!queue.node.isPlaying()) {
+                    await queue.node.play()
+                }
             }
 
             debugLog({
@@ -188,7 +239,8 @@ export class MusicSessionSnapshotService {
 
             return {
                 restoredCount,
-                sessionSnapshotId: snapshot.sessionSnapshotId,
+                sessionSnapshotId:
+                    restoredCount > 0 ? snapshot.sessionSnapshotId : null,
             }
         } catch (error) {
             errorLog({


### PR DESCRIPTION
## Summary

Closes #243 (wave1 slice 4 — queue snapshot restore guardrails).

Addresses 5 gaps in the existing `MusicSessionSnapshotService`:

- **Staleness guard** (`Gap 2`): `restoreSnapshot()` now enforces a configurable `maxAgeMs` threshold (default 30 min). Snapshots older than the threshold are silently skipped rather than replaying stale state.
- **Double-restore prevention** (`Gap 3`): The snapshot is deleted from Redis after a successful restore via the new `deleteSnapshot()` method. A second crash before a new `saveSnapshot()` call will no longer re-apply the same stale session.
- **currentTrack recovery** (`Gap 4`): The track that was actively playing at disconnect time is now prepended to the restore list so it is re-enqueued first, not dropped.
- **Config source alignment** (`Gap 6`): `lifecycleHandlers.ts` now reads `ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED` instead of raw `process.env.MUSIC_SESSION_RESTORE_ENABLED`.
- **TTL env-configurability** (`Gap 7`): `MusicSessionSnapshotService` constructor now defaults to `ENVIRONMENT_CONFIG.SESSIONS.QUEUE_SESSION_TTL` so `QUEUE_SESSION_TTL` env var actually applies at the singleton level.

## Test coverage added

6 new tests in `sessionSnapshots.spec.ts`:
- Empty queue returns null (no Redis write)
- Snapshot cleared after successful restore (Gap 3)
- `currentTrack` prepended and restored (Gap 4)
- Stale snapshot rejected by `maxAgeMs` guard (Gap 2)
- Fresh snapshot within window is accepted and snapshot deleted
- No snapshot delete when zero tracks are restored

All 59 bot test suites pass (347 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of restored music session snapshots to prevent duplicate restoration.
  * Enforced 30-minute freshness threshold; older snapshots are skipped during restoration.
  * Improved session recovery to include the currently playing track alongside queued tracks.

* **Bug Fixes**
  * Session restoration now properly recovers the previously playing track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->