### PR TITLE
chore(release): prepare v2.6.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.38] - 2026-03-19
+
 ### Fixed
 
 - Root Docker build now sets `YOUTUBE_DL_SKIP_DOWNLOAD=1` during dependency install to avoid yt-dlp GitHub API rate-limit failures in CI image builds.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.37",
+    "version": "2.6.38",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- bump package version from 2.6.37 to 2.6.38
- cut release notes for recent production fixes: dashboard runtime hardening and Docker yt-dlp CI reliability
- keep Unreleased section ready for next patch cycle