### PR TITLE
chore: release v2.6.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.49] - 2026-03-31
+
+### Fixed
+
+- `playerFactory.test.ts`: update spawn mock to fire close/data events immediately so tests don't hang on 3s availability timeout. Clear timeout on early resolve in `checkYtDlpAvailability` to prevent open timer leaks. Fixes CI Quality Gates (1 failing test). (#414)
+
 ## [2.6.48] - 2026-03-31
 
 ### Tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.48",
+    "version": "2.6.49",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
Bump to v2.6.49. Fixes CI Quality Gates broken by playerFactory test mock (#414).