### PR TITLE
chore(release): prepare v2.6.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.23] - 2026-03-15
+
+### Added
+
+- **Autoplay liked-track boost** — tracks the user has liked now receive a
+  `+0.3` score bonus in `calculateRecommendationScore`, making them more likely
+  to appear in autoplay suggestions. A `'liked track'` reason tag is appended
+  to the recommendation when the boost applies (#294).
+
 ## [2.6.22] - 2026-03-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.22",
+  "version": "2.6.23",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## v2.6.23

### Added
- **Autoplay liked-track boost** — tracks the user has liked now receive a `+0.3` score bonus in `calculateRecommendationScore`, making them more likely to appear in autoplay suggestions. A `'liked track'` reason tag is appended to the recommendation when the boost applies (#294).

### Changes
- Bumped `package.json` version `2.6.22` → `2.6.23`
- Promoted `[Unreleased]` CHANGELOG entries to `[2.6.23] - 2026-03-15`