### PR TITLE
chore: release 2.6.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.60] - 2026-04-01
+
+### Fixed
+
+- **play command**: Validation (guild context and voice channel) now runs before `deferReply`. Errors reply ephemerally via `interaction.reply` so the user sees the message privately without a public "bot is thinking" indicator.
+- **guildconfig command**: Same validation-before-defer fix — guild-only guard now replies ephemerally before deferring.
+- **embed converter**: Removed hardcoded Portuguese strings (`"erro"`, `"Erro"`, `"Informação"`) from `interactionReply.ts`; error/info embed detection is now language-agnostic.
+- **command loader**: De-duplicate when a flat file (e.g. `play.ts`) and a subdirectory index (e.g. `play/index.ts`) both exist — flat file takes precedence, preventing the same command loading twice.
+
+### Changed
+
+- **version command**: Read bot version from `process.env.npm_package_version` at startup instead of streaming `package.json` at runtime — eliminates the file I/O on every `/version` invocation.
+
+### CI/Infrastructure
+
+- **deploy pipeline**: Wait for `docker-publish` to complete before firing the homelab webhook. Fail closed when no docker-publish run is found for the commit SHA (opt-out via `FORCE_UNVERIFIED_DEPLOY=true`).
+
 ## [2.6.59] - 2026-04-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **version command**: Read bot version from `process.env.npm_package_version` at startup instead of streaming `package.json` at runtime — eliminates the file I/O on every `/version` invocation.
 
+### Added
+
+- **`GET /api/health/version`**: New endpoint returning `{ commitSha, version }` from Docker build args and `npm_package_version`. Enables the deploy pipeline to verify the exact commit SHA went live before marking the deploy successful.
+
 ### CI/Infrastructure
 
 - **deploy pipeline**: Wait for `docker-publish` to complete before firing the homelab webhook. Fail closed when no docker-publish run is found for the commit SHA (opt-out via `FORCE_UNVERIFIED_DEPLOY=true`).
+- **deploy pipeline**: New *Validate deployed version* step polls `/api/health/version` until the deployed `commitSha` matches `github.sha` before proceeding to OAuth smoke checks — eliminates false-positive green deploys against stale images.
+- **docker build**: `COMMIT_SHA` build arg injected in `docker-publish.yml` and set as `ENV` in the backend stage of the Dockerfile.
 
 ## [2.6.59] - 2026-04-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.59",
+    "version": "2.6.60",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.59",
+    "version": "2.6.60",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.59",
+    "version": "2.6.60",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.59",
+    "version": "2.6.60",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.59",
+    "version": "2.6.60",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps all package versions from `2.6.59` → `2.6.60`
- Updates CHANGELOG with fixes and changes since `2.6.59`

## Changes included

- `fix(bot)`: play command validation-before-defer, ephemeral errors (#446)
- `fix(bot)`: guildconfig validation-before-defer, ephemeral guild guard (#448)
- `fix(bot)`: remove hardcoded Portuguese from embed converter (#449)
- `fix(bot)`: command loader deduplication flat vs subdirectory (#447)
- `refactor(bot)`: version command reads from `npm_package_version` env var (#450)
- `ci`: deploy wait for docker-publish + fail-closed (#437, #447)

## Test plan

- [ ] CI passes
- [ ] Version shows `2.6.60` in all `package.json` files
- [ ] CHANGELOG entry is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new health check endpoint returning version and commit information.

* **Bug Fixes**
  * Fixed Discord command handling for `play` and `guildconfig` commands with proper validation and ephemeral error replies.
  * Updated error detection to be language-agnostic across embeds.

* **Changed**
  * Updated `/version` command to read from environment at startup.
  * Enhanced deployment validation with health check verification.

* **Chores**
  * Bumped version to 2.6.60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->