### PR TITLE
refactor(backend): extract validation helpers to reduce buildAuthConfigHealth complexity

### DIFF
--- a/packages/backend/src/utils/authHealth.ts
+++ b/packages/backend/src/utils/authHealth.ts
@@ -70,53 +70,52 @@ export function buildAuthorizeUrlPreview(
     return `${DISCORD_AUTHORIZE_BASE}?${query.toString().replace(/\+/g, '%20')}`
 }
 
-export function buildAuthConfigHealth({
-    clientId,
-    redirectUri,
-    frontendOrigins,
-    backendOrigins = [],
-    requestOrigin,
-    sessionSecretConfigured,
-    redisHealthy,
-    expectedClientId,
-}: AuthConfigHealthInput): AuthConfigHealthResponse {
+function validateClientId(
+    clientId: string,
+    expectedClientId?: string,
+): string[] {
     const warnings: string[] = []
     const clientIdConfigured = clientId.length > 0
-    const normalizedExpectedClientId = expectedClientId?.trim() ?? ''
+    const normalizedExpected = expectedClientId?.trim() ?? ''
 
     if (!clientIdConfigured) {
         warnings.push('CLIENT_ID not configured')
     }
 
     if (
-        normalizedExpectedClientId.length > 0 &&
+        normalizedExpected.length > 0 &&
         clientIdConfigured &&
-        clientId !== normalizedExpectedClientId
+        clientId !== normalizedExpected
     ) {
         warnings.push(
-            `CLIENT_ID does not match expected production app id (${normalizedExpectedClientId})`,
+            `CLIENT_ID does not match expected production app id (${normalizedExpected})`,
         )
     }
 
+    return warnings
+}
+
+function validateInfrastructure(
+    sessionSecretConfigured: boolean,
+    redisHealthy: boolean,
+): string[] {
+    const warnings: string[] = []
     if (!sessionSecretConfigured) {
         warnings.push('WEBAPP_SESSION_SECRET not configured')
     }
-
     if (!redisHealthy) {
         warnings.push('Redis is not healthy for shared services')
     }
+    return warnings
+}
 
-    const normalizedRequestOrigin = normalizeOrigin(requestOrigin)
-
-    if (
-        frontendOrigins.length === 0 &&
-        backendOrigins.length === 0 &&
-        normalizedRequestOrigin.length === 0
-    ) {
-        warnings.push(
-            'No WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL origins configured',
-        )
-    }
+function validateRedirectUri(
+    redirectUri: string,
+    frontendOrigins: string[],
+    backendOrigins: string[],
+    normalizedRequestOrigin: string,
+): string[] {
+    const warnings: string[] = []
 
     try {
         const parsedRedirectUri = new URL(redirectUri)
@@ -125,11 +124,12 @@ export function buildAuthConfigHealth({
             warnings.push('OAuth callback path should be /api/auth/callback')
         }
 
-        if (
+        const hasConfiguredOrigins =
             frontendOrigins.length > 0 ||
             backendOrigins.length > 0 ||
             normalizedRequestOrigin.length > 0
-        ) {
+
+        if (hasConfiguredOrigins) {
             const configuredOrigins = new Set([
                 ...getConfiguredFrontendOrigins(frontendOrigins),
                 ...getConfiguredFrontendOrigins(backendOrigins),
@@ -148,13 +148,46 @@ export function buildAuthConfigHealth({
         warnings.push('OAuth redirect URI is invalid')
     }
 
+    return warnings
+}
+
+export function buildAuthConfigHealth({
+    clientId,
+    redirectUri,
+    frontendOrigins,
+    backendOrigins = [],
+    requestOrigin,
+    sessionSecretConfigured,
+    redisHealthy,
+    expectedClientId,
+}: AuthConfigHealthInput): AuthConfigHealthResponse {
+    const normalizedRequestOrigin = normalizeOrigin(requestOrigin)
+
+    const warnings = [
+        ...validateClientId(clientId, expectedClientId),
+        ...validateInfrastructure(sessionSecretConfigured, redisHealthy),
+        ...(frontendOrigins.length === 0 &&
+        backendOrigins.length === 0 &&
+        normalizedRequestOrigin.length === 0
+            ? [
+                  'No WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL origins configured',
+              ]
+            : []),
+        ...validateRedirectUri(
+            redirectUri,
+            frontendOrigins,
+            backendOrigins,
+            normalizedRequestOrigin,
+        ),
+    ]
+
     return {
         status: warnings.length === 0 ? 'ok' : 'degraded',
         auth: {
             clientId,
             redirectUri,
             frontendOrigins,
-            clientIdConfigured,
+            clientIdConfigured: clientId.length > 0,
             sessionSecretConfigured,
             redisHealthy,
             authorizeUrlPreview: buildAuthorizeUrlPreview(


### PR DESCRIPTION
## Summary

- Extract `validateClientId`, `validateInfrastructure`, and `validateRedirectUri` from the monolithic `buildAuthConfigHealth` function.
- Reduces cyclomatic complexity from 21 to well under 15.
- No behavior changes — same warnings, same response shape, same test coverage.

## Context

ESLint flagged `buildAuthConfigHealth` with complexity 21 (max 15). The function had 6+ independent conditional branches that each push warnings — natural candidates for extract-function refactoring.

The remaining 3 complexity warnings are in `GuildAutomationExecutionService.ts` (`remapManifestEntityIds: 22`, `applyRolesAndChannels: 32`, `executeApplyPlan: 25`) and will be addressed in a follow-up PR due to the larger scope and risk.

## Verification

- [x] `npm run type:check --workspace=packages/backend` passes
- [x] `npm run test --workspace=packages/backend -- --ci` passes (672/672)
- [x] `npm run lint --workspace=packages/backend` — authHealth warning eliminated
- [ ] CI Quality Gates green

## Checklist

- [x] Conventional commits
- [x] No behavior changes
- [x] No new files created
- [x] Tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and structure for authentication health checks to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->