### PR TITLE
test: add twitch integration test coverage (95 tests)

### DIFF
--- a/packages/bot/src/functions/general/commands/twitch.spec.ts
+++ b/packages/bot/src/functions/general/commands/twitch.spec.ts
@@ -1,0 +1,264 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('@lucky/shared/services', () => ({
+    featureToggleService: {
+        isEnabled: jest.fn(),
+    },
+}))
+
+jest.mock('../../../utils/general/interactionReply.js', () => ({
+    interactionReply: jest.fn(),
+}))
+
+jest.mock('../../../utils/general/embeds.js', () => ({
+    errorEmbed: (title: string, desc: string) => ({
+        data: { title, description: desc },
+    }),
+    successEmbed: (title: string, desc: string) => ({
+        data: { title, description: desc },
+    }),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+}))
+
+jest.mock('../../../utils/command/commandValidations.js', () => ({
+    requireGuild: jest.fn(),
+}))
+
+jest.mock('../handlers/twitchHandlers.js', () => ({
+    handleTwitchAdd: jest.fn(),
+    handleTwitchRemove: jest.fn(),
+    handleTwitchList: jest.fn(),
+}))
+
+import twitchCommand from './twitch.js'
+import { featureToggleService } from '@lucky/shared/services'
+import { interactionReply } from '../../../utils/general/interactionReply.js'
+import { requireGuild } from '../../../utils/command/commandValidations.js'
+import {
+    handleTwitchAdd,
+    handleTwitchRemove,
+    handleTwitchList,
+} from '../handlers/twitchHandlers.js'
+import { errorLog } from '@lucky/shared/utils'
+
+const featureToggleMock =
+    featureToggleService.isEnabled as jest.MockedFunction<any>
+const interactionReplyMock = interactionReply as jest.MockedFunction<any>
+const requireGuildMock = requireGuild as jest.MockedFunction<any>
+const handleAddMock = handleTwitchAdd as jest.MockedFunction<any>
+const handleRemoveMock = handleTwitchRemove as jest.MockedFunction<any>
+const handleListMock = handleTwitchList as jest.MockedFunction<any>
+const errorLogMock = errorLog as jest.MockedFunction<any>
+
+function createGuild(id = 'guild-123', ownerId = 'owner-123') {
+    return { id, ownerId, name: 'Test Guild' }
+}
+
+function createUser(id = 'user-123') {
+    return { id }
+}
+
+function createInteraction({
+    guildId = 'guild-123',
+    userId = 'user-123',
+    subcommand = 'add',
+} = {}) {
+    const guild = createGuild(guildId)
+    const user = createUser(userId)
+
+    const interaction = {
+        guild,
+        guildId,
+        user,
+        options: {
+            getSubcommand: jest.fn(() => subcommand),
+        },
+    }
+    return interaction as any
+}
+
+describe('twitch command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('command structure', () => {
+        test('command has name "twitch"', () => {
+            expect(twitchCommand.data.name).toBe('twitch')
+        })
+
+        test('command has description', () => {
+            expect(twitchCommand.data.description).toBeDefined()
+            expect(twitchCommand.data.description).toContain('Twitch')
+        })
+
+        test('command requires ManageGuild permission', () => {
+            const permissions = twitchCommand.data.default_member_permissions
+            expect(permissions).toBeDefined()
+        })
+
+        test('command is registered', () => {
+            expect(twitchCommand).toBeDefined()
+            expect(twitchCommand.category).toBe('general')
+        })
+
+        test('has execute function', () => {
+            expect(twitchCommand.execute).toBeDefined()
+            expect(typeof twitchCommand.execute).toBe('function')
+        })
+    })
+
+    describe('execution', () => {
+        test('rejects when guild validation fails', async () => {
+            const interaction = createInteraction()
+            requireGuildMock.mockResolvedValueOnce(false)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(requireGuildMock).toHaveBeenCalledWith(interaction)
+            expect(handleAddMock).not.toHaveBeenCalled()
+        })
+
+        test('rejects when interaction.guild is null', async () => {
+            const interaction = createInteraction()
+            interaction.guild = null
+            requireGuildMock.mockResolvedValueOnce(true)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(handleAddMock).not.toHaveBeenCalled()
+        })
+
+        test('rejects when feature is disabled', async () => {
+            const interaction = createInteraction()
+            requireGuildMock.mockResolvedValueOnce(true)
+            featureToggleMock.mockResolvedValueOnce(false)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    content: 'Twitch notifications are currently disabled.',
+                    ephemeral: true,
+                },
+            })
+        })
+
+        test('routes "add" subcommand to handleTwitchAdd', async () => {
+            const interaction = createInteraction({ subcommand: 'add' })
+            requireGuildMock.mockResolvedValueOnce(true)
+            featureToggleMock.mockResolvedValueOnce(true)
+            handleAddMock.mockResolvedValueOnce(undefined)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(handleAddMock).toHaveBeenCalledWith(interaction)
+            expect(handleRemoveMock).not.toHaveBeenCalled()
+            expect(handleListMock).not.toHaveBeenCalled()
+        })
+
+        test('routes "remove" subcommand to handleTwitchRemove', async () => {
+            const interaction = createInteraction({ subcommand: 'remove' })
+            requireGuildMock.mockResolvedValueOnce(true)
+            featureToggleMock.mockResolvedValueOnce(true)
+            handleRemoveMock.mockResolvedValueOnce(undefined)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(handleRemoveMock).toHaveBeenCalledWith(interaction)
+            expect(handleAddMock).not.toHaveBeenCalled()
+            expect(handleListMock).not.toHaveBeenCalled()
+        })
+
+        test('routes "list" subcommand to handleTwitchList', async () => {
+            const interaction = createInteraction({ subcommand: 'list' })
+            requireGuildMock.mockResolvedValueOnce(true)
+            featureToggleMock.mockResolvedValueOnce(true)
+            handleListMock.mockResolvedValueOnce(undefined)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(handleListMock).toHaveBeenCalledWith(interaction)
+            expect(handleAddMock).not.toHaveBeenCalled()
+            expect(handleRemoveMock).not.toHaveBeenCalled()
+        })
+
+        test('passes correct guild and user to feature toggle', async () => {
+            const interaction = createInteraction({
+                guildId: 'guild-xyz',
+                userId: 'user-abc',
+            })
+            requireGuildMock.mockResolvedValueOnce(true)
+            featureToggleMock.mockResolvedValueOnce(true)
+            handleAddMock.mockResolvedValueOnce(undefined)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(featureToggleMock).toHaveBeenCalledWith(
+                'TWITCH_NOTIFICATIONS',
+                {
+                    guildId: 'guild-xyz',
+                    userId: 'user-abc',
+                },
+            )
+        })
+
+        test('catches handler errors and sends error embed', async () => {
+            const interaction = createInteraction({ subcommand: 'add' })
+            requireGuildMock.mockResolvedValueOnce(true)
+            featureToggleMock.mockResolvedValueOnce(true)
+            const testError = new Error('handler error')
+            handleAddMock.mockRejectedValueOnce(testError)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(errorLogMock).toHaveBeenCalledWith({
+                message: 'Twitch command error',
+                error: testError,
+            })
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Error',
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
+
+        test('catches remove handler errors', async () => {
+            const interaction = createInteraction({ subcommand: 'remove' })
+            requireGuildMock.mockResolvedValueOnce(true)
+            featureToggleMock.mockResolvedValueOnce(true)
+            const testError = new Error('remove error')
+            handleRemoveMock.mockRejectedValueOnce(testError)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(errorLogMock).toHaveBeenCalled()
+            expect(interactionReplyMock).toHaveBeenCalled()
+        })
+
+        test('catches list handler errors', async () => {
+            const interaction = createInteraction({ subcommand: 'list' })
+            requireGuildMock.mockResolvedValueOnce(true)
+            featureToggleMock.mockResolvedValueOnce(true)
+            const testError = new Error('list error')
+            handleListMock.mockRejectedValueOnce(testError)
+
+            await twitchCommand.execute({ interaction })
+
+            expect(errorLogMock).toHaveBeenCalled()
+            expect(interactionReplyMock).toHaveBeenCalled()
+        })
+    })
+})

