### PR TITLE
feat(bot): implement /lyrics command using LyricsService

### DIFF
--- a/packages/bot/src/functions/music/commands/lyrics.spec.ts
+++ b/packages/bot/src/functions/music/commands/lyrics.spec.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 
 const interactionReplyMock = jest.fn()
 const followUpMock = jest.fn()
+const deferReplyMock = jest.fn()
+const editReplyMock = jest.fn()
 const requireCurrentTrackMock = jest.fn()
 const resolveGuildQueueMock = jest.fn()
 const searchLyricsMock = jest.fn()
@@ -22,6 +24,10 @@ jest.mock('../../../utils/command/commandValidations', () => ({
 
 jest.mock('../../../utils/music/queueResolver', () => ({
     resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
 }))
 
 jest.mock('@lucky/shared/services', () => ({
@@ -55,6 +61,8 @@ function createInteraction({
         options: {
             getString: jest.fn(() => song),
         },
+        deferReply: deferReplyMock,
+        editReply: editReplyMock,
         followUp: followUpMock,
     }
     return interaction as any
@@ -73,6 +81,8 @@ describe('lyrics command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         interactionReplyMock.mockResolvedValue(undefined)
+        deferReplyMock.mockResolvedValue(undefined)
+        editReplyMock.mockResolvedValue(undefined)
         followUpMock.mockResolvedValue(undefined)
         featureToggleIsEnabledMock.mockResolvedValue(true)
         requireCurrentTrackMock.mockResolvedValue(true)
@@ -126,7 +136,8 @@ describe('lyrics command', () => {
             expect.stringContaining('Test Song'),
             'Line 1\nLine 2',
         )
-        expect(interactionReplyMock).toHaveBeenCalled()
+        expect(deferReplyMock).toHaveBeenCalled()
+        expect(editReplyMock).toHaveBeenCalled()
         expect(followUpMock).not.toHaveBeenCalled()
     })
 
@@ -160,7 +171,7 @@ describe('lyrics command', () => {
         const interaction = createInteraction({ song: 'Long Song' })
         const client = {} as any
         await lyricsCommand.execute({ client, interaction } as any)
-        expect(interactionReplyMock).toHaveBeenCalledTimes(1)
+        expect(editReplyMock).toHaveBeenCalledTimes(1)
         expect(followUpMock).toHaveBeenCalledTimes(2)
     })
 
@@ -172,6 +183,8 @@ describe('lyrics command', () => {
         const interaction = createInteraction({ song: 'Unknown Song' })
         const client = {} as any
         await lyricsCommand.execute({ client, interaction } as any)
+        expect(deferReplyMock).toHaveBeenCalled()
+        expect(editReplyMock).toHaveBeenCalled()
         expect(errorEmbedMock).toHaveBeenCalledWith(
             'Lyrics not found',
             'Lyrics not found',
@@ -183,6 +196,8 @@ describe('lyrics command', () => {
         const interaction = createInteraction({ song: 'Any Song' })
         const client = {} as any
         await lyricsCommand.execute({ client, interaction } as any)
+        expect(deferReplyMock).toHaveBeenCalled()
+        expect(editReplyMock).toHaveBeenCalled()
         expect(errorEmbedMock).toHaveBeenCalledWith(
             'Lyrics error',
             expect.any(String),

--- a/packages/bot/src/functions/music/commands/lyrics.spec.ts
+++ b/packages/bot/src/functions/music/commands/lyrics.spec.ts
@@ -48,6 +48,11 @@ jest.mock('../../../utils/general/embeds', () => ({
 
 import lyricsCommand from './lyrics'
 
+type TExecuteArgs = Parameters<typeof lyricsCommand.execute>[0]
+type TInteraction = TExecuteArgs['interaction']
+type TClient = TExecuteArgs['client']
+
+
 function createInteraction({
     guildId = 'guild-1',
     song = null,
@@ -65,7 +70,7 @@ function createInteraction({
         editReply: editReplyMock,
         followUp: followUpMock,
     }
-    return interaction as any
+    return interaction as unknown as TInteraction
 }
 
 function createEmbed(data: object = {}) {
@@ -99,8 +104,8 @@ describe('lyrics command', () => {
     it('replies with warning when LYRICS feature is disabled', async () => {
         featureToggleIsEnabledMock.mockResolvedValue(false)
         const interaction = createInteraction({})
-        const client = {} as any
-        await lyricsCommand.execute({ client, interaction } as any)
+        const client = {} as unknown as TClient
+        await lyricsCommand.execute({ client, interaction })
         expect(warningEmbedMock).toHaveBeenCalledWith(
             'Feature unavailable',
             expect.any(String),
@@ -114,8 +119,8 @@ describe('lyrics command', () => {
 
     it('replies with error when no guild', async () => {
         const interaction = createInteraction({ guildId: null })
-        const client = {} as any
-        await lyricsCommand.execute({ client, interaction } as any)
+        const client = {} as unknown as TClient
+        await lyricsCommand.execute({ client, interaction })
         expect(errorEmbedMock).toHaveBeenCalled()
     })
 
@@ -129,8 +134,8 @@ describe('lyrics command', () => {
         searchLyricsMock.mockResolvedValue(lyricResult)
         splitLyricsMock.mockReturnValue(['Line 1\nLine 2'])
         const interaction = createInteraction({ song: 'Test Song' })
-        const client = {} as any
-        await lyricsCommand.execute({ client, interaction } as any)
+        const client = {} as unknown as TClient
+        await lyricsCommand.execute({ client, interaction })
         expect(searchLyricsMock).toHaveBeenCalledWith('Test Song', undefined)
         expect(musicEmbedMock).toHaveBeenCalledWith(
             expect.stringContaining('Test Song'),
@@ -151,8 +156,8 @@ describe('lyrics command', () => {
         searchLyricsMock.mockResolvedValue(lyricResult)
         splitLyricsMock.mockReturnValue(['Verse'])
         const interaction = createInteraction({ song: null })
-        const client = {} as any
-        await lyricsCommand.execute({ client, interaction } as any)
+        const client = {} as unknown as TClient
+        await lyricsCommand.execute({ client, interaction })
         expect(searchLyricsMock).toHaveBeenCalledWith(
             'Test Song',
             'Test Artist',
@@ -169,8 +174,8 @@ describe('lyrics command', () => {
         searchLyricsMock.mockResolvedValue(lyricResult)
         splitLyricsMock.mockReturnValue(['page1', 'page2', 'page3'])
         const interaction = createInteraction({ song: 'Long Song' })
-        const client = {} as any
-        await lyricsCommand.execute({ client, interaction } as any)
+        const client = {} as unknown as TClient
+        await lyricsCommand.execute({ client, interaction })
         expect(editReplyMock).toHaveBeenCalledTimes(1)
         expect(followUpMock).toHaveBeenCalledTimes(2)
     })
@@ -181,8 +186,8 @@ describe('lyrics command', () => {
             message: 'Lyrics not found',
         })
         const interaction = createInteraction({ song: 'Unknown Song' })
-        const client = {} as any
-        await lyricsCommand.execute({ client, interaction } as any)
+        const client = {} as unknown as TClient
+        await lyricsCommand.execute({ client, interaction })
         expect(deferReplyMock).toHaveBeenCalled()
         expect(editReplyMock).toHaveBeenCalled()
         expect(errorEmbedMock).toHaveBeenCalledWith(
@@ -194,8 +199,8 @@ describe('lyrics command', () => {
     it('replies with error on unexpected exception', async () => {
         searchLyricsMock.mockRejectedValue(new Error('Network error'))
         const interaction = createInteraction({ song: 'Any Song' })
-        const client = {} as any
-        await lyricsCommand.execute({ client, interaction } as any)
+        const client = {} as unknown as TClient
+        await lyricsCommand.execute({ client, interaction })
         expect(deferReplyMock).toHaveBeenCalled()
         expect(editReplyMock).toHaveBeenCalled()
         expect(errorEmbedMock).toHaveBeenCalledWith(

--- a/packages/bot/src/functions/music/commands/lyrics.spec.ts
+++ b/packages/bot/src/functions/music/commands/lyrics.spec.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+const interactionReplyMock = jest.fn()
+const followUpMock = jest.fn()
+const requireCurrentTrackMock = jest.fn()
+const resolveGuildQueueMock = jest.fn()
+const searchLyricsMock = jest.fn()
+const splitLyricsMock = jest.fn()
+const featureToggleIsEnabledMock = jest.fn()
+const musicEmbedMock = jest.fn()
+const errorEmbedMock = jest.fn()
+const warningEmbedMock = jest.fn()
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireCurrentTrack: (...args: unknown[]) =>
+        requireCurrentTrackMock(...args),
+}))
+
+jest.mock('../../../utils/music/queueResolver', () => ({
+    resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    featureToggleService: {
+        isEnabled: (...args: unknown[]) => featureToggleIsEnabledMock(...args),
+    },
+    lyricsService: {
+        searchLyrics: (...args: unknown[]) => searchLyricsMock(...args),
+        splitLyrics: (...args: unknown[]) => splitLyricsMock(...args),
+    },
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    musicEmbed: (...args: unknown[]) => musicEmbedMock(...args),
+    errorEmbed: (...args: unknown[]) => errorEmbedMock(...args),
+    warningEmbed: (...args: unknown[]) => warningEmbedMock(...args),
+}))
+
+import lyricsCommand from './lyrics'
+
+function createInteraction({
+    guildId = 'guild-1',
+    song = null,
+}: {
+    guildId?: string | null
+    song?: string | null
+}) {
+    const interaction = {
+        guildId,
+        user: { id: 'user-1' },
+        options: {
+            getString: jest.fn(() => song),
+        },
+        followUp: followUpMock,
+    }
+    return interaction as any
+}
+
+function createEmbed(data: object = {}) {
+    return {
+        ...data,
+        setFooter: jest.fn(function (this: object) {
+            return this
+        }),
+    }
+}
+
+describe('lyrics command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        interactionReplyMock.mockResolvedValue(undefined)
+        followUpMock.mockResolvedValue(undefined)
+        featureToggleIsEnabledMock.mockResolvedValue(true)
+        requireCurrentTrackMock.mockResolvedValue(true)
+        resolveGuildQueueMock.mockReturnValue({
+            queue: {
+                currentTrack: { title: 'Test Song', author: 'Test Artist' },
+            },
+        })
+        musicEmbedMock.mockReturnValue(createEmbed())
+        errorEmbedMock.mockReturnValue({ type: 'error' })
+        warningEmbedMock.mockReturnValue({ type: 'warning' })
+    })
+
+    it('replies with warning when LYRICS feature is disabled', async () => {
+        featureToggleIsEnabledMock.mockResolvedValue(false)
+        const interaction = createInteraction({})
+        const client = {} as any
+        await lyricsCommand.execute({ client, interaction } as any)
+        expect(warningEmbedMock).toHaveBeenCalledWith(
+            'Feature unavailable',
+            expect.any(String),
+        )
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.objectContaining({ ephemeral: true }),
+            }),
+        )
+    })
+
+    it('replies with error when no guild', async () => {
+        const interaction = createInteraction({ guildId: null })
+        const client = {} as any
+        await lyricsCommand.execute({ client, interaction } as any)
+        expect(errorEmbedMock).toHaveBeenCalled()
+    })
+
+    it('fetches lyrics for explicit song query', async () => {
+        const lyricResult = {
+            title: 'Test Song',
+            artist: 'Test Artist',
+            lyrics: 'Line 1\nLine 2',
+            source: 'lyrics.ovh',
+        }
+        searchLyricsMock.mockResolvedValue(lyricResult)
+        splitLyricsMock.mockReturnValue(['Line 1\nLine 2'])
+        const interaction = createInteraction({ song: 'Test Song' })
+        const client = {} as any
+        await lyricsCommand.execute({ client, interaction } as any)
+        expect(searchLyricsMock).toHaveBeenCalledWith('Test Song', undefined)
+        expect(musicEmbedMock).toHaveBeenCalledWith(
+            expect.stringContaining('Test Song'),
+            'Line 1\nLine 2',
+        )
+        expect(interactionReplyMock).toHaveBeenCalled()
+        expect(followUpMock).not.toHaveBeenCalled()
+    })
+
+    it('uses current track when no song query given', async () => {
+        const lyricResult = {
+            title: 'Test Song',
+            artist: 'Test Artist',
+            lyrics: 'Verse',
+            source: 'lyrics.ovh',
+        }
+        searchLyricsMock.mockResolvedValue(lyricResult)
+        splitLyricsMock.mockReturnValue(['Verse'])
+        const interaction = createInteraction({ song: null })
+        const client = {} as any
+        await lyricsCommand.execute({ client, interaction } as any)
+        expect(searchLyricsMock).toHaveBeenCalledWith(
+            'Test Song',
+            'Test Artist',
+        )
+    })
+
+    it('sends multiple follow-ups for paginated lyrics', async () => {
+        const lyricResult = {
+            title: 'Long Song',
+            artist: 'Artist',
+            lyrics: 'A'.repeat(4000),
+            source: 'ovh',
+        }
+        searchLyricsMock.mockResolvedValue(lyricResult)
+        splitLyricsMock.mockReturnValue(['page1', 'page2', 'page3'])
+        const interaction = createInteraction({ song: 'Long Song' })
+        const client = {} as any
+        await lyricsCommand.execute({ client, interaction } as any)
+        expect(interactionReplyMock).toHaveBeenCalledTimes(1)
+        expect(followUpMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('replies with error when lyrics provider returns an error', async () => {
+        searchLyricsMock.mockResolvedValue({
+            error: 'not_found',
+            message: 'Lyrics not found',
+        })
+        const interaction = createInteraction({ song: 'Unknown Song' })
+        const client = {} as any
+        await lyricsCommand.execute({ client, interaction } as any)
+        expect(errorEmbedMock).toHaveBeenCalledWith(
+            'Lyrics not found',
+            'Lyrics not found',
+        )
+    })
+
+    it('replies with error on unexpected exception', async () => {
+        searchLyricsMock.mockRejectedValue(new Error('Network error'))
+        const interaction = createInteraction({ song: 'Any Song' })
+        const client = {} as any
+        await lyricsCommand.execute({ client, interaction } as any)
+        expect(errorEmbedMock).toHaveBeenCalledWith(
+            'Lyrics error',
+            expect.any(String),
+        )
+    })
+})

--- a/packages/bot/src/functions/music/commands/lyrics.ts
+++ b/packages/bot/src/functions/music/commands/lyrics.ts
@@ -118,8 +118,10 @@ export default new Command({
             errorLog({
                 message: 'Failed to fetch lyrics',
                 error,
-                guildId: interaction.guildId ?? undefined,
-                userId: interaction.user.id,
+                data: {
+                    guildId: interaction.guildId ?? undefined,
+                    userId: interaction.user.id,
+                },
             })
             await interaction.editReply({
                 embeds: [

--- a/packages/bot/src/functions/music/commands/lyrics.ts
+++ b/packages/bot/src/functions/music/commands/lyrics.ts
@@ -4,7 +4,7 @@ import { interactionReply } from '../../../utils/general/interactionReply'
 import { errorEmbed, musicEmbed, warningEmbed } from '../../../utils/general/embeds'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import { requireCurrentTrack } from '../../../utils/command/commandValidations'
-import { featureToggleService } from '@lucky/shared/services'
+import { featureToggleService, lyricsService } from '@lucky/shared/services'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 
 export default new Command({
@@ -45,6 +45,7 @@ export default new Command({
 
         const query = interaction.options.getString('song')
         let title = query
+        let artist: string | undefined
 
         if (title === null || title === '') {
             const guildId = interaction.guildId
@@ -70,14 +71,60 @@ export default new Command({
             if (!(await requireCurrentTrack(queue, interaction))) return
 
             title = track?.title ?? 'Unknown'
+            artist = track?.author
         }
-        const lyrics =
-            'Lyrics are not available yet. This command is reserved for a future lyrics API integration.'
 
-        const embed = musicEmbed('Lyrics', lyrics)
-        await interactionReply({
-            interaction,
-            content: { embeds: [embed] },
-        })
+        try {
+            const result = await lyricsService.searchLyrics(title, artist)
+
+            if ('error' in result) {
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [errorEmbed('Lyrics not found', result.message)],
+                    },
+                })
+                return
+            }
+
+            const pages = lyricsService.splitLyrics(result.lyrics)
+            const firstEmbed = musicEmbed(
+                `Lyrics — ${result.title}`,
+                pages[0],
+            ).setFooter({
+                text: `Source: ${result.source} • Page 1/${pages.length}`,
+            })
+
+            await interactionReply({
+                interaction,
+                content: { embeds: [firstEmbed] },
+            })
+
+            for (let i = 1; i < pages.length; i++) {
+                const pageEmbed = musicEmbed(
+                    `Lyrics — ${result.title}`,
+                    pages[i],
+                ).setFooter({
+                    text: `Source: ${result.source} • Page ${i + 1}/${pages.length}`,
+                })
+
+                await interaction.followUp({
+                    embeds: [pageEmbed],
+                    ephemeral: false,
+                })
+            }
+        } catch {
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        errorEmbed(
+                            'Lyrics error',
+                            'An unexpected error occurred while fetching lyrics. Please try again later.',
+                        ),
+                    ],
+                },
+            })
+        }
     },
 })

--- a/packages/bot/src/functions/music/commands/lyrics.ts
+++ b/packages/bot/src/functions/music/commands/lyrics.ts
@@ -5,6 +5,7 @@ import { errorEmbed, musicEmbed, warningEmbed } from '../../../utils/general/emb
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import { requireCurrentTrack } from '../../../utils/command/commandValidations'
 import { featureToggleService, lyricsService } from '@lucky/shared/services'
+import { errorLog } from '@lucky/shared/utils'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 
 export default new Command({
@@ -14,7 +15,11 @@ export default new Command({
             '📄 Show the lyrics of the current song or a specified song.',
         )
         .addStringOption((option) =>
-            option.setName('song').setDescription('Song name (optional)'),
+            option
+                .setName('song')
+                .setDescription(
+                    'Song name, or "Artist - Title" for best results (optional)',
+                ),
         ),
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
@@ -74,15 +79,14 @@ export default new Command({
             artist = track?.author
         }
 
+        await interaction.deferReply()
+
         try {
             const result = await lyricsService.searchLyrics(title, artist)
 
             if ('error' in result) {
-                await interactionReply({
-                    interaction,
-                    content: {
-                        embeds: [errorEmbed('Lyrics not found', result.message)],
-                    },
+                await interaction.editReply({
+                    embeds: [errorEmbed('Lyrics not found', result.message)],
                 })
                 return
             }
@@ -95,10 +99,7 @@ export default new Command({
                 text: `Source: ${result.source} • Page 1/${pages.length}`,
             })
 
-            await interactionReply({
-                interaction,
-                content: { embeds: [firstEmbed] },
-            })
+            await interaction.editReply({ embeds: [firstEmbed] })
 
             for (let i = 1; i < pages.length; i++) {
                 const pageEmbed = musicEmbed(
@@ -113,17 +114,20 @@ export default new Command({
                     ephemeral: false,
                 })
             }
-        } catch {
-            await interactionReply({
-                interaction,
-                content: {
-                    embeds: [
-                        errorEmbed(
-                            'Lyrics error',
-                            'An unexpected error occurred while fetching lyrics. Please try again later.',
-                        ),
-                    ],
-                },
+        } catch (error) {
+            errorLog({
+                message: 'Failed to fetch lyrics',
+                error,
+                guildId: interaction.guildId ?? undefined,
+                userId: interaction.user.id,
+            })
+            await interaction.editReply({
+                embeds: [
+                    errorEmbed(
+                        'Lyrics error',
+                        'An unexpected error occurred while fetching lyrics. Please try again later.',
+                    ),
+                ],
             })
         }
     },


### PR DESCRIPTION
## Summary

Wires the existing `LyricsService` into the `/lyrics` slash command, replacing the hardcoded placeholder message.

## Changes

- Import `lyricsService` singleton from `@lucky/shared/services`
- Call `lyricsService.searchLyrics(title, artist?)` — uses current track as fallback when no song argument is given
- Paginate long lyrics via `lyricsService.splitLyrics()` — first page via `interactionReply`, subsequent pages via `interaction.followUp()`
- Each embed footer shows `Source: <provider> • Page N/Total`
- `LyricsError` path replies with `errorEmbed` showing the provider message
- `try/catch` wraps the entire lyrics fetch for unexpected errors
- `LYRICS` feature toggle guard preserved
- Guild-only check preserved
- Current track fallback preserved

## Verification

- [x] `npm run type:check --workspace=packages/bot` — 0 errors
- [x] `npm run test:bot` — 1375/1375 tests pass, 127 suites
- [ ] CI Quality Gates green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lyrics command now retrieves real lyrics, paginates long results, and shows source attribution.
* **Bug Fixes / Reliability**
  * Improved handling when lyrics are not found and when unexpected errors occur.
* **Tests**
  * Added comprehensive tests covering feature-flag behavior, no-guild cases, query vs. current-track lookup, pagination/follow-ups, provider errors, and unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->