### PR TITLE
fix(ci): skip yt-dlp binary download during Docker install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Root Docker build now sets `YOUTUBE_DL_SKIP_DOWNLOAD=1` during dependency install to avoid yt-dlp GitHub API rate-limit failures in CI image builds.
+
 ## [2.6.37] - 2026-03-18
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
 RUN --mount=type=cache,id=npm-build-stage,target=/root/.npm,sharing=locked \
+    YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     npm ci --legacy-peer-deps --no-audit --no-fund && \
     (npm cache verify 2>/dev/null || true)
 
@@ -64,6 +65,7 @@ COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
 RUN --mount=type=cache,id=npm-deps-production,target=/root/.npm,sharing=locked \
+    YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     YOUTUBE_DL_SKIP_PYTHON_CHECK=1 \
     npm ci --legacy-peer-deps --omit=dev --no-audit --no-fund && \
     (npm cache verify 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- set YOUTUBE_DL_SKIP_DOWNLOAD=1 in root Docker build dependency install stages
- avoid GitHub API rate-limit failures from youtube-dl-exec postinstall during CI image builds
- add changelog note under Unreleased