### PR TITLE
chore(repo): sync lockfile metadata and ignore worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ build
 
 # Session data
 .data/
+.worktrees/
 
 # Downloads and logs
 downloads/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.24",
+    "version": "2.6.37",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.24",
+            "version": "2.6.37",
             "license": "ISC",
             "workspaces": [
                 "packages/*"


### PR DESCRIPTION
## Summary
- align top-level package-lock version metadata with package.json (2.6.37)
- ignore local .worktrees/ directory to reduce noisy untracked state in root checkout

## Verification
- metadata-only change; no runtime code modified