--- a/packages/bot/src/functions/general/handlers/twitchHandlers.spec.ts
+++ b/packages/bot/src/functions/general/handlers/twitchHandlers.spec.ts
@@ -1,0 +1,558 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('@lucky/shared/services', () => ({
+    twitchNotificationService: {
+        add: jest.fn(),
+        remove: jest.fn(),
+        listByGuild: jest.fn(),
+    },
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    getPrismaClient: jest.fn(),
+}))
+
+jest.mock('../../../utils/general/interactionReply.js', () => ({
+    interactionReply: jest.fn(),
+}))
+
+jest.mock('../../../utils/general/embeds.js', () => ({
+    errorEmbed: (title: string, desc: string) => ({
+        data: { title, description: desc },
+    }),
+    successEmbed: (title: string, desc: string) => ({
+        data: { title, description: desc },
+    }),
+}))
+
+jest.mock('../../../twitch/twitchApi.js', () => ({
+    getTwitchUserByLogin: jest.fn(),
+}))
+
+jest.mock('../../../twitch/index.js', () => ({
+    refreshTwitchSubscriptions: jest.fn(),
+}))
+
+import {
+    handleTwitchAdd,
+    handleTwitchRemove,
+    handleTwitchList,
+} from './twitchHandlers.js'
+import { twitchNotificationService } from '@lucky/shared/services'
+import { getPrismaClient } from '@lucky/shared/utils'
+import { interactionReply } from '../../../utils/general/interactionReply.js'
+import { getTwitchUserByLogin } from '../../../twitch/twitchApi.js'
+import { refreshTwitchSubscriptions } from '../../../twitch/index.js'
+
+const twitchServiceAddMock =
+    twitchNotificationService.add as jest.MockedFunction<any>
+const twitchServiceRemoveMock =
+    twitchNotificationService.remove as jest.MockedFunction<any>
+const twitchServiceListMock =
+    twitchNotificationService.listByGuild as jest.MockedFunction<any>
+const getPrismaMock = getPrismaClient as jest.MockedFunction<any>
+const interactionReplyMock = interactionReply as jest.MockedFunction<any>
+const getTwitchUserMock = getTwitchUserByLogin as jest.MockedFunction<any>
+const refreshSubscriptionsMock =
+    refreshTwitchSubscriptions as jest.MockedFunction<any>
+
+function createGuild(id = '1', discordId = 'guild-123') {
+    return { id, discordId, name: 'Test Guild', ownerId: 'owner-123' }
+}
+
+function createTwitchUser(
+    id = 'twitch-123',
+    login = 'testuser',
+    display_name = 'TestUser',
+) {
+    return { id, login, display_name }
+}
+
+function createChannel(id = 'channel-123') {
+    return {
+        id,
+        isTextBased: () => true,
+    }
+}
+
+function createInteraction({
+    guildId = 'guild-123',
+    username = 'testuser',
+    channel = null as any,
+} = {}) {
+    const guild = { id: guildId, ownerId: 'owner-123', name: 'Test Guild' }
+
+    const interaction = {
+        guild,
+        guildId,
+        channel: channel || createChannel(),
+        options: {
+            getString: jest.fn((name: string) => {
+                if (name === 'username') return username
+                return null
+            }),
+            getChannel: jest.fn((name: string) => {
+                if (name === 'channel') return channel
+                return null
+            }),
+        },
+    }
+    return interaction as any
+}
+
+describe('twitchHandlers', () => {
+    let mockPrisma: any
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockPrisma = {
+            guild: {
+                findUnique: jest.fn(),
+                create: jest.fn(),
+            },
+        }
+        getPrismaMock.mockReturnValue(mockPrisma)
+    })
+
+    describe('handleTwitchAdd', () => {
+        test('adds notification successfully', async () => {
+            const twitchUser = createTwitchUser()
+            const guild = createGuild()
+            const interaction = createInteraction()
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceAddMock.mockResolvedValueOnce(true)
+            refreshSubscriptionsMock.mockResolvedValueOnce(undefined)
+
+            await handleTwitchAdd(interaction)
+
+            expect(getTwitchUserMock).toHaveBeenCalledWith('testuser')
+            expect(mockPrisma.guild.findUnique).toHaveBeenCalledWith({
+                where: { discordId: 'guild-123' },
+            })
+            expect(twitchServiceAddMock).toHaveBeenCalledWith(
+                guild.id,
+                expect.any(String),
+                'twitch-123',
+                'testuser',
+            )
+            expect(refreshSubscriptionsMock).toHaveBeenCalled()
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Twitch notification added',
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
+
+        test('creates guild if not found', async () => {
+            const twitchUser = createTwitchUser()
+            const guild = createGuild()
+            const interaction = createInteraction()
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(null)
+            mockPrisma.guild.create.mockResolvedValueOnce(guild)
+            twitchServiceAddMock.mockResolvedValueOnce(true)
+            refreshSubscriptionsMock.mockResolvedValueOnce(undefined)
+
+            await handleTwitchAdd(interaction)
+
+            expect(mockPrisma.guild.create).toHaveBeenCalledWith({
+                data: {
+                    discordId: 'guild-123',
+                    name: 'Test Guild',
+                    ownerId: 'owner-123',
+                },
+            })
+            expect(twitchServiceAddMock).toHaveBeenCalled()
+        })
+
+        test('trims and lowercases username', async () => {
+            const twitchUser = createTwitchUser()
+            const guild = createGuild()
+            const interaction = createInteraction({ username: '  TestUser  ' })
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceAddMock.mockResolvedValueOnce(true)
+            refreshSubscriptionsMock.mockResolvedValueOnce(undefined)
+
+            await handleTwitchAdd(interaction)
+
+            expect(getTwitchUserMock).toHaveBeenCalledWith('testuser')
+        })
+
+        test('sends error when Twitch user not found', async () => {
+            const interaction = createInteraction()
+            getTwitchUserMock.mockResolvedValueOnce(null)
+
+            await handleTwitchAdd(interaction)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Twitch user not found',
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+            expect(twitchServiceAddMock).not.toHaveBeenCalled()
+        })
+
+        test('sends error when channel is invalid', async () => {
+            const twitchUser = createTwitchUser()
+            const interaction = createInteraction({ channel: null })
+            interaction.channel = null
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+
+            await handleTwitchAdd(interaction)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Error',
+                                description: expect.stringContaining('channel'),
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
+
+        test('sends error when service returns false', async () => {
+            const twitchUser = createTwitchUser()
+            const guild = createGuild()
+            const interaction = createInteraction()
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceAddMock.mockResolvedValueOnce(false)
+
+            await handleTwitchAdd(interaction)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Error',
+                                description: expect.stringContaining('Failed'),
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+            expect(refreshSubscriptionsMock).not.toHaveBeenCalled()
+        })
+
+        test('uses channel option when provided', async () => {
+            const twitchUser = createTwitchUser()
+            const guild = createGuild()
+            const channelOption = createChannel('custom-channel-123')
+            const interaction = createInteraction({ channel: channelOption })
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceAddMock.mockResolvedValueOnce(true)
+            refreshSubscriptionsMock.mockResolvedValueOnce(undefined)
+
+            await handleTwitchAdd(interaction)
+
+            expect(twitchServiceAddMock).toHaveBeenCalledWith(
+                guild.id,
+                'custom-channel-123',
+                'twitch-123',
+                'testuser',
+            )
+        })
+    })
+
+    describe('handleTwitchRemove', () => {
+        test('removes notification successfully', async () => {
+            const twitchUser = createTwitchUser()
+            const guild = createGuild()
+            const interaction = createInteraction()
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceRemoveMock.mockResolvedValueOnce(true)
+            refreshSubscriptionsMock.mockResolvedValueOnce(undefined)
+
+            await handleTwitchRemove(interaction)
+
+            expect(getTwitchUserMock).toHaveBeenCalledWith('testuser')
+            expect(twitchServiceRemoveMock).toHaveBeenCalledWith(
+                guild.id,
+                'twitch-123',
+            )
+            expect(refreshSubscriptionsMock).toHaveBeenCalled()
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Twitch notification removed',
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
+
+        test('sends error when Twitch user not found', async () => {
+            const interaction = createInteraction()
+            getTwitchUserMock.mockResolvedValueOnce(null)
+
+            await handleTwitchRemove(interaction)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Twitch user not found',
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+            expect(twitchServiceRemoveMock).not.toHaveBeenCalled()
+        })
+
+        test('sends error when guild not found', async () => {
+            const twitchUser = createTwitchUser()
+            const interaction = createInteraction()
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(null)
+
+            await handleTwitchRemove(interaction)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Not found',
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+            expect(twitchServiceRemoveMock).not.toHaveBeenCalled()
+        })
+
+        test('sends error when service returns false', async () => {
+            const twitchUser = createTwitchUser()
+            const guild = createGuild()
+            const interaction = createInteraction()
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceRemoveMock.mockResolvedValueOnce(false)
+
+            await handleTwitchRemove(interaction)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Error',
+                                description: expect.stringContaining('Failed'),
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+            expect(refreshSubscriptionsMock).not.toHaveBeenCalled()
+        })
+
+        test('trims and lowercases username', async () => {
+            const twitchUser = createTwitchUser()
+            const guild = createGuild()
+            const interaction = createInteraction({ username: '  TestUser  ' })
+
+            getTwitchUserMock.mockResolvedValueOnce(twitchUser)
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceRemoveMock.mockResolvedValueOnce(true)
+            refreshSubscriptionsMock.mockResolvedValueOnce(undefined)
+
+            await handleTwitchRemove(interaction)
+
+            expect(getTwitchUserMock).toHaveBeenCalledWith('testuser')
+        })
+    })
+
+    describe('handleTwitchList', () => {
+        test('lists notifications successfully', async () => {
+            const guild = createGuild()
+            const notifications = [
+                {
+                    twitchLogin: 'streamer1',
+                    discordChannelId: 'channel-1',
+                },
+                {
+                    twitchLogin: 'streamer2',
+                    discordChannelId: 'channel-2',
+                },
+            ]
+            const interaction = createInteraction()
+
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceListMock.mockResolvedValueOnce(notifications)
+
+            await handleTwitchList(interaction)
+
+            expect(twitchServiceListMock).toHaveBeenCalledWith(guild.id)
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Twitch notifications',
+                                description:
+                                    expect.stringContaining('streamer1'),
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
+
+        test('shows empty message when guild not found', async () => {
+            const interaction = createInteraction()
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(null)
+
+            await handleTwitchList(interaction)
+
+            expect(twitchServiceListMock).not.toHaveBeenCalled()
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Twitch notifications',
+                                description: expect.stringContaining(
+                                    'No Twitch streamers',
+                                ),
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
+
+        test('shows empty message when no notifications found', async () => {
+            const guild = createGuild()
+            const interaction = createInteraction()
+
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceListMock.mockResolvedValueOnce([])
+
+            await handleTwitchList(interaction)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Twitch notifications',
+                                description: expect.stringContaining(
+                                    'No Twitch streamers',
+                                ),
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
+
+        test('formats notification list correctly', async () => {
+            const guild = createGuild()
+            const notifications = [
+                {
+                    twitchLogin: 'alice',
+                    discordChannelId: 'ch-1',
+                },
+                {
+                    twitchLogin: 'bob',
+                    discordChannelId: 'ch-2',
+                },
+                {
+                    twitchLogin: 'charlie',
+                    discordChannelId: 'ch-3',
+                },
+            ]
+            const interaction = createInteraction()
+
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceListMock.mockResolvedValueOnce(notifications)
+
+            await handleTwitchList(interaction)
+
+            const call = interactionReplyMock.mock.calls[0][0]
+            const desc = call.content.embeds[0].data.description
+            expect(desc).toContain('• **alice**')
+            expect(desc).toContain('• **bob**')
+            expect(desc).toContain('• **charlie**')
+            expect(desc).toContain('<#ch-1>')
+            expect(desc).toContain('<#ch-2>')
+            expect(desc).toContain('<#ch-3>')
+        })
+
+        test('marks reply as ephemeral', async () => {
+            const guild = createGuild()
+            const notifications = [
+                {
+                    twitchLogin: 'streamer',
+                    discordChannelId: 'channel-1',
+                },
+            ]
+            const interaction = createInteraction()
+
+            mockPrisma.guild.findUnique.mockResolvedValueOnce(guild)
+            twitchServiceListMock.mockResolvedValueOnce(notifications)
+
+            await handleTwitchList(interaction)
+
+            const call = interactionReplyMock.mock.calls[0][0]
+            expect(call.content.ephemeral).toBe(true)
+        })
+    })
+})

--- a/packages/bot/src/twitch/eventsubClient.spec.ts
+++ b/packages/bot/src/twitch/eventsubClient.spec.ts
@@ -1,0 +1,274 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import WebSocket from 'ws'
+
+jest.mock('ws')
+jest.mock('./token.js', () => ({
+    getTwitchUserAccessToken: jest.fn(),
+}))
+jest.mock('./eventsubSubscriptions.js', () => ({
+    subscribeToStreamOnline: jest.fn(),
+    handleStreamOnline: jest.fn(),
+}))
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+    infoLog: jest.fn(),
+    debugLog: jest.fn(),
+}))
+
+import { TwitchEventSubClient } from './eventsubClient.js'
+import { getTwitchUserAccessToken } from './token.js'
+import {
+    subscribeToStreamOnline,
+    handleStreamOnline,
+} from './eventsubSubscriptions.js'
+import { infoLog } from '@lucky/shared/utils'
+
+const getTwitchTokenMock = getTwitchUserAccessToken as jest.MockedFunction<any>
+const subscribeToStreamOnlineMock =
+    subscribeToStreamOnline as jest.MockedFunction<any>
+const handleStreamOnlineMock = handleStreamOnline as jest.MockedFunction<any>
+const WebSocketMock = WebSocket as jest.MockedClass<typeof WebSocket>
+
+function createMockWebSocket() {
+    const ws = {
+        on: jest.fn(),
+        off: jest.fn(),
+        send: jest.fn(),
+        close: jest.fn(),
+        pong: jest.fn(),
+        readyState: WebSocket.OPEN,
+    }
+    return ws as any
+}
+
+function createMockClient() {
+    return {
+        channels: {
+            fetch: jest.fn(),
+        },
+    } as any
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    jest.setTimeout(5000)
+    process.env.TWITCH_CLIENT_ID = 'test-client-id'
+    WebSocketMock.mockClear()
+})
+
+describe('TwitchEventSubClient', () => {
+    describe('start', () => {
+        test('skips when TWITCH_CLIENT_ID not set', async () => {
+            delete process.env.TWITCH_CLIENT_ID
+            const client = createMockClient()
+
+            const eventSubClient = new TwitchEventSubClient()
+            await eventSubClient.start(client)
+
+            expect(WebSocketMock).not.toHaveBeenCalled()
+        })
+
+        test('skips when access token unavailable', async () => {
+            const client = createMockClient()
+            getTwitchTokenMock.mockResolvedValueOnce(null)
+
+            const eventSubClient = new TwitchEventSubClient()
+            await eventSubClient.start(client)
+
+            expect(WebSocketMock).not.toHaveBeenCalled()
+        })
+
+        test('creates WebSocket when fully configured', async () => {
+            const client = createMockClient()
+            const mockWs = createMockWebSocket()
+            WebSocketMock.mockImplementationOnce(() => mockWs)
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+
+            const eventSubClient = new TwitchEventSubClient()
+
+            const startPromise = Promise.race([
+                eventSubClient.start(client),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('timeout')), 1000),
+                ),
+            ]).catch(() => {})
+
+            await startPromise
+
+            expect(WebSocketMock).toHaveBeenCalledWith(
+                'wss://eventsub.wss.twitch.tv/ws',
+            )
+        })
+
+        test('registers event handlers on connect', async () => {
+            const client = createMockClient()
+            const mockWs = createMockWebSocket()
+            WebSocketMock.mockImplementationOnce(() => mockWs)
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+
+            const eventSubClient = new TwitchEventSubClient()
+
+            const startPromise = Promise.race([
+                eventSubClient.start(client),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('timeout')), 1000),
+                ),
+            ]).catch(() => {})
+
+            await startPromise
+
+            expect(mockWs.on).toHaveBeenCalledWith('open', expect.any(Function))
+            expect(mockWs.on).toHaveBeenCalledWith(
+                'message',
+                expect.any(Function),
+            )
+            expect(mockWs.on).toHaveBeenCalledWith(
+                'close',
+                expect.any(Function),
+            )
+            expect(mockWs.on).toHaveBeenCalledWith(
+                'error',
+                expect.any(Function),
+            )
+            expect(mockWs.on).toHaveBeenCalledWith('ping', expect.any(Function))
+        })
+    })
+
+    describe('stop', () => {
+        test('closes WebSocket when started', () => {
+            const mockWs = createMockWebSocket()
+            WebSocketMock.mockImplementationOnce(() => mockWs)
+
+            const eventSubClient = new TwitchEventSubClient()
+            eventSubClient.stop()
+
+            expect(infoLog).toHaveBeenCalledWith({
+                message: 'Twitch EventSub: client stopped',
+            })
+        })
+
+        test('is safe to call multiple times', () => {
+            const eventSubClient = new TwitchEventSubClient()
+
+            eventSubClient.stop()
+            eventSubClient.stop()
+
+            expect(infoLog).toHaveBeenCalledTimes(2)
+        })
+    })
+
+    describe('refreshSubscriptions', () => {
+        test('returns without error when not connected', async () => {
+            const eventSubClient = new TwitchEventSubClient()
+
+            await eventSubClient.refreshSubscriptions()
+
+            expect(subscribeToStreamOnlineMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('WebSocket connection', () => {
+        test('uses correct EventSub WebSocket URL', async () => {
+            const client = createMockClient()
+            const mockWs = createMockWebSocket()
+            WebSocketMock.mockImplementationOnce(() => mockWs)
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+
+            const eventSubClient = new TwitchEventSubClient()
+
+            const startPromise = Promise.race([
+                eventSubClient.start(client),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('timeout')), 1000),
+                ),
+            ]).catch(() => {})
+
+            await startPromise
+
+            expect(WebSocketMock).toHaveBeenCalledWith(
+                'wss://eventsub.wss.twitch.tv/ws',
+            )
+        })
+
+        test('allows calling stop when not connected', () => {
+            const eventSubClient = new TwitchEventSubClient()
+
+            eventSubClient.stop()
+
+            expect(infoLog).toHaveBeenCalledWith({
+                message: 'Twitch EventSub: client stopped',
+            })
+        })
+    })
+
+    describe('message handler registration', () => {
+        test('registers handler for ping events', async () => {
+            const client = createMockClient()
+            const mockWs = createMockWebSocket()
+            WebSocketMock.mockImplementationOnce(() => mockWs)
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+
+            const eventSubClient = new TwitchEventSubClient()
+
+            const startPromise = Promise.race([
+                eventSubClient.start(client),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('timeout')), 1000),
+                ),
+            ]).catch(() => {})
+
+            await startPromise
+
+            const pingCall = mockWs.on.mock.calls.find(
+                (call) => call[0] === 'ping',
+            )
+            expect(pingCall).toBeDefined()
+        })
+
+        test('registers handler for message events', async () => {
+            const client = createMockClient()
+            const mockWs = createMockWebSocket()
+            WebSocketMock.mockImplementationOnce(() => mockWs)
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+
+            const eventSubClient = new TwitchEventSubClient()
+
+            const startPromise = Promise.race([
+                eventSubClient.start(client),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('timeout')), 1000),
+                ),
+            ]).catch(() => {})
+
+            await startPromise
+
+            const messageCall = mockWs.on.mock.calls.find(
+                (call) => call[0] === 'message',
+            )
+            expect(messageCall).toBeDefined()
+        })
+
+        test('registers handler for error events', async () => {
+            const client = createMockClient()
+            const mockWs = createMockWebSocket()
+            WebSocketMock.mockImplementationOnce(() => mockWs)
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+
+            const eventSubClient = new TwitchEventSubClient()
+
+            const startPromise = Promise.race([
+                eventSubClient.start(client),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('timeout')), 1000),
+                ),
+            ]).catch(() => {})
+
+            await startPromise
+
+            const errorCall = mockWs.on.mock.calls.find(
+                (call) => call[0] === 'error',
+            )
+            expect(errorCall).toBeDefined()
+        })
+    })
+})

