### PR TITLE
fix(bot): use yt-dlp --get-url for reliable youtube stream resolution

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.spec.ts
@@ -6,11 +6,17 @@ describe('playerFactory', () => {
             const isYouTubeUrl = (url: string): boolean =>
                 url.includes('youtube.com') || url.includes('youtu.be')
 
-            expect(isYouTubeUrl('https://www.youtube.com/watch?v=test')).toBe(true)
+            expect(isYouTubeUrl('https://www.youtube.com/watch?v=test')).toBe(
+                true,
+            )
             expect(isYouTubeUrl('https://youtu.be/test')).toBe(true)
             expect(isYouTubeUrl('https://soundcloud.com/track')).toBe(false)
-            expect(isYouTubeUrl('https://open.spotify.com/track/abc')).toBe(false)
-            expect(isYouTubeUrl('https://music.youtube.com/watch?v=test')).toBe(true)
+            expect(isYouTubeUrl('https://open.spotify.com/track/abc')).toBe(
+                false,
+            )
+            expect(isYouTubeUrl('https://music.youtube.com/watch?v=test')).toBe(
+                true,
+            )
         })
 
         it('should validate player creation parameters', () => {
@@ -40,7 +46,10 @@ describe('playerFactory', () => {
         it('should omit createStream when yt-dlp is unavailable', () => {
             const buildOptions = (ytDlpAvailable: boolean) =>
                 ytDlpAvailable
-                    ? { streamOptions: { useClient: 'IOS' as const }, createStream: () => {} }
+                    ? {
+                          streamOptions: { useClient: 'IOS' as const },
+                          createStream: () => {},
+                      }
                     : { streamOptions: { useClient: 'IOS' as const } }
 
             expect(buildOptions(true)).toHaveProperty('createStream')
@@ -48,83 +57,91 @@ describe('playerFactory', () => {
         })
     })
 
-    describe('yt-dlp command arguments', () => {
-        it('should include --no-check-certificates for robustness', () => {
+    describe('yt-dlp --get-url command arguments', () => {
+        it('should use --get-url for direct stream URL resolution', () => {
             const ytDlpArgs = [
-                '-f', 'bestaudio/best',
-                '-o', '-',
+                '-f',
+                'bestaudio',
+                '--get-url',
                 '--no-warnings',
-                '--quiet',
                 '--no-check-certificates',
             ]
 
-            expect(ytDlpArgs).toContain('bestaudio/best')
+            expect(ytDlpArgs).toContain('bestaudio')
+            expect(ytDlpArgs).toContain('--get-url')
             expect(ytDlpArgs).toContain('--no-check-certificates')
             expect(ytDlpArgs).toContain('--no-warnings')
-            expect(ytDlpArgs).toContain('--quiet')
-            expect(ytDlpArgs).toHaveLength(7)
         })
 
-        it('should pipe stdout and ignore stdin', () => {
-            const spawnOptions = { stdio: ['ignore', 'pipe', 'pipe'] as const }
-
-            expect(spawnOptions.stdio[0]).toBe('ignore')
-            expect(spawnOptions.stdio[1]).toBe('pipe')
-            expect(spawnOptions.stdio[2]).toBe('pipe')
+        it('should use 30s timeout for URL resolution', () => {
+            const execOptions = { timeout: 30000 }
+            expect(execOptions.timeout).toBe(30000)
         })
     })
 
-    describe('tryYtDlpStream fallback logic', () => {
-        it('should fall back to native IOS streaming when yt-dlp returns null', async () => {
-            const tryYtDlpStream = async (_url: string): Promise<null> => null
+    describe('getYtDlpUrl fallback logic', () => {
+        it('should fall back to original URL when yt-dlp returns null', async () => {
+            const getYtDlpUrl = async (_url: string): Promise<null> => null
 
-            const createStream = async (track: { url: string }): Promise<string> => {
+            const createStream = async (track: {
+                url: string
+            }): Promise<string> => {
                 const url = track.url
-                const isYt = url.includes('youtube.com') || url.includes('youtu.be')
+                const isYt =
+                    url.includes('youtube.com') || url.includes('youtu.be')
                 if (isYt) {
-                    const stream = await tryYtDlpStream(url)
-                    if (stream) return 'yt-dlp'
+                    const streamUrl = await getYtDlpUrl(url)
+                    if (streamUrl) return streamUrl
                 }
                 return url
             }
 
-            const result = await createStream({ url: 'https://youtube.com/watch?v=abc' })
-            expect(result).toBe('https://youtube.com/watch?v=abc')
+            const youtubeUrl = 'https://youtube.com/watch?v=abc'
+            const result = await createStream({ url: youtubeUrl })
+            expect(result).toBe(youtubeUrl)
         })
 
-        it('should return yt-dlp stream when it succeeds', async () => {
-            const mockStream = { pipe: () => {} }
-            const tryYtDlpStream = async (_url: string) => mockStream
+        it('should return direct googlevideo URL when yt-dlp succeeds', async () => {
+            const googlevideoUrl =
+                'https://rr3---sn.googlevideo.com/videoplayback?test=1'
+            const getYtDlpUrl = async (_url: string) => googlevideoUrl
 
             const createStream = async (track: { url: string }) => {
                 const url = track.url
                 if (url.includes('youtube.com')) {
-                    const stream = await tryYtDlpStream(url)
-                    if (stream) return stream
+                    const streamUrl = await getYtDlpUrl(url)
+                    if (streamUrl) return streamUrl
                 }
                 return url
             }
 
-            const result = await createStream({ url: 'https://youtube.com/watch?v=abc' })
-            expect(result).toBe(mockStream)
+            const result = await createStream({
+                url: 'https://youtube.com/watch?v=abc',
+            })
+            expect(result).toBe(googlevideoUrl)
         })
 
         it('should return URL directly for non-YouTube tracks', async () => {
-            const tryYtDlpStream = async (_url: string): Promise<null> => null
+            const getYtDlpUrl = async (_url: string): Promise<null> => null
 
-            const createStream = async (track: { url: string }): Promise<string> => {
+            const createStream = async (track: {
+                url: string
+            }): Promise<string> => {
                 const url = track.url
-                const isYt = url.includes('youtube.com') || url.includes('youtu.be')
+                const isYt =
+                    url.includes('youtube.com') || url.includes('youtu.be')
                 if (isYt) {
-                    const stream = await tryYtDlpStream(url)
-                    if (stream) return 'yt-dlp-stream'
+                    const streamUrl = await getYtDlpUrl(url)
+                    if (streamUrl) return streamUrl
                 }
                 return url
             }
 
             const spotifyUrl = 'https://open.spotify.com/track/abc'
             expect(await createStream({ url: spotifyUrl })).toBe(spotifyUrl)
-            expect(await createStream({ url: 'https://soundcloud.com/track' })).toBe('https://soundcloud.com/track')
+            expect(
+                await createStream({ url: 'https://soundcloud.com/track' }),
+            ).toBe('https://soundcloud.com/track')
         })
     })
 
@@ -157,7 +174,11 @@ describe('playerFactory', () => {
                 }
             }
 
-            expect(registerSafely(() => { throw new Error('extractor not found') })).toBe(false)
+            expect(
+                registerSafely(() => {
+                    throw new Error('extractor not found')
+                }),
+            ).toBe(false)
             expect(registerSafely(() => {})).toBe(true)
         })
 

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -1,9 +1,12 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { spawn } from 'child_process'
-import type { Readable } from 'stream'
 import { Player } from 'discord-player'
 import { DefaultExtractors } from '@discord-player/extractor'
 import type { CustomClient } from '../../types'
 import { errorLog, infoLog, warnLog, debugLog } from '@lucky/shared/utils'
+
+const execFileAsync = promisify(execFile)
 
 type CreatePlayerParams = {
     client: CustomClient
@@ -40,74 +43,31 @@ const registerExtractors = (player: Player): void => {
 const isYouTubeUrl = (url: string): boolean =>
     url.includes('youtube.com') || url.includes('youtu.be')
 
-const getYtDlpStream = (url: string): Readable => {
-    debugLog({ message: `yt-dlp piping audio stream: ${url}` })
-    const proc = spawn(
-        'yt-dlp',
-        [
-            '-f',
-            'bestaudio/best',
-            '-o',
-            '-',
-            '--no-warnings',
-            '--quiet',
-            '--no-check-certificates',
-            url,
-        ],
-        { stdio: ['ignore', 'pipe', 'pipe'] },
-    )
-
-    proc.stderr?.on('data', (data: Buffer) => {
-        warnLog({ message: `yt-dlp stderr: ${data.toString().trim()}` })
-    })
-
-    proc.on('error', (err) => {
-        errorLog({ message: 'yt-dlp process error:', error: err })
-    })
-
-    return proc.stdout as Readable
-}
-
-const tryYtDlpStream = (url: string): Promise<Readable | null> => {
-    return new Promise((resolve) => {
-        try {
-            const stream = getYtDlpStream(url)
-            let hasData = false
-
-            const timeout = setTimeout(() => {
-                if (!hasData) {
-                    warnLog({
-                        message: `yt-dlp timed out for ${url}, falling back to native streaming`,
-                    })
-                    stream.destroy()
-                    resolve(null)
-                }
-            }, 8000)
-
-            stream.once('data', () => {
-                hasData = true
-                clearTimeout(timeout)
-                resolve(stream)
-            })
-
-            stream.once('error', (err) => {
-                clearTimeout(timeout)
-                warnLog({
-                    message: `yt-dlp stream error for ${url}: ${String(err)}`,
-                })
-                resolve(null)
-            })
-
-            stream.once('end', () => {
-                if (!hasData) {
-                    clearTimeout(timeout)
-                    resolve(null)
-                }
-            })
-        } catch {
-            resolve(null)
-        }
-    })
+const getYtDlpUrl = async (url: string): Promise<string | null> => {
+    try {
+        debugLog({ message: `yt-dlp resolving stream URL: ${url}` })
+        const { stdout } = await execFileAsync(
+            'yt-dlp',
+            [
+                '-f',
+                'bestaudio',
+                '--get-url',
+                '--no-warnings',
+                '--no-check-certificates',
+                url,
+            ],
+            { timeout: 30000 },
+        )
+        const streamUrl = stdout.trim().split('\n')[0] ?? ''
+        if (!streamUrl) return null
+        debugLog({ message: `yt-dlp resolved stream URL for: ${url}` })
+        return streamUrl
+    } catch {
+        warnLog({
+            message: `yt-dlp --get-url failed for ${url}, falling back to native IOS`,
+        })
+        return null
+    }
 }
 
 const checkYtDlpAvailability = (): Promise<boolean> => {
@@ -155,13 +115,13 @@ const loadYoutubeExtractor = async (player: Player): Promise<void> => {
                   createStream: async (
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
                       track: any,
-                  ): Promise<Readable | string> => {
+                  ): Promise<string> => {
                       const url = track?.url ?? String(track)
                       debugLog({ message: `createStream for: ${url}` })
 
                       if (isYouTubeUrl(url)) {
-                          const stream = await tryYtDlpStream(url)
-                          if (stream) return stream
+                          const streamUrl = await getYtDlpUrl(url)
+                          if (streamUrl) return streamUrl
 
                           warnLog({
                               message: `yt-dlp failed for ${url}, falling back to native IOS streaming`,

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -1,6 +1,5 @@
-import { execFile } from 'child_process'
-
 const mockSpawn = jest.fn()
+const mockExecFile = jest.fn()
 
 jest.mock('discord-player', () => {
     const loadMulti = jest.fn().mockResolvedValue(undefined)
@@ -32,7 +31,7 @@ jest.mock('@lucky/shared/utils', () => ({
 }))
 
 jest.mock('child_process', () => ({
-    execFile: jest.fn(),
+    execFile: (...args: unknown[]) => mockExecFile(...args),
     spawn: (...args: unknown[]) => mockSpawn(...args),
 }))
 
@@ -49,29 +48,11 @@ jest.mock('util', () => ({
     }),
 }))
 
-const mockExecFile = execFile as unknown as jest.MockedFunction<typeof execFile>
-
-function createSpawnProcessMock(
-    opts: { fireClose?: number; fireData?: boolean } = {},
-) {
+function createSpawnProcessMock(opts: { fireClose?: number } = {}) {
     const listeners: Record<string, ((...args: unknown[]) => void)[]> = {}
-    const stdoutListeners: Record<string, ((...args: unknown[]) => void)[]> = {}
 
     const proc = {
-        stdout: {
-            on: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
-                stdoutListeners[event] = stdoutListeners[event] ?? []
-                stdoutListeners[event].push(cb)
-            }),
-            once: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
-                stdoutListeners[event] = stdoutListeners[event] ?? []
-                stdoutListeners[event].push(cb)
-                if (opts.fireData && event === 'data') {
-                    Promise.resolve().then(() => cb(Buffer.from('audio')))
-                }
-            }),
-            destroy: jest.fn(),
-        },
+        stdout: { on: jest.fn(), destroy: jest.fn() },
         stderr: { on: jest.fn() },
         on: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
             listeners[event] = listeners[event] ?? []
@@ -90,11 +71,12 @@ describe('playerFactory', () => {
     beforeEach(() => {
         jest.resetModules()
         mockSpawn.mockReset()
+        mockExecFile.mockReset()
         mockSpawn.mockImplementation((_cmd: unknown, args: string[]) => {
             if (Array.isArray(args) && args[0] === '--version') {
                 return createSpawnProcessMock({ fireClose: 0 })
             }
-            return createSpawnProcessMock({ fireData: true })
+            return createSpawnProcessMock()
         })
     })
 
@@ -120,7 +102,7 @@ describe('playerFactory', () => {
     })
 
     describe('yt-dlp URL resolution', () => {
-        it('uses execFile with --get-url for YouTube URLs', () => {
+        it('uses execFile with --get-url for YouTube URLs', async () => {
             const url = 'https://youtube.com/watch?v=abc123'
             const streamUrl =
                 'https://rr3---sn.googlevideo.com/videoplayback?...'
@@ -132,33 +114,12 @@ describe('playerFactory', () => {
                 },
             )
 
-            execFile(
-                'yt-dlp',
-                ['-f', 'bestaudio', '--get-url', '--no-warnings', url],
-                { timeout: 30000 },
-                (err, result) => {
-                    expect(err).toBeNull()
-                    expect((result as any).stdout.trim()).toBe(streamUrl)
-                },
-            )
-
-            expect(mockExecFile).toHaveBeenCalledWith(
-                'yt-dlp',
-                expect.arrayContaining(['-f', 'bestaudio', '--get-url', url]),
-                expect.objectContaining({ timeout: 30000 }),
-                expect.any(Function),
-            )
-        })
-
-        it('uses resilient yt-dlp format fallback for YouTube streams', async () => {
             const { createPlayer } =
                 await import('../../../src/handlers/player/playerFactory')
 
             const player = createPlayer({
                 client: { user: { id: '123' } } as any,
-            }) as unknown as {
-                extractors: { register: jest.Mock }
-            }
+            }) as unknown as { extractors: { register: jest.Mock } }
 
             for (let i = 0; i < 50; i++) {
                 if (player.extractors.register.mock.calls.length > 0) break
@@ -169,28 +130,78 @@ describe('playerFactory', () => {
 
             const extractorOptions = player.extractors.register.mock
                 .calls[0][1] as {
-                createStream: (_track: unknown) => Promise<unknown>
+                createStream: (_track: unknown) => Promise<string>
             }
 
-            await extractorOptions.createStream({
-                url: 'https://youtube.com/watch?v=abc123',
+            const result = await extractorOptions.createStream({ url })
+
+            expect(result).toBe(streamUrl)
+            expect(mockExecFile).toHaveBeenCalledWith(
+                'yt-dlp',
+                expect.arrayContaining(['-f', 'bestaudio', '--get-url', url]),
+                expect.objectContaining({ timeout: 30000 }),
+                expect.any(Function),
+            )
+        })
+
+        it('falls back to original URL when yt-dlp --get-url fails', async () => {
+            mockExecFile.mockImplementation(
+                (_cmd: any, _args: any, _opts: any, cb: any) => {
+                    cb(new Error('yt-dlp failed'), null)
+                    return {} as any
+                },
+            )
+
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+
+            const player = createPlayer({
+                client: { user: { id: '123' } } as any,
+            }) as unknown as { extractors: { register: jest.Mock } }
+
+            for (let i = 0; i < 50; i++) {
+                if (player.extractors.register.mock.calls.length > 0) break
+                await new Promise((resolve) => setTimeout(resolve, 10))
+            }
+
+            const extractorOptions = player.extractors.register.mock
+                .calls[0][1] as {
+                createStream: (_track: unknown) => Promise<string>
+            }
+
+            const youtubeUrl = 'https://youtube.com/watch?v=abc123'
+            const result = await extractorOptions.createStream({
+                url: youtubeUrl,
             })
 
-            expect(mockSpawn).toHaveBeenCalledWith(
-                'yt-dlp',
-                expect.arrayContaining([
-                    '-f',
-                    'bestaudio/best',
-                    '-o',
-                    '-',
-                    '--no-warnings',
-                    '--quiet',
-                    'https://youtube.com/watch?v=abc123',
-                ]),
-                expect.objectContaining({
-                    stdio: ['ignore', 'pipe', 'pipe'],
-                }),
-            )
+            expect(result).toBe(youtubeUrl)
+        })
+
+        it('returns non-YouTube URLs without calling yt-dlp', async () => {
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+
+            const player = createPlayer({
+                client: { user: { id: '123' } } as any,
+            }) as unknown as { extractors: { register: jest.Mock } }
+
+            for (let i = 0; i < 50; i++) {
+                if (player.extractors.register.mock.calls.length > 0) break
+                await new Promise((resolve) => setTimeout(resolve, 10))
+            }
+
+            const extractorOptions = player.extractors.register.mock
+                .calls[0][1] as {
+                createStream: (_track: unknown) => Promise<string>
+            }
+
+            const spotifyUrl = 'https://open.spotify.com/track/abc'
+            const result = await extractorOptions.createStream({
+                url: spotifyUrl,
+            })
+
+            expect(result).toBe(spotifyUrl)
+            expect(mockExecFile).not.toHaveBeenCalled()
         })
     })
 })


### PR DESCRIPTION
## Summary

- Replaces `spawn yt-dlp -o -` (pipe) with `execFile yt-dlp --get-url` to get the direct googlevideo URL
- Root cause of continued play failures: `stream.once('data')` puts the Readable in flowing mode before discord-player attaches a consumer, causing dropped audio chunks
- Returns the direct stream URL as a string — discord-player streams it via its own HTTP client, no piping needed
- Falls back to native IOS client if yt-dlp `--get-url` fails
- Removes `getYtDlpStream`, `tryYtDlpStream`, and the 8s data-arrival timeout
- Updated tests to use closure-pattern mock (same fix as prior spawn mock issue)

## Test plan

- [x] 1365 bot tests passing (126 suites)
- [x] `playerFactory.test.ts` covers: URL resolved via execFile, fallback to original URL on error, non-YouTube URLs bypass yt-dlp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * YouTube audio streaming now uses URL resolution with a 30-second timeout for improved reliability
  * Enhanced fallback behavior—returns original URL when resolution fails instead of alternative approaches
  * Simplified URL retrieval mechanism for YouTube content

* **Tests**
  * Expanded test coverage for YouTube URL detection across music and standard YouTube domains
  * Added and updated test scenarios for URL resolution success and fallback cases
  * Improved test mocking structure for stream handling validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->