### PR TITLE
feat(bot): /automod preset — apply balanced/strict/light rule packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.25] - 2026-03-16
+
+### Added
+
+- **`/automod preset`**: apply pre-built auto-moderation rule packs (`balanced`, `strict`, `light`) with a single command. Omit the `name` option to list all available presets with descriptions. Merges allowed domains and banned words with existing settings, preserving exempt channels and roles.
+
+
 ## [2.6.24] - 2026-03-16
 
 ### Added

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # Lucky Implementation Status
 
-**Last Updated:** 2026-03-15  
-**Current Version:** v2.6.20
+**Last Updated:** 2026-03-16  
+**Current Version:** v2.6.24
 
 This document reflects what is currently shipped and running in production.
 
@@ -21,7 +21,9 @@ This document reflects what is currently shipped and running in production.
 
 #### Music (`/play`, `/queue`, `/skip`, `/stop`, `/pause`, `/resume`, `/volume`, etc.)
 - Full playback lifecycle with Discord Player v7
-- Queue management: `/queue show`, `/queue clear`, `/queue remove`, `/queue move`, `/queue shuffle`
+- Queue management: `/queue show`, `/queue clear`, `/queue remove`, `/queue move`
+- `/queue shuffle` — standard Fisher-Yates shuffle
+- `/queue smartshuffle` — energy-aware shuffle ordered by source/duration energy score, interleaved high/low buckets, per-requester streak limit (v2.6.24)
 - `/queue rescue` — probe-based detection and removal of unresolvable tracks (v2.6.20)
 - `/lyrics` — paginated lyrics via lyrics.ovh with smart query cleaning
 - `/repeat`, `/autoplay` — repeat mode and autoplay toggle
@@ -30,29 +32,35 @@ This document reflects what is currently shipped and running in production.
 - **Autoplay** — recommendation engine with similarity scoring (genre, tag, artist, duration, popularity)
 - **Diversity caps** — max 2 tracks per artist, max 3 per source; same-source penalty −0.15 (v2.6.19)
 - **Recommendation reason tags** — shows why a track was autoplay-queued (v2.6.20)
-- **Feedback** — `/recommendation feedback` (like/dislike) stored per guild+user in Redis, 24h TTL
+- **Autoplay like-boost** — liked tracks receive +0.3 score bonus and appear more often (v2.6.23)
+- **Feedback** — `/recommendation feedback` (like/dislike) stored per-user in Redis, 30-day TTL; `/music clearfeedback` to reset (v2.6.21)
 - **`/music health`** — provider health, watchdog state, queue diagnostics, session snapshot, feedback count
 
 #### Music Reliability
-- **ProviderHealthService** — score-based provider ordering, cooldown on repeated failures, configurable via `MUSIC_PROVIDER_COOLDOWN_MS`
-- **MusicWatchdogService** — per-guild arm/clear/recover cycle; detects stale connection and retries rejoin + replay
+- **ProviderHealthService** — score-based provider ordering, cooldown on repeated failures, Redis-persisted state across restarts; configurable via `MUSIC_PROVIDER_COOLDOWN_MS`, `MUSIC_PROVIDER_FAILURE_THRESHOLD` (v2.6.21)
+- **MusicWatchdogService** — per-guild arm/clear/recover cycle; detects stale connection and retries rejoin + replay; periodic cross-guild orphan scan (default 60s) via `MUSIC_WATCHDOG_SCAN_INTERVAL_MS` (v2.6.21, v2.6.22)
 - **Session snapshots** — Redis-backed queue state (`music:snapshot:{guildId}`, 30-min TTL); restored on bot restart via `restoreSessionsOnStartup`
 
-#### Moderation (`/warn`, `/mute`, `/unmute`, `/kick`, `/ban`, `/unban`, `/case`)
+#### Moderation (`/warn`, `/mute`, `/unmute`, `/kick`, `/ban`, `/unban`, `/case`, `/cases`, `/history`)
 - Full case management with case number tracking, DM notifications, evidence logging
-- **AutoModService** — spam detection, caps lock threshold, link filtering, word filter, raid detection
-- Configurable per-guild via management commands
+- **`/digest`** — moderation activity digest with period-filtered stats and top 5 moderators (7d/30d/90d) (v2.6.24)
+
+#### Auto-Moderation (`/automod`)
+- **AutoModService** — spam detection, caps lock threshold, link filtering, invite filtering, word filter
+- Configurable per-guild: `/automod spam`, `/automod caps`, `/automod links`, `/automod invites`, `/automod words`
+- **`/automod status`** — view current settings
+- **`/automod preset`** — apply pre-built rule packs: `balanced`, `strict`, `light`; merges with existing exempt channels/roles (v2.6.25, in progress)
 
 #### Management
