### PR TITLE
feat(bot): boost liked tracks in autoplay scoring

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -14,11 +14,14 @@ jest.mock('@lucky/shared/utils', () => ({
 }))
 
 const dislikedTrackKeysMock = jest.fn()
+const likedTrackKeysMock = jest.fn()
 
 jest.mock('../../services/musicRecommendation/feedbackService', () => ({
     recommendationFeedbackService: {
         getDislikedTrackKeys: (...args: unknown[]) =>
             dislikedTrackKeysMock(...args),
+        getLikedTrackKeys: (...args: unknown[]) =>
+            likedTrackKeysMock(...args),
     },
 }))
 
@@ -61,6 +64,7 @@ function createQueueMock(overrides: Partial<QueueMock> = {}): QueueMock {
 describe('queueManipulation.replenishQueue', () => {
     beforeEach(() => {
         dislikedTrackKeysMock.mockResolvedValue(new Set())
+        likedTrackKeysMock.mockResolvedValue(new Set())
     })
 
     async function replenishWithSingleCandidate(options: {
@@ -259,6 +263,48 @@ describe('queueManipulation.replenishQueue', () => {
             }),
         )
     })
+    it('boosts liked tracks to the top of autoplay recommendations', async () => {
+        likedTrackKeysMock.mockResolvedValue(
+            new Set(['likedtrack::artistb']),
+        )
+
+        const queue = createQueueMock({
+            tracks: {
+                size: 0,
+                toArray: jest.fn().mockReturnValue([]),
+            },
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Neutral Track',
+                            author: 'Artist C',
+                            url: 'https://example.com/neutral',
+                        },
+                        {
+                            title: 'Liked Track',
+                            author: 'Artist B',
+                            url: 'https://example.com/liked',
+                        },
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const calls = queue.addTrack.mock.calls
+        expect(calls.length).toBeGreaterThan(0)
+        const firstAdded = calls[0][0] as Track
+        expect(firstAdded.url).toBe('https://example.com/liked')
+        expect(firstAdded.metadata).toEqual(
+            expect.objectContaining({
+                isAutoplay: true,
+                recommendationReason: expect.stringContaining('liked track'),
+            }),
+        )
+    })
+
 
     it.each([
         {

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -200,11 +200,16 @@ export async function replenishQueue(queue: GuildQueue): Promise<void> {
             HISTORY_SEED_LIMIT + 1,
         )
         const requestedBy = getRequestedBy(queue, currentTrack)
-        const dislikedTrackKeys =
-            await recommendationFeedbackService.getDislikedTrackKeys(
+        const [dislikedTrackKeys, likedTrackKeys] = await Promise.all([
+            recommendationFeedbackService.getDislikedTrackKeys(
                 queue.guild.id,
                 requestedBy?.id,
-            )
+            ),
+            recommendationFeedbackService.getLikedTrackKeys(
+                queue.guild.id,
+                requestedBy?.id,
+            ),
+        ])
         const excludedUrls = buildExcludedUrls(queue, currentTrack, historyTracks)
         const excludedKeys = buildExcludedKeys(queue, currentTrack, historyTracks)
         const recentArtists = buildRecentArtists(currentTrack, historyTracks)
@@ -215,6 +220,7 @@ export async function replenishQueue(queue: GuildQueue): Promise<void> {
             excludedUrls,
             excludedKeys,
             dislikedTrackKeys,
+            likedTrackKeys,
             currentTrack,
             recentArtists,
         )
@@ -298,6 +304,7 @@ async function collectRecommendationCandidates(
     excludedUrls: Set<string>,
     excludedKeys: Set<string>,
     dislikedTrackKeys: Set<string>,
+    likedTrackKeys: Set<string>,
     currentTrack: Track,
     recentArtists: Set<string>,
 ): Promise<Map<string, ScoredTrack>> {
@@ -316,7 +323,7 @@ async function collectRecommendationCandidates(
             upsertScoredCandidate(
                 candidates,
                 candidate,
-                calculateRecommendationScore(candidate, currentTrack, recentArtists),
+                calculateRecommendationScore(candidate, currentTrack, recentArtists, likedTrackKeys),
             )
         }
     }
@@ -544,11 +551,18 @@ function calculateRecommendationScore(
     candidate: Track,
     currentTrack: Track,
     recentArtists: Set<string>,
+    likedTrackKeys: Set<string> = new Set(),
 ): { score: number; reason: string } {
     let score = 1
     const reasons: string[] = []
     const currentArtist = currentTrack.author.toLowerCase()
     const candidateArtist = candidate.author.toLowerCase()
+
+    const candidateKey = normalizeTrackKey(candidate.title, candidate.author)
+    if (likedTrackKeys.has(candidateKey)) {
+        score += 0.3
+        reasons.push('liked track')
+    }
 
     if (candidateArtist === currentArtist) {
         score -= 0.35


### PR DESCRIPTION
## Summary

Closes #282 (partial — like-boost signal).

When a user has liked a track via `/recommendation feedback like`, that track's normalized key is stored in their feedback profile. During autoplay candidate scoring, if a candidate matches a liked key, it receives a **+0.3 score boost** and the reason tag `liked track` is appended to the recommendation reason shown in `/queue`.

## Changes

- `queueManipulation.ts`: fetch `likedTrackKeys` alongside `dislikedTrackKeys` (parallel `Promise.all`), pass through to `collectRecommendationCandidates` and `calculateRecommendationScore`
- `calculateRecommendationScore`: accepts optional `likedTrackKeys` param; applies `+0.3` boost and adds `'liked track'` to reasons when candidate key matches
- `queueManipulation.spec.ts`: updated mock to include `getLikedTrackKeys`, added test verifying liked track is selected first

## Score impact

| Signal | Delta |
|--------|-------|
| Liked track | +0.3 |
| Same artist as current | −0.35 |
| Recent artist | −0.25 |
| Same source | −0.15 |
| Title token match | +0.05–0.2 |