### PR TITLE
chore: remove netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[build]
-  base = "."
-  command = "npm ci --legacy-peer-deps --ignore-scripts && npm run db:generate && npm run build --workspace=packages/frontend"
-  publish = "packages/frontend/dist"
-
-[build.environment]
-  NODE_VERSION = "22"


### PR DESCRIPTION
## Summary
- Remove `netlify.toml` — deployment uses Vercel (frontend) and homelab (backend/bot). Netlify config is stale and misleading.
- `vercel.json` is kept as it is the active frontend deployment config.

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed build configuration settings from deployment setup, including build context, build command, publish directory specification, and Node.js version configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->