### PR TITLE
feat(bot): persist provider health cooldown to Redis (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Provider health cooldown state is now **persisted to Redis** and restored on bot startup, so rate-limited providers remain in cooldown across restarts. TTL is set to `2 × MUSIC_PROVIDER_COOLDOWN_MS` (default 4 min). Falls back gracefully when Redis is unavailable (#280).
+
 ## [2.6.20] - 2026-03-15
 
 ### Added

--- a/packages/bot/src/bot/start/initializer.ts
+++ b/packages/bot/src/bot/start/initializer.ts
@@ -7,6 +7,7 @@ import handleEvents from '../../handlers/eventHandler'
 import type { CustomClient } from '../../types'
 import { ConfigurationError } from '@lucky/shared/types'
 import { redisClient } from '@lucky/shared/services'
+import { initProviderHealth } from '../../utils/music/search/providerHealth'
 import type {
     BotInitializationOptions,
     BotInitializationResult,
@@ -97,6 +98,7 @@ export class BotInitializer {
             infoLog({ message: 'Starting bot initialization...' })
 
             await this.initializeRedisServices(options)
+            await initProviderHealth()
             await this.createDiscordClient()
             await this.initializePlayer(options)
             await this.setupCommands(options)

--- a/packages/bot/src/utils/music/search/providerHealth.spec.ts
+++ b/packages/bot/src/utils/music/search/providerHealth.spec.ts
@@ -1,11 +1,35 @@
-import { describe, expect, it } from '@jest/globals'
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import {
     ProviderHealthService,
     providerFromQueryType,
     providerFromTrack,
+    initProviderHealth,
+    providerHealthService,
 } from './providerHealth'
 
+const getMock = jest.fn<() => Promise<string | null>>()
+const setexMock = jest.fn<() => Promise<void>>()
+const isHealthyMock = jest.fn<() => boolean>()
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+    errorLog: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    redisClient: {
+        isHealthy: (...args: unknown[]) => isHealthyMock(...args),
+        get: (...args: unknown[]) => getMock(...args),
+        setex: (...args: unknown[]) => setexMock(...args),
+    },
+}))
+
 describe('ProviderHealthService', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        isHealthyMock.mockReturnValue(false)
+    })
+
     it('marks provider unavailable after consecutive failures', () => {
         const service = new ProviderHealthService({
             cooldownMs: 5_000,
@@ -99,6 +123,11 @@ describe('ProviderHealthService', () => {
 })
 
 describe('ProviderHealthService cooldown boundary conditions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        isHealthyMock.mockReturnValue(false)
+    })
+
     it('clears cooldownUntil in-place when expiry is reached on isAvailable call', () => {
         const service = new ProviderHealthService({
             cooldownMs: 1_000,
@@ -181,6 +210,11 @@ describe('ProviderHealthService cooldown boundary conditions', () => {
 })
 
 describe('provider mappers', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        isHealthyMock.mockReturnValue(false)
+    })
+
     it('maps query types to providers', () => {
         expect(providerFromQueryType('youtubeSearch' as any)).toBe('youtube')
         expect(providerFromQueryType('spotifySearch' as any)).toBe('spotify')
@@ -211,5 +245,119 @@ describe('provider mappers', () => {
         expect(
             providerFromTrack({ source: 'other', url: 'https://x.com' }),
         ).toBe('unknown')
+    })
+})
+
+describe('ProviderHealthService Redis persistence', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        isHealthyMock.mockReturnValue(true)
+        setexMock.mockResolvedValue(undefined)
+    })
+
+    it('calls setex on recordFailure when Redis is healthy', () => {
+        const service = new ProviderHealthService({
+            cooldownMs: 10_000,
+            failureThreshold: 2,
+        })
+        service.recordFailure('youtube', 1_000, 'timeout')
+
+        expect(isHealthyMock).toHaveBeenCalled()
+        expect(setexMock).toHaveBeenCalledWith(
+            'music:provider_health:youtube',
+            expect.any(Number),
+            expect.stringContaining('youtube'),
+        )
+    })
+
+    it('calls setex on recordSuccess when Redis is healthy', () => {
+        const service = new ProviderHealthService({
+            cooldownMs: 10_000,
+            failureThreshold: 2,
+        })
+        service.recordSuccess('spotify', 2_000)
+
+        expect(setexMock).toHaveBeenCalledWith(
+            'music:provider_health:spotify',
+            expect.any(Number),
+            expect.stringContaining('spotify'),
+        )
+    })
+
+    it('skips setex when Redis is not healthy', () => {
+        isHealthyMock.mockReturnValue(false)
+        const service = new ProviderHealthService({
+            cooldownMs: 10_000,
+            failureThreshold: 2,
+        })
+        service.recordFailure('soundcloud', 1_000, 'fail')
+
+        expect(setexMock).not.toHaveBeenCalled()
+    })
+
+    it('uses TTL of cooldownMs * 2 / 1000 seconds', () => {
+        const service = new ProviderHealthService({
+            cooldownMs: 60_000,
+            failureThreshold: 1,
+        })
+        service.recordFailure('youtube', 1_000, 'fail')
+
+        const ttlArg = (setexMock.mock.calls[0] as unknown[])[1]
+        expect(ttlArg).toBe(120)
+    })
+})
+
+describe('initProviderHealth / loadFromRedis', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        isHealthyMock.mockReturnValue(true)
+    })
+
+    it('restores provider status from Redis on init', async () => {
+        const restoredStatus = {
+            provider: 'youtube',
+            score: 0.4,
+            consecutiveFailures: 2,
+            cooldownUntil: Date.now() + 50_000,
+            lastFailureAt: Date.now() - 1_000,
+            lastSuccessAt: null,
+            lastError: 'rate limited',
+        }
+        getMock.mockImplementation(async (key: unknown) => {
+            if ((key as string).includes('youtube'))
+                return JSON.stringify(restoredStatus)
+            return null
+        })
+
+        await initProviderHealth()
+
+        const status = providerHealthService.getStatus('youtube')
+        expect(status.score).toBeCloseTo(0.4)
+        expect(status.consecutiveFailures).toBe(2)
+        expect(status.lastError).toBe('rate limited')
+    })
+
+    it('skips loading when Redis is not healthy', async () => {
+        isHealthyMock.mockReturnValue(false)
+
+        await initProviderHealth()
+
+        expect(getMock).not.toHaveBeenCalled()
+    })
+
+    it('leaves default state when Redis key is missing', async () => {
+        getMock.mockResolvedValue(null)
+
+        await initProviderHealth()
+
+        const status = providerHealthService.getStatus('soundcloud')
+        expect(status.score).toBe(1)
+        expect(status.consecutiveFailures).toBe(0)
+    })
+
+    it('ignores corrupt Redis data and keeps default state', async () => {
+        getMock.mockResolvedValue('not-valid-json{{')
+
+        await expect(initProviderHealth()).resolves.not.toThrow()
     })
 })

