### PR TITLE
feat(bot): improve autoplay diversity scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   UI access that led to API 403 responses.
 - Added `BOT_PRESENCE_STATUS` support so rotating bot presence and music now-playing
   presence can use `online`, `idle`, `dnd`, or `invisible` without code changes.
+- Autoplay recommendation selection now caps liked-feedback boosted picks to half
+  of each replenish batch (with fallback fill) and adds reason tags for session
+  novelty and similar track length.
 
 ## [2.6.38] - 2026-03-19
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -35,6 +35,8 @@ This document reflects what is currently shipped and running in production.
 - **Diversity caps** — max 2 tracks per artist, max 3 per source; same-source penalty −0.15 (v2.6.19)
 - **Recommendation reason tags** — shows why a track was autoplay-queued (v2.6.20)
 - **Autoplay like-boost** — liked tracks receive +0.3 score bonus and appear more often (v2.6.23)
+- **Feedback diversity cap** — liked-feedback tracks are limited to 50% of each autoplay replenish batch with fallback fill when only liked candidates exist (v2.6.39)
+- **Expanded reason tags** — autoplay metadata now includes `new in session` and `similar track length` context when applicable (v2.6.39)
 - **Feedback** — `/recommendation feedback` (like/dislike) stored per-user in Redis, 30-day TTL; `/music clearfeedback` to reset (v2.6.21)
 - **`/music health`** — provider health, watchdog state, queue diagnostics, session snapshot, feedback count
 
@@ -104,7 +106,7 @@ This document reflects what is currently shipped and running in production.
 
 | Area               | Description                                          | Complexity |
 | ------------------ | ---------------------------------------------------- | ---------- |
-| Autoplay diversity | Reason tag expansion, feedback diversity constraints | M          |
+| Autoplay diversity | Additional tuning of diversity heuristics            | S          |
 | Presence/activity  | Activity template customization                      | S          |
 
 ---

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -363,6 +363,230 @@ describe('queueManipulation.replenishQueue', () => {
         )
     })
 
