### PR TITLE
feat(backend): health version endpoint and deploy SHA validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,6 +214,44 @@ jobs:
                   echo "::error::Response body: $failure_body_compact"
                   exit 1
 
+            - name: Validate deployed version
+              env:
+                  WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+              run: |
+                  set -euo pipefail
+                  base_url=$(node -e 'const u = new URL(process.env.WEBHOOK_URL); console.log(`${u.protocol}//${u.host}`)')
+                  version_url="${base_url}/api/health/version"
+                  expected="${{ github.sha }}"
+
+                  echo "==> Validating deployed SHA at $version_url (expected: $expected)..."
+
+                  for attempt in $(seq 1 20); do
+                    echo "Attempt ${attempt}/20..."
+                    response=$(curl -sS --max-time 20 -w "\n%{http_code}" "$version_url" || true)
+                    http_code=$(echo "$response" | tail -1)
+                    body=$(echo "$response" | sed '$d')
+
+                    if [ "$http_code" = "200" ]; then
+                      actual=$(echo "$body" | node -e '
+                        let d=""; process.stdin.on("data",c=>d+=c);
+                        process.stdin.on("end",()=>{
+                          try { const p=JSON.parse(d); console.log(p.commitSha ?? ""); }
+                          catch { process.exit(1); }
+                        })')
+                      if [ "$actual" = "$expected" ]; then
+                        echo "==> Deployed SHA matches: $actual"
+                        exit 0
+                      fi
+                      echo "SHA mismatch (expected=$expected, actual=$actual). Waiting 15s..."
+                    else
+                      echo "Not ready (HTTP $http_code). Waiting 15s..."
+                    fi
+                    sleep 15
+                  done
+
+                  echo "::error::Deployed version SHA did not match expected after all attempts"
+                  exit 1
+
             - name: Auth config smoke check
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,5 +70,6 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  build-args: COMMIT_SHA=${{ github.sha }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,8 +104,10 @@ CMD ["sh", "-c", "npx prisma migrate deploy && node packages/bot/dist/index.js"]
 # Production stage — backend (slim runtime, no media tools)
 FROM base-runtime-backend AS production-backend
 
+ARG COMMIT_SHA
 ENV NODE_ENV=production \
-    NPM_CONFIG_LOGLEVEL=silent
+    NPM_CONFIG_LOGLEVEL=silent \
+    COMMIT_SHA=$COMMIT_SHA
 
 WORKDIR /app
 

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -44,6 +44,13 @@ export function setupHealthRoutes(app: Express): void {
         })
     })
 
+    app.get('/api/health/version', (_req: Request, res: Response) => {
+        res.json({
+            commitSha: process.env.COMMIT_SHA ?? null,
+            version: process.env.npm_package_version ?? null,
+        })
+    })
+
     app.get('/api/health/cache', (_req: Request, res: Response) => {
         const metrics = redisClient.getMetrics()
         res.json({

--- a/packages/backend/tests/unit/routes/health.test.ts
+++ b/packages/backend/tests/unit/routes/health.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import express from 'express'
+import request from 'supertest'
+
+jest.mock('@lucky/shared/services', () => ({
+    redisClient: {
+        isHealthy: jest.fn().mockReturnValue(true),
+        getMetrics: jest
+            .fn()
+            .mockReturnValue({ hitRate: 0.9, hits: 9, misses: 1 }),
+    },
+}))
+
+jest.mock('../../../src/utils/frontendOrigin', () => ({
+    getFrontendOrigins: jest.fn().mockReturnValue([]),
+}))
+
+jest.mock('../../../src/utils/oauthRedirectUri', () => ({
+    getOAuthRedirectUri: jest
+        .fn()
+        .mockReturnValue('http://localhost/api/auth/callback'),
+}))
+
+jest.mock('../../../src/utils/authHealth', () => ({
+    buildAuthConfigHealth: jest.fn().mockReturnValue({ status: 'ok' }),
+}))
+
+import { setupHealthRoutes } from '../../../src/routes/health'
+
+function buildApp() {
+    const app = express()
+    setupHealthRoutes(app)
+    return app
+}
+
+describe('GET /api/health/version', () => {
+    const originalEnv = process.env
+
+    beforeEach(() => {
+        process.env = { ...originalEnv }
+    })
+
+    afterEach(() => {
+        process.env = originalEnv
+    })
+
+    test('returns commitSha and version from env vars', async () => {
+        process.env.COMMIT_SHA = 'abc123def456'
+        process.env.npm_package_version = '2.6.60'
+
+        const res = await request(buildApp()).get('/api/health/version')
+
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({
+            commitSha: 'abc123def456',
+            version: '2.6.60',
+        })
+    })
+
+    test('returns null for missing env vars', async () => {
+        delete process.env.COMMIT_SHA
+        delete process.env.npm_package_version
+
+        const res = await request(buildApp()).get('/api/health/version')
+
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ commitSha: null, version: null })
+    })
+
+    test('returns commitSha null when only version is set', async () => {
+        delete process.env.COMMIT_SHA
+        process.env.npm_package_version = '1.0.0'
+
+        const res = await request(buildApp()).get('/api/health/version')
+
+        expect(res.status).toBe(200)
+        expect(res.body.commitSha).toBeNull()
+        expect(res.body.version).toBe('1.0.0')
+    })
+})


### PR DESCRIPTION
## Summary

- Add `GET /api/health/version` returning `{ commitSha, version }` from env vars
- Inject `COMMIT_SHA` as Docker build arg in `docker-publish.yml` and `Dockerfile`
- Add **Validate deployed version** step in `deploy.yml` that polls `/api/health/version` until the deployed SHA matches `github.sha` before proceeding to smoke checks

## Motivation

Fixes the false-positive deploy scenario described in #442: smoke checks previously validated health against the *old* running service, masking silent deploy failures. Now the pipeline fails fast when the new SHA isn't confirmed live.

## Test plan

- [ ] Unit tests in `packages/backend/tests/unit/routes/health.test.ts` pass (3 tests)
- [ ] `GET /api/health/version` returns `{ commitSha: null, version: null }` locally (no env vars)
- [ ] After Docker build with `--build-arg COMMIT_SHA=abc123`, endpoint returns the correct SHA
- [ ] Deploy workflow validates SHA before auth-config smoke check

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)