--- a/packages/bot/src/utils/music/search/providerHealth.ts
+++ b/packages/bot/src/utils/music/search/providerHealth.ts
@@ -1,4 +1,6 @@
 import { QueryType } from 'discord-player'
+import { redisClient } from '@lucky/shared/services'
+import { debugLog, errorLog } from '@lucky/shared/utils'
 
 export type MusicProvider = 'youtube' | 'spotify' | 'soundcloud' | 'unknown'
 
@@ -32,6 +34,12 @@ const DEFAULT_OPTIONS = {
     failurePenalty: 0.2,
     successBoost: 0.05,
 } satisfies Required<ProviderHealthOptions>
+
+const REDIS_KEY_PREFIX = 'music:provider_health:'
+
+function redisKey(provider: MusicProvider): string {
+    return `${REDIS_KEY_PREFIX}${provider}`
+}
 
 function createInitialStatus(provider: MusicProvider): ProviderStatus {
     return {
@@ -68,6 +76,36 @@ export class ProviderHealthService {
         return status
     }
 
+    private persistToRedis(status: ProviderStatus): void {
+        if (!redisClient.isHealthy()) return
+        const ttlSeconds = Math.ceil((this.options.cooldownMs * 2) / 1000)
+        redisClient
+            .setex(redisKey(status.provider), ttlSeconds, JSON.stringify(status))
+            .catch((err) => {
+                errorLog({ message: 'Failed to persist provider health', error: err })
+            })
+    }
+
+    async loadFromRedis(): Promise<void> {
+        if (!redisClient.isHealthy()) return
+        for (const provider of DEFAULT_PROVIDERS) {
+            try {
+                const raw = await redisClient.get(redisKey(provider))
+                if (!raw) continue
+                const parsed: ProviderStatus = JSON.parse(raw) as ProviderStatus
+                if (parsed.provider === provider) {
+                    this.statuses.set(provider, parsed)
+                    debugLog({
+                        message: `Restored provider health from Redis: ${provider}`,
+                        data: { score: parsed.score, cooldownUntil: parsed.cooldownUntil },
+                    })
+                }
+            } catch {
+                // leave default in-memory state if Redis data is corrupt
+            }
+        }
+    }
+
     recordFailure(
         provider: MusicProvider,
         now = Date.now(),
@@ -83,6 +121,8 @@ export class ProviderHealthService {
         if (status.consecutiveFailures >= this.options.failureThreshold) {
             status.cooldownUntil = now + this.options.cooldownMs
         }
+
+        this.persistToRedis(status)
     }
 
     recordSuccess(provider: MusicProvider, now = Date.now()): void {
@@ -93,6 +133,8 @@ export class ProviderHealthService {
         status.cooldownUntil = null
         status.lastError = null
         status.score = Math.min(1, status.score + this.options.successBoost)
+
+        this.persistToRedis(status)
     }
 
     isAvailable(provider: MusicProvider, now = Date.now()): boolean {
@@ -134,6 +176,10 @@ export const providerHealthService = new ProviderHealthService({
     ),
     failureThreshold: 2,
 })
+
+export async function initProviderHealth(): Promise<void> {
+    await providerHealthService.loadFromRedis()
+}
 
 export function providerFromQueryType(queryType?: QueryType): MusicProvider {
     const typeValue = String(queryType ?? '').toLowerCase()


### PR DESCRIPTION
## Summary

Closes #280

Provider health cooldown state is now persisted to Redis and restored on bot startup. Previously, a rate-limited provider would reset to healthy after a bot restart, causing immediate re-hammering of the same provider.

## Changes

- **`providerHealth.ts`**: Added `persistToRedis()` (fire-and-forget `setex` with TTL = `2 × cooldownMs`) called after every `recordFailure` and `recordSuccess`. Added `loadFromRedis()` to restore all provider statuses on startup. Exported `initProviderHealth()`.
- **`initializer.ts`**: Calls `await initProviderHealth()` after Redis services are initialized.
- **`providerHealth.spec.ts`**: 8 new tests covering Redis persistence, skip-when-unhealthy, state restore, and corrupt-data resilience.
- **`CHANGELOG.md`**: Added entry under `[Unreleased]`.

## Behavior

- On `recordFailure`/`recordSuccess`: status JSON is written to `music:provider_health:<provider>` with TTL = `2 × MUSIC_PROVIDER_COOLDOWN_MS` (default 4 min).
- On bot startup: all provider statuses are restored from Redis if available.
- If Redis is unavailable (`isHealthy() === false`): silently skips — in-memory behavior unchanged.
- Corrupt Redis data: caught silently, default in-memory state preserved.