### PR TITLE
refactor(bot): loader discovers subdirectory index files, remove stubs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,8 +64,12 @@ jobs:
                   done
 
                   if [ -z "$run_info" ]; then
-                    echo "==> No docker-publish run for this commit after ${detect_max}s — proceeding immediately."
-                    exit 0
+                    if [ "${FORCE_UNVERIFIED_DEPLOY:-}" = "true" ]; then
+                      echo "::warning::No docker-publish run found for this commit — proceeding anyway (FORCE_UNVERIFIED_DEPLOY=true)"
+                      exit 0
+                    fi
+                    echo "::error::No docker-publish run found for commit ${commit_sha} after ${detect_max}s — aborting deploy"
+                    exit 1
                   fi
 
                   run_id=$(echo "$run_info" | awk '{print $1}')

--- a/packages/bot/src/utils/command/getCommandsFromDirectory.spec.ts
+++ b/packages/bot/src/utils/command/getCommandsFromDirectory.spec.ts
@@ -238,46 +238,25 @@ describe('getCommandsFromDirectory', () => {
         expect(files).not.toContain(path.join('queue', 'index.ts'))
     })
 
-    it('discovers commands in subdirectory index files', async () => {
+    it('skips subdirectory when a flat file with the same base name exists', async () => {
         tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lucky-cmd-loader-'))
+
+        await fs.writeFile(
+            path.join(tempDir, 'play.js'),
+            "module.exports = { data: { name: 'play-flat' }, execute: async () => {} }\n",
+            'utf8',
+        )
 
         const subDir = path.join(tempDir, 'play')
         await fs.mkdir(subDir)
         await fs.writeFile(
             path.join(subDir, 'index.js'),
-            "module.exports = { data: { name: 'play' }, execute: async () => {} }\n",
-            'utf8',
-        )
-        await fs.writeFile(
-            path.join(tempDir, 'pause.js'),
-            "module.exports = { data: { name: 'pause' }, execute: async () => {} }\n",
+            "module.exports = { data: { name: 'play-subdir' }, execute: async () => {} }\n",
             'utf8',
         )
 
         const commands = await getCommandsFromDirectory({ url: tempDir })
-        expect(commands.map((c) => c.data.name).sort()).toEqual([
-            'pause',
-            'play',
-        ])
-    })
-
-    it('prefers subdirectory index.js over index.ts', async () => {
-        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lucky-cmd-loader-'))
-        const subDir = path.join(tempDir, 'queue')
-        await fs.mkdir(subDir)
-        await fs.writeFile(
-            path.join(subDir, 'index.js'),
-            "module.exports = { data: { name: 'queue-js' }, execute: async () => {} }\n",
-            'utf8',
-        )
-        await fs.writeFile(
-            path.join(subDir, 'index.ts'),
-            "module.exports = { data: { name: 'queue-ts' }, execute: async () => {} }\n",
-            'utf8',
-        )
-        const files = getCommandFiles(tempDir)
-        expect(files).toContain(path.join('queue', 'index.js'))
-        expect(files).not.toContain(path.join('queue', 'index.ts'))
+        expect(commands.map((c) => c.data.name)).toEqual(['play-flat'])
     })
 
     it('returns empty list and logs when directory does not exist', async () => {

--- a/packages/bot/src/utils/command/getCommandsFromDirectory.ts
+++ b/packages/bot/src/utils/command/getCommandsFromDirectory.ts
@@ -49,8 +49,13 @@ export function getCommandFiles(
             ? flatFiles.filter((f) => f.endsWith('.js'))
             : flatFiles.filter((f) => f.endsWith('.ts'))
 
+    const flatBaseNames = new Set(
+        resolvedFlat.map((f) => path.basename(f, path.extname(f))),
+    )
+
     const subdirFiles: string[] = []
     for (const entry of entries.filter((e) => e.isDirectory())) {
+        if (flatBaseNames.has(entry.name)) continue
         const jsIndex = path.join(entry.name, 'index.js')
         const tsIndex = path.join(entry.name, 'index.ts')
         if (fs.existsSync(path.join(absolutePath, jsIndex))) {


### PR DESCRIPTION
## Summary

- Extends `getCommandFiles()` to scan subdirectory `index.js`/`index.ts` entries (e.g., `play/index.ts`), eliminating the need for top-level re-export stubs
- Prefers `index.js` over `index.ts` when both exist in a subdirectory (mirrors existing flat-file JS-over-TS logic)
- Removes `play.ts`, `queue.ts`, `recommendation.ts` stub files that were solely re-exporting their subdirectory counterparts
- Fixes a pre-existing missing-closing-paren syntax error in the loader spec's `beforeEach` block that ts-jest silently ignored but Prettier caught

Closes #440

## Test plan

- [ ] `getCommandFiles` returns subdirectory `index.js` entries
- [ ] `getCommandFiles` prefers `index.js` over `index.ts` in subdirectories
- [ ] All 1379 bot tests pass
- [ ] Prettier passes on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deploy workflow now waits for Docker images to be ready before proceeding, reducing failed deploys.

* **Chores**
  * Command discovery now loads commands from subdirectories alongside flat files.
  * Music play command now responds directly in error cases and defers only after validation.

* **Breaking Changes**
  * Certain command entrypoint re-exports were removed; some imports may no longer resolve the previous defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->