### PR TITLE
fix(deploy): async webhook wrapper to prevent CI curl timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,14 +44,14 @@ jobs:
                       -X POST \
                       -H "X-Webhook-Secret: $WEBHOOK_SECRET" \
                       --connect-timeout 10 \
-                      --max-time 20 \
+                      --max-time 30 \
                       "$url"
                   }
 
                   call_webhook_with_retry() {
                     local url="$1"
                     local attempt http body response max_attempts
-                    max_attempts=8
+                    max_attempts=3
 
                     for attempt in $(seq 1 "$max_attempts"); do
                       response=$(call_webhook "$url" || true)
@@ -66,7 +66,7 @@ jobs:
                       fi
 
                       if [ "$attempt" -lt "$max_attempts" ] && { [ "$http" -ge 500 ] || [ "$http" = "000" ]; }; then
-                        sleep $((attempt * 4))
+                        sleep $((attempt * 5))
                         continue
                       fi
 

--- a/deploy/hooks.json
+++ b/deploy/hooks.json
@@ -1,6 +1,6 @@
 [{
   "id": "deploy",
-  "execute-command": "/home/luk-server/Lucky/scripts/deploy.sh",
+  "execute-command": "/home/luk-server/Lucky/scripts/deploy-wrapper.sh",
   "command-working-directory": "/home/luk-server/Lucky",
   "response-message": "Deploy triggered",
   "include-command-output-in-response": true,

--- a/scripts/deploy-wrapper.sh
+++ b/scripts/deploy-wrapper.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Async wrapper for deploy.sh — returns immediately while deploy runs in background.
+# The almir/webhook binary blocks until the execute-command completes; this wrapper
+# exits in <1s so the CI curl never times out, while the real deploy.sh runs detached.
+set -euo pipefail
+
+DEPLOY_DIR="${DEPLOY_DIR:-/repo}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/deploy.sh"
+LOG_FILE="/tmp/lucky-deploy.log"
+
+if [[ ! -x "$DEPLOY_SCRIPT" ]]; then
+    echo "[deploy-wrapper] ERROR: $DEPLOY_SCRIPT is not executable"
+    exit 1
+fi
+
+# Launch the real deploy detached from this process.
+# stdout/stderr go to a log file so webhook doesn't try to capture them.
+nohup bash "$DEPLOY_SCRIPT" "$@" > "$LOG_FILE" 2>&1 &
+DEPLOY_PID=$!
+
+echo "[deploy-wrapper] Deploy started (pid=$DEPLOY_PID, log=$LOG_FILE)"


### PR DESCRIPTION
## Summary

The `almir/webhook` binary blocks until `execute-command` completes. Since `deploy.sh` takes 3-5 minutes (git pull, docker compose build, migrations, health checks), the CI `curl` always times out at `--max-time 20`, triggering 8 retries that all hit `LOCK_CONTENTION` (HTTP 500).

This caused every deploy workflow run since v2.6.16 to fail:
- Run `23104888735` (v2.6.17): HTTP 000 → 502 → 500 LOCK_CONTENTION → HTTP 000 timeouts
- Run `23104755274` (PR #255): HTTP 500 LOCK_CONTENTION (all 8 attempts)

## Changes

### `scripts/deploy-wrapper.sh` (new)
Async launcher that starts `deploy.sh` via `nohup` in the background and returns immediately, so the webhook responds in <1s.

### `deploy/hooks.json`
Points `execute-command` to `deploy-wrapper.sh` instead of `deploy.sh`.

### `.github/workflows/deploy.yml`
- `--max-time`: 20 → 30 (generous for the wrapper's <1s response)
- `max_attempts`: 8 → 3 (wrapper returns fast; retries are unnecessary)
- `sleep` backoff: `attempt * 4` → `attempt * 5`

## Verification

- `deploy-wrapper.sh` is `100755` (executable bit set in git index)
- Homelab is currently at v2.6.17 and healthy (manual deploy succeeded earlier)
- The wrapper pattern isolates the long-running deploy from the webhook HTTP response cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified deployment retry strategy with increased request timeout (30s), reduced retry attempts (3), and extended backoff intervals (5s) between retries.
  * Refactored deployment process to run asynchronously in the background, enabling faster workflow completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->