### PR TITLE
fix(deploy): mount hooks.json to /hooks/ to bypass VOLUME shadow

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,6 +3,9 @@ FROM almir/webhook:latest
 USER root
 RUN apk add --no-cache git docker-cli docker-cli-compose bash
 
-# Copy hooks config at build time so the VOLUME /etc/webhook declared
-# in the base image is initialised with the correct content.
-COPY hooks.json /etc/webhook/hooks.json
+# Copy hooks config to /hooks/ — a path NOT declared as VOLUME by the
+# base image.  The base image declares VOLUME /etc/webhook which causes
+# anonymous-volume shadowing and makes bind-mounts or COPY to that path
+# unreliable across container recreates.
+RUN mkdir -p /hooks
+COPY hooks.json /hooks/hooks.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,14 +172,16 @@ services:
         container_name: lucky-webhook
         restart: unless-stopped
         command: >
-            -hooks /etc/webhook/hooks.json
+            -hooks /hooks/hooks.json
             -verbose
+            -hotreload
         environment:
             - DEPLOY_WEBHOOK_SECRET=${DEPLOY_WEBHOOK_SECRET}
             - DISCORD_DEPLOY_WEBHOOK=${DISCORD_DEPLOY_WEBHOOK:-}
             - DEPLOY_DIR=/home/luk-server/Lucky
         volumes:
             - .:/home/luk-server/Lucky
+            - ./deploy/hooks.json:/hooks/hooks.json:ro
             - ${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:ro
             - /var/run/docker.sock:/var/run/docker.sock
         working_dir: /home/luk-server/Lucky

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -460,10 +460,12 @@ log "Pruning old images..."
 docker image prune -f --filter "until=24h"
 
 # Rebuild the webhook container last so it picks up any hooks.json changes.
+# -V (--renew-anon-volumes) ensures the VOLUME /etc/webhook from the base
+# image gets a fresh anonymous volume instead of reusing a stale one.
 # This kills the current deploy-wrapper.sh process, so it MUST be the final step.
 log "Rebuilding webhook container..."
 docker_compose build --no-cache webhook
-docker_compose up -d --force-recreate --no-deps webhook
+docker_compose up -d -V --force-recreate --no-deps webhook
 
 log "Deploy complete!"
 notify 65280 "Deploy Successful" "All services healthy and running"


### PR DESCRIPTION
## Summary

PR #261 attempted to fix the webhook VOLUME shadow by `COPY`ing `hooks.json` into `/etc/webhook/` at build time. This does **not** work because Docker's `VOLUME` directive creates an anonymous volume at container runtime that shadows the image layer — the `COPY`'d file is hidden by a stale (0-byte) anonymous volume from the previous container.

## Root Cause

The `almir/webhook` base image declares `VOLUME /etc/webhook`. Any content written to that path during `docker build` (via `COPY` or `RUN`) gets committed to the image layer, but at container startup Docker mounts an anonymous volume over it. On `--force-recreate`, Docker reuses the old anonymous volume (with stale/empty content), making the bind mount and `COPY` approaches both ineffective.

## Fix

1. **Dockerfile**: `COPY hooks.json` to `/hooks/hooks.json` — a path NOT declared as `VOLUME` by the base image
2. **docker-compose.yml**: Bind-mount `./deploy/hooks.json:/hooks/hooks.json:ro` and update the command to `-hooks /hooks/hooks.json -verbose -hotreload`
3. **deploy.sh**: Add `-V` (`--renew-anon-volumes`) flag to `docker compose up` during webhook rebuild to prevent stale anonymous volume reuse

## Impact

- Webhook container will now always see the correct `hooks.json` configuration
- `-hotreload` works again since it watches the bind-mounted file at `/hooks/`
- Future deploys via the async wrapper (`deploy-wrapper.sh`) should succeed through the CI webhook call