### PR TITLE
feat(bot): add configurable presence status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ BOT_AVATAR_URL=
 BOT_COLOR=0x5865F2
 BOT_WEBSITE=
 BOT_SUPPORT_SERVER=
+# Bot online status for rotating and music presence: online | idle | dnd | invisible
+BOT_PRESENCE_STATUS=online
 
 # Optional: Disable specific commands (comma-separated)
 # Example: COMMANDS_DISABLED=ping,help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aligned Guild Automation dashboard access controls to backend policy by requiring
   `settings:manage` on both route and sidebar visibility, preventing false-positive
   UI access that led to API 403 responses.
+- Added `BOT_PRESENCE_STATUS` support so rotating bot presence and music now-playing
+  presence can use `online`, `idle`, `dnd`, or `invisible` without code changes.
 
 ## [2.6.38] - 2026-03-19
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Lucky Implementation Status
 
-**Last Updated:** 2026-03-23  
+**Last Updated:** 2026-03-24  
 **Current Version:** v2.6.38
 
 This document reflects what is currently shipped and running in production.
@@ -105,8 +105,7 @@ This document reflects what is currently shipped and running in production.
 | Area               | Description                                          | Complexity |
 | ------------------ | ---------------------------------------------------- | ---------- |
 | Autoplay diversity | Reason tag expansion, feedback diversity constraints | M          |
-| Guild automation   | RBAC follow-up sweep for route/sidebar guard parity  | M          |
-| Presence/activity  | Bot activity/status customization                    | S          |
+| Presence/activity  | Activity template customization                      | S          |
 
 ---
 
@@ -120,3 +119,4 @@ This document reflects what is currently shipped and running in production.
 | `MUSIC_PROVIDER_COOLDOWN_MS`       | `240000` | Provider cooldown duration in ms                          |
 | `MUSIC_WATCHDOG_SCAN_INTERVAL_MS`  | `60000`  | Periodic orphan session scan interval                     |
 | `QUEUE_RESCUE_PROBE_TIMEOUT_MS`    | `5000`   | Probe timeout for /queue rescue                           |
+| `BOT_PRESENCE_STATUS`              | `online` | Bot presence status for rotation and now-playing updates  |

--- a/packages/bot/src/handlers/clientHandler/presence.ts
+++ b/packages/bot/src/handlers/clientHandler/presence.ts
@@ -1,5 +1,6 @@
 import { ActivityType } from 'discord.js'
 import type { CustomClient } from '../../types'
