### PR TITLE
chore(release): prepare v2.6.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.36] - 2026-03-18
+
 ### Fixed
 
 - Music playback now invokes yt-dlp with `-f bestaudio/best` so tracks with missing `bestaudio` variants still stream.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.35",
+    "version": "2.6.36",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- bump root package version from 2.6.35 to 2.6.36
- promote current Unreleased fixes into the 2.6.36 changelog section
- prepare patch release that includes play/autoplay reliability fixes from #338