### PR TITLE
chore(release): prepare v2.6.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.37] - 2026-03-18
+
+### Fixed
+
+- Docker compose postgres service now sets `PGDATA=/var/lib/postgresql/data` to keep Postgres 18 data on the mounted `postgres_data` volume.
+
 ## [2.6.36] - 2026-03-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.36",
+    "version": "2.6.37",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- bump root package version to 2.6.37
- add changelog entry for postgres data directory persistence fix from #337
- prepare patch release after v2.6.36