### PR TITLE
chore(release): bump version to v2.6.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.50] - 2026-03-31
+
+### Fixed
+
+- Play command still unreliable after v2.6.47: `stream.once('data')` was putting the yt-dlp `Readable` into flowing mode before discord-player attached a consumer, causing dropped audio chunks. Replaced yt-dlp pipe (`spawn -o -`) with `execFile --get-url` to resolve the direct googlevideo URL and return it as a string — discord-player streams it via its own HTTP client. Updated tests to use closure-pattern mock. (#416)
+
 ## [2.6.49] - 2026-03-31
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.49",
+    "version": "2.6.50",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "1.0.0",
+    "version": "2.6.50",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "1.0.0",
+    "version": "2.6.50",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "1.0.0",
+    "version": "2.6.50",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "1.0.0",
+    "version": "2.6.50",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Version bump to v2.6.50
- Includes fix from #416: yt-dlp `--get-url` for reliable YouTube stream resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Play command reliability and streaming stability. Fixed stream initialization issues affecting playback since v2.6.47, delivering more consistent playback performance.

* **Chores**
  * Released version 2.6.50
  * Synchronized package versions across backend, bot, frontend, and shared modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->