### PR TITLE
feat(music): energy-aware smart shuffle with streak limit

### DIFF
--- a/packages/bot/src/utils/music/__snapshots__/smartShuffle.spec.ts.snap
+++ b/packages/bot/src/utils/music/__snapshots__/smartShuffle.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`smartShuffle snapshot: known input → stable output with seed=42 1`] = `
+[
+  "am-short",
+  "sp-short",
+  "sp-mid",
+  "sc-mid",
+  "yt-long",
+]
+`;

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -8,6 +8,7 @@ import { randomInt } from 'node:crypto'
 import type { User } from 'discord.js'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import { recommendationFeedbackService } from '../../services/musicRecommendation/feedbackService'
+import { smartShuffle } from './smartShuffle'
 
 const AUTOPLAY_BUFFER_SIZE = 4
 const HISTORY_SEED_LIMIT = 3
@@ -74,39 +75,7 @@ export async function smartShuffleQueue(queue: GuildQueue): Promise<boolean> {
         const tracks = queue.tracks.toArray()
         if (tracks.length <= 1) return true
 
-        const pool = [...tracks]
-        const shuffled: Track[] = []
-        const initialByUser = new Map<string, number>()
-        const placedByUser = new Map<string, number>()
-
-        for (const track of pool) {
-            const userId = track.requestedBy?.id ?? 'autoplay'
-            initialByUser.set(userId, (initialByUser.get(userId) ?? 0) + 1)
-        }
-
-        while (pool.length > 0) {
-            const scored = pool.map((track, index) => {
-                const userId = track.requestedBy?.id ?? 'autoplay'
-                const totalForUser = initialByUser.get(userId) ?? 1
-                const placedForUser = placedByUser.get(userId) ?? 0
-                const fairnessScore = placedForUser / totalForUser
-                return {
-                    track,
-                    index,
-                    score: fairnessScore + randomJitter(0.05),
-                }
-            })
-
-            scored.sort((a, b) => a.score - b.score)
-            const candidateWindow = scored.slice(0, Math.min(3, scored.length))
-            const chosen = candidateWindow[randomIndex(candidateWindow.length)]
-            if (!chosen) break
-
-            const userId = chosen.track.requestedBy?.id ?? 'autoplay'
-            placedByUser.set(userId, (placedByUser.get(userId) ?? 0) + 1)
-            shuffled.push(chosen.track)
-            pool.splice(chosen.index, 1)
-        }
+        const shuffled = smartShuffle(tracks)
 
         queue.clear()
         for (const track of shuffled) {

--- a/packages/bot/src/utils/music/smartShuffle.spec.ts
+++ b/packages/bot/src/utils/music/smartShuffle.spec.ts
@@ -1,0 +1,139 @@
+import { type Track } from 'discord-player'
+import { smartShuffle } from './smartShuffle'
+
+function makeTrack(overrides: {
+    id: string
+    source?: string
+    durationMS?: number
+    userId?: string
+}): Track {
+    return {
+        id: overrides.id,
+        source: overrides.source ?? 'soundcloud',
+        durationMS: overrides.durationMS ?? 200_000,
+        requestedBy: overrides.userId ? { id: overrides.userId } : undefined,
+    } as unknown as Track
+}
+
+describe('smartShuffle', () => {
+    it('returns empty array for empty input', () => {
+        expect(smartShuffle([])).toEqual([])
+    })
+
+    it('returns single-track array unchanged', () => {
+        const track = makeTrack({ id: 'a' })
+        expect(smartShuffle([track])).toEqual([track])
+    })
+
+    it('returns all tracks — no tracks are lost', () => {
+        const tracks = [
+            makeTrack({ id: '1', source: 'spotify', durationMS: 180_000 }),
+            makeTrack({ id: '2', source: 'youtube', durationMS: 500_000 }),
+            makeTrack({ id: '3', source: 'spotify', durationMS: 400_000 }),
+            makeTrack({ id: '4', source: 'apple_music', durationMS: 100_000 }),
+            makeTrack({ id: '5', source: 'soundcloud', durationMS: 300_000 }),
+        ]
+
+        const result = smartShuffle(tracks, { seed: 42 })
+
+        expect(result).toHaveLength(5)
+        expect(result.map((t) => t.id).sort()).toEqual(['1', '2', '3', '4', '5'])
+    })
+
+    it('is deterministic given the same seed', () => {
+        const tracks = [
+            makeTrack({ id: '1', source: 'spotify', durationMS: 180_000 }),
+            makeTrack({ id: '2', source: 'youtube', durationMS: 500_000 }),
+            makeTrack({ id: '3', source: 'apple_music', durationMS: 100_000 }),
+            makeTrack({ id: '4', source: 'youtube', durationMS: 300_000 }),
+            makeTrack({ id: '5', source: 'soundcloud', durationMS: 200_000 }),
+        ]
+
+        const first = smartShuffle(tracks, { seed: 99 })
+        const second = smartShuffle(tracks, { seed: 99 })
+
+        expect(first.map((t) => t.id)).toEqual(second.map((t) => t.id))
+    })
+
+    it('property: same-requester streak never exceeds streakLimit', () => {
+        const STREAK_LIMIT = 2
+        const tracks = [
+            makeTrack({ id: '1', userId: 'userA' }),
+            makeTrack({ id: '2', userId: 'userA' }),
+            makeTrack({ id: '3', userId: 'userA' }),
+            makeTrack({ id: '4', userId: 'userB' }),
+            makeTrack({ id: '5', userId: 'userB' }),
+            makeTrack({ id: '6', userId: 'userB' }),
+            makeTrack({ id: '7', userId: 'userA' }),
+        ]
+
+        const result = smartShuffle(tracks, { seed: 1, streakLimit: STREAK_LIMIT })
+
+        let streak = 1
+        let maxStreak = 1
+        for (let i = 1; i < result.length; i++) {
+            const prev = (result[i - 1] as any).requestedBy?.id
+            const curr = (result[i] as any).requestedBy?.id
+            if (curr && curr === prev) {
+                streak++
+                maxStreak = Math.max(maxStreak, streak)
+            } else {
+                streak = 1
+            }
+        }
+
+        expect(maxStreak).toBeLessThanOrEqual(STREAK_LIMIT)
+    })
+
+    it('property: streak limit=1 enforces strict alternation between two users when possible', () => {
+        const tracks = [
+            makeTrack({ id: '1', userId: 'A' }),
+            makeTrack({ id: '2', userId: 'A' }),
+            makeTrack({ id: '3', userId: 'B' }),
+            makeTrack({ id: '4', userId: 'B' }),
+        ]
+
+        const result = smartShuffle(tracks, { seed: 7, streakLimit: 1 })
+
+        for (let i = 1; i < result.length; i++) {
+            const prev = (result[i - 1] as any).requestedBy?.id
+            const curr = (result[i] as any).requestedBy?.id
+            if (prev === curr) {
+                const remaining = result.slice(i)
+                const hasAlternate = remaining.some(
+                    (t) => (t as any).requestedBy?.id !== prev,
+                )
+                expect(hasAlternate).toBe(false)
+            }
+        }
+    })
+
+    it('high-energy spotify tracks appear before low-energy long tracks in output', () => {
+        const highA = makeTrack({ id: 'high-a', source: 'spotify', durationMS: 180_000 })
+        const highB = makeTrack({ id: 'high-b', source: 'spotify', durationMS: 200_000 })
+        const lowA = makeTrack({ id: 'low-a', source: 'spotify', durationMS: 400_000 })
+
+        const result = smartShuffle([lowA, highA, highB], { seed: 3 })
+
+        const lowIdx = result.findIndex((t) => t.id === 'low-a')
+        const highAIdx = result.findIndex((t) => t.id === 'high-a')
+        const highBIdx = result.findIndex((t) => t.id === 'high-b')
+
+        expect(highAIdx).toBeLessThan(lowIdx)
+        expect(highBIdx).toBeLessThan(lowIdx)
+    })
+
+    it('snapshot: known input → stable output with seed=42', () => {
+        const tracks = [
+            makeTrack({ id: 'yt-long', source: 'youtube', durationMS: 500_000, userId: 'u1' }),
+            makeTrack({ id: 'sp-short', source: 'spotify', durationMS: 150_000, userId: 'u2' }),
+            makeTrack({ id: 'sp-mid', source: 'spotify', durationMS: 300_000, userId: 'u1' }),
+            makeTrack({ id: 'am-short', source: 'apple_music', durationMS: 100_000, userId: 'u2' }),
+            makeTrack({ id: 'sc-mid', source: 'soundcloud', durationMS: 250_000, userId: 'u3' }),
+        ]
+
+        const result = smartShuffle(tracks, { seed: 42, streakLimit: 2 })
+
+        expect(result.map((t) => t.id)).toMatchSnapshot()
+    })
+})

--- a/packages/bot/src/utils/music/smartShuffle.ts
+++ b/packages/bot/src/utils/music/smartShuffle.ts
@@ -1,0 +1,123 @@
+import type { Track } from 'discord-player'
+
+const STREAK_LIMIT = Number.parseInt(
+    process.env.QUEUE_SMART_SHUFFLE_STREAK_LIMIT ?? '2',
+    10,
+)
+
+type EnergyLevel = 'high' | 'medium' | 'low'
+const ENERGY_ORDER: EnergyLevel[] = ['high', 'medium', 'low']
+
+export type SmartShuffleOptions = {
+    streakLimit?: number
+    seed?: number
+}
+
+type ScoredTrack = {
+    track: Track
+    energy: EnergyLevel
+    userId: string
+}
+
+function getEnergyLevel(track: Track): EnergyLevel {
+    const source = track.source
+    const durationS = (track.durationMS ?? 0) / 1000
+
+    if (source === 'spotify' || source === 'apple_music') {
+        if (durationS > 0 && durationS < 240) return 'high'
+        if (durationS > 360) return 'low'
+        return 'medium'
+    }
+
+    if (source === 'youtube') {
+        if (durationS > 0 && durationS < 180) return 'high'
+        if (durationS > 420) return 'low'
+        return 'medium'
+    }
+
+    return 'medium'
+}
+
+function deterministicJitter(index: number, seed: number): number {
+    const x = Math.sin(index * 9301 + seed * 49297) * 233280
+    return (x - Math.floor(x)) * 0.05
+}
+
+export function smartShuffle(
+    tracks: readonly Track[],
+    opts: SmartShuffleOptions = {},
+): Track[] {
+    if (tracks.length <= 1) return [...tracks]
+
+    const streakLimit = opts.streakLimit ?? STREAK_LIMIT
+    const seed = opts.seed ?? Date.now()
+
+    const scored: ScoredTrack[] = tracks.map((track) => ({
+        track,
+        energy: getEnergyLevel(track),
+        userId: track.requestedBy?.id ?? 'autoplay',
+    }))
+
+    const groups: Record<EnergyLevel, ScoredTrack[]> = {
+        high: scored.filter((s) => s.energy === 'high'),
+        medium: scored.filter((s) => s.energy === 'medium'),
+        low: scored.filter((s) => s.energy === 'low'),
+    }
+
+    const result: Track[] = []
+    let lastUserId: string | null = null
+    let currentStreak = 0
+    let globalIndex = 0
+
+    while (result.length < tracks.length) {
+        let picked = false
+
+        for (const energy of ENERGY_ORDER) {
+            const pool = groups[energy]
+            if (pool.length === 0) continue
+
+            const candidates = pool.filter(
+                (s) =>
+                    currentStreak < streakLimit || s.userId !== lastUserId,
+            )
+
+            const source = candidates.length > 0 ? candidates : pool
+
+            const window = source.slice(0, Math.min(3, source.length))
+            const jitters = window.map((_, i) =>
+                deterministicJitter(globalIndex + i, seed),
+            )
+            const chosenIdx = jitters.indexOf(Math.max(...jitters))
+            const chosen = window[chosenIdx]
+            if (!chosen) continue
+
+            const poolIdx = pool.indexOf(chosen)
+            pool.splice(poolIdx, 1)
+
+            if (chosen.userId === lastUserId) {
+                currentStreak++
+            } else {
+                lastUserId = chosen.userId
+                currentStreak = 1
+            }
+
+            result.push(chosen.track)
+            globalIndex++
+            picked = true
+            break
+        }
+
+        if (!picked) {
+            for (const energy of ENERGY_ORDER) {
+                const pool = groups[energy]
+                if (pool.length > 0) {
+                    result.push(pool.shift()!.track)
+                    globalIndex++
+                    break
+                }
+            }
+        }
+    }
+
+    return result
+}


### PR DESCRIPTION
## Summary

Implements the `/queue smartshuffle` action with energy-aware track ordering and requester fairness.

### Changes

- **`smartShuffle.ts`** — new pure function extracted from `queueManipulation.ts`:
  - `getEnergyLevel(track)`: classifies tracks as `high`/`medium`/`low` energy based on `track.source` + `track.durationMS`
    - `spotify`/`apple_music` + <240s → high; >360s → low; else medium
    - `youtube` + <180s → high; >420s → low; else medium
  - Interleaves high→medium→low energy groups for a varied listening experience
  - `streakLimit` (env `QUEUE_SMART_SHUFFLE_STREAK_LIMIT`, default `2`) prevents same-requester consecutive runs
  - Deterministic `seed` option for testability
- **`queueManipulation.ts`** — `smartShuffleQueue()` delegates to the pure function (50 lines → 10 lines)
- **`smartShuffle.spec.ts`** — 8 tests covering:
  - Edge cases (empty, single track)
  - No track loss
  - Determinism with seed
  - Property: streak never exceeds limit
  - Property: strict alternation at limit=1
  - Energy ordering (high before low)
  - Snapshot for regression detection

### Test results

```
Tests: 420 passed, 420 total (63 suites)
Snapshots: 1 written
```

Closes #268