### PR TITLE
fix(bot): defer-first in play command and guard deferReply against 40060

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.57] - 2026-04-01
+
+### Fixed
+
+- **play command interaction timeout**: Moved `deferReply()` to the top of the play command's `execute` before any validation checks, and converted early-exit `reply()` calls to `editReply()`. Prevents `DiscordAPIError[10062]` when pre-checks run after the 3-second window (LUCKY-1Y).
+- **Interaction already acknowledged race condition**: Wrapped `deferReply()` in `handleChatInputCommand` and `handleOtherInteraction` (`interactionReply.ts`) in a try-catch so concurrent or duplicate acknowledgement attempts (40060) are silently discarded instead of throwing (LUCKY-23).
+
 ## [2.6.56] - 2026-03-31
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.52",
+    "version": "2.6.57",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.56",
+    "version": "2.6.57",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -113,8 +113,9 @@ describe('play command', () => {
             interaction,
         } as any)
 
-        expect(interaction.reply).toHaveBeenCalledWith(
-            expect.objectContaining({ ephemeral: true }),
+        expect(interaction.deferReply).toHaveBeenCalled()
+        expect(interaction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({ embeds: expect.any(Array) }),
         )
         expect(requireVoiceChannelMock).not.toHaveBeenCalled()
     })
@@ -131,10 +132,10 @@ describe('play command', () => {
             interaction,
         } as any)
 
-        expect(interaction.reply).toHaveBeenCalledWith(
-            expect.objectContaining({ ephemeral: true }),
+        expect(interaction.deferReply).toHaveBeenCalled()
+        expect(interaction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({ embeds: expect.any(Array) }),
         )
-        expect(interaction.deferReply).not.toHaveBeenCalled()
     })
 
     it('plays track and records contribution', async () => {
@@ -214,7 +215,7 @@ describe('play command', () => {
             interaction,
         } as any)
 
-        expect(interaction.deferReply).not.toHaveBeenCalled()
+        expect(interaction.deferReply).toHaveBeenCalled()
         expect(interaction.editReply).not.toHaveBeenCalled()
     })
 

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -47,15 +47,16 @@ export default new Command({
         client,
         interaction,
     }: CommandExecuteParams): Promise<void> => {
+        await interaction.deferReply()
+
         if (!interaction.guildId) {
-            await interaction.reply({
+            await interaction.editReply({
                 embeds: [
                     createErrorEmbed(
                         'Error',
                         'This command can only be used in a server',
                     ),
                 ],
-                ephemeral: true,
             })
             return
         }
@@ -73,19 +74,16 @@ export default new Command({
             1,
         )
         if (!collaborativeCheck.allowed) {
-            await interaction.reply({
+            await interaction.editReply({
                 embeds: [
                     createErrorEmbed(
                         'Contribution limit reached',
                         `Collaborative mode limit reached (${collaborativeCheck.limit} track requests per user).`,
                     ),
                 ],
-                ephemeral: true,
             })
             return
         }
-
-        await interaction.deferReply()
 
         try {
             const result = await client.player.play(voiceChannel, query, {

--- a/packages/bot/src/utils/general/interactionReply.ts
+++ b/packages/bot/src/utils/general/interactionReply.ts
@@ -83,14 +83,22 @@ async function handleChatInputCommand(
     const processedContent = convertTextToEmbed(content)
 
     if (!interaction.deferred && !interaction.replied) {
-        await interaction.deferReply({
-            flags: processedContent.ephemeral ? 64 : undefined, // 64 is the ephemeral flag
-        })
+        try {
+            await interaction.deferReply({
+                flags: processedContent.ephemeral ? 64 : undefined,
+            })
+        } catch {
+            return
+        }
     }
-    if (interaction.replied) {
-        await interaction.followUp(stripFlags(processedContent))
-    } else {
-        await interaction.editReply(stripFlags(processedContent))
+    try {
+        if (interaction.replied) {
+            await interaction.followUp(stripFlags(processedContent))
+        } else {
+            await interaction.editReply(stripFlags(processedContent))
+        }
+    } catch {
+        // interaction expired or already cleaned up
     }
 }
 
@@ -108,14 +116,22 @@ async function handleOtherInteraction(
     const processedContent = convertTextToEmbed(content)
 
     if (!interaction.deferred && !interaction.replied) {
-        await interaction.deferReply({
-            flags: processedContent.ephemeral ? 64 : undefined,
-        })
+        try {
+            await interaction.deferReply({
+                flags: processedContent.ephemeral ? 64 : undefined,
+            })
+        } catch {
+            return
+        }
     }
-    if (interaction.replied) {
-        await interaction.followUp(stripFlags(processedContent))
-    } else {
-        await interaction.editReply(stripFlags(processedContent))
+    try {
+        if (interaction.replied) {
+            await interaction.followUp(stripFlags(processedContent))
+        } else {
+            await interaction.editReply(stripFlags(processedContent))
+        }
+    } catch {
+        // interaction expired or already cleaned up
     }
 }
 


### PR DESCRIPTION
## Summary
- Move `deferReply()` to the top of play command `execute`, before guildId/voice/collaborative checks. Converts early-exit `reply()` to `editReply()`. Fixes LUCKY-1Y (Unknown interaction on early exits).
- Wrap `deferReply()` in `handleChatInputCommand` and `handleOtherInteraction` in a try-catch — if the interaction is already acknowledged (40060) or expired (10062), we silently return instead of throwing. Fixes LUCKY-23.

## Test plan
- [ ] CI passes
- [ ] `/play` command responds even when user is not in a voice channel
- [ ] No more `DiscordAPIError[40060]` in Sentry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed play command to properly acknowledge Discord interactions within the required time window by deferring responses at the start of execution, before validation checks.
  * Resolved interaction acknowledgement race conditions that could result in duplicate or failed responses in concurrent command scenarios, improving reliability when handling simultaneous interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->