### PR TITLE
feat(bot): add session novelty and similar energy autoplay reason tags

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -573,6 +573,74 @@ describe('queueManipulation.replenishQueue', () => {
             }),
         )
     })
+
+    it('tags session novelty when candidate artist is not in recent history', async () => {
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: {
+                title: 'Current Song',
+                author: 'Current Artist',
+                url: 'https://example.com/current',
+                source: 'youtube',
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Brand New Song',
+                            author: 'Never Heard Before Artist',
+                            url: 'https://example.com/new1',
+                            source: 'spotify',
+                        },
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack).toBeDefined()
+        expect(
+            (addedTrack?.metadata as Record<string, unknown>)
+                ?.recommendationReason,
+        ).toContain('session novelty')
+    })
+
+    it('tags similar energy when candidate duration is within 30% of current track', async () => {
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: {
+                title: 'Current Song',
+                author: 'Current Artist',
+                url: 'https://example.com/current',
+                source: 'youtube',
+                durationMS: 200000,
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Similar Energy Song',
+                            author: 'New Artist',
+                            url: 'https://example.com/similar',
+                            source: 'spotify',
+                            durationMS: 210000,
+                        },
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack).toBeDefined()
+        expect(
+            (addedTrack?.metadata as Record<string, unknown>)
+                ?.recommendationReason,
+        ).toContain('similar energy')
+    })
 })
 
 describe('queueManipulation.queueOperations', () => {

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -615,6 +615,9 @@ function calculateRecommendationScore(
 
     if (candidateArtist === currentArtist) {
         score -= 0.35
+    } else if (!recentArtists.has(candidateArtist)) {
+        score += 0.15
+        reasons.push('session novelty')
     } else {
         reasons.push('fresh artist rotation')
     }
@@ -633,6 +636,17 @@ function calculateRecommendationScore(
     score += tokenScore
     if (tokenScore > 0) {
         reasons.push('similar title mood')
+    }
+    if (
+        currentTrack.durationMS &&
+        candidate.durationMS &&
+        currentTrack.durationMS > 0
+    ) {
+        const ratio = candidate.durationMS / currentTrack.durationMS
+        if (ratio >= 0.7 && ratio <= 1.3) {
+            score += 0.1
+            reasons.push('similar energy')
+        }
     }
 
     return {


### PR DESCRIPTION
## Summary
- New `session novelty` reason tag: candidates whose artist hasn't appeared in recent session history get +0.15 score boost, promoting genuine discovery
- New `similar energy` reason tag: candidates with duration within ±30% of the current track get +0.1 boost as a lightweight energy-bucket signal
- Artist diversity constraint (max 2 per artist per replenish batch) confirmed via existing `MAX_TRACKS_PER_ARTIST = 2`
- 575 bot tests passing (2 new reason tag tests added)

## Test plan
- [ ] `session novelty` reason appears for tracks from artists not in recent history
- [ ] `similar energy` reason appears when candidate duration is within ±30% of current track
- [ ] `fresh artist rotation` still fires for artists in recentArtists but not currentArtist
- [ ] Max 2 tracks per artist per replenish batch enforced