### PR TITLE
refactor(bot): version from npm_package_version env var

### DIFF
--- a/packages/bot/src/functions/general/commands/version.spec.ts
+++ b/packages/bot/src/functions/general/commands/version.spec.ts
@@ -1,94 +1,46 @@
-import { describe, it, expect } from '@jest/globals'
-import { Readable } from 'stream'
-import { createInterface } from 'readline'
-import { createReadStream } from 'fs'
-import path from 'path'
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
 
-async function readVersionFromStream(
-    stream: NodeJS.ReadableStream,
-): Promise<string> {
-    const rl = createInterface({ input: stream })
-    try {
-        for await (const line of rl) {
-            const match = line.match(/"version"\s*:\s*"([^"]+)"/)
-            if (match) return match[1]
-        }
-        return 'unknown'
-    } finally {
-        rl.close()
-    }
+const deferReplyMock = jest.fn().mockResolvedValue(undefined)
+const editReplyMock = jest.fn().mockResolvedValue(undefined)
+const createInfoEmbedMock = jest.fn((title: string, message: string) => ({
+    title,
+    message,
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createInfoEmbed: (...args: unknown[]) =>
+        createInfoEmbedMock(...(args as [string, string])),
+}))
+
+import versionCommand from './version'
+
+function createInteraction() {
+    return {
+        deferReply: deferReplyMock,
+        editReply: editReplyMock,
+    } as any
 }
 
 describe('version command', () => {
-    describe('readVersion', () => {
-        it('extracts version from valid package.json lines', async () => {
-            const stream = Readable.from([
-                '{\n',
-                '  "name": "test",\n',
-                '  "version": "2.6.53"\n',
-                '}\n',
-            ])
-            expect(await readVersionFromStream(stream)).toBe('2.6.53')
-        })
-
-        it('returns unknown when version field is absent', async () => {
-            const stream = Readable.from(['{\n', '  "name": "test"\n', '}\n'])
-            expect(await readVersionFromStream(stream)).toBe('unknown')
-        })
-
-        it('matches version on first line', async () => {
-            const stream = Readable.from(['"version": "1.0.0"\n'])
-            expect(await readVersionFromStream(stream)).toBe('1.0.0')
-        })
-
-        it('closes readline even when version is not found', async () => {
-            const stream = Readable.from(['no version here\n'])
-            await expect(readVersionFromStream(stream)).resolves.toBe('unknown')
-        })
-
-        it('reads actual bot package.json', async () => {
-            const pkgPath = path.resolve(__dirname, '../../../../package.json')
-            const stream = createReadStream(pkgPath)
-            const version = await readVersionFromStream(stream)
-            expect(version).toMatch(
-                /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/,
-            )
-        })
+    beforeEach(() => {
+        jest.clearAllMocks()
     })
 
-    describe('execute error handling', () => {
-        it('falls back to unknown when readVersion throws', async () => {
-            let capturedVersion = ''
-            const mockReadVersion = async (): Promise<string> => {
-                throw new Error('ENOENT: file not found')
-            }
-            const execute = async () => {
-                let version = 'unknown'
-                try {
-                    version = await mockReadVersion()
-                } catch {
-                    // intentionally falls back
-                }
-                capturedVersion = version
-            }
-            await execute()
-            expect(capturedVersion).toBe('unknown')
-        })
+    it('defers reply as ephemeral', async () => {
+        const interaction = createInteraction()
+        await versionCommand.execute({ interaction } as any)
+        expect(deferReplyMock).toHaveBeenCalledWith({ ephemeral: true })
+    })
 
-        it('uses version when readVersion succeeds', async () => {
-            let capturedVersion = ''
-            const mockReadVersion = async (): Promise<string> => '3.0.0'
-            const execute = async () => {
-                let version = 'unknown'
-                try {
-                    version = await mockReadVersion()
-                } catch {
-                    // fallback
-                }
-                capturedVersion = version
-            }
-            await execute()
-            expect(capturedVersion).toBe('3.0.0')
-        })
+    it('replies with a versioned embed', async () => {
+        const interaction = createInteraction()
+        await versionCommand.execute({ interaction } as any)
+        expect(createInfoEmbedMock).toHaveBeenCalledWith(
+            'Bot Version',
+            expect.stringMatching(/^v/),
+        )
+        expect(editReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({ embeds: expect.any(Array) }),
+        )
     })
 })

--- a/packages/bot/src/functions/general/commands/version.ts
+++ b/packages/bot/src/functions/general/commands/version.ts
@@ -1,26 +1,8 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
-import { createReadStream } from 'fs'
-import { createInterface } from 'readline'
-import path from 'path'
-import { fileURLToPath } from 'url'
 import Command from '../../../models/Command'
 import { createInfoEmbed } from '../../../utils/general/embeds'
 
-async function readVersion(): Promise<string> {
-    const dirName = path.dirname(fileURLToPath(import.meta.url))
-    const pkgPath = path.resolve(dirName, '../../../../package.json')
-    const rl = createInterface({ input: createReadStream(pkgPath) })
-
-    try {
-        for await (const line of rl) {
-            const match = line.match(/"version"\s*:\s*"([^"]+)"/)
-            if (match) return match[1]
-        }
-        return 'unknown'
-    } finally {
-        rl.close()
-    }
-}
+const BOT_VERSION = process.env.npm_package_version ?? 'unknown'
 
 export default new Command({
     data: new SlashCommandBuilder()
@@ -29,14 +11,8 @@ export default new Command({
     category: 'general',
     execute: async ({ interaction }) => {
         await interaction.deferReply({ ephemeral: true })
-        let version = 'unknown'
-        try {
-            version = await readVersion()
-        } catch {
-            // package.json unreadable — fall back to 'unknown'
-        }
         await interaction.editReply({
-            embeds: [createInfoEmbed('Bot Version', `v${version}`)],
+            embeds: [createInfoEmbed('Bot Version', `v${BOT_VERSION}`)],
         })
     },
 })


### PR DESCRIPTION
## Summary

- Replaces the runtime streaming line-reader of `package.json` with `process.env.npm_package_version`
- Node.js sets `npm_package_version` automatically when the process is started via npm (e.g. `npm start`, `npm run dev`)
- Eliminates async file I/O and fragile path resolution (`import.meta.url` + 4 levels up) from the `/version` command
- Removes 8 streaming-based spec tests, adds 2 focused behavioral tests

Closes #444

## Test plan

- [ ] `deferReply({ ephemeral: true })` called
- [ ] `createInfoEmbed` called with 'Bot Version' and a string starting with 'v'
- [ ] All 1374 bot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)