-- Embed builder, custom commands, auto-messages (welcome/leave/scheduled), server logs
-- Guild automation (RBAC-aware role assignment, member join/leave events)
-- `/session` — view and restore music session snapshots
+- Embed builder (`/embed`), custom commands (`/customcommand`), auto-messages (`/automessage`)
+- Server logs (`/serverlog`), guild automation (RBAC-aware role assignment)
+- Reaction roles (`/reactionrole`)
 
 #### Download
 - `/download` — yt-dlp powered media download command
 
 #### General
-- `/help`, `/ping`, `/invite`, standard utility commands
+- `/help`, `/ping`, `/lastfm`, `/twitch`, `/roleconfig` — standard utility commands
 
 ### Backend API (`packages/backend`)
 - Express REST API for the web dashboard
@@ -67,23 +75,25 @@ This document reflects what is currently shipped and running in production.
 
 ---
 
-## Known Gaps (Tracked as Issues)
+## Known Gaps / Future Work
 
-| Issue | Title | Status |
-|-------|-------|--------|
-| #279 | Music watchdog cross-guild periodic scan | Open |
-| #280 | `MUSIC_PROVIDER_FAILURE_THRESHOLD` env var | Open |
-| #281 | discord-player-youtubei v2.0.0 | **Closed (merged v2.6.20)** |
-| #282 | Autoplay feedback: user-scoped, 30d TTL, like-boost, clearfeedback | Open |
-| #268 | /queue smartshuffle | Open |
-| #269 | /mod digest | Open |
+| Area | Description | Complexity |
+|------|-------------|------------|
+| `/starboard` | Message star pinning with leaderboard — needs new Prisma model | L |
+| `/level` | XP + role rewards + leaderboard — needs new Prisma model + service | L |
+| Autoplay diversity | Reason tag expansion, feedback diversity constraints | M |
+| Guild automation | RBAC delta review post-v2.6.21 | M |
+| Presence/activity | Bot activity/status customization | S |
 
 ---
 
-## Deferred / Backlog
+## Env Vars Reference
 