--- a/packages/bot/src/twitch/eventsubSubscriptions.spec.ts
+++ b/packages/bot/src/twitch/eventsubSubscriptions.spec.ts
@@ -1,0 +1,464 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('./token.js', () => ({
+    getTwitchUserAccessToken: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    twitchNotificationService: {
+        getDistinctTwitchUserIds: jest.fn(),
+        getNotificationsByTwitchUserId: jest.fn(),
+    },
+}))
+
+jest.mock('discord.js', () => {
+    class MockEmbedBuilder {
+        setColor() {
+            return this
+        }
+        setTitle() {
+            return this
+        }
+        setURL() {
+            return this
+        }
+        setDescription() {
+            return this
+        }
+        addFields() {
+            return this
+        }
+        setTimestamp() {
+            return this
+        }
+        setFooter() {
+            return this
+        }
+    }
+    return {
+        EmbedBuilder: MockEmbedBuilder,
+    }
+})
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+    debugLog: jest.fn(),
+}))
+
+global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>
+
+import {
+    subscribeToStreamOnline,
+    handleStreamOnline,
+} from './eventsubSubscriptions.js'
+import { getTwitchUserAccessToken } from './token.js'
+import { twitchNotificationService } from '@lucky/shared/services'
+import { errorLog, debugLog } from '@lucky/shared/utils'
+
+const getTwitchTokenMock = getTwitchUserAccessToken as jest.MockedFunction<any>
+const getDistinctUserIdsMock =
+    twitchNotificationService.getDistinctTwitchUserIds as jest.MockedFunction<any>
+const getNotificationsMock =
+    twitchNotificationService.getNotificationsByTwitchUserId as jest.MockedFunction<any>
+const fetchMock = global.fetch as jest.MockedFunction<any>
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.TWITCH_CLIENT_ID = 'test-client-id'
+})
+
+describe('eventsubSubscriptions', () => {
+    describe('subscribeToStreamOnline', () => {
+        test('subscribes to all distinct Twitch users', async () => {
+            const userIds = ['user-1', 'user-2', 'user-3']
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            getDistinctUserIdsMock.mockResolvedValueOnce(userIds)
+            fetchMock.mockResolvedValue({
+                ok: true,
+                text: async () => '',
+            })
+
+            const subscribedSet = new Set<string>()
+            await subscribeToStreamOnline(
+                'session-123',
+                'client-id',
+                subscribedSet,
+            )
+
+            expect(fetchMock).toHaveBeenCalledTimes(3)
+            userIds.forEach((userId) => {
+                expect(fetchMock).toHaveBeenCalledWith(
+                    expect.stringContaining('subscriptions'),
+                    expect.objectContaining({
+                        method: 'POST',
+                        body: expect.stringContaining(userId),
+                    }),
+                )
+            })
+        })
+
+        test('skips users already subscribed', async () => {
+            const userIds = ['user-1', 'user-2']
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            getDistinctUserIdsMock.mockResolvedValueOnce(userIds)
+            fetchMock.mockResolvedValue({
+                ok: true,
+                text: async () => '',
+            })
+
+            const subscribedSet = new Set<string>(['user-1'])
+            await subscribeToStreamOnline(
+                'session-123',
+                'client-id',
+                subscribedSet,
+            )
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    body: expect.stringContaining('user-2'),
+                }),
+            )
+        })
+
+        test('returns early when no token available', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce(null)
+
+            const subscribedSet = new Set<string>()
+            await subscribeToStreamOnline(
+                'session-123',
+                'client-id',
+                subscribedSet,
+            )
+
+            expect(getDistinctUserIdsMock).not.toHaveBeenCalled()
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        test('returns early when no streamers to subscribe to', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            getDistinctUserIdsMock.mockResolvedValueOnce([])
+
+            const subscribedSet = new Set<string>()
+            await subscribeToStreamOnline(
+                'session-123',
+                'client-id',
+                subscribedSet,
+            )
+
+            expect(debugLog).toHaveBeenCalledWith({
+                message: 'Twitch EventSub: no streamers to subscribe to',
+            })
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        test('adds successfully subscribed users to set', async () => {
+            const userIds = ['user-1', 'user-2']
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            getDistinctUserIdsMock.mockResolvedValueOnce(userIds)
+            fetchMock.mockResolvedValue({
+                ok: true,
+                text: async () => '',
+            })
+
+            const subscribedSet = new Set<string>()
+            await subscribeToStreamOnline(
+                'session-123',
+                'client-id',
+                subscribedSet,
+            )
+
+            expect(subscribedSet).toContain('user-1')
+            expect(subscribedSet).toContain('user-2')
+        })
+
+        test('does not add failed subscriptions to set', async () => {
+            const userIds = ['user-1', 'user-2']
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            getDistinctUserIdsMock.mockResolvedValueOnce(userIds)
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                text: async () => '',
+            })
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+                status: 400,
+                text: async () => 'Bad request',
+            })
+
+            const subscribedSet = new Set<string>()
+            await subscribeToStreamOnline(
+                'session-123',
+                'client-id',
+                subscribedSet,
+            )
+
+            expect(subscribedSet).toContain('user-1')
+            expect(subscribedSet).not.toContain('user-2')
+        })
+
+        test('sends correct subscription payload', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            getDistinctUserIdsMock.mockResolvedValueOnce(['user-123'])
+            fetchMock.mockResolvedValue({
+                ok: true,
+                text: async () => '',
+            })
+
+            await subscribeToStreamOnline('session-123', 'client-id', new Set())
+
+            const call = fetchMock.mock.calls[0]
+            const body = JSON.parse(call[1].body)
+
+            expect(body).toEqual({
+                type: 'stream.online',
+                version: '1',
+                condition: { broadcaster_user_id: 'user-123' },
+                transport: { method: 'websocket', session_id: 'session-123' },
+            })
+        })
+
+        test('includes correct headers in request', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            getDistinctUserIdsMock.mockResolvedValueOnce(['user-123'])
+            fetchMock.mockResolvedValue({
+                ok: true,
+                text: async () => '',
+            })
+
+            await subscribeToStreamOnline('session-123', 'client-id', new Set())
+
+            const call = fetchMock.mock.calls[0]
+            expect(call[1].headers).toEqual({
+                'Content-Type': 'application/json',
+                Authorization: 'Bearer test-token',
+                'Client-Id': 'client-id',
+            })
+        })
+
+        test('handles network errors gracefully', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            getDistinctUserIdsMock.mockResolvedValueOnce(['user-123'])
+            fetchMock.mockRejectedValueOnce(new Error('Network error'))
+
+            const subscribedSet = new Set<string>()
+            await subscribeToStreamOnline(
+                'session-123',
+                'client-id',
+                subscribedSet,
+            )
+
+            expect(errorLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'create subscription error',
+                    ),
+                }),
+            )
+            expect(subscribedSet.size).toBe(0)
+        })
+    })
+
+    describe('handleStreamOnline', () => {
+        test('dispatches notification to all subscribed channels', async () => {
+            const mockClient = {
+                channels: {
+                    fetch: jest.fn(),
+                },
+            } as any
+
+            const mockChannel = {
+                isTextBased: () => true,
+                isDMBased: () => false,
+                send: jest.fn(),
+            }
+
+            mockClient.channels.fetch.mockResolvedValueOnce(mockChannel)
+            mockClient.channels.fetch.mockResolvedValueOnce(mockChannel)
+
+            const notifications = [
+                { discordChannelId: 'channel-1', twitchLogin: 'user1' },
+                { discordChannelId: 'channel-2', twitchLogin: 'user2' },
+            ]
+
+            getNotificationsMock.mockResolvedValueOnce(notifications)
+
+            const payload = {
+                subscription: { type: 'stream.online' },
+                event: {
+                    id: 'event-123',
+                    broadcaster_user_id: 'user-123',
+                    broadcaster_user_login: 'testuser',
+                    broadcaster_user_name: 'TestUser',
+                    type: 'live',
+                    started_at: '2024-01-01T12:00:00Z',
+                },
+            }
+
+            await handleStreamOnline(payload, mockClient)
+
+            expect(mockClient.channels.fetch).toHaveBeenCalledTimes(2)
+            expect(mockChannel.send).toHaveBeenCalledTimes(2)
+        })
+
+        test('returns early when no notifications found', async () => {
+            const mockClient = {
+                channels: {
+                    fetch: jest.fn(),
+                },
+            } as any
+
+            getNotificationsMock.mockResolvedValueOnce([])
+
+            const payload = {
+                subscription: { type: 'stream.online' },
+                event: {
+                    id: 'event-123',
+                    broadcaster_user_id: 'user-123',
+                    broadcaster_user_login: 'testuser',
+                    broadcaster_user_name: 'TestUser',
+                    type: 'live',
+                    started_at: '2024-01-01T12:00:00Z',
+                },
+            }
+
+            await handleStreamOnline(payload, mockClient)
+
+            expect(mockClient.channels.fetch).not.toHaveBeenCalled()
+        })
+
+        test('skips non-text channels', async () => {
+            const mockClient = {
+                channels: {
+                    fetch: jest.fn(),
+                },
+            } as any
+
+            const mockVoiceChannel = {
+                isTextBased: () => false,
+            }
+
+            mockClient.channels.fetch.mockResolvedValueOnce(mockVoiceChannel)
+
+            getNotificationsMock.mockResolvedValueOnce([
+                { discordChannelId: 'voice-123', twitchLogin: 'user1' },
+            ])
+
+            const payload = {
+                subscription: { type: 'stream.online' },
+                event: {
+                    id: 'event-123',
+                    broadcaster_user_id: 'user-123',
+                    broadcaster_user_login: 'testuser',
+                    broadcaster_user_name: 'TestUser',
+                    type: 'live',
+                    started_at: '2024-01-01T12:00:00Z',
+                },
+            }
+
+            await handleStreamOnline(payload, mockClient)
+
+            expect(mockVoiceChannel.send).toBeUndefined()
+        })
+
+        test('skips DM channels', async () => {
+            const mockClient = {
+                channels: {
+                    fetch: jest.fn(),
+                },
+            } as any
+
+            const mockDMChannel = {
+                isTextBased: () => true,
+                isDMBased: () => true,
+            }
+
+            mockClient.channels.fetch.mockResolvedValueOnce(mockDMChannel)
+
+            getNotificationsMock.mockResolvedValueOnce([
+                { discordChannelId: 'dm-123', twitchLogin: 'user1' },
+            ])
+
+            const payload = {
+                subscription: { type: 'stream.online' },
+                event: {
+                    id: 'event-123',
+                    broadcaster_user_id: 'user-123',
+                    broadcaster_user_login: 'testuser',
+                    broadcaster_user_name: 'TestUser',
+                    type: 'live',
+                    started_at: '2024-01-01T12:00:00Z',
+                },
+            }
+
+            await handleStreamOnline(payload, mockClient)
+
+            expect(mockDMChannel.send).toBeUndefined()
+        })
+
+        test('handles channel fetch errors', async () => {
+            const mockClient = {
+                channels: {
+                    fetch: jest.fn(),
+                },
+            } as any
+
+            mockClient.channels.fetch.mockRejectedValueOnce(
+                new Error('Channel not found'),
+            )
+
+            getNotificationsMock.mockResolvedValueOnce([
+                { discordChannelId: 'channel-1', twitchLogin: 'user1' },
+            ])
+
+            const payload = {
+                subscription: { type: 'stream.online' },
+                event: {
+                    id: 'event-123',
+                    broadcaster_user_id: 'user-123',
+                    broadcaster_user_login: 'testuser',
+                    broadcaster_user_name: 'TestUser',
+                    type: 'live',
+                    started_at: '2024-01-01T12:00:00Z',
+                },
+            }
+
+            await handleStreamOnline(payload, mockClient)
+
+            expect(errorLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'failed to send notification',
+                    ),
+                }),
+            )
+        })
+
+        test('gets notifications by broadcaster user ID', async () => {
+            const mockClient = {
+                channels: {
+                    fetch: jest.fn(),
+                },
+            } as any
+
+            getNotificationsMock.mockResolvedValueOnce([])
+
+            const payload = {
+                subscription: { type: 'stream.online' },
+                event: {
+                    id: 'event-123',
+                    broadcaster_user_id: 'broadcaster-xyz',
+                    broadcaster_user_login: 'testuser',
+                    broadcaster_user_name: 'TestUser',
+                    type: 'live',
+                    started_at: '2024-01-01T12:00:00Z',
+                },
+            }
+
+            await handleStreamOnline(payload, mockClient)
+
+            expect(getNotificationsMock).toHaveBeenCalledWith('broadcaster-xyz')
+        })
+    })
+})

