### PR TITLE
chore(release): bump version to v2.6.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.46] - 2026-03-31
+
+### Tests
+
+- Added test coverage for general commands: help, reactionrole, roleconfig and their handlers (62 tests). (#404)
+- Added test coverage for music queue utilities: asyncQueueManager, queueStrategy, LRU cacheManager, and trackUtils (109 tests). (#405)
+
 ## [2.6.45] - 2026-03-31
 
 ### Tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.45",
+  "version": "2.6.46",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Bump to v2.6.46. Includes #404 (general commands: 62 tests), #405 (music queue utils: 109 tests). Total new tests this release: 171.