-- Presence/activity improvement
-- `/queue smartshuffle` (#268)
-- `/mod digest` (#269)
-- Autoplay intelligence v2: feedback diversity, reason tag expansion
-- Guild automation RBAC deltas
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `SMART_SHUFFLE_STREAK_LIMIT` | `2` | Max consecutive tracks from one requester in smartshuffle |
+| `AUTOPLAY_FEEDBACK_TTL_DAYS` | `30` | Feedback Redis entry TTL in days |
+| `MUSIC_PROVIDER_FAILURE_THRESHOLD` | `2` | Failures before provider enters cooldown |
+| `MUSIC_PROVIDER_COOLDOWN_MS` | `240000` | Provider cooldown duration in ms |
+| `MUSIC_WATCHDOG_SCAN_INTERVAL_MS` | `60000` | Periodic orphan session scan interval |
+| `QUEUE_RESCUE_PROBE_TIMEOUT_MS` | `5000` | Probe timeout for /queue rescue |

--- a/packages/bot/src/functions/automod/commands/automod.spec.ts
+++ b/packages/bot/src/functions/automod/commands/automod.spec.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import automodCommand from './automod'
+
+const getSettingsMock = jest.fn()
+const updateSettingsMock = jest.fn()
+const listTemplatesMock = jest.fn()
+const applyTemplateMock = jest.fn()
+const interactionReplyMock = jest.fn()
+const infoLogMock = jest.fn()
+const errorLogMock = jest.fn()
+
+jest.mock('@lucky/shared/services', () => ({
+    autoModService: {
+        getSettings: (...args: unknown[]) => getSettingsMock(...args),
+        updateSettings: (...args: unknown[]) => updateSettingsMock(...args),
+        listTemplates: (...args: unknown[]) => listTemplatesMock(...args),
+        applyTemplate: (...args: unknown[]) => applyTemplateMock(...args),
+    },
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: (...args: unknown[]) => infoLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+}))
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+function createInteraction(subcommand: string, options: Record<string, unknown> = {}) {
+    return {
+        guild: { id: '123456789012345678', name: 'TestServer' },
+        user: { tag: 'Admin#0001' },
+        options: {
+            getSubcommand: jest.fn(() => subcommand),
+            getBoolean: jest.fn((name: string) => options[name] ?? null),
+            getString: jest.fn((name: string) => options[name] ?? null),
+            getInteger: jest.fn((name: string) => options[name] ?? null),
+        },
+        replied: false,
+        deferred: false,
+    } as any
+}
+
+const baseSettings = {
+    enabled: true,
+    spamEnabled: true,
+    spamThreshold: 6,
+    spamTimeWindow: 8,
+    capsEnabled: true,
+    capsThreshold: 75,
+    linksEnabled: true,
+    allowedDomains: ['youtube.com'],
+    invitesEnabled: true,
+    wordsEnabled: true,
+    bannedWords: ['badword'],
+    exemptChannels: [],
+    exemptRoles: [],
+}
+
+describe('automod command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        interactionReplyMock.mockResolvedValue(undefined)
+        infoLogMock.mockReturnValue(undefined)
+        errorLogMock.mockReturnValue(undefined)
+    })
+
+    it('has correct command name and description', () => {
+        const data = automodCommand.data.toJSON()
+        expect(data.name).toBe('automod')
+        expect(data.description).toContain('auto-moderation')
+    })
+
+    it('rejects when not in a guild', async () => {
+        const interaction = createInteraction('preset')
+        interaction.guild = null
+        await automodCommand.execute({ interaction, client: {} as any })
+        expect(interactionReplyMock).toHaveBeenCalledTimes(1)
+        const reply = interactionReplyMock.mock.calls[0][0] as any
+        expect(reply.content.content).toContain('server')
+    })
+
+    describe('status subcommand', () => {
+        it('shows status embed when settings exist', async () => {
+            getSettingsMock.mockResolvedValue(baseSettings)
+            const interaction = createInteraction('status')
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(getSettingsMock).toHaveBeenCalledWith('123456789012345678')
+            const reply = interactionReplyMock.mock.calls[0][0] as any
+            expect(reply.content.embeds).toHaveLength(1)
+        })
+
+        it('reports when no settings exist', async () => {
+            getSettingsMock.mockResolvedValue(null)
+            const interaction = createInteraction('status')
+            await automodCommand.execute({ interaction, client: {} as any })
+            const reply = interactionReplyMock.mock.calls[0][0] as any
+            expect(reply.content.content).toBeDefined()
+        })
+    })
+
+    describe('preset subcommand — list', () => {
+        it('lists presets when no name given', async () => {
+            listTemplatesMock.mockResolvedValue([
+                { id: 'balanced', name: 'Balanced', description: 'Balanced baseline.' },
+                { id: 'strict', name: 'Strict Shield', description: 'Aggressive.' },
+                { id: 'light', name: 'Light', description: 'Low friction.' },
+            ])
+            const interaction = createInteraction('preset', { name: null })
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(listTemplatesMock).toHaveBeenCalledTimes(1)
+            const reply = interactionReplyMock.mock.calls[0][0] as any
+            expect(reply.content.embeds).toHaveLength(1)
+        })
+    })
+
+    describe('preset subcommand — apply', () => {
+        it('applies a preset and shows result embed', async () => {
+            applyTemplateMock.mockResolvedValue({
+                settings: { ...baseSettings, spamThreshold: 4 },
+                template: { id: 'strict', name: 'Strict Shield', description: 'Aggressive.' },
+            })
+            const interaction = createInteraction('preset', { name: 'strict' })
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(applyTemplateMock).toHaveBeenCalledWith('123456789012345678', 'strict')
+            const reply = interactionReplyMock.mock.calls[0][0] as any
+            expect(reply.content.embeds).toHaveLength(1)
+            expect(infoLogMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('calls errorLog on service failure', async () => {
+            applyTemplateMock.mockRejectedValue(new Error('DB error'))
+            const interaction = createInteraction('preset', { name: 'balanced' })
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(errorLogMock).toHaveBeenCalledTimes(1)
+            const reply = interactionReplyMock.mock.calls[0][0] as any
+            expect(reply.content.content).toContain('Failed')
+        })
+    })
+
+    describe('module toggle subcommands', () => {
+        it('enables spam with threshold and timewindow', async () => {
+            updateSettingsMock.mockResolvedValue(baseSettings)
+            const interaction = createInteraction('spam', { enabled: true, threshold: 4, timewindow: 5 })
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(updateSettingsMock).toHaveBeenCalledWith('123456789012345678', {
+                spamEnabled: true,
+                spamThreshold: 4,
+                spamTimeWindow: 5,
+            })
+        })
+
+        it('disables caps', async () => {
+            updateSettingsMock.mockResolvedValue({ ...baseSettings, capsEnabled: false })
+            const interaction = createInteraction('caps', { enabled: false })
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(updateSettingsMock).toHaveBeenCalledWith('123456789012345678', { capsEnabled: false })
+        })
+
+        it('enables links', async () => {
+            updateSettingsMock.mockResolvedValue(baseSettings)
+            const interaction = createInteraction('links', { enabled: true })
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(updateSettingsMock).toHaveBeenCalledWith('123456789012345678', { linksEnabled: true })
+        })
+
+        it('enables invites', async () => {
+            updateSettingsMock.mockResolvedValue(baseSettings)
+            const interaction = createInteraction('invites', { enabled: true })
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(updateSettingsMock).toHaveBeenCalledWith('123456789012345678', { invitesEnabled: true })
+        })
+
+        it('enables words', async () => {
+            updateSettingsMock.mockResolvedValue(baseSettings)
+            const interaction = createInteraction('words', { enabled: true })
+            await automodCommand.execute({ interaction, client: {} as any })
+            expect(updateSettingsMock).toHaveBeenCalledWith('123456789012345678', { wordsEnabled: true })
+        })
+    })
+})

--- a/packages/bot/src/functions/automod/commands/automod.ts
+++ b/packages/bot/src/functions/automod/commands/automod.ts
@@ -106,6 +106,22 @@ export default new Command({
         )
         .addSubcommand((subcommand) =>
             subcommand
+                .setName('preset')
+                .setDescription('Apply a preset configuration pack to auto-moderation')
+                .addStringOption((option) =>
+                    option
+                        .setName('name')
+                        .setDescription('Preset to apply — omit to list available presets')
+                        .setRequired(false)
+                        .addChoices(
+                            { name: 'Balanced — baseline for mixed communities', value: 'balanced' },
+                            { name: 'Strict Shield — aggressive anti-spam for public servers', value: 'strict' },
+                            { name: 'Light — basic spam and link protection only', value: 'light' },
+                        ),
+                ),
+        )
+        .addSubcommand((subcommand) =>
+            subcommand
                 .setName('status')
                 .setDescription('View current auto-moderation settings'),
         ),
@@ -115,7 +131,7 @@ export default new Command({
             await interactionReply({
                 interaction,
                 content: {
-                    content: '❌ This command can only be used in a server.',
+                    content: 'This command can only be used in a server.',
                 },
             })
             return
@@ -133,7 +149,7 @@ export default new Command({
                         interaction,
                         content: {
                             content:
-                                '❌ No auto-mod settings found. Use `/automod configure` first.',
+                                'No auto-mod settings found. Use `/automod spam`, `/automod links`, or `/automod preset` first.',
                         },
                     })
                     return
@@ -141,37 +157,35 @@ export default new Command({
 
                 const embed = new EmbedBuilder()
                     .setColor(0x5865f2)
-                    .setTitle('🤖 Auto-Moderation Settings')
+                    .setTitle('Auto-Moderation Settings')
                     .addFields(
                         {
-                            name: '📨 Spam Detection',
+                            name: 'Spam Detection',
                             value: settings.spamEnabled
-                                ? `✅ Enabled\n└ ${settings.spamThreshold} messages in ${settings.spamTimeWindow}s`
-                                : '❌ Disabled',
+                                ? `Enabled — ${settings.spamThreshold} messages in ${settings.spamTimeWindow}s`
+                                : 'Disabled',
                         },
                         {
-                            name: '🔠 Caps Detection',
+                            name: 'Caps Detection',
                             value: settings.capsEnabled
-                                ? `✅ Enabled\n└ ${settings.capsThreshold}% caps threshold`
-                                : '❌ Disabled',
+                                ? `Enabled — ${settings.capsThreshold}% caps threshold`
+                                : 'Disabled',
                         },
                         {
-                            name: '🔗 Link Filtering',
+                            name: 'Link Filtering',
                             value: settings.linksEnabled
-                                ? `✅ Enabled\n└ Allowed domains: ${settings.allowedDomains.length}`
-                                : '❌ Disabled',
+                                ? `Enabled — ${settings.allowedDomains.length} allowed domains`
+                                : 'Disabled',
                         },
                         {
-                            name: '📧 Invite Filtering',
-                            value: settings.invitesEnabled
-                                ? `✅ Enabled`
-                                : '❌ Disabled',
+                            name: 'Invite Filtering',
+                            value: settings.invitesEnabled ? 'Enabled' : 'Disabled',
                         },
                         {
-                            name: '🚫 Bad Words Filter',
+                            name: 'Bad Words Filter',
                             value: settings.wordsEnabled
-                                ? `✅ Enabled\n└ ${settings.bannedWords.length} banned words`
-                                : '❌ Disabled',
+                                ? `Enabled — ${settings.bannedWords.length} banned words`
+                                : 'Disabled',
                         },
                     )
                     .setTimestamp()
@@ -201,8 +215,91 @@ export default new Command({
                 return
             }
 
+            if (subcommand === 'preset') {
+                const presetName = interaction.options.getString('name')
+
+                if (!presetName) {
+                    const templates = await autoModService.listTemplates()
+                    const embed = new EmbedBuilder()
+                        .setColor(0x5865f2)
+                        .setTitle('Auto-Moderation Presets')
+                        .setDescription(
+                            'Use `/automod preset name:<preset>` to apply one of these configurations.\n\nExisting settings are merged — exempt channels and roles are preserved.',
+                        )
+
+                    for (const template of templates) {
+                        embed.addFields({
+                            name: template.name,
+                            value: template.description,
+                        })
+                    }
+
+                    await interactionReply({
+                        interaction,
+                        content: { embeds: [embed] },
+                    })
+                    return
+                }
+
+                const { settings, template } = await autoModService.applyTemplate(
+                    interaction.guild.id,
+                    presetName,
+                )
+
+                const embed = new EmbedBuilder()
+                    .setColor(0x51cf66)
+                    .setTitle(`Preset Applied: ${template.name}`)
+                    .setDescription(template.description)
+                    .addFields(
+                        {
+                            name: 'Spam Detection',
+                            value: settings.spamEnabled
+                                ? `Enabled — ${settings.spamThreshold} messages in ${settings.spamTimeWindow}s`
+                                : 'Disabled',
+                            inline: true,
+                        },
+                        {
+                            name: 'Caps Detection',
+                            value: settings.capsEnabled
+                                ? `Enabled — ${settings.capsThreshold}%`
+                                : 'Disabled',
+                            inline: true,
+                        },
+                        {
+                            name: 'Link Filtering',
+                            value: settings.linksEnabled
+                                ? `Enabled — ${settings.allowedDomains.length} domains`
+                                : 'Disabled',
+                            inline: true,
+                        },
+                        {
+                            name: 'Invite Filtering',
+                            value: settings.invitesEnabled ? 'Enabled' : 'Disabled',
+                            inline: true,
+                        },
+                        {
+                            name: 'Bad Words Filter',
+                            value: settings.wordsEnabled
+                                ? `Enabled — ${settings.bannedWords.length} words`
+                                : 'Disabled',
+                            inline: true,
+                        },
+                    )
+                    .setTimestamp()
+
+                await interactionReply({
+                    interaction,
+                    content: { embeds: [embed] },
+                })
+
+                infoLog({
+                    message: `Auto-mod preset '${presetName}' applied by ${interaction.user.tag} in ${interaction.guild.name}`,
+                })
+                return
+            }
+
             const enabled = interaction.options.getBoolean('enabled', true)
-            const updateData: any = {}
+            const updateData: Record<string, unknown> = {}
 
             if (subcommand === 'spam') {
                 updateData.spamEnabled = enabled
@@ -239,7 +336,7 @@ export default new Command({
             const embed = new EmbedBuilder()
                 .setColor(enabled ? 0x51cf66 : 0xc92a2a)
                 .setTitle(
-                    `🤖 Auto-Moderation ${enabled ? 'Enabled' : 'Disabled'}`,
+                    `Auto-Moderation ${enabled ? 'Enabled' : 'Disabled'}`,
                 )
                 .addFields({
                     name: 'Module',
@@ -266,7 +363,7 @@ export default new Command({
                 interaction,
                 content: {
                     content:
-                        '❌ Failed to update auto-moderation settings. Please try again.',
+                        'Failed to update auto-moderation settings. Please try again.',
                 },
             })
         }


### PR DESCRIPTION
## Summary

- Adds `/automod preset` subcommand to the existing `/automod` command
- Omit `name` to list all available presets with descriptions
- Provide `name` (`balanced` / `strict` / `light`) to apply the preset — merges allowed domains and banned words with existing config, preserves exempt channels and roles
- `AutoModService.listTemplates()` and `applyTemplate()` were already implemented; this wires them to the Discord command

## Changes

- `packages/bot/src/functions/automod/commands/automod.ts` — added `preset` subcommand with `balanced`/`strict`/`light` choices
- `packages/bot/src/functions/automod/commands/automod.spec.ts` — 12 tests covering list, apply, error path, guild guard, all module toggles
- `docs/IMPLEMENTATION_STATUS.md` — updated to v2.6.24 state with accurate shipped features

## Test Coverage

All 12 tests pass locally. No schema changes required.