### PR TITLE
fix(bot): restore yt-dlp pipe stream for youtube audio playback

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.spec.ts
@@ -57,73 +57,33 @@ describe('playerFactory', () => {
         })
     })
 
-    describe('yt-dlp --get-url command arguments', () => {
-        it('should use --get-url for direct stream URL resolution', () => {
+    describe('yt-dlp pipe command arguments', () => {
+        it('should pipe audio to stdout with bestaudio/best format', () => {
             const ytDlpArgs = [
                 '-f',
-                'bestaudio',
-                '--get-url',
+                'bestaudio/best',
+                '-o',
+                '-',
                 '--no-warnings',
-                '--no-check-certificates',
+                '--quiet',
             ]
 
-            expect(ytDlpArgs).toContain('bestaudio')
-            expect(ytDlpArgs).toContain('--get-url')
-            expect(ytDlpArgs).toContain('--no-check-certificates')
+            expect(ytDlpArgs).toContain('bestaudio/best')
+            expect(ytDlpArgs).toContain('-o')
+            expect(ytDlpArgs).toContain('-')
             expect(ytDlpArgs).toContain('--no-warnings')
         })
 
-        it('should use 30s timeout for URL resolution', () => {
-            const execOptions = { timeout: 30000 }
-            expect(execOptions.timeout).toBe(30000)
+        it('should use pipe stdio for stream output', () => {
+            const spawnOptions = { stdio: ['ignore', 'pipe', 'pipe'] as const }
+            expect(spawnOptions.stdio[0]).toBe('ignore')
+            expect(spawnOptions.stdio[1]).toBe('pipe')
+            expect(spawnOptions.stdio[2]).toBe('pipe')
         })
     })
 
-    describe('getYtDlpUrl fallback logic', () => {
-        it('should fall back to original URL when yt-dlp returns null', async () => {
-            const getYtDlpUrl = async (_url: string): Promise<null> => null
-
-            const createStream = async (track: {
-                url: string
-            }): Promise<string> => {
-                const url = track.url
-                const isYt =
-                    url.includes('youtube.com') || url.includes('youtu.be')
-                if (isYt) {
-                    const streamUrl = await getYtDlpUrl(url)
-                    if (streamUrl) return streamUrl
-                }
-                return url
-            }
-
-            const youtubeUrl = 'https://youtube.com/watch?v=abc'
-            const result = await createStream({ url: youtubeUrl })
-            expect(result).toBe(youtubeUrl)
-        })
-
-        it('should return direct googlevideo URL when yt-dlp succeeds', async () => {
-            const googlevideoUrl =
-                'https://rr3---sn.googlevideo.com/videoplayback?test=1'
-            const getYtDlpUrl = async (_url: string) => googlevideoUrl
-
-            const createStream = async (track: { url: string }) => {
-                const url = track.url
-                if (url.includes('youtube.com')) {
-                    const streamUrl = await getYtDlpUrl(url)
-                    if (streamUrl) return streamUrl
-                }
-                return url
-            }
-
-            const result = await createStream({
-                url: 'https://youtube.com/watch?v=abc',
-            })
-            expect(result).toBe(googlevideoUrl)
-        })
-
+    describe('createStream pipe logic', () => {
         it('should return URL directly for non-YouTube tracks', async () => {
-            const getYtDlpUrl = async (_url: string): Promise<null> => null
-
             const createStream = async (track: {
                 url: string
             }): Promise<string> => {
@@ -131,8 +91,7 @@ describe('playerFactory', () => {
                 const isYt =
                     url.includes('youtube.com') || url.includes('youtu.be')
                 if (isYt) {
-                    const streamUrl = await getYtDlpUrl(url)
-                    if (streamUrl) return streamUrl
+                    return 'pipe-stream' // would be proc.stdout
                 }
                 return url
             }
@@ -142,6 +101,21 @@ describe('playerFactory', () => {
             expect(
                 await createStream({ url: 'https://soundcloud.com/track' }),
             ).toBe('https://soundcloud.com/track')
+        })
+
+        it('should pipe YouTube URLs through yt-dlp', async () => {
+            const pipedUrls: string[] = []
+            const createStream = async (track: { url: string }) => {
+                const url = track.url
+                if (url.includes('youtube.com') || url.includes('youtu.be')) {
+                    pipedUrls.push(url)
+                    return {} // mock proc.stdout
+                }
+                return url
+            }
+
+            await createStream({ url: 'https://youtube.com/watch?v=abc' })
+            expect(pipedUrls).toContain('https://youtube.com/watch?v=abc')
         })
     })
 

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -1,12 +1,9 @@
-import { execFile } from 'child_process'
-import { promisify } from 'util'
 import { spawn } from 'child_process'
+import type { Readable } from 'stream'
 import { Player } from 'discord-player'
 import { DefaultExtractors } from '@discord-player/extractor'
 import type { CustomClient } from '../../types'
 import { errorLog, infoLog, warnLog, debugLog } from '@lucky/shared/utils'
-
-const execFileAsync = promisify(execFile)
 
 type CreatePlayerParams = {
     client: CustomClient
@@ -43,31 +40,23 @@ const registerExtractors = (player: Player): void => {
 const isYouTubeUrl = (url: string): boolean =>
     url.includes('youtube.com') || url.includes('youtu.be')
 
-const getYtDlpUrl = async (url: string): Promise<string | null> => {
-    try {
-        debugLog({ message: `yt-dlp resolving stream URL: ${url}` })
-        const { stdout } = await execFileAsync(
-            'yt-dlp',
-            [
-                '-f',
-                'bestaudio',
-                '--get-url',
-                '--no-warnings',
-                '--no-check-certificates',
-                url,
-            ],
-            { timeout: 30000 },
-        )
-        const streamUrl = stdout.trim().split('\n')[0] ?? ''
-        if (!streamUrl) return null
-        debugLog({ message: `yt-dlp resolved stream URL for: ${url}` })
-        return streamUrl
-    } catch {
-        warnLog({
-            message: `yt-dlp --get-url failed for ${url}, falling back to native IOS`,
-        })
-        return null
-    }
+const getYtDlpStream = (url: string): Readable => {
+    debugLog({ message: `yt-dlp piping audio stream: ${url}` })
+    const proc = spawn(
+        'yt-dlp',
+        ['-f', 'bestaudio/best', '-o', '-', '--no-warnings', '--quiet', url],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+
+    proc.stderr?.on('data', (data: Buffer) => {
+        warnLog({ message: `yt-dlp stderr: ${data.toString().trim()}` })
+    })
+
+    proc.on('error', (err) => {
+        errorLog({ message: 'yt-dlp process error:', error: err })
+    })
+
+    return proc.stdout as Readable
 }
 
 const checkYtDlpAvailability = (): Promise<boolean> => {
@@ -115,19 +104,12 @@ const loadYoutubeExtractor = async (player: Player): Promise<void> => {
                   createStream: async (
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
                       track: any,
-                  ): Promise<string> => {
+                  ): Promise<Readable | string> => {
                       const url = track?.url ?? String(track)
                       debugLog({ message: `createStream for: ${url}` })
-
                       if (isYouTubeUrl(url)) {
-                          const streamUrl = await getYtDlpUrl(url)
-                          if (streamUrl) return streamUrl
-
-                          warnLog({
-                              message: `yt-dlp failed for ${url}, falling back to native IOS streaming`,
-                          })
+                          return getYtDlpStream(url)
                       }
-
                       return url
                   },
               }
@@ -145,7 +127,7 @@ const loadYoutubeExtractor = async (player: Player): Promise<void> => {
 
         infoLog({
             message: ytDlpAvailable
-                ? 'Registered YoutubeiExtractor (yt-dlp primary, native IOS fallback)'
+                ? 'Registered YoutubeiExtractor (yt-dlp pipe primary, native IOS fallback)'
                 : 'Registered YoutubeiExtractor (native IOS client)',
         })
     } catch {

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -1,5 +1,4 @@
 const mockSpawn = jest.fn()
-const mockExecFile = jest.fn()
 
 jest.mock('discord-player', () => {
     const loadMulti = jest.fn().mockResolvedValue(undefined)
@@ -31,21 +30,7 @@ jest.mock('@lucky/shared/utils', () => ({
 }))
 
 jest.mock('child_process', () => ({
-    execFile: (...args: unknown[]) => mockExecFile(...args),
     spawn: (...args: unknown[]) => mockSpawn(...args),
-}))
-
-jest.mock('util', () => ({
-    ...jest.requireActual('util'),
-    promisify: jest.fn((fn: any) => {
-        return (...args: any[]) =>
-            new Promise((resolve, reject) => {
-                fn(...args, (err: any, result: any) => {
-                    if (err) reject(err)
-                    else resolve(result)
-                })
-            })
-    }),
 }))
 
 function createSpawnProcessMock(opts: { fireClose?: number } = {}) {
@@ -71,7 +56,6 @@ describe('playerFactory', () => {
     beforeEach(() => {
         jest.resetModules()
         mockSpawn.mockReset()
-        mockExecFile.mockReset()
         mockSpawn.mockImplementation((_cmd: unknown, args: string[]) => {
             if (Array.isArray(args) && args[0] === '--version') {
                 return createSpawnProcessMock({ fireClose: 0 })
@@ -101,19 +85,8 @@ describe('playerFactory', () => {
         })
     })
 
-    describe('yt-dlp URL resolution', () => {
-        it('uses execFile with --get-url for YouTube URLs', async () => {
-            const url = 'https://youtube.com/watch?v=abc123'
-            const streamUrl =
-                'https://rr3---sn.googlevideo.com/videoplayback?...'
-
-            mockExecFile.mockImplementation(
-                (_cmd: any, _args: any, _opts: any, cb: any) => {
-                    cb(null, { stdout: streamUrl + '\n', stderr: '' })
-                    return {} as any
-                },
-            )
-
+    describe('yt-dlp stream piping', () => {
+        it('spawns yt-dlp with pipe args for YouTube URLs', async () => {
             const { createPlayer } =
                 await import('../../../src/handlers/player/playerFactory')
 
@@ -130,54 +103,34 @@ describe('playerFactory', () => {
 
             const extractorOptions = player.extractors.register.mock
                 .calls[0][1] as {
-                createStream: (_track: unknown) => Promise<string>
-            }
-
-            const result = await extractorOptions.createStream({ url })
-
-            expect(result).toBe(streamUrl)
-            expect(mockExecFile).toHaveBeenCalledWith(
-                'yt-dlp',
-                expect.arrayContaining(['-f', 'bestaudio', '--get-url', url]),
-                expect.objectContaining({ timeout: 30000 }),
-                expect.any(Function),
-            )
-        })
-
-        it('falls back to original URL when yt-dlp --get-url fails', async () => {
-            mockExecFile.mockImplementation(
-                (_cmd: any, _args: any, _opts: any, cb: any) => {
-                    cb(new Error('yt-dlp failed'), null)
-                    return {} as any
-                },
-            )
-
-            const { createPlayer } =
-                await import('../../../src/handlers/player/playerFactory')
-
-            const player = createPlayer({
-                client: { user: { id: '123' } } as any,
-            }) as unknown as { extractors: { register: jest.Mock } }
-
-            for (let i = 0; i < 50; i++) {
-                if (player.extractors.register.mock.calls.length > 0) break
-                await new Promise((resolve) => setTimeout(resolve, 10))
-            }
-
-            const extractorOptions = player.extractors.register.mock
-                .calls[0][1] as {
-                createStream: (_track: unknown) => Promise<string>
+                createStream: (_track: unknown) => Promise<unknown>
             }
 
             const youtubeUrl = 'https://youtube.com/watch?v=abc123'
-            const result = await extractorOptions.createStream({
-                url: youtubeUrl,
-            })
+            await extractorOptions.createStream({ url: youtubeUrl })
 
-            expect(result).toBe(youtubeUrl)
+            expect(mockSpawn).toHaveBeenCalledWith(
+                'yt-dlp',
+                expect.arrayContaining([
+                    '-f',
+                    'bestaudio/best',
+                    '-o',
+                    '-',
+                    youtubeUrl,
+                ]),
+                expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
+            )
         })
 
-        it('returns non-YouTube URLs without calling yt-dlp', async () => {
+        it('returns proc.stdout as the stream for YouTube URLs', async () => {
+            const mockProc = createSpawnProcessMock()
+            mockSpawn.mockImplementation((_cmd: unknown, args: string[]) => {
+                if (Array.isArray(args) && args[0] === '--version') {
+                    return createSpawnProcessMock({ fireClose: 0 })
+                }
+                return mockProc
+            })
+
             const { createPlayer } =
                 await import('../../../src/handlers/player/playerFactory')
 
@@ -192,16 +145,44 @@ describe('playerFactory', () => {
 
             const extractorOptions = player.extractors.register.mock
                 .calls[0][1] as {
-                createStream: (_track: unknown) => Promise<string>
+                createStream: (_track: unknown) => Promise<unknown>
+            }
+
+            const result = await extractorOptions.createStream({
+                url: 'https://youtube.com/watch?v=abc123',
+            })
+
+            expect(result).toBe(mockProc.stdout)
+        })
+
+        it('returns non-YouTube URLs without spawning yt-dlp', async () => {
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+
+            const player = createPlayer({
+                client: { user: { id: '123' } } as any,
+            }) as unknown as { extractors: { register: jest.Mock } }
+
+            for (let i = 0; i < 50; i++) {
+                if (player.extractors.register.mock.calls.length > 0) break
+                await new Promise((resolve) => setTimeout(resolve, 10))
+            }
+
+            const extractorOptions = player.extractors.register.mock
+                .calls[0][1] as {
+                createStream: (_track: unknown) => Promise<unknown>
             }
 
             const spotifyUrl = 'https://open.spotify.com/track/abc'
+            const spawnCallsBefore = mockSpawn.mock.calls.length
+
             const result = await extractorOptions.createStream({
                 url: spotifyUrl,
             })
 
             expect(result).toBe(spotifyUrl)
-            expect(mockExecFile).not.toHaveBeenCalled()
+            // Only the --version check should have been spawned, not a new yt-dlp for non-YT URLs
+            expect(mockSpawn.mock.calls.length).toBe(spawnCallsBefore)
         })
     })
 })


### PR DESCRIPTION
## Summary

- Restores `getYtDlpStream()` which spawns `yt-dlp -f bestaudio/best -o -` and returns `proc.stdout` as a `Readable` directly to discord-player
- Removes the `--get-url` / `execFile` approach that returned a googlevideo URL string — this was already identified as broken in a prior commit ("fix: pipe yt-dlp audio stream instead of resolving url") and was accidentally re-introduced
- Keeps `checkYtDlpAvailability()` to fall back to native YoutubeiExtractor IOS client when yt-dlp is not installed

## Root Cause

discord-player's audio pipeline cannot reliably consume a raw googlevideo URL string passed from `createStream`. The pipe stream approach (returning `proc.stdout`) was the original working solution that was previously reverted without understanding why it worked.

## Test plan
- [ ] CI passes
- [ ] Bot plays audio in voice channel after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated audio streaming implementation for YouTube content, transitioning from traditional URL resolution-based approach to direct piped streaming architecture.

* **Tests**
  * Updated comprehensive test suite to properly validate the new streaming-based audio handling methodology and error conditions.

* **Bug Fixes**
  * Enhanced error handling, logging, and process stream management for the audio streaming pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->