### PR TITLE
fix(docker): move NOSONAR comment above FROM instruction

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -20,7 +20,8 @@ COPY packages/shared ./packages/shared
 
 RUN npm run build --workspace=packages/frontend
 
-FROM nginx:alpine # NOSONAR: nginx requires root to bind port 80
+# NOSONAR: nginx requires root to bind port 80
+FROM nginx:alpine
 
 COPY --from=builder /app/packages/frontend/dist /usr/share/nginx/html
 COPY nginx/frontend.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,4 +1,5 @@
-FROM nginx:alpine # NOSONAR: nginx requires root to bind port 80
+# NOSONAR: nginx requires root to bind port 80
+FROM nginx:alpine
 
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
## Summary
Docker's parser does not allow inline comments after `FROM` — `FROM nginx:alpine # comment` causes "FROM requires either one or three arguments". Moved the NOSONAR comment to a separate line above `FROM` in both `Dockerfile.frontend` and `Dockerfile.nginx`.

## Test plan
- [ ] CI `Build & Push Docker Images` passes for frontend and nginx targets