### PR TITLE
chore(release): prepare v2.6.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.22] - 2026-03-15
+
 ### Added
 
 - **Music watchdog** now detects orphaned voice sessions (bot disconnected but
@@ -14,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and restores the queue from snapshot if the snapshot is ≤ 30 minutes old and
   at least one non-bot member is present. Configurable interval via
   `MUSIC_WATCHDOG_ORPHAN_INTERVAL_MS` (default 60 s) (#279).
+
+### Changed
+
+- Migrated project skills from `opencode-lucky-workflows` to `Claude-lucky-workflows`,
+  updated SSH references from `server-do-luk` to `luk-server@100.95.204.103` (#289).
+
+### Fixed
+
+- Added `prismaClient` mock to `jest.config.cjs` to prevent `ts-jest` from
+  hitting `SyntaxError: Cannot use 'import.meta' outside a module` when
+  transforming `packages/shared/src/utils/database/prismaClient.ts` (#289).
 
 ## [2.6.21] - 2026-03-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.21",
+  "version": "2.6.22",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## v2.6.22 Release

### Added
- **Music watchdog** orphan session monitor: detects bot-disconnected-but-Redis-active sessions and auto-rejoins voice channel + restores queue from snapshot (≤30 min old, non-bot member present). Configurable via `MUSIC_WATCHDOG_ORPHAN_INTERVAL_MS` (default 60s) (#279, #292).

### Changed
- Migrated project skills from `opencode-lucky-workflows` to `Claude-lucky-workflows`, updated SSH references from `server-do-luk` to `luk-server@100.95.204.103` (#289).

### Fixed
- Added `prismaClient` mock to `jest.config.cjs` to prevent `ts-jest` from hitting `SyntaxError: Cannot use 'import.meta' outside a module` (#289).