### PR TITLE
fix(db): persist postgres data path for postgres 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
             POSTGRES_DB: discordbot
             POSTGRES_USER: discordbot
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD?POSTGRES_PASSWORD_required}
+            PGDATA: /var/lib/postgresql/data
         volumes:
             - postgres_data:/var/lib/postgresql/data
         networks:


### PR DESCRIPTION
## Summary
- Add PGDATA=/var/lib/postgresql/data to the postgres service in docker-compose.yml.
- Align postgres:18 runtime data directory with the mounted postgres_data volume.
- Prevent schema/data loss caused by writes going to an unmounted default path.

## Verification
- POSTGRES_PASSWORD=dummy docker compose config | rg -n 'PGDATA' returns PGDATA: /var/lib/postgresql/data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->