### PR TITLE
docs(state): sync release references to v2.6.37

### DIFF
--- a/.serena/memories/current-state.md
+++ b/.serena/memories/current-state.md
@@ -1,42 +1,27 @@
 # Lucky — Current State
 
-**Updated**: 2026-03-16
-**Latest release**: v2.6.25
-**Main branch**: `de8ab6f` (origin/main and local root checkout)
+**Updated**: 2026-03-18
+**Latest release**: v2.6.37
+**Main branch**: `c896374` (origin/main)
 
-## What's in v2.6.25
-- fix(policy): check cwd instead of repoRoot for worktree detection (#306)
-- feat(bot): /automod preset command (#307)
-- feat(bot): voice channel status and music activity presence (#310)
-- fix(bot): smartShuffle test fix (#311)
-- chore(release): v2.6.25 (#312)
+## Latest Releases
+- **v2.6.37**: fixed PostgreSQL 18 persistence by setting `PGDATA=/var/lib/postgresql/data` in Docker compose (`#337`, `#340`).
+- **v2.6.36**: restored play/autoplay reliability with yt-dlp format fallback and autoplay search fallback (`#338`, `#339`).
 
-## What's on main post-v2.6.25 (unreleased — will be v2.6.26)
-- feat(bot): music button controls, queue pagination, and autoplay blending (PR #315 open, CI running)
-  - 5 music control buttons on now-playing embeds (⏮️⏯️⏭️🔀🔁)
-  - Queue pagination with page buttons
-  - AUTOPLAY_BUFFER_SIZE 4→8
-  - insertUserTrackWithPriority + blendAutoplayTracks functions
-  - queueDisplay splits user/autoplay sections with separator
-
-## CI / Quality
-- npm audit: 0 vulnerabilities
-- All tests: 602/602 bot passing (41 suites; 1 pre-existing redisCaching integration test fails in worktree due to no generated prisma client)
-- SonarCloud: passing on main
-- PR #315: CI in progress (Quality Gates + SonarCloud still running)
+## Platform State
+- Mainline CI checks green on latest release branch merges.
+- Security audit gate clean after fast-xml-parser override uplift.
+- Production release cadence recovered with small, focused PR flow.
 
 ## Active Worktrees
-- `.worktrees/autoplay-buttons` — active (PR #315 open, wt-autoplay-buttons branch, commit ea0f34d)
-- `.worktrees/feat-voice-status` — stale (PR #310 merged, feature/voice-status-music-presence at 48e8487)
+- `.worktrees/fix-319` remains locally with uncommitted frontend test work:
+  - `packages/frontend/src/pages/AutoMessages.test.tsx` (modified)
+  - `packages/frontend/src/services/autoMessagesApi.test.ts` (untracked)
 
-## Open Issues
-- #308: /starboard feature (reaction-based message pinning) — next to implement
-- #309: /level XP tracking + role rewards + leaderboard — after starboard
+## Open PRs / Issues
+- Open PRs: none
+- Open issues: not tracked in this memory snapshot (query GitHub before planning)
 
-## Open PRs
-- #315: feat(bot): music button controls, queue pagination, and autoplay blending — CI running, auto-merge enabled
-
-## Known Issues / Pending Work
-- Stale worktree `.worktrees/feat-voice-status` needs cleanup after PR #315 merges
-- v2.6.26 release not yet cut (waiting for PR #315 to merge)
-- README.md and CHANGELOG.md have not been updated this session
+## Known Follow-up
+- Decide whether to salvage or discard `.worktrees/fix-319` local test changes.
+- Continue documentation/changelog hygiene passes to keep release metadata consistent.

--- a/.serena/memories/next-priorities.md
+++ b/.serena/memories/next-priorities.md
@@ -1,23 +1,20 @@
-# Next Priorities (2026-03-16)
+# Next Priorities (2026-03-18)
 
-## P0 (Pending merge)
-- PR #302 — fix(lint): remove unused params in lucky-policy-lib.mjs — MERGED
-- PR #303 — chore(deps): patch/minor dep updates Mar 2026 — open, CI running, auto-merge enabled
+## P1 — Metadata and docs integrity (small PRs)
+1. Sync stale release references across docs and README to v2.6.37.
+2. Repair `CHANGELOG.md` structure drift (duplicate release blocks, duplicate `Unreleased` section).
+3. Align package metadata (`package-lock.json` top-level version) with `package.json`.
 
-## P1 (Next features)
-No open issues. Potential enhancements identified from codebase:
-1. **Guild automation / RBAC** — `packages/shared` has skeleton for automation manifests; not yet wired to bot commands
-2. **Playback analytics dashboard** — track history stored in DB, frontend `/music/history` route exists; no charts/stats view
-3. **Rate limit UI** — provider health cooldown in Redis/bot; no admin command to view current cooldown state
-4. **Auto-message scheduling** — `AutoMessageService` supports trigger-based; could add cron-based scheduled messages
-5. **Queue persistence** — current queue is in-memory; persisting to Redis on graceful shutdown would allow bot-restart recovery
+## P2 — CI and local hygiene
+1. Resolve or archive local `.worktrees/fix-319` uncommitted frontend tests.
+2. Keep branch/worktree cleanup strict after each release PR.
+3. Preserve required-check reliability posture (avoid weakening release-branch CI requirements).
 
-## P2 (Housekeeping)
-1. Update Serena memories after PR #303 merges (current state will be v2.6.25)
-2. Audit major dep bumps (vite 7→8, zod 3→4) when time allows
-3. Cleanup: 0 worktrees currently (all stale ones removed)
+## P3 — Product backlog candidates
+1. Autoplay intelligence follow-ups: broader reason tags and feedback diversity constraints.
+2. Guild automation RBAC drift follow-up after recent command and route changes.
+3. Presence/activity customization pass (low risk quality-of-life).
 
-## Out of Scope (do not re-raise)
-- PR #268 (smartshuffle) — merged in v2.6.24
-- PR #269 (mod digest) — merged in v2.6.24
-- npm audit — 0 vulnerabilities (CLEAN)
+## Execution preference (user)
+- Prioritize small commits/PRs for fastest production delivery.
+- Avoid batching large cumulative changes.

--- a/README.md
+++ b/README.md
@@ -64,17 +64,11 @@ packages/
 - **Verified announcement**: `assets/lucky-verified-announcement.png` (1280x640)
 - Legacy v1 images kept at `assets/discord-discovery-media/2026-03/final/`
 
-### Latest Release (`v2.6.17`)
-- Hardened queue snapshot restore: staleness guard (30-min default),
-  `deleteSnapshot()` after successful restore prevents double-restore,
-  `currentTrack` now included in restore so the playing track is recovered.
-- Enforced provider health cooldown ordering in search fallback; degraded
-  providers are deprioritized before hitting their cooldown threshold.
-- Deploy pipeline hardened: checkout drift recovery, failure classification
-  (`LOCK_CONTENTION`, `CHECKOUT_RECOVERY_FAILED`, `MIGRATION_FAILED`,
-  `RUNTIME_PRECHECK_FAILED`), and hooks.json output capture for CI diagnosis.
-- Branch protection on main now requires `quality-gates`, `security`, and
-  `SonarCloud Code Analysis` checks with strict mode enabled.
+### Latest Release (`v2.6.37`)
+- Fixed PostgreSQL persistence in Docker by setting `PGDATA=/var/lib/postgresql/data`
+  for Postgres 18 compatibility.
+- Previous release (`v2.6.36`) restored play/autoplay reliability with yt-dlp format
+  fallback (`bestaudio/best`) and autoplay search fallback (`AUTO -> YOUTUBE_SEARCH`).
 
 ## Features
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # Lucky Implementation Status
 
-**Last Updated:** 2026-03-16  
-**Current Version:** v2.6.24
+**Last Updated:** 2026-03-18  
+**Current Version:** v2.6.37
 
 This document reflects what is currently shipped and running in production.
 
@@ -20,6 +20,7 @@ This document reflects what is currently shipped and running in production.
 ### Bot Commands
 
 #### Music (`/play`, `/queue`, `/skip`, `/stop`, `/pause`, `/resume`, `/volume`, etc.)
+
 - Full playback lifecycle with Discord Player v7
 - Queue management: `/queue show`, `/queue clear`, `/queue remove`, `/queue move`
 - `/queue shuffle` — standard Fisher-Yates shuffle
@@ -29,6 +30,7 @@ This document reflects what is currently shipped and running in production.
 - `/repeat`, `/autoplay` — repeat mode and autoplay toggle
 
 #### Music Intelligence
+
 - **Autoplay** — recommendation engine with similarity scoring (genre, tag, artist, duration, popularity)
 - **Diversity caps** — max 2 tracks per artist, max 3 per source; same-source penalty −0.15 (v2.6.19)
 - **Recommendation reason tags** — shows why a track was autoplay-queued (v2.6.20)
@@ -37,38 +39,59 @@ This document reflects what is currently shipped and running in production.
 - **`/music health`** — provider health, watchdog state, queue diagnostics, session snapshot, feedback count
 
 #### Music Reliability
+
 - **ProviderHealthService** — score-based provider ordering, cooldown on repeated failures, Redis-persisted state across restarts; configurable via `MUSIC_PROVIDER_COOLDOWN_MS`, `MUSIC_PROVIDER_FAILURE_THRESHOLD` (v2.6.21)
 - **MusicWatchdogService** — per-guild arm/clear/recover cycle; detects stale connection and retries rejoin + replay; periodic cross-guild orphan scan (default 60s) via `MUSIC_WATCHDOG_SCAN_INTERVAL_MS` (v2.6.21, v2.6.22)
 - **Session snapshots** — Redis-backed queue state (`music:snapshot:{guildId}`, 30-min TTL); restored on bot restart via `restoreSessionsOnStartup`
 
 #### Moderation (`/warn`, `/mute`, `/unmute`, `/kick`, `/ban`, `/unban`, `/case`, `/cases`, `/history`)
+
 - Full case management with case number tracking, DM notifications, evidence logging
 - **`/digest`** — moderation activity digest with period-filtered stats and top 5 moderators (7d/30d/90d) (v2.6.24)
 
 #### Auto-Moderation (`/automod`)
+
 - **AutoModService** — spam detection, caps lock threshold, link filtering, invite filtering, word filter
 - Configurable per-guild: `/automod spam`, `/automod caps`, `/automod links`, `/automod invites`, `/automod words`
 - **`/automod status`** — view current settings
-- **`/automod preset`** — apply pre-built rule packs: `balanced`, `strict`, `light`; merges with existing exempt channels/roles (v2.6.25, in progress)
+- **`/automod preset`** — apply pre-built rule packs: `balanced`, `strict`, `light`; merges with existing exempt channels/roles (v2.6.25)
 
 #### Management
+
 - Embed builder (`/embed`), custom commands (`/customcommand`), auto-messages (`/automessage`)
 - Server logs (`/serverlog`), guild automation (RBAC-aware role assignment)
 - Reaction roles (`/reactionrole`)
 
 #### Download
+
 - `/download` — yt-dlp powered media download command
 
 #### General
+
 - `/help`, `/ping`, `/lastfm`, `/twitch`, `/roleconfig` — standard utility commands
+- `/starboard` — setup/disable/status/top plus reaction-based pinning to a starboard channel (v2.6.26)
+- `/level` — rank, leaderboard, setup, and role rewards powered by XP tracking (v2.6.26)
+
+### Engagement Layer
+
+- **StarboardService** — per-guild starboard config + tracked entries with star counts and source message mapping
+- **LevelService** — XP accrual, level progression (`level^2 * 100`), rank/leaderboard queries, and level-based role rewards
+- **Event wiring** — reaction handler updates starboard entries; message handler awards XP with cooldown, level-up announcement, and role reward assignment
+
+### Playback Stability (v2.6.36)
+
+- **Play reliability** — yt-dlp extraction now uses resilient format fallback `-f bestaudio/best`
+- **Autoplay reliability** — search fallback retries with `YOUTUBE_SEARCH` when `AUTO` parser/search fails
 
 ### Backend API (`packages/backend`)
+
 - Express REST API for the web dashboard
 - Routes: guilds, users, settings, moderation cases, server logs, auth (Discord OAuth2)
 - Session-based auth with Redis store
 - Health endpoints: `/api/health`, `/api/health/auth-config`
 
 ### Frontend (`packages/frontend`)
+
 - React + Vite + Tailwind dashboard
 - Pages: Home, Login, Dashboard, Guild settings, Moderation log, Privacy Policy, Terms of Service
 - Discord OAuth2 login flow integrated
@@ -77,23 +100,21 @@ This document reflects what is currently shipped and running in production.
 
 ## Known Gaps / Future Work
 
-| Area | Description | Complexity |
-|------|-------------|------------|
-| `/starboard` | Message star pinning with leaderboard — needs new Prisma model | L |
-| `/level` | XP + role rewards + leaderboard — needs new Prisma model + service | L |
-| Autoplay diversity | Reason tag expansion, feedback diversity constraints | M |
-| Guild automation | RBAC delta review post-v2.6.21 | M |
-| Presence/activity | Bot activity/status customization | S |
+| Area               | Description                                          | Complexity |
+| ------------------ | ---------------------------------------------------- | ---------- |
+| Autoplay diversity | Reason tag expansion, feedback diversity constraints | M          |
+| Guild automation   | RBAC delta review post-v2.6.21                       | M          |
+| Presence/activity  | Bot activity/status customization                    | S          |
 
 ---
 
 ## Env Vars Reference
 
-| Var | Default | Purpose |
-|-----|---------|---------|
-| `SMART_SHUFFLE_STREAK_LIMIT` | `2` | Max consecutive tracks from one requester in smartshuffle |
-| `AUTOPLAY_FEEDBACK_TTL_DAYS` | `30` | Feedback Redis entry TTL in days |
-| `MUSIC_PROVIDER_FAILURE_THRESHOLD` | `2` | Failures before provider enters cooldown |
-| `MUSIC_PROVIDER_COOLDOWN_MS` | `240000` | Provider cooldown duration in ms |
-| `MUSIC_WATCHDOG_SCAN_INTERVAL_MS` | `60000` | Periodic orphan session scan interval |
-| `QUEUE_RESCUE_PROBE_TIMEOUT_MS` | `5000` | Probe timeout for /queue rescue |
+| Var                                | Default  | Purpose                                                   |
+| ---------------------------------- | -------- | --------------------------------------------------------- |
+| `SMART_SHUFFLE_STREAK_LIMIT`       | `2`      | Max consecutive tracks from one requester in smartshuffle |
+| `AUTOPLAY_FEEDBACK_TTL_DAYS`       | `30`     | Feedback Redis entry TTL in days                          |
+| `MUSIC_PROVIDER_FAILURE_THRESHOLD` | `2`      | Failures before provider enters cooldown                  |
+| `MUSIC_PROVIDER_COOLDOWN_MS`       | `240000` | Provider cooldown duration in ms                          |
+| `MUSIC_WATCHDOG_SCAN_INTERVAL_MS`  | `60000`  | Periodic orphan session scan interval                     |
+| `QUEUE_RESCUE_PROBE_TIMEOUT_MS`    | `5000`   | Probe timeout for /queue rescue                           |


### PR DESCRIPTION
## Summary
- update README latest-release section from stale v2.6.17 to current v2.6.37/v2.6.36 context
- refresh docs/IMPLEMENTATION_STATUS.md version metadata and shipped feature status for /starboard, /level, and play/autoplay reliability fixes
- remove outdated "in progress" and stale gap entries that were already delivered

## Verification
- docs-only change; no runtime code paths modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new music commands: `/lyrics`, `/queue rescue`, and `/automod preset`
  * Introduced energy-aware queue handling and smart shuffle capability

* **Bug Fixes**
  * Fixed PostgreSQL persistence compatibility with Postgres 18
  * Improved play/autoplay reliability

* **Documentation**
  * Updated implementation status and feature documentation for v2.6.37

<!-- end of auto-generated comment: release notes by coderabbit.ai -->