### PR TITLE
chore(release): prepare v2.6.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.31] - 2026-03-16
+
+### Added
+
+- **Reaction Roles**: read-only list page in the dashboard showing all reaction-role messages and their button mappings (emoji, label, style, role ID). Accessible via Management → Reaction Roles in the sidebar (#325)
+- New `reactionRolesApi` frontend service client with `list` and `listExclusions` methods (#325)
+
+### Fixed
+
+- Track History: `playedBy` field now rendered in each track row (was fetched from API but never displayed) (#326)
+- Servers page: Premium and Settings navigation buttons now navigate to `/features` and `/settings` respectively; were previously non-functional dead buttons (#326)
+
 ## [2.6.30] - 2026-03-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.30",
+  "version": "2.6.31",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## v2.6.31

### Added
- **Reaction Roles**: read-only list page in the dashboard showing all reaction-role messages and their button mappings (#325)
- New `reactionRolesApi` frontend service client (#325)

### Fixed
- Track History: `playedBy` field now rendered in each track row (#326)
- Servers page: Premium and Settings navigation buttons now functional (#326)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only Reaction Roles management page in the dashboard (Management → Reaction Roles) displaying emoji, label, style, and role mappings.

* **Bug Fixes**
  * Fixed the playedBy field display in Track History rows.
  * Corrected navigation routing for premium and settings buttons on the Servers page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->