### PR TITLE
chore(release): prepare v2.6.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.26] - 2026-03-16
+
+### Added
+
+- **`/starboard`**: star-worthy messages rise to a configurable starboard channel. Subcommands: `setup` (set channel, emoji, threshold, self-star toggle), `disable`, `top` (top starred messages), `status`. Powered by new `StarboardService` with Prisma-backed `StarboardConfig` and `StarboardEntry` models.
+- **`/level`**: per-guild XP system with level-up announcements and role rewards. Subcommands: `rank` (your or another member's XP/level), `leaderboard`, `setup` (configure XP per message, cooldown, announce channel), `reward add/remove`. Powered by new `LevelService` with `LevelConfig`, `MemberXP`, and `LevelReward` Prisma models. XP is awarded on each message after a configurable cooldown.
+
 ## [2.6.25] - 2026-03-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.25",
+  "version": "2.6.26",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## v2.6.26 Release

### Added
- `/starboard` command — message star pinning with leaderboard (#308)
- `/level` command — XP system with role rewards and leaderboard (#309)

Both powered by new Prisma models (StarboardConfig, StarboardEntry, LevelConfig, MemberXP, LevelReward) and corresponding shared services.