### PR TITLE
fix(docker): skip yt-dlp binary download in frontend build

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -11,6 +11,7 @@ COPY packages/frontend/package*.json ./packages/frontend/
 
 RUN --mount=type=cache,id=npm-frontend-builder,target=/root/.npm,sharing=locked \
     YOUTUBE_DL_SKIP_PYTHON_CHECK=1 \
+    YOUTUBE_DL_SKIP_DOWNLOAD=true \
     npm ci --legacy-peer-deps --no-audit --no-fund && \
     (npm cache verify 2>/dev/null || true)
 


### PR DESCRIPTION
## Summary

- Adds `YOUTUBE_DL_SKIP_DOWNLOAD=true` to the frontend Docker build stage
- Prevents `youtube-dl-exec` postinstall from calling GitHub Releases API during `npm ci`
- The frontend image does not need the yt-dlp binary; only the bot uses it at runtime

## Root Cause

The Build & Push workflow for the frontend image was failing with GitHub API rate limit errors:
```
npm error Error: {
  "message": "API rate limit exceeded for 52.159.243.193..."
}
```

During `npm ci` in the Docker build, `youtube-dl-exec` postinstall script fetches the yt-dlp binary from GitHub Releases. In CI (Docker builder), this request is unauthenticated and hits the rate limit. The existing `YOUTUBE_DL_SKIP_PYTHON_CHECK=1` only skips the Python check, not the download.

## Fix

Add `YOUTUBE_DL_SKIP_DOWNLOAD=true` which is the documented env var for this package to skip the binary download entirely during postinstall.