### PR TITLE
chore(skills): add deploy-homelab skill and fix stale URLs

### DIFF
--- a/.cursor/skills/deploy-homelab/SKILL.md
+++ b/.cursor/skills/deploy-homelab/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: deploy-homelab
+description: Debug and manage Lucky homelab deployments. Use when deploy workflow fails, webhook returns errors, or containers need recovery on the homelab server.
+---
+
+# Lucky Deploy to Homelab
+
+## When to use
+
+- Deploy workflow fails in GitHub Actions
+- Webhook returns HTTP 500, 502, or 000 (timeout)
+- Need to manually deploy or recover containers on homelab
+- Investigating deploy lock contention or script failures
+
+## Architecture
+
+```
+GitHub Actions (deploy.yml)
+  -> curl POST -> Cloudflare tunnel
+                    -> nginx:80
+                        -> /webhook/* -> webhook:9000 (almir/webhook)
+                                          -> deploy-wrapper.sh (async)
+                                                -> deploy.sh (nohup background)
+```
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/deploy.yml` | CI workflow: triggers on CI/CD Pipeline success on main or workflow_dispatch |
+| `scripts/deploy-wrapper.sh` | Async launcher: nohup starts deploy.sh, returns immediately |
+| `scripts/deploy.sh` | Full deploy: git pull, docker compose build, migrations, health checks, Discord notify |
+| `deploy/hooks.json` | Webhook binary config: points to deploy-wrapper.sh |
+| `deploy/Dockerfile` | Webhook container image (almir/webhook + git + docker-cli + compose) |
+| `docker-compose.yml` | Production compose with 8 services |
+
+## Common failure patterns
+
+### HTTP 000 (timeout)
+- **Old cause**: deploy.yml had `--max-time 20` but deploy takes 3-5 min and webhook blocked. Fixed by async wrapper.
+- **Current**: `--max-time 30` with wrapper returning in <1s. If still 000, check Cloudflare tunnel or nginx.
+
+### HTTP 500 empty body
+- **Cause**: `deploy.sh` not executable (mode 100644). Webhook can't execute it.
+- **Fix**: `git update-index --chmod=+x scripts/deploy.sh`
+
+### HTTP 500 LOCK_CONTENTION
+- **Cause**: Another deploy is already running. Deploy.sh uses flock at `/tmp/lucky-deploy.lock`.
+- **Fix**: Wait for current deploy to finish, or remove lock: `docker exec lucky-webhook rm -f /tmp/lucky-deploy.lock`
+
+### HTTP 502 Bad Gateway
+- **Cause**: nginx can't reach webhook container. Check if webhook is running.
+- **Fix**: `docker compose restart webhook`
+
+## SSH access
+
+```bash
+# Via Tailscale
+ssh luk-server@100.95.204.103
+
+# Check containers
+docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+
+# Check deploy logs
+docker exec lucky-webhook cat /tmp/lucky-deploy.log
+
+# Manual deploy (bypasses webhook)
+docker exec lucky-webhook bash /home/luk-server/Lucky/scripts/deploy.sh "$DEPLOY_WEBHOOK_SECRET"
+
+# Check file permissions
+docker exec lucky-webhook ls -la /home/luk-server/Lucky/scripts/deploy*.sh
+```
+
+## Deploy workflow triggers
+
+- **Automatic**: `workflow_run` after CI/CD Pipeline completes on main
+- **Manual**: `workflow_dispatch` from Actions tab or `gh workflow run deploy.yml`
+
+## Smoke checks (after deploy)
+
+```bash
+# Internal (from homelab)
+docker exec lucky-nginx curl -s http://lucky-backend:3000/api/health
+docker exec lucky-nginx curl -s http://lucky-backend:3000/api/health/auth-config
+
+# External
+curl -s https://lucky.lucassantana.tech/api/health
+curl -s https://lucky.lucassantana.tech/api/health/auth-config
+```
+
+## Docker services
+
+| Container | Port | Notes |
+|-----------|------|-------|
+| lucky-backend | 3000 (internal) | Express API, no host port mapping |
+| lucky-bot | - | Discord.js bot |
+| lucky-frontend | 80 (internal) | React SPA |
+| lucky-nginx | 80 (host) | Reverse proxy |
+| lucky-postgres | 5432 | PostgreSQL |
+| lucky-redis | 6379 | Redis |
+| lucky-tunnel | - | Cloudflare tunnel |
+| lucky-webhook | 9000 (internal) | almir/webhook, no host port |
+
+## Gotchas
+
+- Backend listens on port 3000 inside container, NOT 3001. No host port mapping.
+- Webhook container has no host port mapping -- traffic only via nginx.
+- `deploy.sh` must be `100755` in git. PRs that touch it can accidentally change mode.
+- `deploy-wrapper.sh` uses nohup -- deploy logs go to `/tmp/lucky-deploy.log` inside webhook container.
+- Nginx rewrites `/webhook/(.*)` to `/hooks/$1` before proxying to webhook:9000.

--- a/.cursor/skills/lucky-ci-gate-recovery/SKILL.md
+++ b/.cursor/skills/lucky-ci-gate-recovery/SKILL.md
@@ -80,13 +80,13 @@ gh pr merge <PR#> --squash --match-head-commit "$SHA"
 ## Post-merge smoke contract
 
 ```bash
