### PR TITLE
chore(release): prepare v2.6.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.18] - 2026-03-15
+
 ### Added
 
 - Startup session sweep (`restoreSessionsOnStartup`) — on `clientReady`, the
@@ -15,6 +17,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Stale snapshots are deleted. Per-guild errors are isolated so one failure
   does not abort the rest. Gated by `MUSIC_SESSION_RESTORE_ENABLED` (default
   enabled).
+- Deploy-homelab skill (`.cursor/skills/deploy-homelab/SKILL.md`) with full
+  architecture diagram, failure patterns, SSH commands, and container details.
+
+### Changed
+
+- Deploy webhook now uses async wrapper (`deploy-wrapper.sh`) that launches
+  `deploy.sh` via `nohup` and returns HTTP 200 immediately, eliminating CI
+  curl timeouts and LOCK_CONTENTION cascades (#258).
+- Deploy workflow (`deploy.yml`) reduced `max_attempts` from 8 to 3 and
+  adjusted `max-time` to 30s to match async response pattern (#258).
+- Webhook hooks.json now mounts at `/hooks/hooks.json` instead of
+  `/etc/webhook/hooks.json` to avoid the `almir/webhook` base image
+  `VOLUME /etc/webhook` anonymous volume shadow (#262).
+- Deploy script rebuilds the webhook container as the final step so
+  hooks.json changes take effect on the next deploy cycle (#261).
+- Replaced `-hotreload` with `-verbose` in webhook command since config
+  is now baked into the image at build time (#261, #262).
+
+### Fixed
+
+- Fixed webhook VOLUME shadow where `almir/webhook` base image `VOLUME`
+  directive created an anonymous volume that shadowed bind-mounted
+  `hooks.json`, causing the container to use stale config (#261, #262).
+- Fixed CI gate URLs in `lucky-ci-gate-recovery` and `lucky-deploy-recovery`
+  skills (corrected domain from `lucky-api` to `lucky`) (#259).
 
 ## [2.6.17] - 2026-03-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.17",
+    "version": "2.6.18",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary

Bumps version to 2.6.18 and promotes CHANGELOG entries for PRs #258-#262:

### Added
- Startup session sweep for music sessions on bot startup (PR #260)
- Deploy-homelab skill with architecture, failure patterns, and SSH commands (PR #259)

### Changed
- Async webhook wrapper (`deploy-wrapper.sh`) eliminates CI curl timeouts (PR #258)
- Deploy workflow reduced retry attempts and adjusted timeouts (PR #258)
- Webhook hooks.json moved to `/hooks/` to avoid VOLUME shadow (PR #262)
- Webhook container rebuilt as final deploy step (PR #261)

### Fixed
- Webhook VOLUME shadow causing stale hooks.json config (PRs #261, #262)
- CI gate URLs in deploy recovery skills (PR #259)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced deployment capabilities with asynchronous support
  * Improved webhook and CI workflow configuration
  * Optimized volume path management

* **Bug Fixes**
  * Resolved webhook volume configuration issues
  * Fixed CI gate URL references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->