### PR TITLE
fix(bot): resolve autoplay queue by metadata guild id

### DIFF
--- a/.cursor/skills/music-queue-player/SKILL.md
+++ b/.cursor/skills/music-queue-player/SKILL.md
@@ -41,8 +41,12 @@ description: Work with Discord Player, queue, and music commands in Lucky. Use w
 - This protects direct-provider queries (for example direct YouTube URLs) from false negatives when provider health cooldown is stale.
 - Keep regression coverage in `packages/bot/src/utils/music/search/engineManager.spec.ts`:
   - `still tries preferred engine for direct provider queries even during cooldown`
+- In `packages/bot/src/utils/music/queueResolver.ts`, also resolve by `queue.metadata.channel.guildId` / `queue.metadata.channel.guild.id` to avoid false queue misses when cache keys are non-standard.
+- Keep regression coverage in `packages/bot/src/utils/music/queueResolver.spec.ts`:
+  - `falls back to cache scan by metadata.channel.guildId`
 
 ## Fast verification commands
 
 - `node /home/luk-server/Lucky/node_modules/.bin/jest --config packages/bot/jest.config.cjs packages/bot/src/utils/music/search/engineManager.spec.ts --runInBand`
+- `node /home/luk-server/Lucky/node_modules/.bin/jest --config packages/bot/jest.config.cjs packages/bot/src/utils/music/queueResolver.spec.ts --runInBand`
 - `node /home/luk-server/Lucky/node_modules/.bin/jest --config packages/bot/jest.config.cjs --testPathPatterns="engineManager.spec|autoplay.spec|queueManipulation.spec|playerFactory.test|play/index.spec" --runInBand`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `/autoplay` queue resolution now falls back to queue metadata channel guild IDs, so autoplay can be enabled while a single current track is playing even when the queue cache key is non-standard.
+
 ## [2.6.39] - 2026-03-24
 
 ### Fixed

--- a/packages/bot/src/utils/music/queueResolver.spec.ts
+++ b/packages/bot/src/utils/music/queueResolver.spec.ts
@@ -12,6 +12,12 @@ jest.mock('@lucky/shared/utils', () => ({
 type QueueLike = {
     id?: string
     guild?: { id?: string }
+    metadata?: {
+        channel?: {
+            guildId?: string
+            guild?: { id?: string }
+        }
+    }
 }
 
 function createQueue(id: string, guildId = id): QueueLike {
@@ -123,6 +129,24 @@ describe('queueResolver', () => {
 
     it('falls back to cache scan by queue.guild.id', () => {
         const queue = createQueue('queue-id', 'guild-1')
+        const cacheMap = new Map<string, QueueLike>([['different-key', queue]])
+        const client = createClient({ cacheMap })
+
+        const result = resolveGuildQueue(client, 'guild-1')
+
+        expect(result.queue).toBe(queue)
+        expect(result.source).toBe('cache.guild')
+    })
+
+    it('falls back to cache scan by metadata.channel.guildId', () => {
+        const queue: QueueLike = {
+            id: 'queue-id',
+            metadata: {
+                channel: {
+                    guildId: 'guild-1',
+                },
+            },
+        }
         const cacheMap = new Map<string, QueueLike>([['different-key', queue]])
         const client = createClient({ cacheMap })
 

--- a/packages/bot/src/utils/music/queueResolver.ts
+++ b/packages/bot/src/utils/music/queueResolver.ts
@@ -26,6 +26,12 @@ export type QueueResolutionResult = {
 type QueueNodeLike = {
     id?: string
     guild?: { id?: string }
+    metadata?: {
+        channel?: {
+            guildId?: string
+            guild?: { id?: string }
+        }
+    }
 }
 
 type QueueCacheLike = {
@@ -142,7 +148,10 @@ export function resolveGuildQueue(
 
         const fromCacheGuild = resolveByCacheScan(
             cache,
-            (queue) => queue.guild?.id === guildId,
+            (queue) =>
+                queue.guild?.id === guildId ||
+                queue.metadata?.channel?.guildId === guildId ||
+                queue.metadata?.channel?.guild?.id === guildId,
         )
         if (fromCacheGuild) {
             return resolveWithSource(fromCacheGuild, 'cache.guild', diagnostics)


### PR DESCRIPTION
## Summary
- extend queue resolution fallback to match queue instances by guild identity in metadata (metadata.channel.guildId and metadata.channel.guild.id)
- keep existing resolution order intact while covering non-standard cache key shapes observed in production
- add regression coverage for metadata-based queue resolution and document the guardrail in the music skill/changelog

## Verification
- npm run test:music:incident
- jest --config packages/bot/jest.config.cjs packages/bot/src/utils/music/queueResolver.spec.ts --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `/autoplay` queue resolution to work correctly with non-standard cache configurations, enabling autoplay during single-track playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->