### PR TITLE
fix(shared): capture all error logs in Sentry and fix error serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.58] - 2026-04-01
+
+### Fixed
+
+- **Sentry error logging**: `errorLog({ message })` without an `error` object now calls `captureMessage` so all error-level logs reach Sentry. Previously only calls with an attached `Error` object were captured.
+- **Sentry exception context**: `params.message` and `params.data` are now passed as `extras` on every `captureException` call so Sentry events include the log message alongside the stack trace.
+- **Error serialization in console**: Replaced `JSON.stringify(error)` (which returns `{}` for native `Error` objects) with a `serializeError` helper that extracts `name`, `message`, and `stack`.
+
 ## [2.6.57] - 2026-04-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.57",
+    "version": "2.6.58",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.57",
+    "version": "2.6.58",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/shared/src/utils/general/log/service.ts
+++ b/packages/shared/src/utils/general/log/service.ts
@@ -1,7 +1,27 @@
 /* eslint-disable no-console */
 import chalk from 'chalk'
-import { addBreadcrumb, captureException } from '../../monitoring'
+import {
+    addBreadcrumb,
+    captureException,
+    captureMessage,
+} from '../../monitoring'
 import type { LogLevelType, LogParams, LogConfig } from './types'
+
+function serializeError(err: unknown): string {
+    if (err instanceof Error) {
+        return `${err.name}: ${err.message}\n${err.stack ?? ''}`
+    }
+    try {
+        return JSON.stringify(err, null, 2)
+    } catch {
+        return String(err)
+    }
+}
+
+function toError(err: unknown): Error {
+    if (err instanceof Error) return err
+    return new Error(typeof err === 'string' ? err : JSON.stringify(err))
+}
 
 /**
  * Log service
@@ -73,15 +93,20 @@ export class LogService {
         }
 
         if (params.error) {
-            console.error(color(JSON.stringify(params.error, null, 2)))
+            console.error(color(serializeError(params.error)))
         }
     }
 
     error(params: LogParams): void {
         this.log(0, params)
 
+        const extras: Record<string, unknown> = { message: params.message }
+        if (params.data) extras.data = params.data
+
         if (params.error) {
-            captureException(params.error as Error)
+            captureException(toError(params.error), extras)
+        } else {
+            captureMessage(params.message, 'error', extras)
         }
 
         addBreadcrumb('error', params.message, 'error')


### PR DESCRIPTION
## Summary
- `errorLog({ message })` without an `error` object now calls `captureMessage('error')` so every error-level log reaches Sentry — previously these were silently dropped
- `params.message` and `params.data` are passed as `extras` on `captureException` so Sentry events include the log message alongside the stack trace
- Replaced `JSON.stringify(error)` in console output with a `serializeError` helper that extracts `name`, `message`, and `stack` from native `Error` objects (which return `{}` from JSON.stringify)

## Test plan
- [ ] CI passes
- [ ] Error-level logs without an attached Error object appear in Sentry
- [ ] Sentry exception events include the originating log message in `extras`