--- a/packages/bot/src/twitch/index.spec.ts
+++ b/packages/bot/src/twitch/index.spec.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('@lucky/shared/services', () => ({
+    featureToggleService: {
+        isEnabled: jest.fn(),
+    },
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: jest.fn(),
+}))
+
+jest.mock('./token.js', () => ({
+    isTwitchConfigured: jest.fn(),
+}))
+
+jest.mock('./eventsubClient.js', () => ({
+    twitchEventSubClient: {
+        start: jest.fn(),
+        stop: jest.fn(),
+        refreshSubscriptions: jest.fn(),
+    },
+}))
+
+import {
+    startTwitchService,
+    stopTwitchService,
+    refreshTwitchSubscriptions,
+} from './index.js'
+import { featureToggleService } from '@lucky/shared/services'
+import { isTwitchConfigured } from './token.js'
+import { twitchEventSubClient } from './eventsubClient.js'
+import { infoLog } from '@lucky/shared/utils'
+
+const featureToggleMock =
+    featureToggleService.isEnabled as jest.MockedFunction<any>
+const isTwitchConfiguredMock = isTwitchConfigured as jest.MockedFunction<any>
+const startMock = twitchEventSubClient.start as jest.MockedFunction<any>
+const stopMock = twitchEventSubClient.stop as jest.MockedFunction<any>
+const refreshMock =
+    twitchEventSubClient.refreshSubscriptions as jest.MockedFunction<any>
+const infoLogMock = infoLog as jest.MockedFunction<any>
+
+function createMockClient() {
+    return {} as any
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+})
+
+describe('twitch module', () => {
+    describe('startTwitchService', () => {
+        test('starts EventSub client when enabled and configured', async () => {
+            const client = createMockClient()
+            featureToggleMock.mockResolvedValueOnce(true)
+            isTwitchConfiguredMock.mockReturnValueOnce(true)
+            startMock.mockResolvedValueOnce(undefined)
+
+            await startTwitchService(client)
+
+            expect(startMock).toHaveBeenCalledWith(client)
+            expect(infoLogMock).toHaveBeenCalledWith({
+                message: 'Twitch EventSub service started',
+            })
+        })
+
+        test('skips when feature is disabled', async () => {
+            const client = createMockClient()
+            featureToggleMock.mockResolvedValueOnce(false)
+
+            await startTwitchService(client)
+
+            expect(startMock).not.toHaveBeenCalled()
+        })
+
+        test('skips when not configured', async () => {
+            const client = createMockClient()
+            featureToggleMock.mockResolvedValueOnce(true)
+            isTwitchConfiguredMock.mockReturnValueOnce(false)
+
+            await startTwitchService(client)
+
+            expect(startMock).not.toHaveBeenCalled()
+        })
+
+        test('skips when both disabled and not configured', async () => {
+            const client = createMockClient()
+            featureToggleMock.mockResolvedValueOnce(false)
+            isTwitchConfiguredMock.mockReturnValueOnce(false)
+
+            await startTwitchService(client)
+
+            expect(startMock).not.toHaveBeenCalled()
+        })
+
+        test('logs non-fatal error if start fails', async () => {
+            const client = createMockClient()
+            const testError = new Error('Start failed')
+            featureToggleMock.mockResolvedValueOnce(true)
+            isTwitchConfiguredMock.mockReturnValueOnce(true)
+            startMock.mockRejectedValueOnce(testError)
+
+            await startTwitchService(client)
+
+            expect(infoLogMock).toHaveBeenCalledWith({
+                message: 'Twitch EventSub service failed to start (non-fatal)',
+                data: testError,
+            })
+        })
+
+        test('checks feature toggle', async () => {
+            const client = createMockClient()
+            featureToggleMock.mockResolvedValueOnce(true)
+            isTwitchConfiguredMock.mockReturnValueOnce(true)
+            startMock.mockResolvedValueOnce(undefined)
+
+            await startTwitchService(client)
+
+            expect(featureToggleMock).toHaveBeenCalledWith(
+                'TWITCH_NOTIFICATIONS',
+            )
+        })
+    })
+
+    describe('stopTwitchService', () => {
+        test('stops EventSub client', () => {
+            stopTwitchService()
+
+            expect(stopMock).toHaveBeenCalled()
+        })
+    })
+
+    describe('refreshTwitchSubscriptions', () => {
+        test('calls eventSubClient refresh', async () => {
+            refreshMock.mockResolvedValueOnce(undefined)
+
+            await refreshTwitchSubscriptions()
+
+            expect(refreshMock).toHaveBeenCalled()
+        })
+
+        test('returns successfully', async () => {
+            refreshMock.mockResolvedValueOnce(undefined)
+
+            const result = await refreshTwitchSubscriptions()
+
+            expect(result).toBeUndefined()
+        })
+    })
+})

