### PR TITLE
ci(deploy): wait for docker-publish before firing homelab webhook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        permissions:
+            actions: read
         if: >
             github.event_name == 'workflow_dispatch' ||
             github.event_name == 'push'
@@ -31,6 +33,7 @@ jobs:
             - name: Wait for Docker images
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_PAGER: cat
               run: |
                   set -euo pipefail
                   commit_sha="${{ github.sha }}"
@@ -40,17 +43,28 @@ jobs:
 
                   echo "==> Checking if docker-publish is running for ${commit_sha}..."
 
-                  run_info=$(gh run list \
-                    --repo "${{ github.repository }}" \
-                    --workflow=docker-publish.yml \
-                    --json headSha,status,conclusion,databaseId \
-                    --limit 10 \
-                    | jq -r --arg sha "$commit_sha" \
-                      '.[] | select(.headSha == $sha) | "\(.databaseId) \(.status) \(.conclusion)"' \
-                    | head -1)
+                  # Poll up to 60s for docker-publish to appear (it may not be queued yet)
+                  detect_elapsed=0
+                  detect_max=60
+                  detect_interval=5
+                  run_info=""
+                  while [ $detect_elapsed -lt $detect_max ]; do
+                    run_info=$(gh run list \
+                      --repo "${{ github.repository }}" \
+                      --workflow=docker-publish.yml \
+                      --json headSha,status,conclusion,databaseId \
+                      --limit 10 \
+                      | jq -r --arg sha "$commit_sha" \
+                        '.[] | select(.headSha == $sha) | "\(.databaseId) \(.status) \(.conclusion)"' \
+                      | head -1)
+                    [ -n "$run_info" ] && break
+                    echo "  No docker-publish run yet, waiting ${detect_interval}s... (${detect_elapsed}s elapsed)"
+                    sleep $detect_interval
+                    detect_elapsed=$((detect_elapsed + detect_interval))
+                  done
 
                   if [ -z "$run_info" ]; then
-                    echo "==> No docker-publish run for this commit — proceeding immediately."
+                    echo "==> No docker-publish run for this commit after ${detect_max}s — proceeding immediately."
                     exit 0
                   fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,76 @@ jobs:
                     exit 1
                   fi
 
+            - name: Wait for Docker images
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  commit_sha="${{ github.sha }}"
+                  max_wait=600
+                  interval=15
+                  elapsed=0
+
+                  echo "==> Checking if docker-publish is running for ${commit_sha}..."
+
+                  run_info=$(gh run list \
+                    --repo "${{ github.repository }}" \
+                    --workflow=docker-publish.yml \
+                    --json headSha,status,conclusion,databaseId \
+                    --limit 10 \
+                    | jq -r --arg sha "$commit_sha" \
+                      '.[] | select(.headSha == $sha) | "\(.databaseId) \(.status) \(.conclusion)"' \
+                    | head -1)
+
+                  if [ -z "$run_info" ]; then
+                    echo "==> No docker-publish run for this commit — proceeding immediately."
+                    exit 0
+                  fi
+
+                  run_id=$(echo "$run_info" | awk '{print $1}')
+                  status=$(echo "$run_info" | awk '{print $2}')
+                  conclusion=$(echo "$run_info" | awk '{print $3}')
+
+                  if [ "$status" = "completed" ]; then
+                    if [ "$conclusion" = "success" ]; then
+                      echo "==> Docker images already built successfully."
+                      exit 0
+                    else
+                      echo "::error::docker-publish failed (conclusion=$conclusion) — aborting deploy"
+                      exit 1
+                    fi
+                  fi
+
+                  echo "==> Docker build in progress (run $run_id), waiting up to ${max_wait}s..."
+
+                  while [ $elapsed -lt $max_wait ]; do
+                    sleep $interval
+                    elapsed=$((elapsed + interval))
+
+                    run_info=$(gh run view "$run_id" \
+                      --repo "${{ github.repository }}" \
+                      --json status,conclusion \
+                      --jq '"\(.status) \(.conclusion)"')
+
+                    status=$(echo "$run_info" | awk '{print $1}')
+                    conclusion=$(echo "$run_info" | awk '{print $2}')
+
+                    echo "  Docker build: $status (${elapsed}s elapsed)"
+
+                    if [ "$status" = "completed" ]; then
+                      if [ "$conclusion" = "success" ]; then
+                        echo "==> Docker images ready!"
+                        exit 0
+                      else
+                        echo "::error::docker-publish failed (conclusion=$conclusion) — aborting deploy"
+                        exit 1
+                      fi
+                    fi
+                  done
+
+                  echo "::error::Timed out waiting for Docker images after ${max_wait}s"
+                  exit 1
+
             - name: Trigger deploy webhook
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}


### PR DESCRIPTION
## Problem

`deploy.yml` and `docker-publish.yml` both trigger on `push` to main and run **in parallel**. The deploy job fires the homelab webhook ~4 seconds after the push, while Docker images take 2–6 minutes to build. `deploy.sh` then runs `docker pull latest` and gets stale images — homelab never receives the new code.

**Timeline from the last push:**
| Event | Time (UTC) |
|-------|-----------|
| Webhook fired | 02:32:51Z |
| nginx image ready | 02:33:16Z (+25s) |
| frontend image ready | 02:34:46Z (+2m) |
| bot image ready | 02:37:48Z (+5m) |
| backend image ready | 02:38:21Z (+5.5m) |

## Fix

Add a **"Wait for Docker images"** step in `deploy.yml` (before the webhook trigger) that:

1. Checks if `docker-publish.yml` is running for the same commit SHA via the GitHub API
2. If not found → no Docker changes in this push, proceeds immediately
3. If in progress → polls every 15s until completed (up to 10 min timeout)
4. If docker-publish failed → aborts the deploy to avoid deploying with broken images

## Behavior

- Pushes with Docker changes: deploy waits ~5min for images, then fires webhook with fresh `latest` tags
- Pushes without Docker changes (docs, config, etc.): deploy fires immediately as before
- `workflow_dispatch`: no docker-publish run for that SHA → fires immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment pipeline now waits for Docker image publishing to complete before deploying, polling for completion and proceeding only when the publish succeeds.
  * Deployment will abort if image publishing fails or times out, reducing failed releases.
  * Workflow permissions tightened to use a more restricted token scope for safer pipeline operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->