### PR TITLE
fix(bot): standardize command responses to embeds and English

### DIFF
--- a/packages/bot/src/functions/general/commands/help.ts
+++ b/packages/bot/src/functions/general/commands/help.ts
@@ -11,6 +11,7 @@ import {
     getCommandCategory,
     getAllCategories,
 } from '../../../utils/command/commandCategory'
+import { EMBED_COLORS } from '../../../utils/general/embeds'
 
 function buildCategoryCommands(
     commands: Map<string, Command>,
@@ -26,7 +27,7 @@ function buildCategoryCommands(
         const category = getCommandCategory(command)
         const commandData = command.data
         categoryCommands[category].push(
-            `**/${commandData.name}** - ${commandData.description}`,
+            `**/${commandData.name}** — ${commandData.description}`,
         )
     })
 
@@ -39,21 +40,28 @@ function createHelpEmbed(
     interaction: ChatInputCommandInteraction,
 ): EmbedBuilder {
     const categories = getAllCategories()
+    const totalCommands = Object.values(categoryCommands).reduce(
+        (sum, cmds) => sum + cmds.length,
+        0,
+    )
+
     const embed = new EmbedBuilder()
-        .setColor('#0099ff')
-        .setTitle('📚 Bot Help — Commands by Category')
-        .setDescription('Available DiscordBot commands.')
+        .setColor(EMBED_COLORS.INFO)
+        .setTitle('📚 Lucky — Command Reference')
+        .setDescription(
+            'All available slash commands grouped by category. Use `/` to start any command.',
+        )
         .setThumbnail(client.user?.displayAvatarURL() ?? '')
         .setTimestamp()
         .setFooter({
-            text: `Requested by ${interaction.user.tag}`,
+            text: `${totalCommands} commands · Requested by ${interaction.user.tag}`,
             iconURL: interaction.user.displayAvatarURL(),
         })
 
     for (const { key, label } of categories) {
         if (categoryCommands[key].length > 0) {
             embed.addFields({
-                name: label,
+                name: `${label} (${categoryCommands[key].length})`,
                 value: `\u200B\n${categoryCommands[key].join('\n')}`,
                 inline: false,
             })

--- a/packages/bot/src/functions/music/commands/leave.ts
+++ b/packages/bot/src/functions/music/commands/leave.ts
@@ -13,7 +13,7 @@ import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 export default new Command({
     data: new SlashCommandBuilder()
         .setName('leave')
-        .setDescription('🚪 Sai do canal de voz e limpa a fila'),
+        .setDescription('🚪 Leave the voice channel and clear the queue.'),
     category: 'music',
     execute: async ({
         client,
@@ -38,8 +38,8 @@ export default new Command({
                 content: {
                     embeds: [
                         successEmbed(
-                            '👋 Até logo!',
-                            'Desconectei do canal de voz e limpei a fila.',
+                            'Goodbye!',
+                            '🚪 Disconnected from the voice channel and cleared the queue.',
                         ),
                     ],
                 },
@@ -52,7 +52,7 @@ export default new Command({
                     embeds: [
                         errorEmbed(
                             'Error',
-                            'An error occurred while trying to leave the voice channel!',
+                            'An error occurred while trying to leave the voice channel.',
                         ),
                     ],
                 },

--- a/packages/bot/src/functions/music/commands/lyrics.ts
+++ b/packages/bot/src/functions/music/commands/lyrics.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
 import { interactionReply } from '../../../utils/general/interactionReply'
-import { musicEmbed } from '../../../utils/general/embeds'
+import { errorEmbed, musicEmbed, warningEmbed } from '../../../utils/general/embeds'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import { requireCurrentTrack } from '../../../utils/command/commandValidations'
 import { featureToggleService } from '@lucky/shared/services'
@@ -31,7 +31,13 @@ export default new Command({
             await interactionReply({
                 interaction,
                 content: {
-                    content: 'Lyrics feature is currently disabled',
+                    embeds: [
+                        warningEmbed(
+                            'Feature unavailable',
+                            'The lyrics feature is currently disabled.',
+                        ),
+                    ],
+                    ephemeral: true,
                 },
             })
             return
@@ -46,7 +52,12 @@ export default new Command({
                 await interactionReply({
                     interaction,
                     content: {
-                        content: 'This command can only be used in a server.',
+                        embeds: [
+                            errorEmbed(
+                                'Server only',
+                                'This command can only be used in a server.',
+                            ),
+                        ],
                         ephemeral: true,
                     },
                 })

--- a/packages/bot/src/functions/music/commands/pause.ts
+++ b/packages/bot/src/functions/music/commands/pause.ts
@@ -7,6 +7,7 @@ import {
     requireVoiceChannel,
 } from "../../../utils/command/commandValidations"
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import { successEmbed, warningEmbed } from '../../../utils/general/embeds'
 
 export default new Command({
     data: new SlashCommandBuilder()
@@ -24,7 +25,13 @@ export default new Command({
             await interactionReply({
                 interaction,
                 content: {
-                    content: '⏸️ Music is already paused.',
+                    embeds: [
+                        warningEmbed(
+                            'Already paused',
+                            '⏸️ Music is already paused.',
+                        ),
+                    ],
+                    ephemeral: true,
                 },
             })
             return
@@ -35,7 +42,12 @@ export default new Command({
         await interactionReply({
             interaction,
             content: {
-                content: '⏸️ Music has been paused.',
+                embeds: [
+                    successEmbed(
+                        'Paused',
+                        '⏸️ Music has been paused.',
+                    ),
+                ],
             },
         })
     },

--- a/packages/bot/src/functions/music/commands/queueResolverWiring.spec.ts
+++ b/packages/bot/src/functions/music/commands/queueResolverWiring.spec.ts
@@ -50,6 +50,7 @@ jest.mock('@lucky/shared/services', () => ({
 jest.mock('../../../utils/general/embeds', () => ({
     errorEmbed: jest.fn(() => ({})),
     successEmbed: jest.fn(() => ({})),
+    warningEmbed: jest.fn(() => ({})),
     musicEmbed: jest.fn(() => ({
         setThumbnail: jest.fn(),
     })),
@@ -198,7 +199,7 @@ describe('music command resolver wiring', () => {
         expect(interactionReplyMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 content: expect.objectContaining({
-                    content: 'This command can only be used in a server.',
+                    embeds: expect.any(Array),
                     ephemeral: true,
                 }),
             }),

--- a/packages/bot/src/functions/music/commands/resume.ts
+++ b/packages/bot/src/functions/music/commands/resume.ts
@@ -4,6 +4,7 @@ import { interactionReply } from "../../../utils/general/interactionReply"
 import type { CommandExecuteParams } from "../../../types/CommandData"
 import { requireQueue } from "../../../utils/command/commandValidations"
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import { successEmbed, warningEmbed } from '../../../utils/general/embeds'
 
 export default new Command({
     data: new SlashCommandBuilder()
@@ -19,7 +20,13 @@ export default new Command({
             await interactionReply({
                 interaction,
                 content: {
-                    content: '▶️ Music is already playing.',
+                    embeds: [
+                        warningEmbed(
+                            'Already playing',
+                            '▶️ Music is already playing.',
+                        ),
+                    ],
+                    ephemeral: true,
                 },
             })
             return
@@ -30,7 +37,12 @@ export default new Command({
         await interactionReply({
             interaction,
             content: {
-                content: '▶️ Music has been resumed.',
+                embeds: [
+                    successEmbed(
+                        'Resumed',
+                        '▶️ Music has been resumed.',
+                    ),
+                ],
             },
         })
     },

--- a/packages/bot/src/functions/music/commands/stop.ts
+++ b/packages/bot/src/functions/music/commands/stop.ts
@@ -4,6 +4,7 @@ import { interactionReply } from "../../../utils/general/interactionReply"
 import type { CommandExecuteParams } from "../../../types/CommandData"
 import { requireQueue } from "../../../utils/command/commandValidations"
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import { successEmbed } from '../../../utils/general/embeds'
 
 export default new Command({
     data: new SlashCommandBuilder()
@@ -20,7 +21,12 @@ export default new Command({
         await interactionReply({
             interaction,
             content: {
-                content: '⏹️ A reprodução foi interrompida e a fila foi limpa.',
+                embeds: [
+                    successEmbed(
+                        'Playback stopped',
+                        '⏹️ Playback has been stopped and the queue has been cleared.',
+                    ),
+                ],
             },
         })
     },


### PR DESCRIPTION
## Summary

- `/stop`, `/resume`, `/pause`: replace raw `content: string` responses with proper `successEmbed`/`warningEmbed` calls
- `/leave`: translate Portuguese embed text to English ('Até logo!' → 'Goodbye!', etc.)
- `/lyrics`: replace raw `content: string` early-exits with `errorEmbed`/`warningEmbed`
- `/help`: use `EMBED_COLORS.INFO` instead of hardcoded `#0099ff`; add command count in footer; improve title to 'Lucky — Command Reference'
- `queueResolverWiring.spec.ts`: update assertion to match new embed response shape (raw content → embeds array)

## Tests

429/429 bot tests pass. Lint clean.