--- a/packages/bot/src/twitch/token.spec.ts
+++ b/packages/bot/src/twitch/token.spec.ts
@@ -1,0 +1,270 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>
+
+import {
+    getTwitchEnv,
+    isTwitchConfigured,
+    getTwitchUserAccessToken,
+    clearTwitchTokenCache,
+} from './token.js'
+
+const fetchMock = global.fetch as jest.MockedFunction<any>
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    clearTwitchTokenCache()
+    delete process.env.TWITCH_CLIENT_ID
+    delete process.env.TWITCH_CLIENT_SECRET
+    delete process.env.TWITCH_ACCESS_TOKEN
+    delete process.env.TWITCH_REFRESH_TOKEN
+})
+
+describe('token', () => {
+    describe('getTwitchEnv', () => {
+        test('returns all environment variables', () => {
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = 'token-789'
+            process.env.TWITCH_REFRESH_TOKEN = 'refresh-000'
+
+            const env = getTwitchEnv()
+
+            expect(env).toEqual({
+                clientId: 'client-123',
+                clientSecret: 'secret-456',
+                accessToken: 'token-789',
+                refreshToken: 'refresh-000',
+            })
+        })
+
+        test('returns undefined for missing refresh token', () => {
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = 'token-789'
+
+            const env = getTwitchEnv()
+
+            expect(env.refreshToken).toBeUndefined()
+        })
+
+        test('returns empty strings for missing required fields', () => {
+            const env = getTwitchEnv()
+
+            expect(env.clientId).toBe('')
+            expect(env.clientSecret).toBe('')
+            expect(env.accessToken).toBeUndefined()
+        })
+    })
+
+    describe('isTwitchConfigured', () => {
+        test('returns true when all required fields present', () => {
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = 'token-789'
+
+            expect(isTwitchConfigured()).toBe(true)
+        })
+
+        test('returns false when client ID missing', () => {
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = 'token-789'
+
+            expect(isTwitchConfigured()).toBe(false)
+        })
+
+        test('returns false when client secret missing', () => {
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_ACCESS_TOKEN = 'token-789'
+
+            expect(isTwitchConfigured()).toBe(false)
+        })
+
+        test('returns false when access token missing', () => {
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+
+            expect(isTwitchConfigured()).toBe(false)
+        })
+
+        test('returns false when all fields missing', () => {
+            expect(isTwitchConfigured()).toBe(false)
+        })
+    })
+
+    describe('getTwitchUserAccessToken', () => {
+        test('returns cached token if not expired', async () => {
+            const token = 'cached-token-123'
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = token
+
+            const result1 = await getTwitchUserAccessToken()
+            const result2 = await getTwitchUserAccessToken()
+
+            expect(result1).toBe(token)
+            expect(result2).toBe(token)
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        test('returns null when not configured', async () => {
+            const result = await getTwitchUserAccessToken()
+
+            expect(result).toBeNull()
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        test('refreshes token when expired', async () => {
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = 'old-token'
+            process.env.TWITCH_REFRESH_TOKEN = 'refresh-token'
+
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    access_token: 'new-token',
+                    expires_in: 3600,
+                }),
+            })
+
+            jest.useFakeTimers()
+            const now = Date.now()
+            jest.setSystemTime(now + 5 * 60 * 60 * 1000)
+
+            const result = await getTwitchUserAccessToken()
+
+            expect(result).toBe('new-token')
+            expect(fetchMock).toHaveBeenCalledWith(
+                'https://id.twitch.tv/oauth2/token',
+                expect.objectContaining({
+                    method: 'POST',
+                }),
+            )
+
+            jest.useRealTimers()
+        })
+
+        test('uses environment token when refresh fails', async () => {
+            const token = 'env-token'
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = token
+            process.env.TWITCH_REFRESH_TOKEN = 'refresh-token'
+
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+            })
+
+            jest.useFakeTimers()
+            const now = Date.now()
+            jest.setSystemTime(now + 5 * 60 * 60 * 1000)
+
+            const result = await getTwitchUserAccessToken()
+
+            expect(result).toBe(token)
+
+            jest.useRealTimers()
+        })
+
+        test('sends correct refresh token request body', async () => {
+            process.env.TWITCH_CLIENT_ID = 'client-id-xyz'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-xyz'
+            process.env.TWITCH_ACCESS_TOKEN = 'old-token'
+            process.env.TWITCH_REFRESH_TOKEN = 'refresh-xyz'
+
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    access_token: 'new-token',
+                    expires_in: 3600,
+                }),
+            })
+
+            jest.useFakeTimers()
+            const now = Date.now()
+            jest.setSystemTime(now + 5 * 60 * 60 * 1000)
+
+            await getTwitchUserAccessToken()
+
+            const call = fetchMock.mock.calls[0]
+            const bodyStr = call[1].body.toString()
+
+            expect(bodyStr).toContain('client_id=client-id-xyz')
+            expect(bodyStr).toContain('client_secret=secret-xyz')
+            expect(bodyStr).toContain('grant_type=refresh_token')
+            expect(bodyStr).toContain('refresh_token=refresh-xyz')
+
+            jest.useRealTimers()
+        })
+
+        test('sends correct refresh token request parameters', async () => {
+            process.env.TWITCH_CLIENT_ID = 'client-id-xyz'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-xyz'
+            process.env.TWITCH_ACCESS_TOKEN = 'old-token'
+            process.env.TWITCH_REFRESH_TOKEN = 'refresh-xyz'
+
+            jest.useFakeTimers()
+            const now = Date.now()
+            jest.setSystemTime(now + 5 * 60 * 60 * 1000)
+
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    access_token: 'new-token',
+                    expires_in: 3600,
+                }),
+            })
+
+            await getTwitchUserAccessToken()
+
+            const call = fetchMock.mock.calls[0]
+            const bodyStr = call[1].body.toString()
+
+            expect(bodyStr).toContain('refresh_token=refresh-xyz')
+            expect(bodyStr).toContain('grant_type=refresh_token')
+
+            jest.useRealTimers()
+        })
+
+        test('handles refresh token network error', async () => {
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = 'old-token'
+            process.env.TWITCH_REFRESH_TOKEN = 'refresh-token'
+
+            fetchMock.mockRejectedValueOnce(new Error('Network error'))
+
+            jest.useFakeTimers()
+            const now = Date.now()
+            jest.setSystemTime(now + 5 * 60 * 60 * 1000)
+
+            const result = await getTwitchUserAccessToken()
+
+            expect(result).toBe('old-token')
+
+            jest.useRealTimers()
+        })
+
+        test('returns env token with default expiry when no refresh', async () => {
+            const token = 'env-token'
+            process.env.TWITCH_CLIENT_ID = 'client-123'
+            process.env.TWITCH_CLIENT_SECRET = 'secret-456'
+            process.env.TWITCH_ACCESS_TOKEN = token
+
+            const result = await getTwitchUserAccessToken()
+
+            expect(result).toBe(token)
+        })
+    })
+
+    describe('clearTwitchTokenCache', () => {
+        test('exports clearTwitchTokenCache function', () => {
+            expect(typeof clearTwitchTokenCache).toBe('function')
+        })
+
+        test('can be called without error', () => {
+            expect(() => clearTwitchTokenCache()).not.toThrow()
+        })
+    })
+})

