### PR TITLE
fix(deploy): bake hooks.json into webhook image to bypass VOLUME shadow

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,3 +2,7 @@ FROM almir/webhook:latest
 
 USER root
 RUN apk add --no-cache git docker-cli docker-cli-compose bash
+
+# Copy hooks config at build time so the VOLUME /etc/webhook declared
+# in the base image is initialised with the correct content.
+COPY hooks.json /etc/webhook/hooks.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,13 +173,12 @@ services:
         restart: unless-stopped
         command: >
             -hooks /etc/webhook/hooks.json
-            -hotreload
+            -verbose
         environment:
             - DEPLOY_WEBHOOK_SECRET=${DEPLOY_WEBHOOK_SECRET}
             - DISCORD_DEPLOY_WEBHOOK=${DISCORD_DEPLOY_WEBHOOK:-}
             - DEPLOY_DIR=/home/luk-server/Lucky
         volumes:
-            - ./deploy/hooks.json:/etc/webhook/hooks.json:ro
             - .:/home/luk-server/Lucky
             - ${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:ro
             - /var/run/docker.sock:/var/run/docker.sock

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -459,5 +459,11 @@ fi
 log "Pruning old images..."
 docker image prune -f --filter "until=24h"
 
+# Rebuild the webhook container last so it picks up any hooks.json changes.
+# This kills the current deploy-wrapper.sh process, so it MUST be the final step.
+log "Rebuilding webhook container..."
+docker_compose build --no-cache webhook
+docker_compose up -d --force-recreate --no-deps webhook
+
 log "Deploy complete!"
 notify 65280 "Deploy Successful" "All services healthy and running"


### PR DESCRIPTION
## Summary

The `almir/webhook` base image declares `VOLUME /etc/webhook`, which creates an anonymous volume that **shadows** the docker-compose bind mount of `hooks.json`. This caused the webhook container to use a stale copy of `hooks.json`, ignoring the switch from `deploy.sh` to `deploy-wrapper.sh` (PR #258).

## Root Cause

1. Base image: `VOLUME /etc/webhook` creates anonymous volume
2. Bind mount: `./deploy/hooks.json:/etc/webhook/hooks.json:ro` is shadowed
3. Container sees hooks.json frozen from first creation, not the updated host file
4. `-hotreload` watches the volume copy (stale), not the bind mount
5. `deploy.sh` never rebuilt/restarted the webhook container

This is why deploy runs after PR #258 still called `deploy.sh` directly instead of `deploy-wrapper.sh`.

## Changes

- **`deploy/Dockerfile`**: `COPY hooks.json` at build time — anonymous volume initialized with correct content
- **`docker-compose.yml`**: Remove shadowed bind mount, replace `-hotreload` with `-verbose`
- **`scripts/deploy.sh`**: Rebuild webhook container as the **last** deploy step (after all health checks pass)

## Impact

- Fixes 11 consecutive deploy failures since `afec5890`
- Future `hooks.json` changes will be picked up on every deploy via image rebuild
- The webhook rebuild kills the running `deploy-wrapper.sh` process, so it MUST be the last step

## Testing

After merge, trigger a `workflow_dispatch` deploy and verify:
1. CI curl gets HTTP 200 with "Deploy triggered" (fast response from async wrapper)
2. `docker exec lucky-webhook cat /etc/webhook/hooks.json` shows `deploy-wrapper.sh`
3. All containers healthy after deploy completes

Fixes the remaining issue from #258.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Webhook configuration is now built into the Docker image at build time rather than mounted at runtime.
  * Webhook service now runs in verbose mode for enhanced logging.
  * Deployment process now automatically rebuilds and restarts the webhook container to ensure configuration updates are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->