### PR TITLE
fix(frontend): align guild automation access guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/IMPLEMENTATION_STATUS.md`, and root lockfile version fields (`#354`).
 - Tightened npm overrides for `flatted` and `effect` to patched bounded ranges
   so required Security checks no longer fail on high-severity audit findings.
+- Aligned Guild Automation dashboard access controls to backend policy by requiring
+  `settings:manage` on both route and sidebar visibility, preventing false-positive
+  UI access that led to API 403 responses.
 
 ## [2.6.38] - 2026-03-19
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -105,7 +105,7 @@ This document reflects what is currently shipped and running in production.
 | Area               | Description                                          | Complexity |
 | ------------------ | ---------------------------------------------------- | ---------- |
 | Autoplay diversity | Reason tag expansion, feedback diversity constraints | M          |
-| Guild automation   | RBAC delta review post-v2.6.21                       | M          |
+| Guild automation   | RBAC follow-up sweep for route/sidebar guard parity  | M          |
 | Presence/activity  | Bot activity/status customization                    | S          |
 
 ---

--- a/packages/frontend/src/App.authRoutes.test.tsx
+++ b/packages/frontend/src/App.authRoutes.test.tsx
@@ -36,6 +36,10 @@ vi.mock('./pages/Features', () => ({
     default: () => <h1>Features Page</h1>,
 }))
 
+vi.mock('./pages/GuildAutomation', () => ({
+    default: () => <h1>Guild Automation Page</h1>,
+}))
+
 type AuthState = {
     isAuthenticated: boolean
     isLoading: boolean
@@ -261,5 +265,34 @@ describe('App authenticated routing', () => {
         expect(
             await screen.findByRole('heading', { name: 'Servers Page' }),
         ).toBeInTheDocument()
+    })
+
+    test('requires settings manage access for /guild-automation route', async () => {
+        mockAuthStore({ isAuthenticated: true })
+        mockGuildStore({
+            selectedGuild: {
+                id: '123',
+                name: 'Guild',
+                effectiveAccess: {
+                    ...NONE_ACCESS,
+                    overview: 'view',
+                    settings: 'view',
+                    automation: 'manage',
+                },
+            },
+            memberContextLoading: false,
+        })
+
+        renderAt('/guild-automation')
+
+        expect(await screen.findByText('Access denied')).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'You do not have permission to view the settings module for this server.',
+            ),
+        ).toBeInTheDocument()
+        expect(
+            screen.queryByText('Guild Automation Page'),
+        ).not.toBeInTheDocument()
     })
 })

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import Layout from './components/Layout/Layout'
 import PageLoader from './components/ui/PageLoader'
 import EmptyState from './components/ui/EmptyState'
 import { hasModuleAccess } from './lib/rbac'
-import type { ModuleKey } from './types'
+import type { AccessMode, ModuleKey } from './types'
 
 const LoginPage = lazy(() => import('./pages/Login'))
 const ServersPage = lazy(() => import('./pages/ServersPage'))
