### PR TITLE
chore(release): prepare v2.6.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.32] - 2026-03-16
+
+### Added
+
+- **Manager Roles**: new role multi-select field in Server Settings to configure which Discord roles can manage the bot; previously the `managerRoles` setting existed in the data model but had no UI (#328)
+
+### Fixed
+
+- **Config page**: Moderation tile now navigates to `/automod` instead of loading `ModerationConfig` component which called a non-existent backend endpoint; avoids broken fetch on load (#328)
+- **AutoMod**: exempt channels and exempt roles fields now use Select dropdowns populated from the Discord guild's channel/role list, showing names instead of raw IDs; falls back to manual ID input when data unavailable (#328)
+- **Server Settings**: Updates Channel field now uses a channel picker dropdown instead of a raw ID text input; requires channel data to be loaded from Discord (#328)
+
 ## [2.6.31] - 2026-03-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.31",
+  "version": "2.6.32",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## v2.6.32

### Added
- **Manager Roles**: new role multi-select field in Server Settings (#328)

### Fixed
- Config page: Moderation tile navigates to `/automod` instead of broken `ModerationConfig` (#328)
- AutoMod: exempt channels/roles use Select dropdowns with names, not raw IDs (#328)
- Server Settings: Updates Channel uses channel picker dropdown (#328)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Manager Roles configuration field in Server Settings to designate which Discord roles can manage the bot

* **Bug Fixes**
  * Fixed Config page Moderation tile navigation
  * AutoMod now displays channel and role names instead of IDs with fallback support
  * Improved Server Settings Channel field with dropdown picker functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->