### PR TITLE
fix(frontend): channel/role pickers, Config cleanup, managerRoles field

### DIFF
--- a/packages/frontend/src/pages/AutoMod.tsx
+++ b/packages/frontend/src/pages/AutoMod.tsx
@@ -13,6 +13,8 @@ import {
     Loader2,
     CheckCircle2,
     Sparkles,
+    Hash,
+    Shield,
 } from 'lucide-react'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
@@ -20,13 +22,20 @@ import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
 import Skeleton from '@/components/ui/Skeleton'
 import { toast } from 'sonner'
 import { api } from '@/services/api'
 import { ApiError } from '@/services/ApiError'
 import { useGuildStore } from '@/stores/guildStore'
 import { cn } from '@/lib/utils'
-import type { AutoModSettings, AutoModTemplate } from '@/types'
+import type { AutoModSettings, AutoModTemplate, GuildChannelOption, GuildRoleOption } from '@/types'
 
 interface FilterCardProps {
     title: string
@@ -182,6 +191,134 @@ function TagList({
     )
 }
 
+function ChannelPicker({
+    selectedIds,
+    channels,
+    onAdd,
+    onRemove,
+}: {
+    selectedIds: string[]
+    channels: GuildChannelOption[]
+    onAdd: (id: string) => void
+    onRemove: (id: string) => void
+}) {
+    const available = channels.filter((c) => !selectedIds.includes(c.id))
+
+    const getChannelName = (id: string) =>
+        channels.find((c) => c.id === id)?.name ?? id
+
+    return (
+        <div className='space-y-2'>
+            {available.length > 0 && (
+                <Select onValueChange={onAdd}>
+                    <SelectTrigger className='h-9 bg-lucky-bg-tertiary border-lucky-border text-white text-sm'>
+                        <SelectValue placeholder='Select a channel...' />
+                    </SelectTrigger>
+                    <SelectContent className='bg-lucky-bg-secondary border-lucky-border'>
+                        {available.map((channel) => (
+                            <SelectItem key={channel.id} value={channel.id}>
+                                <span className='flex items-center gap-2'>
+                                    <Hash className='w-3 h-3 text-lucky-text-tertiary' />
+                                    {channel.name}
+                                </span>
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            )}
+            {selectedIds.length > 0 && (
+                <div className='flex flex-wrap gap-1.5'>
+                    {selectedIds.map((id) => (
+                        <Badge
+                            key={id}
+                            variant='outline'
+                            className='bg-lucky-bg-tertiary border-lucky-border text-lucky-text-secondary text-xs gap-1 pr-1'
+                        >
+                            <Hash className='w-3 h-3' />
+                            {getChannelName(id)}
+                            <button
+                                onClick={() => onRemove(id)}
+                                className='hover:text-lucky-error transition-colors p-0.5'
+                            >
+                                <X className='w-3 h-3' />
+                            </button>
+                        </Badge>
+                    ))}
+                </div>
+            )}
+            {channels.length === 0 && (
+                <p className='text-xs text-lucky-text-tertiary'>
+                    Channels unavailable — enter IDs manually below
+                </p>
+            )}
+        </div>
+    )
+}
+
+function RolePicker({
+    selectedIds,
+    roles,
+    onAdd,
+    onRemove,
+}: {
+    selectedIds: string[]
+    roles: GuildRoleOption[]
+    onAdd: (id: string) => void
+    onRemove: (id: string) => void
+}) {
+    const available = roles.filter((r) => !selectedIds.includes(r.id))
+
+    const getRoleName = (id: string) =>
+        roles.find((r) => r.id === id)?.name ?? id
+
+    return (
+        <div className='space-y-2'>
+            {available.length > 0 && (
+                <Select onValueChange={onAdd}>
+                    <SelectTrigger className='h-9 bg-lucky-bg-tertiary border-lucky-border text-white text-sm'>
+                        <SelectValue placeholder='Select a role...' />
+                    </SelectTrigger>
+                    <SelectContent className='bg-lucky-bg-secondary border-lucky-border'>
+                        {available.map((role) => (
+                            <SelectItem key={role.id} value={role.id}>
+                                <span className='flex items-center gap-2'>
+                                    <Shield className='w-3 h-3 text-lucky-text-tertiary' />
+                                    {role.name}
+                                </span>
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            )}
+            {selectedIds.length > 0 && (
+                <div className='flex flex-wrap gap-1.5'>
+                    {selectedIds.map((id) => (
+                        <Badge
+                            key={id}
+                            variant='outline'
+                            className='bg-lucky-bg-tertiary border-lucky-border text-lucky-text-secondary text-xs gap-1 pr-1'
+                        >
+                            <Shield className='w-3 h-3' />
+                            {getRoleName(id)}
+                            <button
+                                onClick={() => onRemove(id)}
+                                className='hover:text-lucky-error transition-colors p-0.5'
+                            >
+                                <X className='w-3 h-3' />
+                            </button>
+                        </Badge>
+                    ))}
+                </div>
+            )}
+            {roles.length === 0 && (
+                <p className='text-xs text-lucky-text-tertiary'>
+                    Roles unavailable — enter IDs manually below
+                </p>
+            )}
+        </div>
+    )
+}
+
 const DEFAULT_SETTINGS: AutoModSettings = {
     id: '',
     guildId: '',
@@ -212,6 +349,8 @@ export default function AutoModPage() {
     const [applyingTemplateId, setApplyingTemplateId] = useState<
         string | null
     >(null)
+    const [channels, setChannels] = useState<GuildChannelOption[]>([])
+    const [roles, setRoles] = useState<GuildRoleOption[]>([])
 
     useEffect(() => {
         if (!selectedGuild?.id) return
@@ -233,6 +372,18 @@ export default function AutoModPage() {
             .then((res) => setTemplates(res.data.templates))
             .catch(() => setTemplates([]))
             .finally(() => setTemplatesLoading(false))
+    }, [selectedGuild?.id])
+
+    useEffect(() => {
+        if (!selectedGuild?.id) return
+        api.guilds
+            .getChannels(selectedGuild.id)
+            .then((res) => setChannels(res.data.channels))
+            .catch(() => setChannels([]))
+        api.guilds
+            .getRbac(selectedGuild.id)
+            .then((res) => setRoles(res.data.roles))
+            .catch(() => setRoles([]))
     }, [selectedGuild?.id])
 
     const update = <K extends keyof AutoModSettings>(
@@ -579,49 +730,89 @@ export default function AutoModPage() {
                     <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
                         <div className='space-y-2'>
                             <Label className='text-xs text-lucky-text-secondary'>
-                                Exempt Channels (IDs)
+                                Exempt Channels
                             </Label>
-                            <TagList
-                                items={settings.exemptChannels}
-                                onAdd={(c) =>
+                            <ChannelPicker
+                                selectedIds={settings.exemptChannels}
+                                channels={channels}
+                                onAdd={(id) =>
                                     update('exemptChannels', [
                                         ...settings.exemptChannels,
-                                        c,
+                                        id,
                                     ])
                                 }
-                                onRemove={(c) =>
+                                onRemove={(id) =>
                                     update(
                                         'exemptChannels',
                                         settings.exemptChannels.filter(
-                                            (x) => x !== c,
+                                            (x) => x !== id,
                                         ),
                                     )
                                 }
-                                placeholder='Channel ID...'
                             />
+                            {channels.length === 0 && (
+                                <TagList
+                                    items={settings.exemptChannels}
+                                    onAdd={(c) =>
+                                        update('exemptChannels', [
+                                            ...settings.exemptChannels,
+                                            c,
+                                        ])
+                                    }
+                                    onRemove={(c) =>
+                                        update(
+                                            'exemptChannels',
+                                            settings.exemptChannels.filter(
+                                                (x) => x !== c,
+                                            ),
+                                        )
+                                    }
+                                    placeholder='Channel ID...'
+                                />
+                            )}
                         </div>
                         <div className='space-y-2'>
                             <Label className='text-xs text-lucky-text-secondary'>
-                                Exempt Roles (IDs)
+                                Exempt Roles
                             </Label>
-                            <TagList
-                                items={settings.exemptRoles}
-                                onAdd={(r) =>
+                            <RolePicker
+                                selectedIds={settings.exemptRoles}
+                                roles={roles}
+                                onAdd={(id) =>
                                     update('exemptRoles', [
                                         ...settings.exemptRoles,
-                                        r,
+                                        id,
                                     ])
                                 }
-                                onRemove={(r) =>
+                                onRemove={(id) =>
                                     update(
                                         'exemptRoles',
                                         settings.exemptRoles.filter(
-                                            (x) => x !== r,
+                                            (x) => x !== id,
                                         ),
                                     )
                                 }
-                                placeholder='Role ID...'
                             />
+                            {roles.length === 0 && (
+                                <TagList
+                                    items={settings.exemptRoles}
+                                    onAdd={(r) =>
+                                        update('exemptRoles', [
+                                            ...settings.exemptRoles,
+                                            r,
+                                        ])
+                                    }
+                                    onRemove={(r) =>
+                                        update(
+                                            'exemptRoles',
+                                            settings.exemptRoles.filter(
+                                                (x) => x !== r,
+                                            ),
+                                        )
+                                    }
+                                    placeholder='Role ID...'
+                                />
+                            )}
                         </div>
                     </div>
                 </Card>

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -1,4 +1,5 @@
 import { useState, lazy, Suspense } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Music, MessageSquare, Shield } from 'lucide-react'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
@@ -8,9 +9,6 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner'
 
 const MusicConfig = lazy(() => import('@/components/Config/MusicConfig'))
 const CommandsConfig = lazy(() => import('@/components/Config/CommandsConfig'))
-const ModerationConfig = lazy(
-    () => import('@/components/Config/ModerationConfig'),
-)
 
 export default function ConfigPage() {
     usePageMetadata({
@@ -19,6 +17,7 @@ export default function ConfigPage() {
     })
     const [selectedModule, setSelectedModule] = useState<string | null>(null)
     const { selectedGuild } = useGuildSelection()
+    const navigate = useNavigate()
 
     const modules = [
         {
@@ -42,6 +41,14 @@ export default function ConfigPage() {
             icon: Shield,
         },
     ]
+
+    const handleModuleClick = (moduleId: string) => {
+        if (moduleId === 'moderation') {
+            navigate('/automod')
+            return
+        }
+        setSelectedModule(moduleId)
+    }
 
     if (!selectedGuild) {
         return (
@@ -79,13 +86,13 @@ export default function ConfigPage() {
                             <Card
                                 key={module.id}
                                 className='p-6 hover:bg-lucky-bg-tertiary transition-colors cursor-pointer'
-                                onClick={() => setSelectedModule(module.id)}
+                                onClick={() => handleModuleClick(module.id)}
                                 role='button'
                                 tabIndex={0}
                                 onKeyDown={(e) => {
                                     if (e.key === 'Enter' || e.key === ' ') {
                                         e.preventDefault()
-                                        setSelectedModule(module.id)
+                                        handleModuleClick(module.id)
                                     }
                                 }}
                                 aria-label={`Configure ${module.name}`}
@@ -127,9 +134,6 @@ export default function ConfigPage() {
                         )}
                         {selectedModule === 'commands' && (
                             <CommandsConfig guildId={selectedGuild.id} />
-                        )}
-                        {selectedModule === 'moderation' && (
-                            <ModerationConfig guildId={selectedGuild.id} />
                         )}
                     </Suspense>
                 </section>

--- a/packages/frontend/src/pages/ServerSettings.tsx
+++ b/packages/frontend/src/pages/ServerSettings.tsx
@@ -21,12 +21,14 @@ import {
     Shield,
     RotateCcw,
     WandSparkles,
+    X,
 } from 'lucide-react'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import { Badge } from '@/components/ui/badge'
 import {
     Select,
     SelectContent,
@@ -39,7 +41,7 @@ import { toast } from 'sonner'
 import { api } from '@/services/api'
 import { ApiError } from '@/services/ApiError'
 import { useGuildStore } from '@/stores/guildStore'
-import { RBAC_MODULES, type RoleGrant, type ServerSettings } from '@/types'
+import { RBAC_MODULES, type RoleGrant, type ServerSettings, type GuildChannelOption, type GuildRoleOption } from '@/types'
 
 const TIMEZONES = [
     'UTC',
@@ -127,6 +129,8 @@ export default function ServerSettingsPage() {
         Array<{ id: string; name: string }>
     >([])
     const [rbacGrants, setRbacGrants] = useState<RoleGrant[]>([])
+    const [channels, setChannels] = useState<GuildChannelOption[]>([])
+    const [managerRoleOptions, setManagerRoleOptions] = useState<GuildRoleOption[]>([])
     const rbacRequestIdRef = useRef(0)
     const settingsRequestVersion = useRef(0)
 
@@ -215,6 +219,18 @@ export default function ServerSettingsPage() {
 
         loadRbac(selectedGuild.id)
     }, [selectedGuild?.id, canManageRbac, loadRbac])
+
+    useEffect(() => {
+        if (!selectedGuild?.id) return
+        api.guilds
+            .getChannels(selectedGuild.id)
+            .then((res) => setChannels(res.data.channels))
+            .catch(() => setChannels([]))
+        api.guilds
+            .getRbac(selectedGuild.id)
+            .then((res) => setManagerRoleOptions(res.data.roles))
+            .catch(() => setManagerRoleOptions([]))
+    }, [selectedGuild?.id])
 
     const update = <K extends keyof ServerSettings>(
         key: K,
@@ -530,6 +546,12 @@ export default function ServerSettingsPage() {
         )
     }
 
+    const availableManagerRoles = managerRoleOptions.filter(
+        (r) => !(settings.managerRoles ?? []).includes(r.id),
+    )
+    const getManagerRoleName = (id: string) =>
+        managerRoleOptions.find((r) => r.id === id)?.name ?? id
+
     return (
         <div className='space-y-6'>
             <div className='flex items-start justify-between'>
@@ -640,16 +662,112 @@ export default function ServerSettingsPage() {
                             <Label className='text-xs text-lucky-text-secondary flex items-center gap-1.5'>
                                 <Bell className='w-3 h-3' /> Updates Channel
                             </Label>
-                            <Input
-                                value={settings.updatesChannel}
-                                onChange={(e) =>
-                                    update('updatesChannel', e.target.value)
-                                }
-                                placeholder='Channel ID for bot updates'
-                                className='bg-lucky-bg-tertiary border-lucky-border text-white'
-                            />
+                            {channels.length > 0 ? (
+                                <Select
+                                    value={settings.updatesChannel || '__none__'}
+                                    onValueChange={(v) =>
+                                        update('updatesChannel', v === '__none__' ? '' : v)
+                                    }
+                                >
+                                    <SelectTrigger className='bg-lucky-bg-tertiary border-lucky-border text-white'>
+                                        <SelectValue placeholder='Select a channel...' />
+                                    </SelectTrigger>
+                                    <SelectContent className='bg-lucky-bg-secondary border-lucky-border'>
+                                        <SelectItem value='__none__'>
+                                            <span className='text-lucky-text-tertiary'>None</span>
+                                        </SelectItem>
+                                        {channels.map((ch) => (
+                                            <SelectItem key={ch.id} value={ch.id}>
+                                                <span className='flex items-center gap-2'>
+                                                    <Hash className='w-3 h-3 text-lucky-text-tertiary' />
+                                                    {ch.name}
+                                                </span>
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            ) : (
+                                <Input
+                                    value={settings.updatesChannel}
+                                    onChange={(e) =>
+                                        update('updatesChannel', e.target.value)
+                                    }
+                                    placeholder='Channel ID for bot updates'
+                                    className='bg-lucky-bg-tertiary border-lucky-border text-white'
+                                />
+                            )}
                         </div>
                     </div>
+                </Card>
+            </motion.div>
+
+            {/* Manager Roles */}
+            <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.08 }}
+            >
+                <Card className='p-5 space-y-4'>
+                    <div className='flex items-center gap-2'>
+                        <Shield className='w-5 h-5 text-lucky-text-secondary' />
+                        <div>
+                            <h2 className='text-base font-semibold text-white'>
+                                Manager Roles
+                            </h2>
+                            <p className='text-xs text-lucky-text-tertiary mt-0.5'>
+                                Roles that can manage bot settings via commands
+                            </p>
+                        </div>
+                    </div>
+                    {managerRoleOptions.length > 0 && availableManagerRoles.length > 0 && (
+                        <Select
+                            onValueChange={(id) => {
+                                update('managerRoles', [...(settings.managerRoles ?? []), id])
+                            }}
+                        >
+                            <SelectTrigger className='bg-lucky-bg-tertiary border-lucky-border text-white h-9 text-sm'>
+                                <SelectValue placeholder='Add a manager role...' />
+                            </SelectTrigger>
+                            <SelectContent className='bg-lucky-bg-secondary border-lucky-border'>
+                                {availableManagerRoles.map((role) => (
+                                    <SelectItem key={role.id} value={role.id}>
+                                        {role.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    )}
+                    {(settings.managerRoles ?? []).length > 0 ? (
+                        <div className='flex flex-wrap gap-1.5'>
+                            {(settings.managerRoles ?? []).map((id) => (
+                                <Badge
+                                    key={id}
+                                    variant='outline'
+                                    className='bg-lucky-bg-tertiary border-lucky-border text-lucky-text-secondary text-xs gap-1 pr-1'
+                                >
+                                    <Shield className='w-3 h-3' />
+                                    {getManagerRoleName(id)}
+                                    <button
+                                        onClick={() =>
+                                            update(
+                                                'managerRoles',
+                                                (settings.managerRoles ?? []).filter(
+                                                    (r) => r !== id,
+                                                ),
+                                            )
+                                        }
+                                        className='hover:text-lucky-error transition-colors p-0.5'
+                                    >
+                                        <X className='w-3 h-3' />
+                                    </button>
+                                </Badge>
+                            ))}
+                        </div>
+                    ) : (
+                        <p className='text-xs text-lucky-text-tertiary'>
+                            No manager roles configured.
+                        </p>
+                    )}
                 </Card>
             </motion.div>
 


### PR DESCRIPTION
## Summary

- **Config.tsx**: Moderation tile now navigates to `/automod` instead of loading the broken `ModerationConfig` component that called a non-existent API endpoint (`api.modules.getSettings`)
- **AutoMod.tsx**: Exempt Channels and Exempt Roles inputs replaced with dropdown pickers populated from the guilds API (`/guilds/:id/channels` and `/guilds/:id/rbac`). Falls back to raw ID text input when API unavailable
- **ServerSettings.tsx**: Updates Channel input replaced with channel dropdown picker when channels are available. Added new **Manager Roles** card with role multi-select (roles that can manage bot settings via commands)

## Changes
- `packages/frontend/src/pages/Config.tsx` — remove broken ModerationConfig lazy import, route to /automod
- `packages/frontend/src/pages/AutoMod.tsx` — add ChannelPicker + RolePicker components, fetch channels/roles on guild change
- `packages/frontend/src/pages/ServerSettings.tsx` — channel picker for updatesChannel, managerRoles multi-select card, fetch channels/roles on guild change

TypeScript: ✅ | Lint: ✅