### PR TITLE
chore(ci): add stale issue and PR management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Stale
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 14
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned,security,good first issue'
+          exempt-pr-labels: 'pinned,security'


### PR DESCRIPTION
Adds stale bot — marks issues/PRs stale after 30 days, closes after 14 more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Implemented automatic stale issue and pull request management to maintain repository health. Items inactive for 30 days will be marked as stale and closed after 14 additional days, with exemptions for items labeled as pinned, security-related, or marked as good first issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->