### PR TITLE
fix(bot): fix playerfactory timer cleanup and test mock

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -113,13 +113,21 @@ const tryYtDlpStream = (url: string): Promise<Readable | null> => {
 const checkYtDlpAvailability = (): Promise<boolean> => {
     return new Promise((resolve) => {
         const proc = spawn('yt-dlp', ['--version'], { stdio: 'pipe' })
+        let done = false
 
-        proc.on('close', (code) => resolve(code === 0))
-        proc.on('error', () => resolve(false))
+        const finish = (result: boolean): void => {
+            if (done) return
+            done = true
+            clearTimeout(timer)
+            resolve(result)
+        }
 
-        setTimeout(() => {
+        proc.on('close', (code) => finish(code === 0))
+        proc.on('error', () => finish(false))
+
+        const timer = setTimeout(() => {
             proc.kill()
-            resolve(false)
+            finish(false)
         }, 3000)
     })
 }
@@ -170,7 +178,10 @@ const loadYoutubeExtractor = async (player: Player): Promise<void> => {
                   },
               }
 
-        await player.extractors.register(mod.YoutubeiExtractor, extractorOptions)
+        await player.extractors.register(
+            mod.YoutubeiExtractor,
+            extractorOptions,
+        )
 
         infoLog({
             message: ytDlpAvailable

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -51,19 +51,51 @@ jest.mock('util', () => ({
 
 const mockExecFile = execFile as unknown as jest.MockedFunction<typeof execFile>
 
-function createSpawnProcessMock() {
-    return {
-        stdout: { on: jest.fn() },
+function createSpawnProcessMock(
+    opts: { fireClose?: number; fireData?: boolean } = {},
+) {
+    const listeners: Record<string, ((...args: unknown[]) => void)[]> = {}
+    const stdoutListeners: Record<string, ((...args: unknown[]) => void)[]> = {}
+
+    const proc = {
+        stdout: {
+            on: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+                stdoutListeners[event] = stdoutListeners[event] ?? []
+                stdoutListeners[event].push(cb)
+            }),
+            once: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+                stdoutListeners[event] = stdoutListeners[event] ?? []
+                stdoutListeners[event].push(cb)
+                if (opts.fireData && event === 'data') {
+                    Promise.resolve().then(() => cb(Buffer.from('audio')))
+                }
+            }),
+            destroy: jest.fn(),
+        },
         stderr: { on: jest.fn() },
-        on: jest.fn(),
+        on: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+            listeners[event] = listeners[event] ?? []
+            listeners[event].push(cb)
+            if (opts.fireClose !== undefined && event === 'close') {
+                Promise.resolve().then(() => cb(opts.fireClose))
+            }
+        }),
+        kill: jest.fn(),
     }
+
+    return proc
 }
 
 describe('playerFactory', () => {
     beforeEach(() => {
         jest.resetModules()
         mockSpawn.mockReset()
-        mockSpawn.mockReturnValue(createSpawnProcessMock())
+        mockSpawn.mockImplementation((_cmd: unknown, args: string[]) => {
+            if (Array.isArray(args) && args[0] === '--version') {
+                return createSpawnProcessMock({ fireClose: 0 })
+            }
+            return createSpawnProcessMock({ fireData: true })
+        })
     })
 
     describe('module exports', () => {
@@ -128,9 +160,9 @@ describe('playerFactory', () => {
                 extractors: { register: jest.Mock }
             }
 
-            for (let i = 0; i < 20; i++) {
+            for (let i = 0; i < 50; i++) {
                 if (player.extractors.register.mock.calls.length > 0) break
-                await new Promise((resolve) => setTimeout(resolve, 0))
+                await new Promise((resolve) => setTimeout(resolve, 10))
             }
 
             expect(player.extractors.register).toHaveBeenCalled()


### PR DESCRIPTION
## Summary
Follow-up to #411 (play command fix):

- `checkYtDlpAvailability`: clear the 3s timeout when the promise resolves early to prevent open timer leaks in tests
- `playerFactory.test.ts`: update spawn mock to fire `close` event for `--version` calls (resolves immediately) and `data` event for audio streaming calls, so the availability-check polling loop doesn't time out

## Test plan
- [ ] All 17 playerFactory tests pass (was: 1 failing)
- [ ] CI Quality Gates pass