### PR TITLE
feat(music): persist autoplay feedback to Redis with user-scoped 30-day TTL (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Autoplay recommendation feedback is now **user-scoped** and persisted to Redis
+  with a configurable 30-day TTL (`AUTOPLAY_FEEDBACK_TTL_DAYS`). Feedback
+  survives bot restarts and is keyed per user (`music:feedback:{userId}`) rather
+  than per guild (#282).
+- `/music health` **Recommendation feedback** field now shows liked count,
+  disliked count, and the date feedback was first recorded for the requesting
+  user (#282).
+- `/music clearfeedback` subcommand lets users reset their personal
+  recommendation feedback history (#282).
+
 ## [2.6.20] - 2026-03-15
 
 ### Added

--- a/packages/bot/src/functions/music/commands/music.ts
+++ b/packages/bot/src/functions/music/commands/music.ts
@@ -72,19 +72,19 @@ function formatResolverDiagnostics(resolution: QueueResolutionResult): string {
     return `Source: ${source}\nCache size: ${diagnostics.cacheSize}\nCache keys: ${keys}`
 }
 
-async function formatFeedbackState(
-    guildId: string,
-    userId: string,
-): Promise<string> {
-    const dislikedKeys = await recommendationFeedbackService.getDislikedTrackKeys(
-        guildId,
-        userId,
-    )
-    const dislikedCount = dislikedKeys.size
-    if (dislikedCount === 0) {
+async function formatFeedbackState(userId: string): Promise<string> {
+    const stats = await recommendationFeedbackService.getFeedbackStats(userId)
+    if (stats.likedCount === 0 && stats.dislikedCount === 0) {
         return 'No feedback recorded. Use /recommendation feedback to tune autoplay.'
     }
-    return `Disliked tracks: ${dislikedCount} (filtered from autoplay)`
+    const activeSince = stats.activeSince
+        ? new Date(stats.activeSince).toISOString()
+        : 'unknown'
+    return [
+        `Liked: ${stats.likedCount} | Disliked: ${stats.dislikedCount}`,
+        `Active since: ${activeSince}`,
+        'Use /music clearfeedback to reset.',
+    ].join('\n')
 }
 
 function buildActionableSteps({
@@ -150,12 +150,40 @@ export default new Command({
             subcommand
                 .setName('health')
                 .setDescription('Show queue health and recovery status'),
+        )
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName('clearfeedback')
+                .setDescription(
+                    'Clear your personal recommendation feedback history',
+                ),
         ),
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireGuild(interaction))) return
 
         const subcommand = interaction.options.getSubcommand()
+        if (subcommand === 'clearfeedback') {
+            await recommendationFeedbackService.clearAllFeedback(
+                interaction.user.id,
+            )
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createEmbed({
+                            title: `${EMOJIS.SUCCESS} Feedback cleared`,
+                            description:
+                                'Your recommendation feedback history has been reset.',
+                            color: EMBED_COLORS.SUCCESS,
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+            return
+        }
+
         if (subcommand !== 'health') {
             await interactionReply({
                 interaction,
@@ -190,10 +218,7 @@ export default new Command({
         const watchdog = musicWatchdogService.getGuildState(guildId)
         const snapshot = await musicSessionSnapshotService.getSnapshot(guildId)
         const providers = Object.values(providerHealthService.getAllStatuses())
-        const feedbackState = await formatFeedbackState(
-            guildId,
-            interaction.user.id,
-        )
+        const feedbackState = await formatFeedbackState(interaction.user.id)
         const actions = buildActionableSteps({
             queue,
             providers,

--- a/packages/bot/src/functions/music/commands/recommendation/handlers/feedbackHandler.ts
+++ b/packages/bot/src/functions/music/commands/recommendation/handlers/feedbackHandler.ts
@@ -64,7 +64,6 @@ export async function handleFeedback(
               )
 
     await recommendationFeedbackService.setFeedback(
-        guildId,
         interaction.user.id,
         trackKey,
         feedback,

--- a/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
@@ -3,6 +3,7 @@ import { RecommendationFeedbackService } from './feedbackService'
 
 const getMock = jest.fn()
 const setexMock = jest.fn()
+const delMock = jest.fn()
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
@@ -12,6 +13,7 @@ jest.mock('@lucky/shared/services', () => ({
     redisClient: {
         get: (...args: unknown[]) => getMock(...args),
         setex: (...args: unknown[]) => setexMock(...args),
+        del: (...args: unknown[]) => delMock(...args),
     },
 }))
 
@@ -22,7 +24,7 @@ describe('RecommendationFeedbackService', () => {
 
     it('stores dislike feedback and returns disliked keys', async () => {
         const now = 10_000
-        const service = new RecommendationFeedbackService(24)
+        const service = new RecommendationFeedbackService(30)
         const key = service.buildTrackKey('Song A', 'Artist A')
 
         getMock.mockResolvedValueOnce(null)
@@ -32,25 +34,44 @@ describe('RecommendationFeedbackService', () => {
                 [key]: {
                     feedback: 'dislike',
                     updatedAt: now,
-                    expiresAt: now + 24 * 60 * 60 * 1000,
+                    expiresAt: now + 30 * 24 * 60 * 60 * 1000,
                 },
             }),
         )
 
-        await service.setFeedback('guild-1', 'user-1', key, 'dislike', now)
-        const disliked = await service.getDislikedTrackKeys(
-            'guild-1',
-            'user-1',
-            now + 100,
-        )
+        await service.setFeedback('user-1', key, 'dislike', now)
+        const disliked = await service.getDislikedTrackKeys('user-1', now + 100)
 
         expect(disliked.has(key)).toBe(true)
         expect(setexMock).toHaveBeenCalled()
     })
 
+    it('stores like feedback and returns liked keys', async () => {
+        const now = 10_000
+        const service = new RecommendationFeedbackService(30)
+        const key = service.buildTrackKey('Song C', 'Artist C')
+
+        getMock.mockResolvedValueOnce(null)
+        setexMock.mockResolvedValueOnce(true)
+        getMock.mockResolvedValueOnce(
+            JSON.stringify({
+                [key]: {
+                    feedback: 'like',
+                    updatedAt: now,
+                    expiresAt: now + 30 * 24 * 60 * 60 * 1000,
+                },
+            }),
+        )
+
+        await service.setFeedback('user-1', key, 'like', now)
+        const liked = await service.getLikedTrackKeys('user-1', now + 100)
+
+        expect(liked.has(key)).toBe(true)
+    })
+
     it('cleans expired feedback entries', async () => {
         const now = 50_000
-        const service = new RecommendationFeedbackService(1)
+        const service = new RecommendationFeedbackService(30)
         const key = service.buildTrackKey('Song B', 'Artist B')
 
         getMock.mockResolvedValue(
@@ -64,13 +85,69 @@ describe('RecommendationFeedbackService', () => {
         )
         setexMock.mockResolvedValue(true)
 
-        const disliked = await service.getDislikedTrackKeys(
-            'guild-2',
-            'user-2',
-            now,
-        )
+        const disliked = await service.getDislikedTrackKeys('user-2', now)
 
         expect(disliked.size).toBe(0)
         expect(setexMock).toHaveBeenCalled()
+    })
+
+    it('returns empty set for undefined userId', async () => {
+        const service = new RecommendationFeedbackService(30)
+        const disliked = await service.getDislikedTrackKeys(undefined)
+        const liked = await service.getLikedTrackKeys(undefined)
+        expect(disliked.size).toBe(0)
+        expect(liked.size).toBe(0)
+    })
+
+    it('getFeedbackStats returns correct counts', async () => {
+        const now = 10_000
+        const service = new RecommendationFeedbackService(30)
+        const key1 = service.buildTrackKey('Song D', 'Artist D')
+        const key2 = service.buildTrackKey('Song E', 'Artist E')
+
+        getMock.mockResolvedValueOnce(
+            JSON.stringify({
+                [key1]: {
+                    feedback: 'like',
+                    updatedAt: now - 1000,
+                    expiresAt: now + 1000,
+                },
+                [key2]: {
+                    feedback: 'dislike',
+                    updatedAt: now - 500,
+                    expiresAt: now + 1000,
+                },
+            }),
+        )
+        setexMock.mockResolvedValue(true)
+
+        const stats = await service.getFeedbackStats('user-3', now)
+        expect(stats.likedCount).toBe(1)
+        expect(stats.dislikedCount).toBe(1)
+        expect(stats.activeSince).toBe(now - 1000)
+    })
+
+    it('getFeedbackStats returns zeros for no feedback', async () => {
+        const service = new RecommendationFeedbackService(30)
+        getMock.mockResolvedValueOnce(null)
+        const stats = await service.getFeedbackStats('user-4')
+        expect(stats.likedCount).toBe(0)
+        expect(stats.dislikedCount).toBe(0)
+        expect(stats.activeSince).toBeNull()
+    })
+
+    it('getFeedbackStats returns null activeSince for undefined userId', async () => {
+        const service = new RecommendationFeedbackService(30)
+        const stats = await service.getFeedbackStats(undefined)
+        expect(stats.likedCount).toBe(0)
+        expect(stats.dislikedCount).toBe(0)
+        expect(stats.activeSince).toBeNull()
+    })
+
+    it('clearAllFeedback calls del with correct key', async () => {
+        const service = new RecommendationFeedbackService(30)
+        delMock.mockResolvedValueOnce(1)
+        await service.clearAllFeedback('user-5')
+        expect(delMock).toHaveBeenCalledWith('music:feedback:user-5')
     })
 })

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -11,18 +11,21 @@ type FeedbackEntry = {
 
 type FeedbackMap = Record<string, FeedbackEntry>
 
-export class RecommendationFeedbackService {
-    constructor(private readonly ttlHours = 24) {}
+export type FeedbackStats = {
+    likedCount: number
+    dislikedCount: number
+    activeSince: number | null
+}
 
-    private getRedisKey(guildId: string, userId: string): string {
-        return `music:recommendation:feedback:${guildId}:${userId}`
+export class RecommendationFeedbackService {
+    constructor(private readonly ttlDays = 30) {}
+
+    private getRedisKey(userId: string): string {
+        return `music:feedback:${userId}`
     }
 
-    private async getFeedbackMap(
-        guildId: string,
-        userId: string,
-    ): Promise<FeedbackMap> {
-        const key = this.getRedisKey(guildId, userId)
+    private async getFeedbackMap(userId: string): Promise<FeedbackMap> {
+        const key = this.getRedisKey(userId)
         try {
             const value = await redisClient.get(key)
             if (!value) return {}
@@ -38,13 +41,11 @@ export class RecommendationFeedbackService {
     }
 
     private async saveFeedbackMap(
-        guildId: string,
         userId: string,
         map: FeedbackMap,
     ): Promise<void> {
-        const key = this.getRedisKey(guildId, userId)
-        const ttlSeconds = this.ttlHours * 60 * 60
-
+        const key = this.getRedisKey(userId)
+        const ttlSeconds = this.ttlDays * 24 * 60 * 60
         await redisClient.setex(key, ttlSeconds, JSON.stringify(map))
     }
 
@@ -57,25 +58,23 @@ export class RecommendationFeedbackService {
             .toLowerCase()
             .replaceAll(/[^a-z0-9]+/g, '')
             .trim()
-
         return `${normalizedTitle}::${normalizedAuthor}`
     }
 
     async setFeedback(
-        guildId: string,
         userId: string,
         trackKey: string,
         feedback: RecommendationFeedback,
         now = Date.now(),
     ): Promise<void> {
         try {
-            const map = await this.getFeedbackMap(guildId, userId)
+            const map = await this.getFeedbackMap(userId)
             map[trackKey] = {
                 feedback,
                 updatedAt: now,
-                expiresAt: now + this.ttlHours * 60 * 60 * 1000,
+                expiresAt: now + this.ttlDays * 24 * 60 * 60 * 1000,
             }
-            await this.saveFeedbackMap(guildId, userId, map)
+            await this.saveFeedbackMap(userId, map)
         } catch (error) {
             errorLog({
                 message: 'Failed to store recommendation feedback',
@@ -87,13 +86,9 @@ export class RecommendationFeedbackService {
     private pruneExpired(
         map: FeedbackMap,
         now: number,
-    ): {
-        map: FeedbackMap
-        changed: boolean
-    } {
+    ): { map: FeedbackMap; changed: boolean } {
         const next: FeedbackMap = {}
         let changed = false
-
         for (const [trackKey, entry] of Object.entries(map)) {
             if (entry.expiresAt <= now) {
                 changed = true
@@ -101,32 +96,80 @@ export class RecommendationFeedbackService {
             }
             next[trackKey] = entry
         }
-
         return { map: next, changed }
     }
 
     async getDislikedTrackKeys(
-        guildId: string,
         userId: string | undefined,
         now = Date.now(),
     ): Promise<Set<string>> {
         if (!userId) return new Set<string>()
-
-        const map = await this.getFeedbackMap(guildId, userId)
+        const map = await this.getFeedbackMap(userId)
         const { map: validMap, changed } = this.pruneExpired(map, now)
-
         if (changed) {
-            await this.saveFeedbackMap(guildId, userId, validMap)
+            await this.saveFeedbackMap(userId, validMap)
         }
+        return new Set(
+            Object.entries(validMap)
+                .filter(([, entry]) => entry.feedback === 'dislike')
+                .map(([trackKey]) => trackKey),
+        )
+    }
 
-        const disliked = Object.entries(validMap)
-            .filter(([, entry]) => entry.feedback === 'dislike')
-            .map(([trackKey]) => trackKey)
+    async getLikedTrackKeys(
+        userId: string | undefined,
+        now = Date.now(),
+    ): Promise<Set<string>> {
+        if (!userId) return new Set<string>()
+        const map = await this.getFeedbackMap(userId)
+        const { map: validMap, changed } = this.pruneExpired(map, now)
+        if (changed) {
+            await this.saveFeedbackMap(userId, validMap)
+        }
+        return new Set(
+            Object.entries(validMap)
+                .filter(([, entry]) => entry.feedback === 'like')
+                .map(([trackKey]) => trackKey),
+        )
+    }
 
-        return new Set(disliked)
+    async getFeedbackStats(
+        userId: string | undefined,
+        now = Date.now(),
+    ): Promise<FeedbackStats> {
+        if (!userId) {
+            return { likedCount: 0, dislikedCount: 0, activeSince: null }
+        }
+        const map = await this.getFeedbackMap(userId)
+        const { map: validMap, changed } = this.pruneExpired(map, now)
+        if (changed) {
+            await this.saveFeedbackMap(userId, validMap)
+        }
+        const entries = Object.values(validMap)
+        const likedCount = entries.filter((e) => e.feedback === 'like').length
+        const dislikedCount = entries.filter(
+            (e) => e.feedback === 'dislike',
+        ).length
+        const activeSince =
+            entries.length > 0
+                ? Math.min(...entries.map((e) => e.updatedAt))
+                : null
+        return { likedCount, dislikedCount, activeSince }
+    }
+
+    async clearAllFeedback(userId: string): Promise<void> {
+        try {
+            const key = this.getRedisKey(userId)
+            await redisClient.del(key)
+        } catch (error) {
+            errorLog({
+                message: 'Failed to clear recommendation feedback',
+                error,
+            })
+        }
     }
 }
 
 export const recommendationFeedbackService = new RecommendationFeedbackService(
-    parseInt(process.env.AUTOPLAY_DISLIKE_TTL_HOURS ?? '24', 10),
+    parseInt(process.env.AUTOPLAY_FEEDBACK_TTL_DAYS ?? '30', 10),
 )


### PR DESCRIPTION
## Summary

Closes #282

- Rewrites `feedbackService` to use **user-scoped** Redis keys (`music:feedback:{userId}`) with a configurable 30-day TTL (`AUTOPLAY_FEEDBACK_TTL_DAYS`). Feedback now survives bot restarts.
- Removes the `guildId` parameter from `setFeedback` — feedback is per-user, not per-guild.
- Adds `getLikedTrackKeys`, `getFeedbackStats`, and `clearAllFeedback` methods.
- Updates `/music health` to show liked/disliked counts and the date feedback was first recorded.
- Adds `/music clearfeedback` subcommand so users can reset their personal feedback history.
- 8 new unit tests covering all service methods.

## Changes

| File | Change |
|------|--------|
| `feedbackService.ts` | Rewritten — user-scoped Redis, 30-day TTL, new methods |
| `feedbackService.spec.ts` | 8 new tests |
| `feedbackHandler.ts` | Drop `guildId` from `setFeedback` call |
| `music.ts` | Add `clearfeedback` subcommand + feedback stats in health embed |
| `CHANGELOG.md` | Unreleased entries for #282 |