### PR TITLE
ci: exclude test files from sonarcloud duplication analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,4 +12,6 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/*.t
 
 sonar.coverage.exclusions=packages/shared/src/**
 
+sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts
+
 sonar.javascript.lcov.reportPaths=packages/backend/coverage/lcov.info,packages/bot/coverage/lcov.info,packages/frontend/coverage/lcov.info


### PR DESCRIPTION
## Summary
- Adds `sonar.cpd.exclusions` for `*.test.ts`, `*.test.tsx`, and `*.spec.ts` files
- Test files inherently have repetitive patterns (mock setup, assertion chains) that trigger the ≤3% duplication quality gate — excluding them from CPD is standard practice

## Why
PRs #381, #383, and #384 all required admin bypass because SonarCloud flagged test files for duplication. Integration tests repeat `authed(app).METHOD().expect()` chains, and unit tests repeat `jest.Mocked<...>` setup blocks — this is unavoidable without harming readability.

## Test plan
- [ ] SonarCloud Analysis passes on this PR
- [ ] Future test-only PRs no longer hit the 3% duplication gate