### PR TITLE
fix(deploy): deferred webhook recreate to survive self-rebuild

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -459,13 +459,26 @@ fi
 log "Pruning old images..."
 docker image prune -f --filter "until=24h"
 
-# Rebuild the webhook container last so it picks up any hooks.json changes.
-# -V (--renew-anon-volumes) ensures the VOLUME /etc/webhook from the base
-# image gets a fresh anonymous volume instead of reusing a stale one.
-# This kills the current deploy-wrapper.sh process, so it MUST be the final step.
+# Rebuild the webhook container to pick up any hooks.json / Dockerfile changes.
+# When deploy.sh runs INSIDE the webhook container (via deploy-wrapper.sh),
+# the recreate command kills our own container. We handle this by:
+#   1. Building the new image first (safe, doesn't kill anything)
+#   2. Releasing the deploy lock BEFORE the recreate
+#   3. Firing the recreate detached so the Docker daemon completes it
+#      even after our process is killed
 log "Rebuilding webhook container..."
 docker_compose build --no-cache webhook
-docker_compose up -d -V --force-recreate --no-deps webhook
 
 log "Deploy complete!"
 notify 65280 "Deploy Successful" "All services healthy and running"
+
+# Release lock before recreating webhook (which may kill this process)
+# Lock is normally released by the EXIT trap, but we need it gone before
+# the detached recreate fires (which kills this process and triggers EXIT).
+rm -rf "$LOCK_DIR" 2>/dev/null || true
+trap - EXIT
+
+# Detach the recreate so Docker daemon handles it independently of this process.
+# The -V flag renews anonymous volumes to avoid stale VOLUME shadow.
+log "Recreating webhook container (detached)..."
+nohup docker_compose up -d -V --force-recreate --no-deps webhook > /dev/null 2>&1 &


### PR DESCRIPTION
## Summary

When `deploy.sh` runs inside the webhook container (via `deploy-wrapper.sh`), the `docker compose up --force-recreate webhook` at the end kills the container it's running inside. This leaves the webhook in `Exited(0)` state with a mangled container name, breaking subsequent deploys.

## Root Cause

`deploy.sh` lines 462-468 ran `docker compose up -d -V --force-recreate --no-deps webhook` synchronously as the final step. Since the script runs inside the webhook container, this command kills its own host container mid-execution, leaving Docker in an inconsistent state.

## Fix

1. **Build first** — `docker compose build --no-cache webhook` (safe, doesn't kill anything)
2. **Send success notification** — deploy is complete before the risky recreate
3. **Release deploy lock** — explicitly remove lock dir and clear EXIT trap before the recreate
4. **Detached recreate** — `nohup docker compose up -d -V --force-recreate --no-deps webhook > /dev/null 2>&1 &` so the Docker daemon completes it independently

## Testing

After this fix:
- Automated CI deploys should complete green (HTTP 200 from async wrapper)
- The webhook container will be recreated by the Docker daemon even if the parent process is killed
- No stale lock files will be left behind
- Subsequent deploys will work without manual intervention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow by converting webhook container recreation to asynchronous background processing, eliminating blocking operations and accelerating deployment cycles.
  * Improved deployment reliability with enhanced lock management, including cleanup safeguards and better logging visibility into the deployment process flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->