### PR TITLE
fix(bot): stabilize eventHandler spec for parallel Jest execution

### DIFF
--- a/packages/bot/src/handlers/eventHandler.spec.ts
+++ b/packages/bot/src/handlers/eventHandler.spec.ts
@@ -87,6 +87,11 @@ describe('eventHandler', () => {
         createUserFriendlyErrorMock.mockReturnValue('Friendly error')
     })
 
+    // Drain all pending microtasks so fire-and-forget async handlers
+    // (the .catch() wrapper in handleEvents) fully settle before assertions.
+    const flushAsyncHandlers = () =>
+        new Promise<void>((resolve) => setImmediate(resolve))
+
     it('replies with command-not-found message when command is missing', async () => {
         const { client, onMock } = createMockClient()
         handleEvents(client as unknown as never)
@@ -101,8 +106,7 @@ describe('eventHandler', () => {
             deferred: false,
         } as unknown as Interaction)
 
-        await Promise.resolve()
-        await Promise.resolve()
+        await flushAsyncHandlers()
 
         expect(interactionReplyMock).toHaveBeenCalledWith({
             interaction: expect.objectContaining({ commandName: 'unknown' }),
@@ -130,8 +134,7 @@ describe('eventHandler', () => {
             deferred: false,
         } as unknown as ChatInputCommandInteraction)
 
-        await Promise.resolve()
-        await Promise.resolve()
+        await flushAsyncHandlers()
 
         expect(createUserFriendlyErrorMock).toHaveBeenCalledWith(
             expect.any(Error),


### PR DESCRIPTION
## Summary

- Replace fragile `await Promise.resolve()` microtick flushing with a `setImmediate`-based `flushAsyncHandlers()` helper that deterministically drains all pending microtasks before assertions run.
- Fixes the `eventHandler.spec.ts` test "sends user-friendly error reply when command execution fails" which failed intermittently under parallel Jest workers but always passed with `--runInBand`.

## Root cause

The `InteractionCreate` listener in `eventHandler.ts` wraps `handleInteractionCreate` in a fire-and-forget `.catch()` pattern. The error-handling path traverses ~5 microtick turns (rejection → propagation → `handleInteractionError` → `await interactionReply`), but the test only flushed 2 via `Promise.resolve()`. Under parallel worker contention, those 2 ticks weren't enough.

## Test plan

- [x] `npm run test --workspace=packages/bot -- --ci` passes (parallel mode, 1375/1375)
- [x] Two consecutive runs confirm zero flakiness
- [ ] CI Quality Gates green

## Checklist

- [x] Commits follow conventional commits
- [x] No production code changes
- [x] Tests pass locally