### PR TITLE
chore(release): prepare v2.6.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`/automod preset`**: apply pre-built auto-moderation rule packs (`balanced`, `strict`, `light`) with a single command. Omit the `name` option to list all available presets with descriptions. Merges allowed domains and banned words with existing settings, preserving exempt channels and roles.
+- **Voice channel status + music presence**: while music is playing, sets the voice channel status to the current track and overrides bot presence to `Listening to Track — Artist`. Clears both automatically when music stops or the bot disconnects. Multi-guild aware.
+
+### Fixed
+
+- Replaced `opusscript` with `@discordjs/opus` native binding for improved audio performance.
+- Standardized command responses to use embeds and English throughout.
+
+### Tests
+
+- Fixed flaky `smartShuffle` streak test by using balanced requester pools.
 
 
 ## [2.6.24] - 2026-03-16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.24",
+  "version": "2.6.25",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## v2.6.25

### Added
- `/automod preset` — apply balanced/strict/light rule packs (#307)
- Voice channel status + music activity presence (#310)

### Fixed
- Replaced opusscript with @discordjs/opus native binding
- Standardized command responses to embeds and English (#305)

### Tests
- Fixed flaky smartShuffle streak test (#311)