### PR TITLE
chore: release v2.6.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.48] - 2026-03-31
+
+### Tests
+
+- Added test coverage for Twitch integration: TwitchService, twitchHandlers, twitchApi, EventSub client/subscriptions, index bootstrap, token refresh (74 tests). (#410)
+- Added test coverage for music recommendation/autoplay: RecommendationEngine, helpers, counters, stats, autoplay recommendations (93 tests). (#410)
+
 ## [2.6.47] - 2026-03-31
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.47",
+    "version": "2.6.48",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
## Summary
- Bump version to v2.6.48
- Twitch integration test coverage: 74 tests across 7 spec files (#410)
- Music recommendation/autoplay test coverage: 93 tests (#410)

## Test plan
- [ ] CI passes