### PR TITLE
chore(release): bump version to v2.6.44

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.43",
+    "version": "2.6.44",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary

- Bump version to v2.6.44
- Includes: #397 (kick/mute test coverage), #398 (music play handler tests), #399 (automod spam + link fix)

## Key fix in this release

**Automod false positives (#399)**: Spam detection was broken (never triggered), and `vercel.app`/GitHub/Netlify/Render links were being deleted in showcase channels. Both fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)