### PR TITLE
chore(release): bump version to v2.6.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.43] - 2026-03-30
+
+### Tests
+
+- Added test coverage for moderation commands: ban, cases, and case handler interactions (39 tests). (#394)
+- Added test coverage for automessage commands and handlers (28 tests). (#395)
+
 ## [2.6.42] - 2026-03-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.42",
+    "version": "2.6.43",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary

- Bumps root package version from v2.6.42 → v2.6.43
- Updates CHANGELOG with 2 commits since v2.6.42: moderation test coverage (#394), automessage test coverage (#395)

## Changes since v2.6.42

- `test(bot)`: 39 tests for ban/cases/caseHandlers moderation commands
- `test(bot)`: 28 tests for automessage commands and handlers