### PR TITLE
fix(automod): stop false positives for gifs, links, and laughter

### DIFF
--- a/packages/backend/tests/unit/services/AutoModService.regressions.test.ts
+++ b/packages/backend/tests/unit/services/AutoModService.regressions.test.ts
@@ -1,10 +1,20 @@
 import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 
-const mockPrisma: any = {
+type MockAutoModSettingsDelegate = {
+    findUnique: jest.Mock
+    create: jest.Mock
+    upsert: jest.Mock
+}
+
+type MockPrisma = {
+    autoModSettings: MockAutoModSettingsDelegate
+}
+
+const mockPrisma: MockPrisma = {
     autoModSettings: {
-        findUnique: jest.fn<any>(),
-        create: jest.fn<any>(),
-        upsert: jest.fn<any>(),
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        upsert: jest.fn(),
     },
 }
 
@@ -86,6 +96,21 @@ describe('AutoModService regressions', () => {
         )
 
         expect(result).toBe(false)
+    })
+
+    test('checkLinks blocks deceptive hostnames that contain allowed domain', async () => {
+        mockPrisma.autoModSettings.findUnique.mockResolvedValue({
+            ...DEFAULT_SETTINGS,
+            linksEnabled: true,
+            allowedDomains: ['tenor.com'],
+        })
+
+        const result = await service.checkLinks(
+            DEFAULT_SETTINGS.guildId,
+            'https://tenor.com.evil.tld/some-gif',
+        )
+
+        expect(result).toBe(true)
     })
 
     test('checkWords does not match partial substrings like laughter', async () => {

--- a/packages/shared/src/services/AutoModService.ts
+++ b/packages/shared/src/services/AutoModService.ts
@@ -126,25 +126,46 @@ const AUTO_MOD_TEMPLATES: AutoModTemplate[] = [
     },
 ]
 
-const escapeRegExp = (value: string): string =>
-    value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
 const normalizeForMatch = (value: string): string =>
     value
         .normalize('NFD')
-        .replace(/\p{M}+/gu, '')
+        .replaceAll(/\p{M}+/gu, '')
         .toLowerCase()
 
 const normalizeAllowedDomains = (domains: string[]): string[] =>
     domains
         .map((domain) => domain.trim().toLowerCase())
-        .map((domain) => domain.replace(/^https?:\/\//, ''))
-        .map((domain) => domain.replace(/^www\./, ''))
-        .map((domain) => domain.replace(/\/+$/, ''))
+        .map((domain) => {
+            if (!domain) return ''
+
+            const candidate = domain.includes('://')
+                ? domain
+                : `https://${domain}`
+
+            try {
+                return new URL(candidate).hostname.toLowerCase()
+            } catch {
+                return domain.split(/[/:?#]/, 1)[0]?.toLowerCase() ?? ''
+            }
+        })
+        .map((domain) =>
+            domain.startsWith('www.') ? domain.slice(4) : domain,
+        )
         .filter((domain) => domain.length > 0)
 
+const trimTrailingUrlPunctuation = (value: string): string => {
+    let result = value.trim()
+    const trailing = new Set([')', ',', '.', '!', '?', ';', ':'])
+
+    while (result.length > 0 && trailing.has(result.at(-1) ?? '')) {
+        result = result.slice(0, -1)
+    }
+
+    return result
+}
+
 const extractHostname = (rawUrl: string): string | null => {
-    const sanitized = rawUrl.trim().replace(/[),.!?;:]+$/g, '')
+    const sanitized = trimTrailingUrlPunctuation(rawUrl)
 
     try {
         const parsed = new URL(sanitized)
@@ -314,6 +335,9 @@ export class AutoModService {
         if (settings.bannedWords.length === 0) return false
 
         const normalizedContent = normalizeForMatch(content)
+        const contentTokens = normalizedContent
+            .split(/[^\p{L}\p{N}_]+/u)
+            .filter((token) => token.length > 0)
 
         return settings.bannedWords.some((word) => {
             const normalizedWord = normalizeForMatch(word.trim())
@@ -323,8 +347,7 @@ export class AutoModService {
                 return normalizedContent.includes(normalizedWord)
             }
 
-            const pattern = new RegExp(`(^|[^\\p{L}\\p{N}_])${escapeRegExp(normalizedWord)}([^\\p{L}\\p{N}_]|$)`, 'u')
-            return pattern.test(normalizedContent)
+            return contentTokens.includes(normalizedWord)
         })
     }
 


### PR DESCRIPTION
## Summary
- fix AutoMod link checks so URLs are not deleted when no allowlist domains are configured
- switch URL domain validation to strict hostname/subdomain matching instead of substring matching
- fix banned-word matching to use token boundaries so laughter like `kkkkkkkk` is not treated as banned `kkk`
- add regression tests for empty allowlist links, subdomain links, and laughter token behavior

## Why
These regressions caused normal user messages (GIF links, regular URLs, and laughter text) to be deleted even without intentional filtering configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter and more precise link validation: hostnames are normalized and only exact matches or true subdomains of allowed domains are permitted; empty allowed-domain lists block links.
  * Improved word filtering: messages and banned terms are normalized (diacritics/case) and tokenized so single-word bans match whole words while multi-word phrases still match.

* **Tests**
  * Added regression tests covering link and word matching behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->