@@ -66,9 +66,11 @@ function ForbiddenModulePage({ module }: { module: ModuleKey }) {
 
 function RouteModuleGuard({
     module,
+    requiredMode = 'view',
     children,
 }: {
     module: ModuleKey
+    requiredMode?: AccessMode
     children: ReactNode
 }) {
     const { selectedGuild, memberContext, memberContextLoading } =
@@ -86,15 +88,23 @@ function RouteModuleGuard({
 
     const effectiveAccess = memberContext?.effectiveAccess ?? fallbackAccess
 
-    if (!hasModuleAccess(effectiveAccess, module, 'view')) {
+    if (!hasModuleAccess(effectiveAccess, module, requiredMode)) {
         return <ForbiddenModulePage module={module} />
     }
 
     return <>{children}</>
 }
 
-function guardedRoute(module: ModuleKey, element: ReactNode) {
-    return <RouteModuleGuard module={module}>{element}</RouteModuleGuard>
+function guardedRoute(
+    module: ModuleKey,
+    element: ReactNode,
+    requiredMode: AccessMode = 'view',
+) {
+    return (
+        <RouteModuleGuard module={module} requiredMode={requiredMode}>
+            {element}
+        </RouteModuleGuard>
+    )
 }
 
 function AuthenticatedRoutes() {
@@ -147,7 +157,11 @@ function AuthenticatedRoutes() {
             />
             <Route
                 path='/guild-automation'
-                element={guardedRoute('automation', <GuildAutomationPage />)}
+                element={guardedRoute(
+                    'settings',
+                    <GuildAutomationPage />,
+                    'manage',
+                )}
             />
             <Route
                 path='/levels'

--- a/packages/frontend/src/components/Layout/Sidebar.test.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.test.tsx
@@ -6,6 +6,7 @@ import Sidebar from './Sidebar'
 import { useAuthStore } from '@/stores/authStore'
 import { useGuildStore } from '@/stores/guildStore'
 import type { User, Guild } from '@/types'
+import type { EffectiveAccessMap } from '@/types/rbac'
 
 vi.mock('@/stores/authStore')
 vi.mock('@/stores/guildStore')
@@ -35,6 +36,15 @@ const mockGuild2: Guild = {
     permissions: '0',
     features: [],
     botAdded: true,
+}
+
+const ACCESS_NONE: EffectiveAccessMap = {
+    overview: 'none',
+    settings: 'none',
+    moderation: 'none',
+    automation: 'none',
+    music: 'none',
+    integrations: 'none',
 }
 
 describe('Sidebar', () => {
@@ -336,6 +346,51 @@ describe('Sidebar', () => {
                 screen.queryByRole('link', { name: 'Re-authenticate' }),
             ).not.toBeInTheDocument()
         })
+    })
+
+    test('hides Guild Automation nav item without settings manage access', () => {
+        mockGuildStoreState({
+            memberContext: {
+                guildId: mockGuild.id,
+                nickname: null,
+                username: 'TestUser',
+                globalName: null,
+                roleIds: [],
+                effectiveAccess: {
+                    ...ACCESS_NONE,
+                    overview: 'view',
+                    settings: 'view',
+                    automation: 'manage',
+                },
+                canManageRbac: false,
+            },
+        })
+
+        renderSidebar()
+
+        expect(screen.queryByText('Guild Automation')).not.toBeInTheDocument()
+    })
+
+    test('shows Guild Automation nav item with settings manage access', () => {
+        mockGuildStoreState({
+            memberContext: {
+                guildId: mockGuild.id,
+                nickname: null,
+                username: 'TestUser',
+                globalName: null,
+                roleIds: [],
+                effectiveAccess: {
+                    ...ACCESS_NONE,
+                    overview: 'view',
+                    settings: 'manage',
+                },
+                canManageRbac: true,
+            },
+        })
+
+        renderSidebar()
+
+        expect(screen.getByText('Guild Automation')).toBeInTheDocument()
     })
 
     test('opens and closes mobile sidebar', async () => {

--- a/packages/frontend/src/components/Layout/Sidebar.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.tsx
@@ -33,13 +33,14 @@ import { useGuildStore } from '@/stores/guildStore'
 import { api } from '@/services/api'
 import { cn } from '@/lib/utils'
 import { hasModuleAccess } from '@/lib/rbac'
-import type { ModuleKey } from '@/types'
+import type { AccessMode, ModuleKey } from '@/types'
 
 interface NavItem {
     path: string
     label: string
     icon: React.ComponentType<{ className?: string }>
     module: ModuleKey
+    requiredMode?: AccessMode
     badge?: number
 }
 
@@ -120,7 +121,8 @@ const navSections: NavSection[] = [
                 path: '/guild-automation',
                 label: 'Guild Automation',
                 icon: GitBranch,
-                module: 'automation',
+                module: 'settings',
+                requiredMode: 'manage',
             },
             {
                 path: '/levels',
@@ -207,12 +209,12 @@ function Sidebar() {
     const effectiveAccess =
         memberContext?.effectiveAccess ?? selectedGuild?.effectiveAccess
 
-    const canViewModule = (module: ModuleKey) => {
+    const canViewModule = (module: ModuleKey, requiredMode: AccessMode = 'view') => {
         if (!selectedGuild || !effectiveAccess) {
             return true
         }
 
-        return hasModuleAccess(effectiveAccess, module, 'view')
+        return hasModuleAccess(effectiveAccess, module, requiredMode)
     }
 
     const profileName =
@@ -427,7 +429,10 @@ function Sidebar() {
                             <div className='space-y-1'>
                                 {section.items
                                     .filter((item) =>
-                                        canViewModule(item.module),
+                                        canViewModule(
+                                            item.module,
+                                            item.requiredMode,
+                                        ),
                                     )
                                     .map((item) => {
                                         const active = isActive(item.path)


### PR DESCRIPTION
## Summary
- align Guild Automation route and sidebar guards with backend policy by requiring `settings:manage`
- add regression tests for route denial and sidebar visibility when only `automation` access is present
- update changelog and implementation status notes to reflect RBAC guard parity follow-up

## Verification
- npm run test --workspace=packages/frontend -- src/App.authRoutes.test.tsx src/components/Layout/Sidebar.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated Guild Automation dashboard access controls to require `settings:manage` permission for both route-level access and sidebar visibility, ensuring UI access aligns with backend authorization and prevents 403 errors.

* **Tests**
  * Added tests for Guild Automation route and sidebar visibility based on permission levels.

* **Documentation**
  * Updated implementation status for Guild Automation RBAC alignment work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->