-curl -i https://lucky-api.lucassantana.tech/api/health
-curl -i https://lucky-api.lucassantana.tech/api/health/auth-config
-curl -i https://lucky-api.lucassantana.tech/api/auth/discord
+curl -i https://lucky.lucassantana.tech/api/health
+curl -i https://lucky.lucassantana.tech/api/health/auth-config
+curl -i https://lucky.lucassantana.tech/api/auth/discord
 ```
 
 Expect:
 
-- `/api/health` => `200`
-- `/api/health/auth-config` => `status: ok`
-- `/api/auth/discord` => `302`
+- `/api/health` => `200` with `{"status":"ok","redis":true}`
+- `/api/health/auth-config` => `200` with `status: ok`, valid clientId, redirectUri, redis healthy
+- `/api/auth/discord` => `302` to `discord.com/api/oauth2/authorize`

--- a/.cursor/skills/lucky-deploy-recovery/SKILL.md
+++ b/.cursor/skills/lucky-deploy-recovery/SKILL.md
@@ -50,9 +50,9 @@ gh run watch <RUN_ID> --exit-status
 5. Post-deploy smoke:
 
 ```bash
-curl -i https://lucky-api.lucassantana.tech/api/health
-curl -i https://lucky-api.lucassantana.tech/api/health/auth-config
-curl -i https://lucky-api.lucassantana.tech/api/auth/discord
+curl -i https://lucky.lucassantana.tech/api/health
+curl -i https://lucky.lucassantana.tech/api/health/auth-config
+curl -i https://lucky.lucassantana.tech/api/auth/discord
 ```
 
 ## Rerun policy
@@ -60,3 +60,7 @@ curl -i https://lucky-api.lucassantana.tech/api/auth/discord
 - One immediate rerun is allowed for `LOCK_CONTENTION`.
 - If rerun still fails with `CHECKOUT_RECOVERY_FAILED`, perform host checkout cleanup before another rerun.
 - Do not keep blind rerunning on repeated `CHECKOUT_RECOVERY_FAILED`; require host cleanup evidence first.
+
+## See also
+
+- `deploy-homelab` skill for full architecture, SSH access, container details, and manual deploy procedures

--- a/.cursor/skills/lucky-docker-dev/SKILL.md
+++ b/.cursor/skills/lucky-docker-dev/SKILL.md
@@ -44,6 +44,8 @@ description: Run and test Lucky with Docker. Use when changing docker-compose, D
     - wrong secret request -> non-2xx with explicit error
     - correct secret request -> waits for deploy command completion and returns command output
 4. If proxy timeout interferes, test direct webhook endpoint via container IP (`http://<webhook-ip>:9000/hooks/deploy`) to isolate signaling from edge timeouts.
-5. Keep deploy workflow trigger timeouts aligned with synchronous webhook behavior:
-    - trigger curl `--max-time` must exceed full deploy duration
-    - retries should be transport-only (`HTTP 000`) to avoid duplicate deploy storms
+5. Deploy uses async wrapper (`deploy-wrapper.sh`) that returns immediately while `deploy.sh` runs in background via nohup:
+    - Webhook responds in <1s, so CI curl timeout (30s) is sufficient
+    - Deploy logs go to `/tmp/lucky-deploy.log` inside webhook container
+    - Lock contention is still possible if a previous deploy is still running
+    - For detailed deploy debugging, see the `deploy-homelab` skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ At the start of every session:
 | Schema, migrations, DB/Redis in shared            | `prisma-redis-lucky`       |
 | Docker, compose, local run                        | `lucky-docker-dev`         |
 | Workflow green but production stale deploy drift  | `lucky-deploy-recovery`    |
+| Deploy fails, webhook errors, container recovery   | `deploy-homelab`           |
 | Frontend (React, Vite, Tailwind)                  | `frontend-react-vite`      |
 | Backend (Express API, routes, services)           | `backend-express`          |
 | E2E tests, Playwright, browser verification       | `e2e-playwright`           |


### PR DESCRIPTION
## Summary

- **New skill**: `deploy-homelab` — comprehensive reference for debugging and managing Lucky homelab deployments (architecture diagram, failure patterns, SSH commands, smoke checks, container details)
- **Fix**: `lucky-ci-gate-recovery` — corrected smoke URLs from `lucky-api.lucassantana.tech` to `lucky.lucassantana.tech`, added richer expected response details
- **Fix**: `lucky-deploy-recovery` — corrected same wrong domain, added cross-reference to `deploy-homelab`
- **Update**: `lucky-docker-dev` — replaced stale synchronous webhook docs with async wrapper (`deploy-wrapper.sh`) details, added backend port clarification
- **Update**: `AGENTS.md` — added `deploy-homelab` to the project skills table

## Why

During the v2.6.17 deploy incident investigation, we discovered:
1. No skill existed for the full deploy architecture (webhook → nginx → tunnel → containers)
2. Three skills had `lucky-api.lucassantana.tech` URLs that don't exist (correct: `lucky.lucassantana.tech`)
3. Docker dev skill still referenced synchronous webhook behavior after PR #258 switched to async wrapper

## Testing

Skills are documentation-only (Markdown). No runtime impact.