### PR TITLE
chore(release): bump version to v2.6.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.42] - 2026-03-30
+
+### Added
+
+- Role audit event handlers: `GuildRoleCreate` and `GuildRoleDelete` now log to the audit trail via the existing audit handler infrastructure. (#388)
+
+### Tests
+
+- Added test coverage for guild automation execution service (`captureGuildAutomationState`, `executeApplyPlan`). (#389)
+- Added tests for bot client, player, and queue handlers. (#390)
+- Added tests for frontend embed builder, guild automation, levels, starboard, and reaction roles pages. (#391, #392)
+- Added tests for bot command and interaction handlers. (#393)
+
 ## [2.6.41] - 2026-03-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.41",
+    "version": "2.6.42",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary

- Bumps root package version from v2.6.41 → v2.6.42
- Updates CHANGELOG with 7 commits since v2.6.41: role audit handlers (PR #388), test coverage for automation execution service (#389), bot handlers (#390), frontend pages (#391, #392)

## Changes since v2.6.41

- `feat(bot)`: Role create/delete audit handlers
- `test(backend)`: Guild automation execution service coverage
- `test(bot)`: Client, player, queue handler coverage (x2 PRs)
- `test(frontend)`: Embed builder, guild automation, levels, starboard, reaction roles coverage (x2 PRs)