### PR TITLE
test(frontend): enable skipped Moderation filter tests

### DIFF
--- a/packages/frontend/src/pages/Moderation.test.tsx
+++ b/packages/frontend/src/pages/Moderation.test.tsx
@@ -81,6 +81,10 @@ function renderPage() {
 describe('ModerationPage', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        Object.defineProperty(globalThis.HTMLElement.prototype, 'scrollIntoView', {
+            configurable: true,
+            value: vi.fn(),
+        })
     })
 
     test('shows no server selected message when no guild selected', () => {
@@ -202,7 +206,7 @@ describe('ModerationPage', () => {
         expect(searchInput).toHaveValue('')
     })
 
-    test.skip('type filter dropdown filters cases', async () => {
+    test('type filter dropdown filters cases', async () => {
         const user = userEvent.setup()
         mockGuildStore(mockGuild)
         vi.mocked(api.moderation.getCases).mockResolvedValue({
@@ -401,7 +405,7 @@ describe('ModerationPage', () => {
         })
     })
 
-    test.skip('resetting filters resets page to 1', async () => {
+    test('resetting filters resets page to 1', async () => {
         const user = userEvent.setup()
         mockGuildStore(mockGuild)
         vi.mocked(api.moderation.getCases).mockResolvedValue({


### PR DESCRIPTION
## Summary

- Add `scrollIntoView` polyfill to `beforeEach` in `Moderation.test.tsx` so Radix UI Select dropdown portal renders correctly in JSDOM
- Un-skip two previously skipped tests:
  - `'type filter dropdown filters cases'` — clicks combobox, selects Warnings, asserts `getCases` called with `{type:'warn', page:1, limit:15}`
  - `'resetting filters resets page to 1'` — navigates to page 2, changes filter to Bans, asserts page resets and `getCases` called with `{type:'ban', page:1, limit:15}`

Both tests now pass (18/18 total in the file). Same pattern used by `TwitchNotifications.test.tsx`.