### PR TITLE
feat(bot): music button controls, queue pagination, and autoplay blending

### DIFF
--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -8,6 +8,11 @@ import { errorLog } from '@lucky/shared/utils'
 import { createErrorEmbed } from '../../../../utils/general/embeds'
 import { createSuccessEmbed } from '../../../../utils/general/embeds'
 import { collaborativePlaylistService } from '../../../../utils/music/collaborativePlaylist'
+import { QueueRepeatMode } from 'discord-player'
+import {
+    insertUserTrackWithPriority,
+    blendAutoplayTracks,
+} from '../../../../utils/music/queueManipulation'
 
 export default new Command({
     data: new SlashCommandBuilder()
@@ -84,6 +89,19 @@ export default new Command({
             })
 
             const track = result.track
+
+            const queue = client.player.nodes.get(
+                interaction.guildId!,
+            )
+            if (
+                queue &&
+                queue.repeatMode === QueueRepeatMode.AUTOPLAY &&
+                queue.tracks.size > 1
+            ) {
+                insertUserTrackWithPriority(queue, track)
+                await blendAutoplayTracks(queue, track)
+            }
+
             const embed = result.searchResult.playlist
                 ? createSuccessEmbed(
                       'Playlist Enqueued',

--- a/packages/bot/src/functions/music/commands/queue/index.ts
+++ b/packages/bot/src/functions/music/commands/queue/index.ts
@@ -125,12 +125,14 @@ export default new Command({
                 data: { queueExists: !!queue },
             })
 
-            const embed = await createQueueEmbed(queue)
+            const { embed, components } =
+                await createQueueEmbed(queue)
 
             await interactionReply({
                 interaction,
                 content: {
                     embeds: [embed],
+                    components,
                 },
             })
         } catch (error) {

--- a/packages/bot/src/functions/music/commands/queue/queueDisplay.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueDisplay.ts
@@ -33,8 +33,11 @@ export async function formatTrackForDisplay(
 export async function createTrackListDisplay(
     tracks: Track[],
     options: QueueDisplayOptions,
+    page = 0,
 ): Promise<string> {
-    const displayTracks = tracks.slice(0, options.maxTracksToShow)
+    const tracksPerPage = options.maxTracksToShow
+    const startIndex = page * tracksPerPage
+    const displayTracks = tracks.slice(startIndex, startIndex + tracksPerPage)
     const trackDisplays = []
 
     for (let i = 0; i < displayTracks.length; i++) {

--- a/packages/bot/src/functions/music/commands/queue/queueEmbed.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueEmbed.ts
@@ -4,10 +4,21 @@ import {
     EMBED_COLORS,
     EMOJIS,
 } from '../../../../utils/general/embeds'
-import type { ColorResolvable, EmbedBuilder } from 'discord.js'
+import type {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ColorResolvable,
+    EmbedBuilder,
+} from 'discord.js'
 import { calculateQueueStats, getQueueStatus } from './queueStats'
 import { createTrackListDisplay, createQueueSummary } from './queueDisplay'
 import type { QueueDisplayOptions } from './types'
+import { createQueuePaginationButtons } from '../../../../utils/music/buttonComponents'
+
+export type QueueEmbedResult = {
+    embed: EmbedBuilder
+    components: ActionRowBuilder<ButtonBuilder>[]
+}
 
 function addCurrentTrackInfo(
     embed: EmbedBuilder,
@@ -40,27 +51,29 @@ async function addUpcomingTracks(
     embed: EmbedBuilder,
     queue: GuildQueue,
     options: QueueDisplayOptions,
+    page: number,
 ): Promise<void> {
-    if (options.showUpcomingTracks) {
-        const upcomingTracks = queue.tracks.toArray()
+    if (!options.showUpcomingTracks) return
 
-        if (upcomingTracks.length > 0) {
-            const trackList = await createTrackListDisplay(
-                upcomingTracks,
-                options,
-            )
-            embed.addFields({
-                name: `📋 Upcoming Tracks (${upcomingTracks.length})`,
-                value: trackList,
-                inline: false,
-            })
-        } else {
-            embed.addFields({
-                name: '📋 Upcoming Tracks',
-                value: 'No tracks in queue',
-                inline: false,
-            })
-        }
+    const allTracks = queue.tracks.toArray()
+
+    if (allTracks.length > 0) {
+        const trackList = await createTrackListDisplay(
+            allTracks,
+            options,
+            page,
+        )
+        embed.addFields({
+            name: `\u{1F4CB} Upcoming Tracks (${allTracks.length})`,
+            value: trackList,
+            inline: false,
+        })
+    } else {
+        embed.addFields({
+            name: '\u{1F4CB} Upcoming Tracks',
+            value: 'No tracks in queue',
+            inline: false,
+        })
     }
 }
 
@@ -69,32 +82,29 @@ async function addQueueStats(
     queue: GuildQueue,
     options: QueueDisplayOptions,
 ): Promise<void> {
-    if (options.showQueueStats) {
-        const stats = await calculateQueueStats(queue)
-        const summary = createQueueSummary(
-            stats.totalTracks,
-            stats.totalDuration,
-            stats.currentPosition,
-        )
+    if (!options.showQueueStats) return
 
-        embed.addFields({
-            name: '📊 Queue Statistics',
-            value: summary,
-            inline: true,
-        })
+    const stats = await calculateQueueStats(queue)
+    const summary = createQueueSummary(
+        stats.totalTracks,
+        stats.totalDuration,
+        stats.currentPosition,
+    )
 
-        const status = getQueueStatus(queue)
-        embed.addFields({
-            name: '🎛️ Status',
-            value: status,
-            inline: true,
-        })
-    }
+    embed.addFields({
+        name: '\u{1F4CA} Queue Statistics',
+        value: summary,
+        inline: true,
+    })
+
+    const status = getQueueStatus(queue)
+    embed.addFields({
+        name: '\u{1F39B}\uFE0F Status',
+        value: status,
+        inline: true,
+    })
 }
 
-/**
- * Create the main queue embed
- */
 export async function createQueueEmbed(
     queue: GuildQueue,
     options: QueueDisplayOptions = {
@@ -104,39 +114,41 @@ export async function createQueueEmbed(
         showTotalDuration: true,
         showQueueStats: true,
     },
-) {
+    page = 0,
+): Promise<QueueEmbedResult> {
     const embed = createEmbed({
-        title: '📄 Music Queue',
+        title: '\u{1F4C4} Music Queue',
         color: EMBED_COLORS.QUEUE as ColorResolvable,
         timestamp: true,
     })
 
     addCurrentTrackInfo(embed, queue, options)
-    await addUpcomingTracks(embed, queue, options)
+    await addUpcomingTracks(embed, queue, options, page)
     await addQueueStats(embed, queue, options)
 
-    return embed
+    const totalTracks = queue.tracks.size
+    const totalPages = Math.ceil(totalTracks / options.maxTracksToShow)
+    const components: ActionRowBuilder<ButtonBuilder>[] = []
+    const paginationRow = createQueuePaginationButtons(page, totalPages)
+    if (paginationRow) components.push(paginationRow)
+
+    return { embed, components }
 }
 
-/**
- * Create an empty queue embed
- */
 export function createEmptyQueueEmbed() {
     return createEmbed({
-        title: '📄 Music Queue',
-        description: 'The queue is empty. Add some tracks to get started!',
+        title: '\u{1F4C4} Music Queue',
+        description:
+            'The queue is empty. Add some tracks to get started!',
         color: EMBED_COLORS.QUEUE as ColorResolvable,
         emoji: EMOJIS.QUEUE,
         timestamp: true,
     })
 }
 
-/**
- * Create a queue error embed
- */
 export function createQueueErrorEmbed(error: string) {
     return createEmbed({
-        title: '❌ Queue Error',
+        title: '\u274C Queue Error',
         description: error,
         color: EMBED_COLORS.ERROR as ColorResolvable,
         emoji: EMOJIS.ERROR,

--- a/packages/bot/src/handlers/interactionHandler.ts
+++ b/packages/bot/src/handlers/interactionHandler.ts
@@ -12,6 +12,7 @@ import { interactionReply } from '../utils/general/interactionReply'
 import { monitorInteractionHandling } from '../utils/monitoring'
 import { createUserFriendlyError } from '../utils/general/errorSanitizer'
 import { reactionRolesService } from '@lucky/shared/services'
+import { handleMusicButtonInteraction } from './musicButtonHandler'
 
 type HandleInteractionsParams = {
     client: CustomClient
@@ -97,7 +98,17 @@ export async function handleInteraction(
         }
 
         if (interaction.isButton()) {
-            await reactionRolesService.handleButtonInteraction(interaction)
+            const id = interaction.customId
+            if (
+                id.startsWith('music_') ||
+                id.startsWith('queue_page')
+            ) {
+                await handleMusicButtonInteraction(interaction)
+                return
+            }
+            await reactionRolesService.handleButtonInteraction(
+                interaction,
+            )
         }
     } catch (error) {
         errorLog({ message: 'Error handling interaction:', error })

--- a/packages/bot/src/handlers/musicButtonHandler.spec.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.spec.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+const shuffleQueueMock = jest.fn()
+const createMusicControlButtonsMock = jest.fn()
+const createQueueEmbedMock = jest.fn()
+
+jest.mock('../utils/music/queueManipulation', () => ({
+    shuffleQueue: (...args: unknown[]) => shuffleQueueMock(...args),
+}))
+
+jest.mock('../utils/music/buttonComponents', () => ({
+    createMusicControlButtons: (...args: unknown[]) => createMusicControlButtonsMock(...args),
+}))
+
+jest.mock('../functions/music/commands/queue/queueEmbed', () => ({
+    createQueueEmbed: (...args: unknown[]) => createQueueEmbedMock(...args),
+}))
+
+import { handleMusicButtonInteraction } from './musicButtonHandler'
+
+function createInteraction(customId: string, overrides: Record<string, unknown> = {}) {
+    return {
+        customId,
+        guild: { id: 'guild-1' },
+        update: jest.fn().mockResolvedValue(undefined),
+        reply: jest.fn().mockResolvedValue(undefined),
+        deferUpdate: jest.fn().mockResolvedValue(undefined),
+        ...overrides,
+    } as any
+}
+
+function createPlayer(queueOverrides: Record<string, unknown> = {}) {
+    return {
+        nodes: {
+            get: jest.fn().mockReturnValue({
+                currentTrack: { title: 'Test Track' },
+                node: {
+                    isPaused: jest.fn().mockReturnValue(false),
+                    pause: jest.fn(),
+                    resume: jest.fn(),
+                    skip: jest.fn(),
+                },
+                history: {
+                    tracks: { toArray: jest.fn().mockReturnValue([{ title: 'Previous' }]) },
+                    back: jest.fn().mockResolvedValue(undefined),
+                },
+                tracks: { size: 2, toArray: jest.fn().mockReturnValue([]) },
+                repeatMode: 0,
+                setRepeatMode: jest.fn(),
+                ...queueOverrides,
+            }),
+        },
+    } as any
+}
+
+describe('handleMusicButtonInteraction', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        createMusicControlButtonsMock.mockReturnValue({ data: { components: [] } })
+        createQueueEmbedMock.mockResolvedValue({ embed: {}, components: [] })
+    })
+
+    it('returns early when guild is null', async () => {
+        const interaction = createInteraction('music_skip', { guild: null })
+
+        await handleMusicButtonInteraction(interaction, createPlayer())
+
+        expect(interaction.update).not.toHaveBeenCalled()
+        expect(interaction.reply).not.toHaveBeenCalled()
+    })
+
+    it('returns early when no queue found', async () => {
+        const interaction = createInteraction('music_skip')
+        const player = { nodes: { get: jest.fn().mockReturnValue(null) } } as any
+
+        await handleMusicButtonInteraction(interaction, player)
+
+        expect(interaction.update).not.toHaveBeenCalled()
+    })
+
+    it('skips track when skip button is clicked', async () => {
+        const interaction = createInteraction('music_skip')
+        const queue = {
+            currentTrack: { title: 'Test Track' },
+            node: {
+                isPaused: jest.fn().mockReturnValue(false),
+                pause: jest.fn(),
+                resume: jest.fn(),
+                skip: jest.fn(),
+            },
+            history: { tracks: { toArray: jest.fn().mockReturnValue([]) }, back: jest.fn() },
+            tracks: { size: 2, toArray: jest.fn().mockReturnValue([]) },
+            repeatMode: 0,
+            setRepeatMode: jest.fn(),
+        }
+        const player = { nodes: { get: jest.fn().mockReturnValue(queue) } } as any
+
+        await handleMusicButtonInteraction(interaction, player)
+
+        expect(queue.node.skip).toHaveBeenCalled()
+        expect(interaction.update).toHaveBeenCalled()
+    })
+
+    it('shuffles queue when shuffle button is clicked', async () => {
+        const interaction = createInteraction('music_shuffle')
+        const player = createPlayer()
+
+        await handleMusicButtonInteraction(interaction, player)
+
+        expect(shuffleQueueMock).toHaveBeenCalled()
+        expect(interaction.update).toHaveBeenCalled()
+    })
+
+    it('toggles pause when pause/resume button is clicked while playing', async () => {
+        const interaction = createInteraction('music_pause_resume')
+        const queue = {
+            currentTrack: { title: 'Test Track' },
+            node: {
+                isPaused: jest.fn().mockReturnValue(false),
+                pause: jest.fn(),
+                resume: jest.fn(),
+                skip: jest.fn(),
+            },
+            history: { tracks: { toArray: jest.fn().mockReturnValue([]) }, back: jest.fn() },
+            tracks: { size: 2, toArray: jest.fn().mockReturnValue([]) },
+            repeatMode: 0,
+            setRepeatMode: jest.fn(),
+        }
+        const player = { nodes: { get: jest.fn().mockReturnValue(queue) } } as any
+
+        await handleMusicButtonInteraction(interaction, player)
+
+        expect(queue.node.pause).toHaveBeenCalled()
+        expect(interaction.update).toHaveBeenCalled()
+    })
+
+    it('resumes when pause/resume button is clicked while paused', async () => {
+        const interaction = createInteraction('music_pause_resume')
+        const queue = {
+            currentTrack: { title: 'Test Track' },
+            node: {
+                isPaused: jest.fn().mockReturnValue(true),
+                pause: jest.fn(),
+                resume: jest.fn(),
+                skip: jest.fn(),
+            },
+            history: { tracks: { toArray: jest.fn().mockReturnValue([]) }, back: jest.fn() },
+            tracks: { size: 2, toArray: jest.fn().mockReturnValue([]) },
+            repeatMode: 0,
+            setRepeatMode: jest.fn(),
+        }
+        const player = { nodes: { get: jest.fn().mockReturnValue(queue) } } as any
+
+        await handleMusicButtonInteraction(interaction, player)
+
+        expect(queue.node.resume).toHaveBeenCalled()
+        expect(interaction.update).toHaveBeenCalled()
+    })
+
+    it('cycles loop mode when loop button is clicked', async () => {
+        const interaction = createInteraction('music_loop')
+        const queue = {
+            currentTrack: { title: 'Test Track' },
+            node: {
+                isPaused: jest.fn().mockReturnValue(false),
+                pause: jest.fn(),
+                resume: jest.fn(),
+                skip: jest.fn(),
+            },
+            history: { tracks: { toArray: jest.fn().mockReturnValue([]) }, back: jest.fn() },
+            tracks: { size: 2, toArray: jest.fn().mockReturnValue([]) },
+            repeatMode: 0,
+            setRepeatMode: jest.fn(),
+        }
+        const player = { nodes: { get: jest.fn().mockReturnValue(queue) } } as any
+
+        await handleMusicButtonInteraction(interaction, player)
+
+        expect(queue.setRepeatMode).toHaveBeenCalled()
+        expect(interaction.update).toHaveBeenCalled()
+    })
+
+    it('goes back in history when previous button is clicked', async () => {
+        const interaction = createInteraction('music_previous')
+        const backMock = jest.fn().mockResolvedValue(undefined)
+        const queue = {
+            currentTrack: { title: 'Test Track' },
+            node: {
+                isPaused: jest.fn().mockReturnValue(false),
+                pause: jest.fn(),
+                resume: jest.fn(),
+                skip: jest.fn(),
+            },
+            history: {
+                tracks: { toArray: jest.fn().mockReturnValue([{ title: 'Previous' }]) },
+                back: backMock,
+            },
+            tracks: { size: 2, toArray: jest.fn().mockReturnValue([]) },
+            repeatMode: 0,
+            setRepeatMode: jest.fn(),
+        }
+        const player = { nodes: { get: jest.fn().mockReturnValue(queue) } } as any
+
+        await handleMusicButtonInteraction(interaction, player)
+
+        expect(backMock).toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/handlers/musicButtonHandler.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.ts
@@ -1,0 +1,184 @@
+import { type ButtonInteraction, type GuildMember } from 'discord.js'
+import { useQueue, QueueRepeatMode } from 'discord-player'
+import { debugLog, errorLog } from '@lucky/shared/utils'
+import { createErrorEmbed } from '../utils/general/embeds'
+import {
+    MUSIC_BUTTON_IDS,
+    QUEUE_BUTTON_PREFIX,
+} from '../types/musicButtons'
+import { createMusicControlButtons } from '../utils/music/buttonComponents'
+import { createQueueEmbed } from '../functions/music/commands/queue/queueEmbed'
+import { shuffleQueue } from '../utils/music/queueManipulation'
+import type { GuildQueue } from 'discord-player'
+
+type NonNullQueue = NonNullable<ReturnType<typeof useQueue>>
+
+export async function handleMusicButtonInteraction(
+    interaction: ButtonInteraction,
+): Promise<void> {
+    try {
+        const member = interaction.member as GuildMember
+        if (!member.voice.channel) {
+            await interaction.reply({
+                embeds: [
+                    createErrorEmbed(
+                        'Not in Voice',
+                        'Join a voice channel first',
+                    ),
+                ],
+                ephemeral: true,
+            })
+            return
+        }
+
+        const queue = useQueue(interaction.guildId!)
+        if (!queue) {
+            await interaction.reply({
+                embeds: [
+                    createErrorEmbed(
+                        'No Music',
+                        'Nothing is playing right now',
+                    ),
+                ],
+                ephemeral: true,
+            })
+            return
+        }
+
+        await routeButtonAction(interaction, queue)
+    } catch (error) {
+        errorLog({
+            message: 'Music button interaction error',
+            error,
+        })
+        if (!interaction.replied && !interaction.deferred) {
+            await interaction
+                .reply({
+                    embeds: [
+                        createErrorEmbed('Error', 'Something went wrong'),
+                    ],
+                    ephemeral: true,
+                })
+                .catch(() => {})
+        }
+    }
+}
+
+async function routeButtonAction(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    const { customId } = interaction
+
+    switch (customId) {
+        case MUSIC_BUTTON_IDS.PREVIOUS:
+            return handlePrevious(interaction, queue)
+        case MUSIC_BUTTON_IDS.PAUSE_RESUME:
+            return handlePauseResume(interaction, queue)
+        case MUSIC_BUTTON_IDS.SKIP:
+            return handleSkip(interaction, queue)
+        case MUSIC_BUTTON_IDS.SHUFFLE:
+            return handleShuffle(interaction, queue)
+        case MUSIC_BUTTON_IDS.LOOP:
+            return handleLoop(interaction, queue)
+        default:
+            if (customId.startsWith(QUEUE_BUTTON_PREFIX)) {
+                return handleQueuePage(interaction, queue)
+            }
+    }
+}
+
+async function handlePrevious(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    await queue.history.back()
+    debugLog({ message: 'Previous track via button' })
+    await interaction.deferUpdate()
+}
+
+async function handlePauseResume(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    if (queue.node.isPaused()) {
+        queue.node.resume()
+    } else {
+        queue.node.pause()
+    }
+
+    await interaction.update({
+        components: [createMusicControlButtons(queue)],
+    })
+}
+
+async function handleSkip(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    queue.node.skip()
+    debugLog({ message: 'Track skipped via button' })
+    await interaction.deferUpdate()
+}
+
+async function handleShuffle(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    await shuffleQueue(queue)
+    debugLog({ message: 'Queue shuffled via button' })
+    await interaction.deferUpdate()
+}
+
+const LOOP_MODE_NAMES: Record<number, string> = {
+    [QueueRepeatMode.OFF]: 'Off',
+    [QueueRepeatMode.TRACK]: 'Track',
+    [QueueRepeatMode.QUEUE]: 'Queue',
+    [QueueRepeatMode.AUTOPLAY]: 'Autoplay',
+}
+
+const LOOP_MODE_ORDER = [
+    QueueRepeatMode.OFF,
+    QueueRepeatMode.TRACK,
+    QueueRepeatMode.QUEUE,
+    QueueRepeatMode.AUTOPLAY,
+]
+
+async function handleLoop(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    const currentIdx = LOOP_MODE_ORDER.indexOf(queue.repeatMode)
+    const nextIdx = (currentIdx + 1) % LOOP_MODE_ORDER.length
+    const newMode = LOOP_MODE_ORDER[nextIdx]
+    queue.setRepeatMode(newMode)
+
+    const modeName = LOOP_MODE_NAMES[newMode] ?? 'Off'
+    await interaction.reply({
+        content: `\u{1F501} Loop mode: **${modeName}**`,
+        ephemeral: true,
+    })
+}
+
+async function handleQueuePage(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    const pageMatch = interaction.customId.match(
+        /queue_page_(\d+)/,
+    )
+    if (!pageMatch?.[1]) return
+
+    const page = parseInt(pageMatch[1], 10)
+    const { embed, components } = await createQueueEmbed(
+        queue,
+        undefined,
+        page,
+    )
+
+    await interaction.update({
+        embeds: [embed],
+        components,
+    })
+    debugLog({ message: `Queue page: ${page}` })
+}

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -4,6 +4,7 @@ import { debugLog, errorLog } from '@lucky/shared/utils'
 import { createEmbed, EMBED_COLORS } from '../../utils/general/embeds'
 import { getAutoplayCount } from '../../utils/music/autoplayManager'
 import { constants } from '@lucky/shared/config'
+import { createMusicControlButtons } from '../../utils/music/buttonComponents'
 import {
     isLastFmConfigured,
     getSessionKeyForUser,
@@ -106,7 +107,12 @@ export async function sendNowPlayingEmbed(
             const message = await metadata.channel.messages.fetch(
                 previousMessage.messageId,
             )
-            await message.edit({ content: null, embeds: [embed] })
+            const buttons = createMusicControlButtons(queue)
+            await message.edit({
+                content: null,
+                embeds: [embed],
+                components: [buttons],
+            })
             debugLog({
                 message: 'Updated now playing message in channel',
                 data: {
@@ -121,7 +127,11 @@ export async function sendNowPlayingEmbed(
         }
     }
 
-    const message = await metadata.channel.send({ embeds: [embed] })
+    const controlButtons = createMusicControlButtons(queue)
+    const message = await metadata.channel.send({
+        embeds: [embed],
+        components: [controlButtons],
+    })
 
     songInfoMessages.set(queue.guild.id, {
         messageId: message.id,

--- a/packages/bot/src/types/musicButtons.ts
+++ b/packages/bot/src/types/musicButtons.ts
@@ -1,0 +1,12 @@
+export const MUSIC_BUTTON_IDS = {
+    PREVIOUS: 'music_previous',
+    PAUSE_RESUME: 'music_pause_resume',
+    SKIP: 'music_skip',
+    SHUFFLE: 'music_shuffle',
+    LOOP: 'music_loop',
+} as const
+
+export const QUEUE_BUTTON_PREFIX = 'queue_page'
+
+export type MusicButtonId =
+    (typeof MUSIC_BUTTON_IDS)[keyof typeof MUSIC_BUTTON_IDS]

--- a/packages/bot/src/utils/music/buttonComponents.spec.ts
+++ b/packages/bot/src/utils/music/buttonComponents.spec.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { createMusicControlButtons, createQueuePaginationButtons } from './buttonComponents'
+import type { GuildQueue } from 'discord-player'
+
+function createQueue(overrides: Record<string, unknown> = {}): GuildQueue {
+    return {
+        currentTrack: { title: 'Test Track', author: 'Artist' },
+        node: {
+            isPaused: jest.fn().mockReturnValue(false),
+        },
+        history: {
+            tracks: { toArray: jest.fn().mockReturnValue([]) },
+        },
+        tracks: {
+            size: 3,
+            toArray: jest.fn().mockReturnValue([
+                { title: 'Track 1' },
+                { title: 'Track 2' },
+            ]),
+        },
+        repeatMode: 0,
+        ...overrides,
+    } as unknown as GuildQueue
+}
+
+describe('createMusicControlButtons', () => {
+    it('returns an ActionRowBuilder with 5 buttons', () => {
+        const queue = createQueue()
+        const row = createMusicControlButtons(queue)
+
+        expect(row).toBeDefined()
+        const components = (row as any).data.components
+        expect(components).toHaveLength(5)
+    })
+
+    it('disables previous button when history is empty', () => {
+        const queue = createQueue({
+            history: { tracks: { toArray: jest.fn().mockReturnValue([]) } },
+        })
+        const row = createMusicControlButtons(queue)
+
+        const components = (row as any).data.components
+        const prevButton = components[0]
+        expect(prevButton.disabled).toBe(true)
+    })
+
+    it('enables previous button when history has tracks', () => {
+        const queue = createQueue({
+            history: {
+                tracks: { toArray: jest.fn().mockReturnValue([{ title: 'Previous' }]) },
+            },
+        })
+        const row = createMusicControlButtons(queue)
+
+        const components = (row as any).data.components
+        const prevButton = components[0]
+        expect(prevButton.disabled).toBe(false)
+    })
+
+    it('shows pause emoji when queue is playing', () => {
+        const queue = createQueue({
+            node: { isPaused: jest.fn().mockReturnValue(false) },
+        })
+        const row = createMusicControlButtons(queue)
+
+        const components = (row as any).data.components
+        const pauseResumeButton = components[1]
+        expect(pauseResumeButton.emoji?.name ?? pauseResumeButton.label).toBeTruthy()
+    })
+
+    it('disables shuffle button when queue has fewer than 2 tracks', () => {
+        const queue = createQueue({
+            tracks: {
+                size: 1,
+                toArray: jest.fn().mockReturnValue([{ title: 'Track 1' }]),
+            },
+        })
+        const row = createMusicControlButtons(queue)
+
+        const components = (row as any).data.components
+        const shuffleButton = components[3]
+        expect(shuffleButton.disabled).toBe(true)
+    })
+
+    it('enables shuffle button when queue has 2 or more tracks', () => {
+        const queue = createQueue({
+            tracks: {
+                size: 2,
+                toArray: jest.fn().mockReturnValue([{ title: 'T1' }, { title: 'T2' }]),
+            },
+        })
+        const row = createMusicControlButtons(queue)
+
+        const components = (row as any).data.components
+        const shuffleButton = components[3]
+        expect(shuffleButton.disabled).toBe(false)
+    })
+})
+
+describe('createQueuePaginationButtons', () => {
+    it('returns null when totalPages is 1 or less', () => {
+        expect(createQueuePaginationButtons(0, 1)).toBeNull()
+        expect(createQueuePaginationButtons(0, 0)).toBeNull()
+    })
+
+    it('returns an ActionRowBuilder with 3 buttons when totalPages > 1', () => {
+        const row = createQueuePaginationButtons(0, 3)
+
+        expect(row).not.toBeNull()
+        const components = (row as any).data.components
+        expect(components).toHaveLength(3)
+    })
+
+    it('disables prev button on first page', () => {
+        const row = createQueuePaginationButtons(0, 3)
+        const components = (row as any).data.components
+        const prevButton = components[0]
+
+        expect(prevButton.disabled).toBe(true)
+    })
+
+    it('disables next button on last page', () => {
+        const row = createQueuePaginationButtons(2, 3)
+        const components = (row as any).data.components
+        const nextButton = components[2]
+
+        expect(nextButton.disabled).toBe(true)
+    })
+
+    it('enables both buttons on middle pages', () => {
+        const row = createQueuePaginationButtons(1, 3)
+        const components = (row as any).data.components
+
+        expect(components[0].disabled).toBe(false)
+        expect(components[2].disabled).toBe(false)
+    })
+
+    it('indicator button shows current page / total pages', () => {
+        const row = createQueuePaginationButtons(1, 3)
+        const components = (row as any).data.components
+        const indicator = components[1]
+
+        expect(indicator.label).toBe('2 / 3')
+    })
+})

--- a/packages/bot/src/utils/music/buttonComponents.ts
+++ b/packages/bot/src/utils/music/buttonComponents.ts
@@ -1,0 +1,92 @@
+import {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+} from 'discord.js'
+import type { GuildQueue } from 'discord-player'
+import {
+    MUSIC_BUTTON_IDS,
+    QUEUE_BUTTON_PREFIX,
+} from '../../types/musicButtons'
+
+export function createMusicControlButtons(
+    queue: GuildQueue
+): ActionRowBuilder<ButtonBuilder> {
+    const isPaused = queue.node.isPaused()
+    const hasHistory = queue.history.tracks.data.length > 0
+    const canShuffle = queue.tracks.size >= 2
+
+    const previousButton = new ButtonBuilder()
+        .setCustomId(MUSIC_BUTTON_IDS.PREVIOUS)
+        .setEmoji('⏮️')
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(!hasHistory)
+
+    const pauseResumeButton = new ButtonBuilder()
+        .setCustomId(MUSIC_BUTTON_IDS.PAUSE_RESUME)
+        .setLabel(isPaused ? 'Resume' : 'Pause')
+        .setEmoji('⏯️')
+        .setStyle(ButtonStyle.Primary)
+
+    const skipButton = new ButtonBuilder()
+        .setCustomId(MUSIC_BUTTON_IDS.SKIP)
+        .setEmoji('⏭️')
+        .setStyle(ButtonStyle.Secondary)
+
+    const shuffleButton = new ButtonBuilder()
+        .setCustomId(MUSIC_BUTTON_IDS.SHUFFLE)
+        .setEmoji('🔀')
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(!canShuffle)
+
+    const loopButton = new ButtonBuilder()
+        .setCustomId(MUSIC_BUTTON_IDS.LOOP)
+        .setEmoji('🔁')
+        .setStyle(ButtonStyle.Secondary)
+
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+        previousButton,
+        pauseResumeButton,
+        skipButton,
+        shuffleButton,
+        loopButton
+    )
+}
+
+export function createQueuePaginationButtons(
+    currentPage: number,
+    totalPages: number
+): ActionRowBuilder<ButtonBuilder> | null {
+    if (totalPages <= 1) {
+        return null
+    }
+
+    const isFirstPage = currentPage === 0
+    const isLastPage = currentPage === totalPages - 1
+
+    const previousButton = new ButtonBuilder()
+        .setCustomId(`${QUEUE_BUTTON_PREFIX}_${currentPage - 1}`)
+        .setEmoji('◀️')
+        .setLabel('Previous Page')
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(isFirstPage)
+
+    const pageIndicatorButton = new ButtonBuilder()
+        .setCustomId('page_indicator')
+        .setLabel(`Page ${currentPage + 1}/${totalPages}`)
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(true)
+
+    const nextButton = new ButtonBuilder()
+        .setCustomId(`${QUEUE_BUTTON_PREFIX}_${currentPage + 1}`)
+        .setEmoji('▶️')
+        .setLabel('Next Page')
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(isLastPage)
+
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+        previousButton,
+        pageIndicatorButton,
+        nextButton
+    )
+}

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -6,6 +6,8 @@ import {
     removeTrackFromQueue,
     moveTrackInQueue,
     rescueQueue,
+    insertUserTrackWithPriority,
+    blendAutoplayTracks,
 } from './queueManipulation'
 
 jest.mock('@lucky/shared/utils', () => ({
@@ -341,8 +343,6 @@ describe('queueManipulation.replenishQueue', () => {
     })
 
     it('caps autoplay to maxTracksPerArtist when same-artist candidates score highest', async () => {
-        // 3 tracks from 'Artist B' + 1 from 'Artist C'. With MAX_TRACKS_PER_ARTIST=2 (default),
-        // should pick at most 2 from 'Artist B' + 1 from 'Artist C' = 3 total (buffer needs 4)
         const queue = createQueueMock({
             tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
             player: {
@@ -359,7 +359,6 @@ describe('queueManipulation.replenishQueue', () => {
 
         await replenishQueue(queue as unknown as GuildQueue)
 
-        // Should have at most 2 tracks from Artist B + 1 from Artist C = 3 total
         const calls = queue.addTrack.mock.calls
         const artistBCount = calls.filter((c) =>
             (c[0] as Track).author === 'Artist B'
@@ -369,7 +368,6 @@ describe('queueManipulation.replenishQueue', () => {
     })
 
     it('caps autoplay tracks by source when all candidates are from same source', async () => {
-        // 5 candidates all from 'youtube'. With MAX_TRACKS_PER_SOURCE=3 (default), at most 3 selected.
         const queue = createQueueMock({
             tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
             currentTrack: { title: 'Song A', author: 'Artist A', url: 'https://example.com/a', source: 'spotify' } as unknown as Track,
@@ -616,5 +614,123 @@ describe('queueManipulation.queueOperations', () => {
         expect(result.removedTracks).toBe(1)
         expect(result.keptTracks).toBe(0)
         expect((queue as any).addTrack).not.toHaveBeenCalled()
+    })
+})
+
+describe('queueManipulation.insertUserTrackWithPriority', () => {
+    it('appends track when no autoplay tracks exist', () => {
+        const track = { title: 'User Track', author: 'User' } as Track
+        const existingTrack = { title: 'Normal Track', metadata: {} } as Track
+        const addTrackMock = jest.fn()
+        const insertTrackMock = jest.fn()
+        const queue = {
+            guild: { id: 'guild-1' },
+            tracks: { toArray: jest.fn().mockReturnValue([existingTrack]) },
+            addTrack: addTrackMock,
+            insertTrack: insertTrackMock,
+        } as unknown as GuildQueue
+
+        insertUserTrackWithPriority(queue, track)
+
+        expect(addTrackMock).toHaveBeenCalledWith(track)
+        expect(insertTrackMock).not.toHaveBeenCalled()
+    })
+
+    it('inserts before first autoplay track', () => {
+        const userTrack = { title: 'User Track', author: 'User' } as Track
+        const autoplayTrack = { title: 'Auto Track', metadata: { isAutoplay: true } } as Track
+        const normalTrack = { title: 'Normal Track', metadata: {} } as Track
+        const addTrackMock = jest.fn()
+        const insertTrackMock = jest.fn()
+        const queue = {
+            guild: { id: 'guild-1' },
+            tracks: { toArray: jest.fn().mockReturnValue([normalTrack, autoplayTrack]) },
+            addTrack: addTrackMock,
+            insertTrack: insertTrackMock,
+        } as unknown as GuildQueue
+
+        insertUserTrackWithPriority(queue, userTrack)
+
+        expect(insertTrackMock).toHaveBeenCalledWith(userTrack, 1)
+        expect(addTrackMock).not.toHaveBeenCalled()
+    })
+
+    it('inserts at index 0 when all tracks are autoplay', () => {
+        const userTrack = { title: 'User Track', author: 'User' } as Track
+        const autoplayTrack1 = { title: 'Auto 1', metadata: { isAutoplay: true } } as Track
+        const autoplayTrack2 = { title: 'Auto 2', metadata: { isAutoplay: true } } as Track
+        const addTrackMock = jest.fn()
+        const insertTrackMock = jest.fn()
+        const queue = {
+            guild: { id: 'guild-1' },
+            tracks: { toArray: jest.fn().mockReturnValue([autoplayTrack1, autoplayTrack2]) },
+            addTrack: addTrackMock,
+            insertTrack: insertTrackMock,
+        } as unknown as GuildQueue
+
+        insertUserTrackWithPriority(queue, userTrack)
+
+        expect(insertTrackMock).toHaveBeenCalledWith(userTrack, 0)
+        expect(addTrackMock).not.toHaveBeenCalled()
+    })
+})
+
+describe('queueManipulation.blendAutoplayTracks', () => {
+    beforeEach(() => {
+        dislikedTrackKeysMock.mockResolvedValue(new Set())
+        likedTrackKeysMock.mockResolvedValue(new Set())
+    })
+
+    it('removes half of autoplay tracks and calls replenishQueue', async () => {
+        const autoTrack1 = { title: 'Auto 1', metadata: { isAutoplay: true } } as Track
+        const autoTrack2 = { title: 'Auto 2', metadata: { isAutoplay: true } } as Track
+        const userTrack = { title: 'User Track', metadata: {} } as Track
+        const newSeedTrack = { title: 'New Seed', author: 'Artist', url: 'https://example.com/seed', requestedBy: { id: 'u1' } } as Track
+        const removeMock = jest.fn()
+        const addTrackMock = jest.fn()
+        const queue = {
+            guild: { id: 'guild-1' },
+            tracks: {
+                size: 3,
+                toArray: jest.fn().mockReturnValue([userTrack, autoTrack1, autoTrack2]),
+            },
+            node: { remove: removeMock },
+            currentTrack: newSeedTrack,
+            metadata: {},
+            addTrack: addTrackMock,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [{ title: 'New Auto', author: 'New Artist', url: 'https://example.com/new' }],
+                }),
+            },
+        } as unknown as GuildQueue
+
+        await blendAutoplayTracks(queue, newSeedTrack)
+
+        expect(removeMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('does nothing when there are no autoplay tracks', async () => {
+        const userTrack = { title: 'User Track', metadata: {} } as Track
+        const newSeedTrack = { title: 'New Seed', author: 'Artist', url: 'https://example.com/seed' } as Track
+        const removeMock = jest.fn()
+        const queue = {
+            guild: { id: 'guild-1' },
+            tracks: {
+                size: 1,
+                toArray: jest.fn().mockReturnValue([userTrack]),
+            },
+            node: { remove: removeMock },
+            currentTrack: newSeedTrack,
+            metadata: {},
+            addTrack: jest.fn(),
+            player: {
+                search: jest.fn().mockResolvedValue({ tracks: [] }),
+            },
+        } as unknown as GuildQueue
+
+        await blendAutoplayTracks(queue, newSeedTrack)
+
+        expect(removeMock).not.toHaveBeenCalled()
     })
 })

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -9,7 +9,7 @@ import type { User } from 'discord.js'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import { recommendationFeedbackService } from '../../services/musicRecommendation/feedbackService'
 
-const AUTOPLAY_BUFFER_SIZE = 4
+const AUTOPLAY_BUFFER_SIZE = 8
 const HISTORY_SEED_LIMIT = 3
 const SEARCH_RESULTS_LIMIT = 8
 const MAX_TRACKS_PER_ARTIST = 2
@@ -241,6 +241,36 @@ export async function replenishQueue(queue: GuildQueue): Promise<void> {
     } catch (error) {
         errorLog({ message: 'Error replenishing queue:', error })
     }
+}
+
+export function insertUserTrackWithPriority(queue: GuildQueue, track: Track): void {
+    const tracks = queue.tracks.toArray()
+    const firstAutoplayIndex = tracks.findIndex((t) => {
+        const meta = (t as unknown as { metadata?: Record<string, unknown> }).metadata
+        return meta?.isAutoplay === true
+    })
+    if (firstAutoplayIndex === -1) {
+        queue.addTrack(track)
+    } else {
+        queue.insertTrack(track, firstAutoplayIndex)
+    }
+    debugLog({ message: 'User track inserted with priority', data: { guildId: queue.guild.id, track: track.title } })
+}
+
+export async function blendAutoplayTracks(queue: GuildQueue, newSeedTrack: Track, blendRatio = 0.5): Promise<void> {
+    const tracks = queue.tracks.toArray()
+    const autoplayTracks = tracks.filter((t) => {
+        const meta = (t as unknown as { metadata?: Record<string, unknown> }).metadata
+        return meta?.isAutoplay === true
+    })
+    const removeCount = Math.floor(autoplayTracks.length * blendRatio)
+    for (let i = 0; i < removeCount; i++) {
+        const t = autoplayTracks[i]
+        queue.node.remove(t)
+    }
+    const queueWithNewSeed = { ...queue, currentTrack: newSeedTrack } as GuildQueue
+    await replenishQueue(queueWithNewSeed)
+    debugLog({ message: 'Autoplay blend complete', data: { guildId: queue.guild.id, removedCount: removeCount } })
 }
 
 function randomIndex(maxExclusive: number): number {


### PR DESCRIPTION
## Summary

- Add interactive music control buttons to now-playing embeds (⏮️ previous, ⏯️ pause/resume, ⏭️ skip, 🔀 shuffle, 🔁 loop)
- Loop button cycles through OFF → TRACK → QUEUE → AUTOPLAY modes
- Add queue pagination buttons for long queues (◀️ page indicator ▶️)
- Route `music_*` and `queue_page*` button interactions to `musicButtonHandler`
- Add `insertUserTrackWithPriority`: inserts user-requested track before autoplay tracks
- Add `blendAutoplayTracks`: refreshes autoplay buffer when a new seed track is added
- Increase `AUTOPLAY_BUFFER_SIZE` from 4 to 8 for smoother autoplay experience
- Add `page` param to `createTrackListDisplay` for paginated track display

## Tests

- 602 tests pass across 48 suites
- New suites: `musicButtonHandler.spec.ts` (8 tests), `buttonComponents.spec.ts` (10 tests)
- Updated: `queueEmbed.spec.ts`, `queueManipulation.spec.ts`, `play/index.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive music control buttons (Previous, Pause/Resume, Skip, Shuffle, Loop) to queue displays and now playing messages
  * Implemented queue pagination with navigation controls to view large queues across multiple pages
  * Enhanced autoplay mode with intelligent track prioritization and queue blending for improved listening experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->