### PR TITLE
fix(bot): drop yt-dlp, use native youtubei extractor ios client

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.spec.ts
@@ -43,97 +43,18 @@ describe('playerFactory', () => {
             expect(extractorOptions.streamOptions.highWaterMark).toBe(33554432)
         })
 
-        it('should omit createStream when yt-dlp is unavailable', () => {
-            const buildOptions = (ytDlpAvailable: boolean) =>
-                ytDlpAvailable
-                    ? {
-                          streamOptions: { useClient: 'IOS' as const },
-                          createStream: () => {},
-                      }
-                    : { streamOptions: { useClient: 'IOS' as const } }
-
-            expect(buildOptions(true)).toHaveProperty('createStream')
-            expect(buildOptions(false)).not.toHaveProperty('createStream')
-        })
-    })
-
-    describe('yt-dlp pipe command arguments', () => {
-        it('should pipe audio to stdout with bestaudio/best format', () => {
-            const ytDlpArgs = [
-                '-f',
-                'bestaudio/best',
-                '-o',
-                '-',
-                '--no-warnings',
-                '--quiet',
-            ]
-
-            expect(ytDlpArgs).toContain('bestaudio/best')
-            expect(ytDlpArgs).toContain('-o')
-            expect(ytDlpArgs).toContain('-')
-            expect(ytDlpArgs).toContain('--no-warnings')
-        })
-
-        it('should use pipe stdio for stream output', () => {
-            const spawnOptions = { stdio: ['ignore', 'pipe', 'pipe'] as const }
-            expect(spawnOptions.stdio[0]).toBe('ignore')
-            expect(spawnOptions.stdio[1]).toBe('pipe')
-            expect(spawnOptions.stdio[2]).toBe('pipe')
-        })
-    })
-
-    describe('createStream pipe logic', () => {
-        it('should return URL directly for non-YouTube tracks', async () => {
-            const createStream = async (track: {
-                url: string
-            }): Promise<string> => {
-                const url = track.url
-                const isYt =
-                    url.includes('youtube.com') || url.includes('youtu.be')
-                if (isYt) {
-                    return 'pipe-stream' // would be proc.stdout
-                }
-                return url
+        it('should not override createStream — rely on native IOS client', () => {
+            const extractorOptions: {
+                streamOptions: { useClient: 'IOS'; highWaterMark: number }
+                createStream?: unknown
+            } = {
+                streamOptions: {
+                    useClient: 'IOS' as const,
+                    highWaterMark: 1 << 25,
+                },
             }
 
-            const spotifyUrl = 'https://open.spotify.com/track/abc'
-            expect(await createStream({ url: spotifyUrl })).toBe(spotifyUrl)
-            expect(
-                await createStream({ url: 'https://soundcloud.com/track' }),
-            ).toBe('https://soundcloud.com/track')
-        })
-
-        it('should pipe YouTube URLs through yt-dlp', async () => {
-            const pipedUrls: string[] = []
-            const createStream = async (track: { url: string }) => {
-                const url = track.url
-                if (url.includes('youtube.com') || url.includes('youtu.be')) {
-                    pipedUrls.push(url)
-                    return {} // mock proc.stdout
-                }
-                return url
-            }
-
-            await createStream({ url: 'https://youtube.com/watch?v=abc' })
-            expect(pipedUrls).toContain('https://youtube.com/watch?v=abc')
-        })
-    })
-
-    describe('checkYtDlpAvailability', () => {
-        it('should resolve false when yt-dlp exits with non-zero code', async () => {
-            const simulateCheck = (exitCode: number): Promise<boolean> =>
-                new Promise((resolve) => resolve(exitCode === 0))
-
-            expect(await simulateCheck(0)).toBe(true)
-            expect(await simulateCheck(1)).toBe(false)
-            expect(await simulateCheck(127)).toBe(false)
-        })
-
-        it('should resolve false on process error', async () => {
-            const checkOnError = (): Promise<boolean> =>
-                new Promise((resolve) => resolve(false))
-
-            expect(await checkOnError()).toBe(false)
+            expect(extractorOptions.createStream).toBeUndefined()
         })
     })
 

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -1,9 +1,7 @@
-import { spawn } from 'child_process'
-import type { Readable } from 'stream'
 import { Player } from 'discord-player'
 import { DefaultExtractors } from '@discord-player/extractor'
 import type { CustomClient } from '../../types'
-import { errorLog, infoLog, warnLog, debugLog } from '@lucky/shared/utils'
+import { errorLog, infoLog, warnLog } from '@lucky/shared/utils'
 
 type CreatePlayerParams = {
     client: CustomClient
@@ -37,98 +35,20 @@ const registerExtractors = (player: Player): void => {
     })
 }
 
-const isYouTubeUrl = (url: string): boolean =>
-    url.includes('youtube.com') || url.includes('youtu.be')
-
-const getYtDlpStream = (url: string): Readable => {
-    debugLog({ message: `yt-dlp piping audio stream: ${url}` })
-    const proc = spawn(
-        'yt-dlp',
-        ['-f', 'bestaudio/best', '-o', '-', '--no-warnings', '--quiet', url],
-        { stdio: ['ignore', 'pipe', 'pipe'] },
-    )
-
-    proc.stderr?.on('data', (data: Buffer) => {
-        warnLog({ message: `yt-dlp stderr: ${data.toString().trim()}` })
-    })
-
-    proc.on('error', (err) => {
-        errorLog({ message: 'yt-dlp process error:', error: err })
-    })
-
-    return proc.stdout as Readable
-}
-
-const checkYtDlpAvailability = (): Promise<boolean> => {
-    return new Promise((resolve) => {
-        const proc = spawn('yt-dlp', ['--version'], { stdio: 'pipe' })
-        let done = false
-
-        const finish = (result: boolean): void => {
-            if (done) return
-            done = true
-            clearTimeout(timer)
-            resolve(result)
-        }
-
-        proc.on('close', (code) => finish(code === 0))
-        proc.on('error', () => finish(false))
-
-        const timer = setTimeout(() => {
-            proc.kill()
-            finish(false)
-        }, 3000)
-    })
-}
-
 const loadYoutubeExtractor = async (player: Player): Promise<void> => {
     try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const mod = (await import('discord-player-youtubei')) as any
 
-        const ytDlpAvailable = await checkYtDlpAvailability()
-
-        if (!ytDlpAvailable) {
-            warnLog({
-                message:
-                    'yt-dlp not available — using native YoutubeiExtractor IOS client',
-            })
-        }
-
-        const extractorOptions = ytDlpAvailable
-            ? {
-                  streamOptions: {
-                      useClient: 'IOS' as const,
-                      highWaterMark: 1 << 25,
-                  },
-                  createStream: async (
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      track: any,
-                  ): Promise<Readable | string> => {
-                      const url = track?.url ?? String(track)
-                      debugLog({ message: `createStream for: ${url}` })
-                      if (isYouTubeUrl(url)) {
-                          return getYtDlpStream(url)
-                      }
-                      return url
-                  },
-              }
-            : {
-                  streamOptions: {
-                      useClient: 'IOS' as const,
-                      highWaterMark: 1 << 25,
-                  },
-              }
-
-        await player.extractors.register(
-            mod.YoutubeiExtractor,
-            extractorOptions,
-        )
+        await player.extractors.register(mod.YoutubeiExtractor, {
+            streamOptions: {
+                useClient: 'IOS' as const,
+                highWaterMark: 1 << 25,
+            },
+        })
 
         infoLog({
-            message: ytDlpAvailable
-                ? 'Registered YoutubeiExtractor (yt-dlp pipe primary, native IOS fallback)'
-                : 'Registered YoutubeiExtractor (native IOS client)',
+            message: 'Registered YoutubeiExtractor (native IOS client)',
         })
     } catch {
         warnLog({

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -1,5 +1,3 @@
-const mockSpawn = jest.fn()
-
 jest.mock('discord-player', () => {
     const loadMulti = jest.fn().mockResolvedValue(undefined)
     const register = jest.fn().mockResolvedValue(undefined)
@@ -29,39 +27,9 @@ jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
 }))
 
-jest.mock('child_process', () => ({
-    spawn: (...args: unknown[]) => mockSpawn(...args),
-}))
-
-function createSpawnProcessMock(opts: { fireClose?: number } = {}) {
-    const listeners: Record<string, ((...args: unknown[]) => void)[]> = {}
-
-    const proc = {
-        stdout: { on: jest.fn(), destroy: jest.fn() },
-        stderr: { on: jest.fn() },
-        on: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
-            listeners[event] = listeners[event] ?? []
-            listeners[event].push(cb)
-            if (opts.fireClose !== undefined && event === 'close') {
-                Promise.resolve().then(() => cb(opts.fireClose))
-            }
-        }),
-        kill: jest.fn(),
-    }
-
-    return proc
-}
-
 describe('playerFactory', () => {
     beforeEach(() => {
         jest.resetModules()
-        mockSpawn.mockReset()
-        mockSpawn.mockImplementation((_cmd: unknown, args: string[]) => {
-            if (Array.isArray(args) && args[0] === '--version') {
-                return createSpawnProcessMock({ fireClose: 0 })
-            }
-            return createSpawnProcessMock()
-        })
     })
 
     describe('module exports', () => {
@@ -85,8 +53,8 @@ describe('playerFactory', () => {
         })
     })
 
-    describe('yt-dlp stream piping', () => {
-        it('spawns yt-dlp with pipe args for YouTube URLs', async () => {
+    describe('YoutubeiExtractor registration', () => {
+        it('registers YoutubeiExtractor with IOS client', async () => {
             const { createPlayer } =
                 await import('../../../src/handlers/player/playerFactory')
 
@@ -101,36 +69,12 @@ describe('playerFactory', () => {
 
             expect(player.extractors.register).toHaveBeenCalled()
 
-            const extractorOptions = player.extractors.register.mock
-                .calls[0][1] as {
-                createStream: (_track: unknown) => Promise<unknown>
-            }
-
-            const youtubeUrl = 'https://youtube.com/watch?v=abc123'
-            await extractorOptions.createStream({ url: youtubeUrl })
-
-            expect(mockSpawn).toHaveBeenCalledWith(
-                'yt-dlp',
-                expect.arrayContaining([
-                    '-f',
-                    'bestaudio/best',
-                    '-o',
-                    '-',
-                    youtubeUrl,
-                ]),
-                expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
-            )
+            const [, options] = player.extractors.register.mock.calls[0]
+            expect(options.streamOptions.useClient).toBe('IOS')
+            expect(options.streamOptions.highWaterMark).toBe(1 << 25)
         })
 
-        it('returns proc.stdout as the stream for YouTube URLs', async () => {
-            const mockProc = createSpawnProcessMock()
-            mockSpawn.mockImplementation((_cmd: unknown, args: string[]) => {
-                if (Array.isArray(args) && args[0] === '--version') {
-                    return createSpawnProcessMock({ fireClose: 0 })
-                }
-                return mockProc
-            })
-
+        it('does not set a custom createStream override', async () => {
             const { createPlayer } =
                 await import('../../../src/handlers/player/playerFactory')
 
@@ -143,46 +87,8 @@ describe('playerFactory', () => {
                 await new Promise((resolve) => setTimeout(resolve, 10))
             }
 
-            const extractorOptions = player.extractors.register.mock
-                .calls[0][1] as {
-                createStream: (_track: unknown) => Promise<unknown>
-            }
-
-            const result = await extractorOptions.createStream({
-                url: 'https://youtube.com/watch?v=abc123',
-            })
-
-            expect(result).toBe(mockProc.stdout)
-        })
-
-        it('returns non-YouTube URLs without spawning yt-dlp', async () => {
-            const { createPlayer } =
-                await import('../../../src/handlers/player/playerFactory')
-
-            const player = createPlayer({
-                client: { user: { id: '123' } } as any,
-            }) as unknown as { extractors: { register: jest.Mock } }
-
-            for (let i = 0; i < 50; i++) {
-                if (player.extractors.register.mock.calls.length > 0) break
-                await new Promise((resolve) => setTimeout(resolve, 10))
-            }
-
-            const extractorOptions = player.extractors.register.mock
-                .calls[0][1] as {
-                createStream: (_track: unknown) => Promise<unknown>
-            }
-
-            const spotifyUrl = 'https://open.spotify.com/track/abc'
-            const spawnCallsBefore = mockSpawn.mock.calls.length
-
-            const result = await extractorOptions.createStream({
-                url: spotifyUrl,
-            })
-
-            expect(result).toBe(spotifyUrl)
-            // Only the --version check should have been spawned, not a new yt-dlp for non-YT URLs
-            expect(mockSpawn.mock.calls.length).toBe(spawnCallsBefore)
+            const [, options] = player.extractors.register.mock.calls[0]
+            expect(options.createStream).toBeUndefined()
         })
     })
 })


### PR DESCRIPTION
## Summary

- Drops all yt-dlp pipe/URL stream logic from `playerFactory.ts`
- Registers `YoutubeiExtractor` with only `streamOptions: { useClient: 'IOS', highWaterMark: 32MB }`
- The native IOS client uses YouTube's iOS app InnerTube API — a completely different code path that is not affected by YouTube's bot-detection on the server IP

## Root Cause

`yt-dlp` was throwing `Sign in to confirm you're not a bot` for the server's IP. The pipe stream returned empty data, causing the player to "play" silence until the empty stream ended (~1 min), then leave.

The native `discord-player-youtubei` IOS client does not use `yt-dlp` — it authenticates as the YouTube iOS app which bypasses this restriction.

## Test plan
- [ ] CI passes
- [ ] Bot plays audio after deploy