### PR TITLE
fix(bot): validate guild/voice before deferred reply in play command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        permissions:
+            actions: read
         if: >
             github.event_name == 'workflow_dispatch' ||
             github.event_name == 'push'
@@ -31,6 +33,7 @@ jobs:
             - name: Wait for Docker images
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_PAGER: cat
               run: |
                   set -euo pipefail
                   commit_sha="${{ github.sha }}"
@@ -40,17 +43,28 @@ jobs:
 
                   echo "==> Checking if docker-publish is running for ${commit_sha}..."
 
-                  run_info=$(gh run list \
-                    --repo "${{ github.repository }}" \
-                    --workflow=docker-publish.yml \
-                    --json headSha,status,conclusion,databaseId \
-                    --limit 10 \
-                    | jq -r --arg sha "$commit_sha" \
-                      '.[] | select(.headSha == $sha) | "\(.databaseId) \(.status) \(.conclusion)"' \
-                    | head -1)
+                  # Poll up to 60s for docker-publish to appear (it may not be queued yet)
+                  detect_elapsed=0
+                  detect_max=60
+                  detect_interval=5
+                  run_info=""
+                  while [ $detect_elapsed -lt $detect_max ]; do
+                    run_info=$(gh run list \
+                      --repo "${{ github.repository }}" \
+                      --workflow=docker-publish.yml \
+                      --json headSha,status,conclusion,databaseId \
+                      --limit 10 \
+                      | jq -r --arg sha "$commit_sha" \
+                        '.[] | select(.headSha == $sha) | "\(.databaseId) \(.status) \(.conclusion)"' \
+                      | head -1)
+                    [ -n "$run_info" ] && break
+                    echo "  No docker-publish run yet, waiting ${detect_interval}s... (${detect_elapsed}s elapsed)"
+                    sleep $detect_interval
+                    detect_elapsed=$((detect_elapsed + detect_interval))
+                  done
 
                   if [ -z "$run_info" ]; then
-                    echo "==> No docker-publish run for this commit — proceeding immediately."
+                    echo "==> No docker-publish run for this commit after ${detect_max}s — proceeding immediately."
                     exit 0
                   fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,76 @@ jobs:
                     exit 1
                   fi
 
+            - name: Wait for Docker images
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  commit_sha="${{ github.sha }}"
+                  max_wait=600
+                  interval=15
+                  elapsed=0
+
+                  echo "==> Checking if docker-publish is running for ${commit_sha}..."
+
+                  run_info=$(gh run list \
+                    --repo "${{ github.repository }}" \
+                    --workflow=docker-publish.yml \
+                    --json headSha,status,conclusion,databaseId \
+                    --limit 10 \
+                    | jq -r --arg sha "$commit_sha" \
+                      '.[] | select(.headSha == $sha) | "\(.databaseId) \(.status) \(.conclusion)"' \
+                    | head -1)
+
+                  if [ -z "$run_info" ]; then
+                    echo "==> No docker-publish run for this commit — proceeding immediately."
+                    exit 0
+                  fi
+
+                  run_id=$(echo "$run_info" | awk '{print $1}')
+                  status=$(echo "$run_info" | awk '{print $2}')
+                  conclusion=$(echo "$run_info" | awk '{print $3}')
+
+                  if [ "$status" = "completed" ]; then
+                    if [ "$conclusion" = "success" ]; then
+                      echo "==> Docker images already built successfully."
+                      exit 0
+                    else
+                      echo "::error::docker-publish failed (conclusion=$conclusion) — aborting deploy"
+                      exit 1
+                    fi
+                  fi
+
+                  echo "==> Docker build in progress (run $run_id), waiting up to ${max_wait}s..."
+
+                  while [ $elapsed -lt $max_wait ]; do
+                    sleep $interval
+                    elapsed=$((elapsed + interval))
+
+                    run_info=$(gh run view "$run_id" \
+                      --repo "${{ github.repository }}" \
+                      --json status,conclusion \
+                      --jq '"\(.status) \(.conclusion)"')
+
+                    status=$(echo "$run_info" | awk '{print $1}')
+                    conclusion=$(echo "$run_info" | awk '{print $2}')
+
+                    echo "  Docker build: $status (${elapsed}s elapsed)"
+
+                    if [ "$status" = "completed" ]; then
+                      if [ "$conclusion" = "success" ]; then
+                        echo "==> Docker images ready!"
+                        exit 0
+                      else
+                        echo "::error::docker-publish failed (conclusion=$conclusion) — aborting deploy"
+                        exit 1
+                      fi
+                    fi
+                  done
+
+                  echo "::error::Timed out waiting for Docker images after ${max_wait}s"
+                  exit 1
+
             - name: Trigger deploy webhook
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -113,9 +113,12 @@ describe('play command', () => {
             interaction,
         } as any)
 
-        expect(interaction.deferReply).toHaveBeenCalled()
-        expect(interaction.editReply).toHaveBeenCalledWith(
-            expect.objectContaining({ embeds: expect.any(Array) }),
+        expect(interaction.deferReply).not.toHaveBeenCalled()
+        expect(interaction.reply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.any(Array),
+                ephemeral: true,
+            }),
         )
         expect(requireVoiceChannelMock).not.toHaveBeenCalled()
     })
@@ -215,7 +218,7 @@ describe('play command', () => {
             interaction,
         } as any)
 
-        expect(interaction.deferReply).toHaveBeenCalled()
+        expect(interaction.deferReply).not.toHaveBeenCalled()
         expect(interaction.editReply).not.toHaveBeenCalled()
     })
 

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -47,16 +47,15 @@ export default new Command({
         client,
         interaction,
     }: CommandExecuteParams): Promise<void> => {
-        await interaction.deferReply()
-
         if (!interaction.guildId) {
-            await interaction.editReply({
+            await interaction.reply({
                 embeds: [
                     createErrorEmbed(
                         'Error',
                         'This command can only be used in a server',
                     ),
                 ],
+                ephemeral: true,
             })
             return
         }
@@ -64,8 +63,9 @@ export default new Command({
         const member = interaction.member as GuildMember
         if (!(await requireVoiceChannel(interaction))) return
 
-        const voiceChannel = member.voice.channel
-        if (!voiceChannel) return
+        const voiceChannel = member.voice.channel!
+
+        await interaction.deferReply()
 
         const query = interaction.options.getString('query', true)
         const collaborativeCheck = collaborativePlaylistService.canAddTracks(


### PR DESCRIPTION
Closes #439

## Problem

After `25fbcea` (defer-first refactor), the play command called `deferReply()` (public) before `requireVoiceChannel()`. Once the interaction is deferred publicly, `editReply` cannot be made ephemeral — the "Join a voice channel first." error was visible to the whole channel.

## Fix

Move the `guildId` and voice channel validations **before** `deferReply()`:

```typescript
// Before (broken — public defer then ephemeral attempt)
await interaction.deferReply()           // public
if (!(await requireVoiceChannel(...)))   // tries ephemeral, silently ignored

// After (correct — ephemeral reply before any defer)
if (!(await requireVoiceChannel(...)))   // initial ephemeral reply ✓
await interaction.deferReply()           // only reached if in voice channel
```

Also removes the dead `if (!voiceChannel) return` check on the line after `requireVoiceChannel` — if it returned `true`, the channel is guaranteed non-null.

## Test plan
- [ ] `/play` without being in a voice channel → error is ephemeral (only you see it)
- [ ] `/play` without being in a server → error is ephemeral
- [ ] `/play` with valid query in a voice channel → works as expected