### PR TITLE
fix(policy): check cwd instead of repoRoot for worktree detection

### DIFF
--- a/.opencode/plugins/lucky-policy-lib.mjs
+++ b/.opencode/plugins/lucky-policy-lib.mjs
@@ -122,7 +122,7 @@ export function shouldBlockRootMutation({
   command,
 }) {
   if (!repoRoot || allowRootMutation) return false
-  if (!isPrimaryCheckout(repoRoot)) return false
+  if (!isPrimaryCheckout(cwd)) return false
   if (!isMutatingShellCommand(command)) return false
   const normalizedRoot = path.resolve(repoRoot)
   const normalizedCwd = path.resolve(cwd)

--- a/.serena/memories/current-state.md
+++ b/.serena/memories/current-state.md
@@ -1,38 +1,35 @@
-# Lucky Current State (2026-03-14)
+# Lucky — Current State
 
-## Version / Branch
-- Latest published release: `v2.6.13` (`2026-03-12T17:48:31Z`)
-- Current `origin/main`: `e1d99ce chore(security): remediate high transitive advisories (#211)`
-- Root workspace policy: detached at `origin/main` for orchestration
-- Dedicated main worktree: `/Users/lucassantana/Desenvolvimento/Lucky/.worktrees/fix-pr171-closure-v2612`
+**Updated**: 2026-03-16
+**Latest release**: v2.6.24
+**Main branch**: at `e69c048` (origin/main); local root checkout still at `393b857` (needs pull)
 
-## Mainline Delivery Since `v2.6.13`
-- ✅ PR #205 merged: GitGuardian incident `28574658` remediation
-- ✅ PR #206 merged: env-only OAuth expected client-id and compose secret hardening
-- ✅ PR #207 merged: frontend auth bootstrap probe stabilization
-- ✅ PR #208 merged: deploy OAuth smoke secret contract hardening
-- ✅ PR #209 merged: high npm audit remediation
-- ✅ PR #210 closed as duplicate
-- ✅ PR #211 merged: follow-up high advisory remediation (`undici` / `flatted`)
+## What's in v2.6.24
+- feat: /queue smartshuffle — energy-aware ordering with streak limit (#298)
+- feat: /mod digest command for moderation summary (#299)
 
-## Mainline Health
-- ✅ `CI/CD Pipeline` passed for `e1d99ce`
-- ✅ `SonarCloud Analysis` passed for `e1d99ce`
-- ✅ `Build & Push Docker Images` passed for `e1d99ce`
-- ✅ `Deploy to Homelab` passed for `e1d99ce`
-- ✅ `npm audit` on `main`: `high=0`, `critical=0`, `moderate=10`
+## What's on main post-v2.6.24 (unreleased — will be v2.6.25)
+- fix(lint): remove unused params in lucky-policy-lib.mjs (#302)
+- chore(deps): patch/minor dep updates Mar 2026 (#303)
+- test(frontend): enable skipped Moderation filter tests (#304)
+- fix(bot): standardize command responses to embeds and English (#305)
 
-## Current Contracts
-- Deploy OAuth smoke is derived from `GET /api/health/auth-config`
-- Deploy requires `WEBAPP_EXPECTED_CLIENT_ID` secret
-- Compose runtime requires explicit `POSTGRES_PASSWORD`
-- Root verification contract is now `npm run verify`
-- Playwright remains a separate smoke/regression lane via `npm run test:e2e`
+## CI / Quality
+- npm audit: 0 vulnerabilities
+- All tests: 429/429 bot passing, 18/18 Moderation frontend passing
+- SonarCloud: passing on main
 
-## Operational Gaps
-- Real browser-based Discord login validation is still required to confirm the
-  full callback/session/dashboard path after the March 13 auth/deploy changes
-- GitHub MCP authentication is broken in this environment; `gh` CLI is the
-  current fallback for PR/release/issue operations
-- Moderate dependency findings remain for the `file-type` / `yauzl` transitive
-  chain and need a separate cleanup cycle
+## Active Worktrees
+- `.worktrees/fix-command-polish` — stale (PR #305 merged)
+- `.worktrees/fix-moderation-tests` — stale (PR #304 merged)
+
+## Open Issues
+- None
+
+## Open PRs
+- None
+
+## Known Issues / Pending Work
+- lucky-policy-lib.mjs has a bug: `isPrimaryCheckout(repoRoot)` should be `isPrimaryCheckout(cwd)` — fix has been applied locally, needs to be committed via PR
+- Stale worktrees need cleanup
+- v2.6.25 release not yet cut

--- a/.serena/memories/next-priorities.md
+++ b/.serena/memories/next-priorities.md
@@ -1,39 +1,23 @@
-# Next Priorities (2026-03-14)
+# Next Priorities (2026-03-16)
 
-## P0
-1. Cut the next patch release from `main` (`v2.6.14` unless semver scope changes)
-   so the March 13 stabilization/security wave is published.
-2. Run production smoke on:
-   - `/api/auth/discord`
-   - `/api/health/auth-config`
-   - `https://lucky.lucassantana.tech/install`
-   - legal/discovery URLs
-   - Discord discovery media URLs
-3. Complete a real browser-based Discord login validation and confirm dashboard
-   bootstrap, guild selection, settings, features, and Twitch notifications.
-4. Triage open Dependabot PRs `#212` to `#217` immediately after the release.
+## P0 (Pending merge)
+- PR #302 — fix(lint): remove unused params in lucky-policy-lib.mjs — MERGED
+- PR #303 — chore(deps): patch/minor dep updates Mar 2026 — open, CI running, auto-merge enabled
 
-## P1
-1. Keep CI security enforcement aligned with repo policy:
-   `audit:high` must stay blocking in CI and local release verification.
-2. Use `npm run verify` as the canonical pre-PR gate; keep `npm run test:e2e`
-   separate as the browser smoke/regression lane.
-3. Run a moderate-only dependency cleanup cycle for the `file-type` / `yauzl`
-   transitive chain.
-4. Restore GitHub MCP authentication for this environment.
+## P1 (Next features)
+No open issues. Potential enhancements identified from codebase:
+1. **Guild automation / RBAC** — `packages/shared` has skeleton for automation manifests; not yet wired to bot commands
+2. **Playback analytics dashboard** — track history stored in DB, frontend `/music/history` route exists; no charts/stats view
+3. **Rate limit UI** — provider health cooldown in Redis/bot; no admin command to view current cooldown state
+4. **Auto-message scheduling** — `AutoMessageService` supports trigger-based; could add cron-based scheduled messages
+5. **Queue persistence** — current queue is in-memory; persisting to Redis on graceful shutdown would allow bot-restart recovery
 
-## P2
-1. Triage unmerged local branches/worktrees into `keep`, `salvage`, or `delete`.
-2. Normalize docs that still reflect pre-`main` stabilization assumptions.
-3. Convert backlog items into GitHub issues/epics instead of keeping them only
-   in local branch names and memory files.
+## P2 (Housekeeping)
+1. Update Serena memories after PR #303 merges (current state will be v2.6.25)
+2. Audit major dep bumps (vite 7→8, zod 3→4) when time allows
+3. Cleanup: 0 worktrees currently (all stale ones removed)
 
-## P3
-1. Resume the locked bot reliability roadmap:
-   `/music health`, music watchdog auto-recovery, provider health cooldown,
-   queue snapshot restore.
-2. Follow with autoplay intelligence v2:
-   feedback, diversity constraints, reason tags, `/queue rescue`.
-3. Revisit remaining guild automation / RBAC deltas only after branch triage.
-4. Defer presence/activity improvement work until reliability and admin/runtime
-   follow-up items are closed.
+## Out of Scope (do not re-raise)
+- PR #268 (smartshuffle) — merged in v2.6.24
+- PR #269 (mod digest) — merged in v2.6.24
+- npm audit — 0 vulnerabilities (CLEAN)


### PR DESCRIPTION
## Problem

`shouldBlockRootMutation` in `lucky-policy-lib.mjs` called `isPrimaryCheckout(repoRoot)` to decide whether to block mutations. `repoRoot` is always the primary checkout path (`/Users/.../Lucky`), which never contains `.worktrees` — so the function always returned `true` and blocked every mutation attempted from a worktree.

## Fix

Change `isPrimaryCheckout(repoRoot)` → `isPrimaryCheckout(cwd)`.

`cwd` reflects the actual working directory of the shell command. When running from a `.worktrees/` path, `isPrimaryCheckout(cwd)` returns `false`, correctly allowing the mutation to proceed.

## Impact

- Mutations from `.worktrees/*` paths: now correctly **allowed**
- Mutations from the primary checkout root: still correctly **blocked**
- No behavior change for destructive or direct-main-push guards (those run before this check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation and project planning to reflect current state and priorities as of March 16, 2026.

* **Bug Fixes**
  * Corrected validation logic for checkout status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->