### PR TITLE
chore(release): prepare v2.6.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.29] - 2026-03-16
+
+### Added
+
+- AutoMessages page wired to real backend API (`/api/guilds/:guildId/automessages`): list, create, edit, toggle, and delete auto-messages via a modal form; was a non-functional stub with a fake `setTimeout` (#319)
+- New `autoMessagesApi` service client in the frontend API layer (#319)
+
+### Fixed
+
+- Dashboard Overview: removed hardcoded fake trend percentages (`+8%` / `-3%`) from the Cases by Type section (#319)
+- Server Logs: pagination now correctly passes the page offset to the backend API instead of always fetching the first page (#319)
+
 ## [2.6.28] - 2026-03-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.28",
+  "version": "2.6.29",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## v2.6.29

### Added
- AutoMessages page wired to real backend API (`/api/guilds/:guildId/automessages`): list, create, edit, toggle, and delete auto-messages via a modal form; was a non-functional stub with a fake `setTimeout` (#319)
- New `autoMessagesApi` service client in the frontend API layer (#319)

### Fixed
- Dashboard Overview: removed hardcoded fake trend percentages (`+8%` / `-3%`) from the Cases by Type section (#319)
- Server Logs: pagination now correctly passes the page offset to the backend API instead of always fetching the first page (#319)