### PR TITLE
fix(bot): pass match.url to playdl.stream() for SoundCloud TS2345

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -110,7 +110,7 @@ async function streamViaSoundCloud(track: {
         )
     }
 
-    const scStream = await playdl.stream(match)
+    const scStream = await playdl.stream(match.url)
     return scStream.stream
 }
 


### PR DESCRIPTION
## Summary

- Fixes `TS2345: Argument of type 'SoundCloudTrack' is not assignable to parameter of type 'string'` in `playerFactory.ts:113`
- `playdl.stream()` expects a URL string; was passing the `SoundCloudTrack` object directly
- Fix: `playdl.stream(match.url)` — uses the `url` property on `SoundCloudTrack`

## Root cause

Introduced in v2.6.54 (`fix(bot): SoundCloud audio bridge`) — the `match` variable from `playdl.search()` returns `SoundCloudTrack[]`, but `playdl.stream()` requires a string URL.

## Test plan

- [ ] CI type-check passes
- [ ] CI unit tests pass
- [ ] SoundCloud playback still works in the bot