### PR TITLE
chore(release): prepare v2.6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.19] - 2026-03-15
+
 ### Added
 
 - `/music health` now shows a **Recommendation feedback** field with the count
@@ -24,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   candidates are now preferred over same-source ones.
 - `RecommendationConfig` extended with `maxTracksPerArtist` (default 2) and
   `maxTracksPerSource` (default 3) fields for future tunability.
+
+### Fixed
+
+- Deploy webhook now defers its own restart to prevent self-kill during
+  container update cycles (#270).
+- Webhook container no longer attempts to rebuild itself when it detects it is
+  running inside Docker (#274).
+- Frontend Docker build no longer fails from GitHub API rate-limiting during
+  `youtube-dl-exec` postinstall; binary download is skipped in CI (#272).
 
 ## [2.6.18] - 2026-03-15
 

--- a/package.json
+++ b/package.json
@@ -1,117 +1,117 @@
 {
-    "name": "lucky-bot",
-    "version": "2.6.18",
-    "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
-    "type": "module",
-    "workspaces": [
-        "packages/*"
+  "name": "lucky-bot",
+  "version": "2.6.19",
+  "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
+  "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run db:generate && npm run build --workspace=packages/shared && npm run build --workspace=packages/bot && npm run build --workspace=packages/backend && npm run build --workspace=packages/frontend",
+    "build:shared": "npm run build --workspace=packages/shared",
+    "build:bot": "npm run build --workspace=packages/bot",
+    "build:backend": "npm run build --workspace=packages/backend",
+    "build:frontend": "npm run build --workspace=packages/frontend",
+    "verify:shared-exports": "node scripts/verify-shared-exports.mjs",
+    "dev:bot": "npm run dev --workspace=packages/bot",
+    "dev:backend": "npm run dev --workspace=packages/backend",
+    "dev:frontend": "npm run dev --workspace=packages/frontend",
+    "format": "prettier . --write",
+    "lint": "eslint . -c eslint.config.js",
+    "lint:fix": "eslint . -c eslint.config.js --fix",
+    "type:check": "npm run type:check --workspace=packages/shared && npm run type:check --workspace=packages/bot && npm run type:check --workspace=packages/backend && npm run type:check --workspace=packages/frontend",
+    "test": "npm run test --workspace=packages/backend",
+    "test:backend": "npm run test --workspace=packages/backend -- --ci",
+    "test:bot": "npm run test --workspace=packages/bot -- --ci",
+    "test:frontend": "npm run test --workspace=packages/frontend",
+    "test:all": "npm run test:backend && npm run test:bot && npm run test:frontend",
+    "test:ci": "npm run test --workspace=packages/backend -- --ci",
+    "test:coverage": "npm run test --workspace=packages/backend -- --coverage",
+    "test:e2e": "npm run test:e2e --workspace=packages/frontend",
+    "verify": "npm run lint --workspace=packages/frontend && npm run lint --workspace=packages/backend && npm run build:shared && npm run verify:shared-exports && npm run type:check && npm run build && npm run test:all && npm run audit:high",
+    "audit:critical": "npm audit --audit-level=critical",
+    "audit:high": "npm audit --audit-level=high",
+    "lint:secrets": "secretlint \"**/*\"",
+    "check:outdated": "npm outdated || true",
+    "db:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres} prisma generate --config prisma/prisma.config.ts",
+    "db:migrate": "./scripts/db-migrate-safe.sh",
+    "db:deploy": "prisma migrate deploy --config prisma/prisma.config.ts",
+    "db:reset": "prisma migrate reset --config prisma/prisma.config.ts",
+    "db:seed": "prisma db seed --config prisma/prisma.config.ts",
+    "db:setup": "./scripts/setup-database.sh",
+    "db:status": "prisma migrate status --config prisma/prisma.config.ts",
+    "db:studio": "prisma studio --config prisma/prisma.config.ts",
+    "deploy:remote": "./scripts/deploy-remote.sh",
+    "deploy:homelab": "./scripts/deploy-remote.sh main"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix -c eslint.config.js",
+      "prettier --write"
     ],
-    "scripts": {
-        "build": "npm run db:generate && npm run build --workspace=packages/shared && npm run build --workspace=packages/bot && npm run build --workspace=packages/backend && npm run build --workspace=packages/frontend",
-        "build:shared": "npm run build --workspace=packages/shared",
-        "build:bot": "npm run build --workspace=packages/bot",
-        "build:backend": "npm run build --workspace=packages/backend",
-        "build:frontend": "npm run build --workspace=packages/frontend",
-        "verify:shared-exports": "node scripts/verify-shared-exports.mjs",
-        "dev:bot": "npm run dev --workspace=packages/bot",
-        "dev:backend": "npm run dev --workspace=packages/backend",
-        "dev:frontend": "npm run dev --workspace=packages/frontend",
-        "format": "prettier . --write",
-        "lint": "eslint . -c eslint.config.js",
-        "lint:fix": "eslint . -c eslint.config.js --fix",
-        "type:check": "npm run type:check --workspace=packages/shared && npm run type:check --workspace=packages/bot && npm run type:check --workspace=packages/backend && npm run type:check --workspace=packages/frontend",
-        "test": "npm run test --workspace=packages/backend",
-        "test:backend": "npm run test --workspace=packages/backend -- --ci",
-        "test:bot": "npm run test --workspace=packages/bot -- --ci",
-        "test:frontend": "npm run test --workspace=packages/frontend",
-        "test:all": "npm run test:backend && npm run test:bot && npm run test:frontend",
-        "test:ci": "npm run test --workspace=packages/backend -- --ci",
-        "test:coverage": "npm run test --workspace=packages/backend -- --coverage",
-        "test:e2e": "npm run test:e2e --workspace=packages/frontend",
-        "verify": "npm run lint --workspace=packages/frontend && npm run lint --workspace=packages/backend && npm run build:shared && npm run verify:shared-exports && npm run type:check && npm run build && npm run test:all && npm run audit:high",
-        "audit:critical": "npm audit --audit-level=critical",
-        "audit:high": "npm audit --audit-level=high",
-        "lint:secrets": "secretlint \"**/*\"",
-        "check:outdated": "npm outdated || true",
-        "db:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres} prisma generate --config prisma/prisma.config.ts",
-        "db:migrate": "./scripts/db-migrate-safe.sh",
-        "db:deploy": "prisma migrate deploy --config prisma/prisma.config.ts",
-        "db:reset": "prisma migrate reset --config prisma/prisma.config.ts",
-        "db:seed": "prisma db seed --config prisma/prisma.config.ts",
-        "db:setup": "./scripts/setup-database.sh",
-        "db:status": "prisma migrate status --config prisma/prisma.config.ts",
-        "db:studio": "prisma studio --config prisma/prisma.config.ts",
-        "deploy:remote": "./scripts/deploy-remote.sh",
-        "deploy:homelab": "./scripts/deploy-remote.sh main"
-    },
-    "lint-staged": {
-        "*.{ts,tsx}": [
-            "eslint --fix -c eslint.config.js",
-            "prettier --write"
-        ],
-        "*.{js,json,md}": [
-            "prettier --write"
-        ],
-        "*": [
-            "secretlint"
-        ]
-    },
-    "config": {
-        "commitizen": {
-            "path": "./node_modules/cz-conventional-changelog"
-        }
-    },
-    "engines": {
-        "node": "22.x"
-    },
-    "keywords": [
-        "discord-bot",
-        "typescript",
-        "music-bot",
-        "moderation",
-        "dashboard"
+    "*.{js,json,md}": [
+      "prettier --write"
     ],
-    "author": "",
-    "license": "ISC",
-    "devDependencies": {
-        "@commitlint/cli": "^20.3.1",
-        "@commitlint/config-conventional": "^20.3.1",
-        "@eslint/js": "^9.39.2",
-        "@secretlint/secretlint-rule-preset-recommend": "^8.0.0",
-        "@types/jest": "^30.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.54.0",
-        "@typescript-eslint/parser": "^8.54.0",
-        "eslint-config-prettier": "^10.1.8",
-        "globals": "^17.2.0",
-        "jest": "^30.2.0",
-        "prettier": "^3.8.1",
-        "prisma": "^7.4.2",
-        "secretlint": "^11.0.0",
-        "ts-jest": "^29.4.6",
-        "unfetch": "^5.0.0"
-    },
-    "dependencies": {
-        "@discord-player/extractor": "^7.2.0",
-        "@prisma/adapter-pg": "^7.4.2",
-        "@prisma/client": "^7.4.2",
-        "@snazzah/davey": "^0.1.10",
-        "chalk": "^5.6.2",
-        "discord-player-youtubei": "^2.0.0-dev.2",
-        "jintr": "^3.3.1",
-        "minipass-flush": "^1.0.5",
-        "unleash-client": "^6.10.1"
-    },
-    "overrides": {
-        "fast-xml-parser": ">=4.5.4",
-        "tar": ">=7.5.11",
-        "undici": ">=7.24.0",
-        "flatted": ">=3.4.0",
-        "@smithy/config-resolver": ">=4.4.10",
-        "@aws-sdk/client-sso": ">=3.726.0",
-        "@hono/node-server": ">=1.19.10",
-        "hono": ">=4.12.7",
-        "lodash": ">=4.17.22",
-        "file-type": ">=21.3.2",
-        "yauzl": ">=3.2.1"
+    "*": [
+      "secretlint"
+    ]
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "engines": {
+    "node": "22.x"
+  },
+  "keywords": [
+    "discord-bot",
+    "typescript",
+    "music-bot",
+    "moderation",
+    "dashboard"
+  ],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@commitlint/cli": "^20.3.1",
+    "@commitlint/config-conventional": "^20.3.1",
+    "@eslint/js": "^9.39.2",
+    "@secretlint/secretlint-rule-preset-recommend": "^8.0.0",
+    "@types/jest": "^30.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.54.0",
+    "@typescript-eslint/parser": "^8.54.0",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.2.0",
+    "jest": "^30.2.0",
+    "prettier": "^3.8.1",
+    "prisma": "^7.4.2",
+    "secretlint": "^11.0.0",
+    "ts-jest": "^29.4.6",
+    "unfetch": "^5.0.0"
+  },
+  "dependencies": {
+    "@discord-player/extractor": "^7.2.0",
+    "@prisma/adapter-pg": "^7.4.2",
+    "@prisma/client": "^7.4.2",
+    "@snazzah/davey": "^0.1.10",
+    "chalk": "^5.6.2",
+    "discord-player-youtubei": "^2.0.0-dev.2",
+    "jintr": "^3.3.1",
+    "minipass-flush": "^1.0.5",
+    "unleash-client": "^6.10.1"
+  },
+  "overrides": {
+    "fast-xml-parser": ">=4.5.4",
+    "tar": ">=7.5.11",
+    "undici": ">=7.24.0",
+    "flatted": ">=3.4.0",
+    "@smithy/config-resolver": ">=4.4.10",
+    "@aws-sdk/client-sso": ">=3.726.0",
+    "@hono/node-server": ">=1.19.10",
+    "hono": ">=4.12.7",
+    "lodash": ">=4.17.22",
+    "file-type": ">=21.3.2",
+    "yauzl": ">=3.2.1"
+  }
 }


### PR DESCRIPTION
## v2.6.19

Formalizes 5 commits since v2.6.18 into a patch release.

### Added
- `/music health` now shows a **Recommendation feedback** field with dislike count (#271)

### Changed
- Autoplay enforces artist diversity caps (max 2 per artist) and source diversity caps (max 3 per source) via `selectDiverseCandidates` (#273)
- Same-source bonus replaced with same-source penalty (−0.15) to promote cross-platform variety (#273)

### Fixed
- Deploy webhook defers its own restart to prevent self-kill during updates (#270)
- Webhook container skips self-rebuild when running inside Docker (#274)
- Frontend Docker build skips `youtube-dl-exec` binary download in CI to avoid GitHub API rate-limit (#272)

---
- Bumps `package.json` to `2.6.19`
- Updates `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Music health endpoint now displays recommendation feedback field with autoplay health insights.

* **Improvements**
  * Enhanced autoplay scoring with diversity caps and same-source penalty logic.

* **Bug Fixes**
  * Resolved deployment webhook restart issues during container updates.
  * Fixed frontend installation failures in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->