### PR TITLE
fix(lint): remove unused params from commandTouchesSensitivePath

### DIFF
--- a/.opencode/plugins/lucky-policy-lib.mjs
+++ b/.opencode/plugins/lucky-policy-lib.mjs
@@ -72,7 +72,7 @@ export function isSensitivePath(
 
 export function commandTouchesSensitivePath(
   command,
-  { cwd = process.cwd(), home = os.homedir(), repoRoot } = {},
+  { repoRoot } = {},
 ) {
   if (!command || typeof command !== 'string') return false
   const candidates = [


### PR DESCRIPTION
## Summary

- Removes the `cwd` and `home` destructured parameters from `commandTouchesSensitivePath` in `.opencode/plugins/lucky-policy-lib.mjs`
- These params were never used in the function body (only `repoRoot` is used for path construction)
- Fixes 2 `no-unused-vars` ESLint errors blocking `npm run lint`

The function signature is preserved for callers that pass these options — the extra keys are simply ignored via the rest object.