### PR TITLE
feat(bot): enforce artist and source diversity caps in autoplay selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of tracks the user has disliked, giving visibility into autoplay filtering
   state without leaving the health embed.
 
+### Changed
+
+- Autoplay fallback selection now enforces configurable **artist diversity** (max
+  2 tracks per artist, up from 1) and **source diversity** (max 3 tracks per
+  source) caps via `selectDiverseCandidates`, preventing a single artist or
+  platform from dominating the queue.
+- Same-source bonus in recommendation scoring replaced with a **same-source
+  penalty** (−0.15), promoting cross-platform variety; different-source
+  candidates are now preferred over same-source ones.
+- `RecommendationConfig` extended with `maxTracksPerArtist` (default 2) and
+  `maxTracksPerSource` (default 3) fields for future tunability.
+
 ## [2.6.18] - 2026-03-15
 
 ### Added

--- a/packages/bot/src/services/musicRecommendation/index.ts
+++ b/packages/bot/src/services/musicRecommendation/index.ts
@@ -27,6 +27,8 @@ export class MusicRecommendationService {
             durationWeight: 0.05,
             popularityWeight: 0.05,
             diversityFactor: 0.3,
+            maxTracksPerArtist: 2,
+            maxTracksPerSource: 3,
             ...config,
         }
     }

--- a/packages/bot/src/services/musicRecommendation/types.ts
+++ b/packages/bot/src/services/musicRecommendation/types.ts
@@ -20,6 +20,8 @@ export type RecommendationConfig = {
   durationWeight: number
   popularityWeight: number
   diversityFactor: number
+  maxTracksPerArtist: number
+  maxTracksPerSource: number
 }
 
 export type RecommendationResult = {

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -294,6 +294,60 @@ describe('queueManipulation.replenishQueue', () => {
         )
     })
 
+    it('caps autoplay to maxTracksPerArtist when same-artist candidates score highest', async () => {
+        // 3 tracks from 'Artist B' + 1 from 'Artist C'. With MAX_TRACKS_PER_ARTIST=2 (default),
+        // should pick at most 2 from 'Artist B' + 1 from 'Artist C' = 3 total (buffer needs 4)
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        { title: 'Same Artist 1', author: 'Artist B', url: 'https://example.com/b1', source: 'soundcloud' },
+                        { title: 'Same Artist 2', author: 'Artist B', url: 'https://example.com/b2', source: 'soundcloud' },
+                        { title: 'Same Artist 3', author: 'Artist B', url: 'https://example.com/b3', source: 'soundcloud' },
+                        { title: 'Fresh Song', author: 'Artist C', url: 'https://example.com/c1', source: 'spotify' },
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        // Should have at most 2 tracks from Artist B + 1 from Artist C = 3 total
+        const calls = queue.addTrack.mock.calls
+        const artistBCount = calls.filter((c) =>
+            (c[0] as Track).author === 'Artist B'
+        ).length
+        expect(artistBCount).toBeLessThanOrEqual(2)
+        expect(queue.addTrack).toHaveBeenCalledTimes(3)
+    })
+
+    it('caps autoplay tracks by source when all candidates are from same source', async () => {
+        // 5 candidates all from 'youtube'. With MAX_TRACKS_PER_SOURCE=3 (default), at most 3 selected.
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: { title: 'Song A', author: 'Artist A', url: 'https://example.com/a', source: 'spotify' } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        { title: 'Y Song 1', author: 'Artist B', url: 'https://example.com/y1', source: 'youtube' },
+                        { title: 'Y Song 2', author: 'Artist C', url: 'https://example.com/y2', source: 'youtube' },
+                        { title: 'Y Song 3', author: 'Artist D', url: 'https://example.com/y3', source: 'youtube' },
+                        { title: 'Y Song 4', author: 'Artist E', url: 'https://example.com/y4', source: 'youtube' },
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const calls = queue.addTrack.mock.calls
+        const youtubeCount = calls.filter((c) =>
+            (c[0] as Track).source === 'youtube'
+        ).length
+        expect(youtubeCount).toBeLessThanOrEqual(3)
+    })
+
     it('returns without adding tracks when candidate set is exhausted', async () => {
         const queue = await replenishWithSingleCandidate({
             candidateTitle: 'Song A clone',

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -12,6 +12,8 @@ import { recommendationFeedbackService } from '../../services/musicRecommendatio
 const AUTOPLAY_BUFFER_SIZE = 4
 const HISTORY_SEED_LIMIT = 3
 const SEARCH_RESULTS_LIMIT = 8
+const MAX_TRACKS_PER_ARTIST = 2
+const MAX_TRACKS_PER_SOURCE = 3
 
 type ScoredTrack = {
     track: Track
@@ -355,20 +357,26 @@ function upsertScoredCandidate(
 function selectDiverseCandidates(
     candidates: Map<string, ScoredTrack>,
     missingTracks: number,
+    maxPerArtist = MAX_TRACKS_PER_ARTIST,
+    maxPerSource = MAX_TRACKS_PER_SOURCE,
 ): ScoredTrack[] {
     const sortedCandidates = Array.from(candidates.values()).sort(
         (a, b) => b.score - a.score,
     )
     const selected: ScoredTrack[] = []
-    const selectedArtists = new Set<string>()
+    const artistCount = new Map<string, number>()
+    const sourceCount = new Map<string, number>()
 
     for (const candidate of sortedCandidates) {
         const artistKey = candidate.track.author.toLowerCase()
-        if (selectedArtists.has(artistKey)) {
-            continue
-        }
+        const sourceKey = (candidate.track.source ?? 'unknown').toLowerCase()
+
+        if ((artistCount.get(artistKey) ?? 0) >= maxPerArtist) continue
+        if ((sourceCount.get(sourceKey) ?? 0) >= maxPerSource) continue
+
         selected.push(candidate)
-        selectedArtists.add(artistKey)
+        artistCount.set(artistKey, (artistCount.get(artistKey) ?? 0) + 1)
+        sourceCount.set(sourceKey, (sourceCount.get(sourceKey) ?? 0) + 1)
         if (selected.length >= missingTracks) {
             break
         }
@@ -496,8 +504,9 @@ function calculateRecommendationScore(
         score -= 0.25
     }
     if (candidate.source === currentTrack.source) {
-        score += 0.1
-        reasons.push('same source profile')
+        score -= 0.15
+    } else if (candidate.source) {
+        reasons.push('source variety')
     }
     const tokenScore = sharedTitleTokenScore(
         candidate.title,


### PR DESCRIPTION
## Summary

Closes #265

- **Artist diversity**: `selectDiverseCandidates` now uses a `Map<string, number>` counter instead of a `Set` — up to `MAX_TRACKS_PER_ARTIST` (2) tracks per artist are allowed, preventing a single artist from being excluded after one match while still ensuring variety.
- **Source diversity**: Added `sourceCount` tracking with `MAX_TRACKS_PER_SOURCE` (3) cap so no single platform (YouTube, Spotify, SoundCloud) dominates the autoplay queue.
- **Scoring fix**: Replaced the same-source bonus (+0.1) with a same-source penalty (−0.15) in `calculateRecommendationScore`, so cross-platform candidates are now preferred.
- **Config extension**: `RecommendationConfig` gains `maxTracksPerArtist` and `maxTracksPerSource` fields (defaults 2 and 3) for future tunability via `MusicRecommendationService`.

## Tests

- 2 new tests in `queueManipulation.spec.ts` covering artist-cap and source-cap behaviour
- All 358 bot tests pass (60 suites)