### PR TITLE
fix(ci): correct SonarCloud project key from NexusBot to Lucky

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=LucasSantana-Dev_NexusBot
+sonar.projectKey=LucasSantana-Dev_Lucky
 sonar.organization=lucassantana-dev
 sonar.projectName=Lucky
 


### PR DESCRIPTION
## Summary

- `sonar-project.properties` had `projectKey=LucasSantana-Dev_NexusBot` — pointing at the wrong SonarCloud project
- SonarCloud was evaluating Lucky's PRs against NexusBot's quality gates (33 security hotspots, C reliability rating)
- Fix: `projectKey=LucasSantana-Dev_Lucky`

## Test plan

- [ ] CI passes
- [ ] SonarCloud Code Analysis check passes on next PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration for code quality analysis tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->