### PR TITLE
feat(bot): surface recommendation feedback state in /music health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/music health` now shows a **Recommendation feedback** field with the count
+  of tracks the user has disliked, giving visibility into autoplay filtering
+  state without leaving the health embed.
+
 ## [2.6.18] - 2026-03-15
 
 ### Added

--- a/packages/bot/src/functions/music/commands/music.spec.ts
+++ b/packages/bot/src/functions/music/commands/music.spec.ts
@@ -13,6 +13,14 @@ const getAllStatusesMock = jest.fn()
 const getGuildStateMock = jest.fn()
 const getSnapshotMock = jest.fn()
 const resolveGuildQueueMock = jest.fn()
+const getDislikedTrackKeysMock = jest.fn()
+
+jest.mock('../../../services/musicRecommendation/feedbackService', () => ({
+    recommendationFeedbackService: {
+        getDislikedTrackKeys: (...args: unknown[]) =>
+            getDislikedTrackKeysMock(...args),
+    },
+}))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
     interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
@@ -54,6 +62,7 @@ jest.mock('../../../utils/music/queueResolver', () => ({
 function createInteraction(subcommand = 'health', guildId = 'guild-1') {
     return {
         guildId,
+        user: { id: 'user-1' },
         options: {
             getSubcommand: jest.fn(() => subcommand),
         },
@@ -87,6 +96,7 @@ describe('music command', () => {
             lastRecoveryDetail: null,
         })
         getSnapshotMock.mockResolvedValue(null)
+        getDislikedTrackKeysMock.mockResolvedValue(new Set())
         resolveGuildQueueMock.mockReturnValue({
             queue: null,
             source: 'miss',
@@ -296,5 +306,30 @@ describe('music command', () => {
         expect(watchdogField?.value).toContain(
             'Last recovery detail: started_next_track',
         )
+    })
+
+    it('shows disliked track count in recommendation feedback field', async () => {
+        getDislikedTrackKeysMock.mockResolvedValue(
+            new Set(['track::artist1', 'track::artist2']),
+        )
+
+        await musicCommand.execute({
+            client: createClient(),
+            interaction: {
+                ...createInteraction(),
+                user: { id: 'user-1' },
+            },
+        } as any)
+
+        const payload = createEmbedMock.mock.calls.at(-1)?.[0] as {
+            fields: Array<{ name: string; value: string }>
+        }
+        const feedbackField = payload.fields.find(
+            (field) => field.name === 'Recommendation feedback',
+        )
+
+        expect(feedbackField).toBeDefined()
+        expect(feedbackField?.value).toContain('Disliked tracks: 2')
+        expect(getDislikedTrackKeysMock).toHaveBeenCalledWith('guild-1', expect.any(String))
     })
 })

--- a/packages/bot/src/functions/music/commands/music.ts
+++ b/packages/bot/src/functions/music/commands/music.ts
@@ -22,6 +22,7 @@ import {
     resolveGuildQueue,
     type QueueResolutionResult,
 } from '../../../utils/music/queueResolver'
+import { recommendationFeedbackService } from '../../../services/musicRecommendation/feedbackService'
 import type { GuildQueue } from 'discord-player'
 
 function formatProviderHealth(statuses: ProviderStatus[]): string {
@@ -69,6 +70,21 @@ function formatResolverDiagnostics(resolution: QueueResolutionResult): string {
             : 'none'
 
     return `Source: ${source}\nCache size: ${diagnostics.cacheSize}\nCache keys: ${keys}`
+}
+
+async function formatFeedbackState(
+    guildId: string,
+    userId: string,
+): Promise<string> {
+    const dislikedKeys = await recommendationFeedbackService.getDislikedTrackKeys(
+        guildId,
+        userId,
+    )
+    const dislikedCount = dislikedKeys.size
+    if (dislikedCount === 0) {
+        return 'No feedback recorded. Use /recommendation feedback to tune autoplay.'
+    }
+    return `Disliked tracks: ${dislikedCount} (filtered from autoplay)`
 }
 
 function buildActionableSteps({
@@ -174,6 +190,10 @@ export default new Command({
         const watchdog = musicWatchdogService.getGuildState(guildId)
         const snapshot = await musicSessionSnapshotService.getSnapshot(guildId)
         const providers = Object.values(providerHealthService.getAllStatuses())
+        const feedbackState = await formatFeedbackState(
+            guildId,
+            interaction.user.id,
+        )
         const actions = buildActionableSteps({
             queue,
             providers,
@@ -220,6 +240,11 @@ export default new Command({
                               `Upcoming tracks: ${snapshot.upcomingTracks.length}`,
                           ].join('\n')
                         : 'No snapshot saved',
+                    inline: false,
+                },
+                {
+                    name: 'Recommendation feedback',
+                    value: feedbackState,
                     inline: false,
                 },
                 {


### PR DESCRIPTION
## Summary

- Adds a **Recommendation feedback** field to `/music health` showing the user's disliked track count, making autoplay filtering state visible without needing a separate command.
- New `formatFeedbackState()` helper calls `recommendationFeedbackService.getDislikedTrackKeys()` for the invoking user.
- 1 new test in `music.spec.ts` covering the disliked count path; all 7 tests pass.
- `CHANGELOG.md` updated under `[Unreleased]`.

Closes #264