+import { getBotPresenceStatus } from '../../utils/presenceStatus'
 
 type PresenceActivity = {
     type: ActivityType
@@ -87,7 +88,7 @@ export const setPresenceActivity = (
     const safeIndex =
         ((index % activities.length) + activities.length) % activities.length
     client.user.setPresence({
-        status: 'online',
+        status: getBotPresenceStatus(),
         activities: [activities[safeIndex]],
     })
 

--- a/packages/bot/src/services/MusicPresenceService.spec.ts
+++ b/packages/bot/src/services/MusicPresenceService.spec.ts
@@ -17,9 +17,21 @@ const makeClient = () => ({
     user: { setPresence: jest.fn() },
 })
 
+const originalPresenceStatus = process.env.BOT_PRESENCE_STATUS
+
 beforeEach(() => {
     debugLogMock.mockReset()
     jest.resetModules()
+    delete process.env.BOT_PRESENCE_STATUS
+})
+
+afterAll(() => {
+    if (originalPresenceStatus) {
+        process.env.BOT_PRESENCE_STATUS = originalPresenceStatus
+        return
+    }
+
+    delete process.env.BOT_PRESENCE_STATUS
 })
 
 describe('MusicPresenceService', () => {
@@ -33,6 +45,42 @@ describe('MusicPresenceService', () => {
             setNowPlaying('guild-1', { title: 'Song', author: 'Artist' } as never)
 
             expect(pause).toHaveBeenCalledTimes(1)
+            expect(client.user.setPresence).toHaveBeenCalledWith({
+                status: 'online',
+                activities: [
+                    { type: ActivityType.Listening, name: 'Song — Artist' },
+                ],
+            })
+        })
+
+        it('uses configured presence status when valid', () => {
+            process.env.BOT_PRESENCE_STATUS = 'idle'
+
+            const client = makeClient()
+            const pause = jest.fn()
+            const resume = jest.fn()
+            initMusicPresence(client as never, pause, resume)
+
+            setNowPlaying('guild-1', { title: 'Song', author: 'Artist' } as never)
+
+            expect(client.user.setPresence).toHaveBeenCalledWith({
+                status: 'idle',
+                activities: [
+                    { type: ActivityType.Listening, name: 'Song — Artist' },
+                ],
+            })
+        })
+
+        it('falls back to online when configured presence status is invalid', () => {
+            process.env.BOT_PRESENCE_STATUS = 'away'
+
+            const client = makeClient()
+            const pause = jest.fn()
+            const resume = jest.fn()
+            initMusicPresence(client as never, pause, resume)
+
+            setNowPlaying('guild-1', { title: 'Song', author: 'Artist' } as never)
+
             expect(client.user.setPresence).toHaveBeenCalledWith({
                 status: 'online',
                 activities: [

--- a/packages/bot/src/services/MusicPresenceService.ts
+++ b/packages/bot/src/services/MusicPresenceService.ts
@@ -2,6 +2,7 @@ import { ActivityType } from 'discord.js'
 import type { Track } from 'discord-player'
 import type { CustomClient } from '../types'
 import { debugLog } from '@lucky/shared/utils'
+import { getBotPresenceStatus } from '../utils/presenceStatus'
 
 const activeGuilds = new Set<string>()
 let pauseRotationFn: (() => void) | null = null
@@ -26,7 +27,7 @@ export function setNowPlaying(guildId: string, track: Track): void {
 
     const name = truncateActivityName(`${track.title} — ${track.author}`)
     clientRef.user.setPresence({
-        status: 'online',
+        status: getBotPresenceStatus(),
         activities: [{ type: ActivityType.Listening, name }],
     })
 

--- a/packages/bot/src/utils/presenceStatus.ts
+++ b/packages/bot/src/utils/presenceStatus.ts
@@ -1,0 +1,27 @@
+import type { PresenceStatusData } from 'discord.js'
+
+const DEFAULT_PRESENCE_STATUS: PresenceStatusData = 'online'
+
+const ALLOWED_PRESENCE_STATUSES = new Set<PresenceStatusData>([
+    'online',
+    'idle',
+    'dnd',
+    'invisible',
+])
+
+const isPresenceStatusData = (status: string): status is PresenceStatusData =>
+    ALLOWED_PRESENCE_STATUSES.has(status as PresenceStatusData)
+
+export const getBotPresenceStatus = (): PresenceStatusData => {
+    const configuredStatus = process.env.BOT_PRESENCE_STATUS?.trim().toLowerCase()
+
+    if (!configuredStatus) {
+        return DEFAULT_PRESENCE_STATUS
+    }
+
+    if (isPresenceStatusData(configuredStatus)) {
+        return configuredStatus
+    }
+
+    return DEFAULT_PRESENCE_STATUS
+}

--- a/packages/bot/tests/handlers/clientHandler/presence.test.ts
+++ b/packages/bot/tests/handlers/clientHandler/presence.test.ts
@@ -10,6 +10,21 @@ import {
 } from '../../../src/handlers/clientHandler/presence'
 
 describe('bot presence', () => {
+    const originalPresenceStatus = process.env.BOT_PRESENCE_STATUS
+
+    beforeEach(() => {
+        delete process.env.BOT_PRESENCE_STATUS
+    })
+
+    afterAll(() => {
+        if (originalPresenceStatus) {
+            process.env.BOT_PRESENCE_STATUS = originalPresenceStatus
+            return
+        }
+
+        delete process.env.BOT_PRESENCE_STATUS
+    })
+
     it('builds premium rotation with runtime stats', () => {
         const activities = buildPresenceActivities({
             guildCount: 12,
@@ -106,6 +121,64 @@ describe('bot presence', () => {
                 },
             ],
         })
+    })
+
+    it('uses configured presence status when valid', () => {
+        process.env.BOT_PRESENCE_STATUS = 'dnd'
+
+        const setPresence = jest.fn()
+        const client = {
+            user: { setPresence },
+            commands: { size: 3 },
+            guilds: {
+                cache: {
+                    size: 1,
+                    values: () => [{ memberCount: 8 }],
+                },
+            },
+            player: {
+                nodes: {
+                    cache: {
+                        values: () => [],
+                    },
+                },
+            },
+        }
+
+        setPresenceActivity(client as never, 0)
+
+        expect(setPresence).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'dnd' }),
+        )
+    })
+
+    it('falls back to online when configured presence status is invalid', () => {
+        process.env.BOT_PRESENCE_STATUS = 'busy'
+
+        const setPresence = jest.fn()
+        const client = {
+            user: { setPresence },
+            commands: { size: 3 },
+            guilds: {
+                cache: {
+                    size: 1,
+                    values: () => [{ memberCount: 8 }],
+                },
+            },
+            player: {
+                nodes: {
+                    cache: {
+                        values: () => [],
+                    },
+                },
+            },
+        }
+
+        setPresenceActivity(client as never, 0)
+
+        expect(setPresence).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'online' }),
+        )
     })
 
     it('starts rotation and returns stop function', () => {


### PR DESCRIPTION
## Summary
- add `BOT_PRESENCE_STATUS` support for bot rotation presence and now-playing music presence
- validate configured status values (`online`, `idle`, `dnd`, `invisible`) with fallback to `online`
- add regression tests and update docs/changelog for the new env configuration

## Verification
- `npm run test --workspace=packages/bot -- packages/bot/tests/handlers/clientHandler/presence.test.ts packages/bot/src/services/MusicPresenceService.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot presence status can now be configured via environment variable, enabling dynamic control over availability states (online, idle, do-not-disturb, invisible) without code modifications.

* **Documentation**
  * Updated implementation status guide with new configuration option and related capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->