### PR TITLE
chore(release): bump version to v2.6.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.41] - 2026-03-30
+
 ### Added
 
 - Dashboard sidebar redesigned as a guild command center: persistent guild block at top (avatar, name, Management Console subtitle, switch-server action), navigation reorganized into 6 operational groups (Overview / Moderation / Automation / Community / Media / Integrations), sharper active-item indicator, and collapsible mobile drawer with spring animation. (#379)
 - Autoplay recommendation engine now emits `session novelty` reason tag (+0.15 score boost) for candidates whose artist has not appeared anywhere in the current session, and `similar energy` reason tag (+0.10) for tracks within ±30% duration of the current track. (#380)
 - Last.fm top tracks are now used as additional autoplay seeds: when a user has a linked Last.fm account, their 3-month top 20 tracks are fetched, cached for 1 hour, and randomly sampled to discover taste-aware candidates with a `last.fm taste` reason tag. (#382)
 - Last.fm artist and title normalizers strip YouTube `- Topic` suffix, split multi-artist strings to keep only the primary, and remove `(Official Video)`, `(Official Audio)`, `(feat. X)`, and similar noise patterns before scrobbling. (#382)
+- Test coverage added for audit log and guild member event handlers in bot package. (#384)
 
 ### Fixed
 
 - Guild automation API endpoints (`/manifest`, `/status`, `/capture`, `/plan`, `/apply`, `/reconcile`, `/cutover`, `/presets/criativaria/apply`) now require `settings` module access via RBAC instead of bare session authentication, closing a privilege escalation path. (#381)
 - Last.fm scrobble and nowPlaying duration was always NaN because `track.duration` in discord-player 7 is a formatted string (`"3:45"`), not a number. Fixed to use `track.durationMS / 1000`. (#382)
+- Silent catch blocks now log errors to improve observability and debugging. (#383)
+
+### Internal
+
+- Test files are now excluded from SonarCloud duplication analysis to reduce noise in code quality reports. (#385)
 
 ## [2.6.40] - 2026-03-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.40",
+    "version": "2.6.41",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## [2.6.41] - 2026-03-30

### Added

- Dashboard sidebar redesigned as a guild command center: persistent guild block at top (avatar, name, Management Console subtitle, switch-server action), navigation reorganized into 6 operational groups (Overview / Moderation / Automation / Community / Media / Integrations), sharper active-item indicator, and collapsible mobile drawer with spring animation. (#379)
- Autoplay recommendation engine now emits `session novelty` reason tag (+0.15 score boost) for candidates whose artist has not appeared anywhere in the current session, and `similar energy` reason tag (+0.10) for tracks within ±30% duration of the current track. (#380)
- Last.fm top tracks are now used as additional autoplay seeds: when a user has a linked Last.fm account, their 3-month top 20 tracks are fetched, cached for 1 hour, and randomly sampled to discover taste-aware candidates with a `last.fm taste` reason tag. (#382)
- Last.fm artist and title normalizers strip YouTube `- Topic` suffix, split multi-artist strings to keep only the primary, and remove `(Official Video)`, `(Official Audio)`, `(feat. X)`, and similar noise patterns before scrobbling. (#382)
- Test coverage added for audit log and guild member event handlers in bot package. (#384)

### Fixed

- Guild automation API endpoints (`/manifest`, `/status`, `/capture`, `/plan`, `/apply`, `/reconcile`, `/cutover`, `/presets/criativaria/apply`) now require `settings` module access via RBAC instead of bare session authentication, closing a privilege escalation path. (#381)
- Last.fm scrobble and nowPlaying duration was always NaN because `track.duration` in discord-player 7 is a formatted string (`"3:45"`), not a number. Fixed to use `track.durationMS / 1000`. (#382)
- Silent catch blocks now log errors to improve observability and debugging. (#383)

### Internal

- Test files are now excluded from SonarCloud duplication analysis to reduce noise in code quality reports. (#385)