+    it('caps liked-feedback picks to half of replenished autoplay additions when alternatives exist', async () => {
+        likedTrackKeysMock.mockResolvedValue(
+            new Set([
+                'likedone::artistb',
+                'likedtwo::artistc',
+                'likedthree::artistd',
+                'likedfour::artiste',
+            ]),
+        )
+
+        const queue = createQueueMock({
+            tracks: {
+                size: 4,
+                toArray: jest.fn().mockReturnValue([
+                    {
+                        title: 'Queue Song 1',
+                        author: 'Queue Artist 1',
+                        url: 'https://example.com/q1',
+                    },
+                    {
+                        title: 'Queue Song 2',
+                        author: 'Queue Artist 2',
+                        url: 'https://example.com/q2',
+                    },
+                    {
+                        title: 'Queue Song 3',
+                        author: 'Queue Artist 3',
+                        url: 'https://example.com/q3',
+                    },
+                    {
+                        title: 'Queue Song 4',
+                        author: 'Queue Artist 4',
+                        url: 'https://example.com/q4',
+                    },
+                ]),
+            },
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Liked One',
+                            author: 'Artist B',
+                            url: 'https://example.com/l1',
+                            source: 'youtube',
+                        },
+                        {
+                            title: 'Liked Two',
+                            author: 'Artist C',
+                            url: 'https://example.com/l2',
+                            source: 'spotify',
+                        },
+                        {
+                            title: 'Liked Three',
+                            author: 'Artist D',
+                            url: 'https://example.com/l3',
+                            source: 'soundcloud',
+                        },
+                        {
+                            title: 'Liked Four',
+                            author: 'Artist E',
+                            url: 'https://example.com/l4',
+                            source: 'apple_music',
+                        },
+                        {
+                            title: 'Neutral One',
+                            author: 'Artist F',
+                            url: 'https://example.com/n1',
+                            source: 'youtube',
+                        },
+                        {
+                            title: 'Neutral Two',
+                            author: 'Artist G',
+                            url: 'https://example.com/n2',
+                            source: 'spotify',
+                        },
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(queue.addTrack).toHaveBeenCalledTimes(4)
+        const likedAdds = queue.addTrack.mock.calls.filter((call) => {
+            const track = call[0] as Track
+            const metadata = (track.metadata ?? {}) as {
+                recommendationReason?: string
+            }
+
+            return metadata.recommendationReason?.includes('liked track')
+        })
+        expect(likedAdds).toHaveLength(2)
+    })
+
+    it('fills queue with liked candidates when no neutral alternatives exist', async () => {
+        likedTrackKeysMock.mockResolvedValue(
+            new Set(['likedone::artistb', 'likedtwo::artistc']),
+        )
+
+        const queue = createQueueMock({
+            tracks: {
+                size: 6,
+                toArray: jest.fn().mockReturnValue([
+                    {
+                        title: 'Queue Song 1',
+                        author: 'Queue Artist 1',
+                        url: 'https://example.com/q1',
+                    },
+                    {
+                        title: 'Queue Song 2',
+                        author: 'Queue Artist 2',
+                        url: 'https://example.com/q2',
+                    },
+                    {
+                        title: 'Queue Song 3',
+                        author: 'Queue Artist 3',
+                        url: 'https://example.com/q3',
+                    },
+                    {
+                        title: 'Queue Song 4',
+                        author: 'Queue Artist 4',
+                        url: 'https://example.com/q4',
+                    },
+                    {
+                        title: 'Queue Song 5',
+                        author: 'Queue Artist 5',
+                        url: 'https://example.com/q5',
+                    },
+                    {
+                        title: 'Queue Song 6',
+                        author: 'Queue Artist 6',
+                        url: 'https://example.com/q6',
+                    },
+                ]),
+            },
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Liked One',
+                            author: 'Artist B',
+                            url: 'https://example.com/l1',
+                            source: 'youtube',
+                        },
+                        {
+                            title: 'Liked Two',
+                            author: 'Artist C',
+                            url: 'https://example.com/l2',
+                            source: 'spotify',
+                        },
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(queue.addTrack).toHaveBeenCalledTimes(2)
+        for (const call of queue.addTrack.mock.calls) {
+            const track = call[0] as Track
+            const metadata = (track.metadata ?? {}) as {
+                recommendationReason?: string
+            }
+
+            expect(metadata.recommendationReason).toContain('liked track')
+        }
+    })
+
+    it('adds expanded reason tags for session novelty and duration similarity', async () => {
+        const queue = createQueueMock({
+            tracks: {
+                size: 7,
+                toArray: jest.fn().mockReturnValue([
+                    {
+                        title: 'Queue Song',
+                        author: 'Queue Artist',
+                        url: 'https://example.com/q1',
+                    },
+                ]),
+            },
+            currentTrack: {
+                title: 'Song A',
+                author: 'Artist A',
+                url: 'https://example.com/a',
+                durationMS: 180000,
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Song A Night Mix',
+                            author: 'Artist Z',
+                            url: 'https://example.com/new',
+                            durationMS: 195000,
+                            source: 'youtube',
+                        },
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(queue.addTrack).toHaveBeenCalledTimes(1)
+        expect(queue.addTrack).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metadata: expect.objectContaining({
+                    recommendationReason: expect.stringContaining(
+                        'new in session',
+                    ),
+                }),
+            }),
+        )
+        expect(queue.addTrack).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metadata: expect.objectContaining({
+                    recommendationReason: expect.stringContaining(
+                        'similar track length',
+                    ),
+                }),
+            }),
+        )
+    })
+
     it.each([
         {
             name: 'stores queue metadata requester on autoplay recommendations',

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -14,6 +14,7 @@ const HISTORY_SEED_LIMIT = 3
 const SEARCH_RESULTS_LIMIT = 8
 const MAX_TRACKS_PER_ARTIST = 2
 const MAX_TRACKS_PER_SOURCE = 3
+const MAX_LIKED_TRACK_SHARE = 0.5
 const QUEUE_RESCUE_PROBE_TIMEOUT_MS = Number.parseInt(
     process.env.QUEUE_RESCUE_PROBE_TIMEOUT_MS ?? '5000',
     10,
@@ -27,6 +28,7 @@ type ScoredTrack = {
     track: Track
     score: number
     reason: string
+    isLiked: boolean
 }
 
 export type QueueRescueResult = {
@@ -399,7 +401,7 @@ function shouldIncludeCandidate(
 function upsertScoredCandidate(
     candidates: Map<string, ScoredTrack>,
     candidate: Track,
-    recommendation: { score: number; reason: string },
+    recommendation: { score: number; reason: string; isLiked: boolean },
 ): void {
     const candidateKey = getTrackKey(candidate)
     const existing = candidates.get(candidateKey)
@@ -409,6 +411,7 @@ function upsertScoredCandidate(
             track: candidate,
             score: recommendation.score,
             reason: recommendation.reason,
+            isLiked: recommendation.isLiked,
         })
     }
 }
@@ -418,6 +421,7 @@ function selectDiverseCandidates(
     missingTracks: number,
     maxPerArtist = MAX_TRACKS_PER_ARTIST,
     maxPerSource = MAX_TRACKS_PER_SOURCE,
+    maxLikedShare = MAX_LIKED_TRACK_SHARE,
 ): ScoredTrack[] {
     const sortedCandidates = Array.from(candidates.values()).sort(
         (a, b) => b.score - a.score,
@@ -425,17 +429,53 @@ function selectDiverseCandidates(
     const selected: ScoredTrack[] = []
     const artistCount = new Map<string, number>()
     const sourceCount = new Map<string, number>()
+    const selectedKeys = new Set<string>()
+    const likedCap = Math.max(1, Math.ceil(missingTracks * maxLikedShare))
+    let likedSelected = 0
 
-    for (const candidate of sortedCandidates) {
+    const canAddCandidate = (candidate: ScoredTrack): boolean => {
         const artistKey = candidate.track.author.toLowerCase()
         const sourceKey = (candidate.track.source ?? 'unknown').toLowerCase()
 
-        if ((artistCount.get(artistKey) ?? 0) >= maxPerArtist) continue
-        if ((sourceCount.get(sourceKey) ?? 0) >= maxPerSource) continue
+        if ((artistCount.get(artistKey) ?? 0) >= maxPerArtist) return false
+        if ((sourceCount.get(sourceKey) ?? 0) >= maxPerSource) return false
+
+        return true
+    }
+
+    const addCandidate = (candidate: ScoredTrack): void => {
+        const artistKey = candidate.track.author.toLowerCase()
+        const sourceKey = (candidate.track.source ?? 'unknown').toLowerCase()
 
         selected.push(candidate)
+        selectedKeys.add(getTrackKey(candidate.track))
         artistCount.set(artistKey, (artistCount.get(artistKey) ?? 0) + 1)
         sourceCount.set(sourceKey, (sourceCount.get(sourceKey) ?? 0) + 1)
+
+        if (candidate.isLiked) {
+            likedSelected++
+        }
+    }
+
+    for (const candidate of sortedCandidates) {
+        if (!canAddCandidate(candidate)) continue
+        if (candidate.isLiked && likedSelected >= likedCap) continue
+
+        addCandidate(candidate)
+        if (selected.length >= missingTracks) {
+            break
+        }
+    }
+
+    if (selected.length >= missingTracks) {
+        return selected
+    }
+
+    for (const candidate of sortedCandidates) {
+        if (selectedKeys.has(getTrackKey(candidate.track))) continue
+        if (!canAddCandidate(candidate)) continue
+
+        addCandidate(candidate)
         if (selected.length >= missingTracks) {
             break
         }
@@ -596,16 +636,18 @@ function calculateRecommendationScore(
     currentTrack: Track,
     recentArtists: Set<string>,
     likedTrackKeys: Set<string> = new Set(),
-): { score: number; reason: string } {
+): { score: number; reason: string; isLiked: boolean } {
     let score = 1
     const reasons: string[] = []
     const currentArtist = currentTrack.author.toLowerCase()
     const candidateArtist = candidate.author.toLowerCase()
+    let isLiked = false
 
     const candidateKey = normalizeTrackKey(candidate.title, candidate.author)
     if (likedTrackKeys.has(candidateKey)) {
         score += 0.3
         reasons.push('liked track')
+        isLiked = true
     }
 
     if (candidateArtist === currentArtist) {
@@ -615,6 +657,8 @@ function calculateRecommendationScore(
     }
     if (recentArtists.has(candidateArtist)) {
         score -= 0.25
+    } else {
+        reasons.push('new in session')
     }
     if (candidate.source === currentTrack.source) {
         score -= 0.15
@@ -629,12 +673,28 @@ function calculateRecommendationScore(
     if (tokenScore > 0) {
         reasons.push('similar title mood')
     }
+    const durationScore = getDurationSimilarityScore(candidate, currentTrack)
+    score += durationScore
+    if (durationScore > 0) {
+        reasons.push('similar track length')
+    }
 
     return {
         score,
         reason:
             reasons.length > 0 ? reasons.join(' • ') : 'balanced autoplay pick',
+        isLiked,
     }
+}
+
+function getDurationSimilarityScore(candidate: Track, currentTrack: Track): number {
+    if (typeof candidate.durationMS !== 'number') return 0
+    if (typeof currentTrack.durationMS !== 'number') return 0
+
+    const difference = Math.abs(candidate.durationMS - currentTrack.durationMS)
+    if (difference > 30_000) return 0
+
+    return 0.08
 }
 
 function sharedTitleTokenScore(titleA: string, titleB: string): number {


### PR DESCRIPTION
## Summary
- cap liked-feedback autoplay picks to 50% of each replenish batch when neutral candidates exist
- keep queue fill behavior intact with a fallback pass when only liked candidates are available
- add expanded autoplay reason tags (`new in session`, `similar track length`) and regression coverage

## Verification
- `npm run test --workspace=packages/bot -- packages/bot/src/utils/music/queueManipulation.spec.ts`