--- a/packages/bot/src/twitch/twitchApi.spec.ts
+++ b/packages/bot/src/twitch/twitchApi.spec.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('./token.js', () => ({
+    getTwitchUserAccessToken: jest.fn(),
+}))
+
+global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>
+
+import { getTwitchUserByLogin } from './twitchApi.js'
+import { getTwitchUserAccessToken } from './token.js'
+
+const getTwitchTokenMock = getTwitchUserAccessToken as jest.MockedFunction<any>
+const fetchMock = global.fetch as jest.MockedFunction<any>
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.TWITCH_CLIENT_ID = 'test-client-id'
+})
+
+describe('twitchApi', () => {
+    describe('getTwitchUserByLogin', () => {
+        test('fetches user from Twitch API', async () => {
+            const mockUser = {
+                id: 'twitch-123',
+                login: 'testuser',
+                display_name: 'TestUser',
+            }
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ data: [mockUser] }),
+            })
+
+            const result = await getTwitchUserByLogin('testuser')
+
+            expect(result).toEqual(mockUser)
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.stringContaining('login=testuser'),
+                {
+                    headers: {
+                        Authorization: 'Bearer test-token',
+                        'Client-Id': 'test-client-id',
+                    },
+                },
+            )
+        })
+
+        test('returns null when no token available', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce(null)
+
+            const result = await getTwitchUserByLogin('testuser')
+
+            expect(result).toBeNull()
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        test('returns null when TWITCH_CLIENT_ID not set', async () => {
+            delete process.env.TWITCH_CLIENT_ID
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+
+            const result = await getTwitchUserByLogin('testuser')
+
+            expect(result).toBeNull()
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        test('returns null when API returns error', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+            })
+
+            const result = await getTwitchUserByLogin('testuser')
+
+            expect(result).toBeNull()
+        })
+
+        test('returns null when user not found in response', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ data: [] }),
+            })
+
+            const result = await getTwitchUserByLogin('nonexistent')
+
+            expect(result).toBeNull()
+        })
+
+        test('returns null on network error', async () => {
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            fetchMock.mockRejectedValueOnce(new Error('Network error'))
+
+            const result = await getTwitchUserByLogin('testuser')
+
+            expect(result).toBeNull()
+        })
+
+        test('encodes username in URL', async () => {
+            const mockUser = {
+                id: 'twitch-123',
+                login: 'user@special',
+                display_name: 'User Special',
+            }
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ data: [mockUser] }),
+            })
+
+            await getTwitchUserByLogin('user@special')
+
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.stringContaining('login=user%40special'),
+                expect.anything(),
+            )
+        })
+
+        test('uses correct headers', async () => {
+            const mockUser = {
+                id: 'twitch-123',
+                login: 'testuser',
+                display_name: 'TestUser',
+            }
+            getTwitchTokenMock.mockResolvedValueOnce('my-token')
+            process.env.TWITCH_CLIENT_ID = 'my-client-id'
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ data: [mockUser] }),
+            })
+
+            await getTwitchUserByLogin('testuser')
+
+            const call = fetchMock.mock.calls[0]
+            expect(call[1].headers).toEqual({
+                Authorization: 'Bearer my-token',
+                'Client-Id': 'my-client-id',
+            })
+        })
+
+        test('returns first user when multiple match', async () => {
+            const firstUser = {
+                id: 'id-1',
+                login: 'testuser',
+                display_name: 'First',
+            }
+            const secondUser = {
+                id: 'id-2',
+                login: 'testuser',
+                display_name: 'Second',
+            }
+            getTwitchTokenMock.mockResolvedValueOnce('test-token')
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ data: [firstUser, secondUser] }),
+            })
+
+            const result = await getTwitchUserByLogin('testuser')
+
+            expect(result).toEqual(firstUser)
+        })
+    })
+})


### PR DESCRIPTION
## Summary
- Add 95 tests across 7 spec files covering the Twitch integration module
- Tests cover: TwitchService, twitchHandlers, twitchApi, EventSub client, EventSub subscriptions, index bootstrap, and token refresh
- Improves bot package test coverage

## Test plan
- [ ] All 95 tests pass locally
- [ ] No regressions in existing test suite
- [ ] CI passes