### PR TITLE
refactor(backend): extract helpers to reduce GuildAutomationExecutionService complexity

### DIFF
--- a/packages/backend/src/services/GuildAutomationExecutionService.ts
+++ b/packages/backend/src/services/GuildAutomationExecutionService.ts
@@ -215,6 +215,123 @@ function defaultParityChecklist() {
     ]
 }
 
+
+type RemapFn = (id: string | undefined | null) => string | undefined | null
+
+function remapRolesSection(
+    next: GuildAutomationManifestDocument,
+    remapRole: RemapFn,
+    remapChannel: RemapFn,
+): void {
+    if (!next.roles) return
+    next.roles.roles = next.roles.roles.map((role) => ({
+        ...role,
+        id: remapRole(role.id) ?? role.id,
+    }))
+    next.roles.channels = next.roles.channels.map((channel) => ({
+        ...channel,
+        id: remapChannel(channel.id) ?? channel.id,
+        parentId: remapChannel(channel.parentId) ?? null,
+    }))
+}
+
+function remapOnboardingSection(
+    next: GuildAutomationManifestDocument,
+    remapRole: RemapFn,
+    remapChannel: RemapFn,
+): void {
+    if (!next.onboarding) return
+    next.onboarding.defaultChannelIds = next.onboarding.defaultChannelIds
+        .map((id) => remapChannel(id))
+        .filter((id): id is string => Boolean(id))
+    next.onboarding.prompts = next.onboarding.prompts.map((prompt) => ({
+        ...prompt,
+        options: prompt.options.map((option) => ({
+            ...option,
+            channelIds: option.channelIds
+                ?.map((id) => remapChannel(id))
+                .filter((id): id is string => Boolean(id)),
+            roleIds: option.roleIds
+                ?.map((id) => remapRole(id))
+                .filter((id): id is string => Boolean(id)),
+        })),
+    }))
+}
+
+function remapModerationSection(
+    next: GuildAutomationManifestDocument,
+    remapRole: RemapFn,
+    remapChannel: RemapFn,
+): void {
+    if (next.moderation?.automod) {
+        next.moderation.automod.exemptRoles = next.moderation.automod.exemptRoles
+            ?.map((id) => remapRole(id))
+            .filter((id): id is string => Boolean(id))
+        next.moderation.automod.exemptChannels =
+            next.moderation.automod.exemptChannels
+                ?.map((id) => remapChannel(id))
+                .filter((id): id is string => Boolean(id))
+    }
+    if (next.moderation?.moderationSettings) {
+        const ms = next.moderation.moderationSettings
+        ms.muteRoleId = remapRole(ms.muteRoleId) ?? null
+        ms.modRoleIds = ms.modRoleIds
+            ?.map((id) => remapRole(id))
+            .filter((id): id is string => Boolean(id))
+        ms.adminRoleIds = ms.adminRoleIds
+            ?.map((id) => remapRole(id))
+            .filter((id): id is string => Boolean(id))
+    }
+}
+
+function remapAutoMessagesSection(
+    next: GuildAutomationManifestDocument,
+    remapChannel: RemapFn,
+): void {
+    if (next.automessages?.welcome) {
+        next.automessages.welcome.channelId =
+            remapChannel(next.automessages.welcome.channelId) ?? undefined
+    }
+    if (next.automessages?.leave) {
+        next.automessages.leave.channelId =
+            remapChannel(next.automessages.leave.channelId) ?? undefined
+    }
+}
+
+function remapReactionRolesSection(
+    next: GuildAutomationManifestDocument,
+    remapRole: RemapFn,
+    remapChannel: RemapFn,
+): void {
+    if (!next.reactionroles) return
+    next.reactionroles.messages = next.reactionroles.messages?.map(
+        (message) => ({
+            ...message,
+            channelId: remapChannel(message.channelId) ?? undefined,
+            mappings: message.mappings?.map((mapping) => ({
+                ...mapping,
+                roleId: remapRole(mapping.roleId) ?? mapping.roleId,
+            })),
+        }),
+    )
+    next.reactionroles.exclusiveRoles =
+        next.reactionroles.exclusiveRoles?.map((item) => ({
+            roleId: remapRole(item.roleId) ?? item.roleId,
+            excludedRoleId: remapRole(item.excludedRoleId) ?? item.excludedRoleId,
+        }))
+}
+
+function remapCommandAccessSection(
+    next: GuildAutomationManifestDocument,
+    remapRole: RemapFn,
+): void {
+    if (!next.commandaccess) return
+    next.commandaccess.grants = next.commandaccess.grants.map((grant) => ({
+        ...grant,
+        roleId: remapRole(grant.roleId) ?? grant.roleId,
+    }))
+}
+
 class GuildAutomationExecutionService {
     private getBotToken(): string {
         const token = process.env.DISCORD_TOKEN?.trim()
@@ -412,129 +529,17 @@ class GuildAutomationExecutionService {
         channelRemap: ChannelRemap
     }): GuildAutomationManifestDocument {
         const next = structuredClone(params.manifest)
-        const remapRole = (
-            roleId: string | undefined | null,
-        ): string | undefined | null => {
-            if (!roleId) {
-                return roleId
-            }
+        const remapRole: RemapFn = (id) =>
+            id ? (params.roleRemap.get(id) ?? id) : id
+        const remapChannel: RemapFn = (id) =>
+            id ? (params.channelRemap.get(id) ?? id) : id
 
-            return params.roleRemap.get(roleId) ?? roleId
-        }
-        const remapChannel = (
-            channelId: string | undefined | null,
-        ): string | undefined | null => {
-            if (!channelId) {
-                return channelId
-            }
-
-            return params.channelRemap.get(channelId) ?? channelId
-        }
-
-        if (next.roles) {
-            next.roles.roles = next.roles.roles.map((role) => ({
-                ...role,
-                id: params.roleRemap.get(role.id) ?? role.id,
-            }))
-
-            next.roles.channels = next.roles.channels.map((channel) => ({
-                ...channel,
-                id: params.channelRemap.get(channel.id) ?? channel.id,
-                parentId: remapChannel(channel.parentId) ?? null,
-            }))
-        }
-
-        if (next.onboarding) {
-            next.onboarding.defaultChannelIds =
-                next.onboarding.defaultChannelIds
-                    .map((channelId) => remapChannel(channelId))
-                    .filter((channelId): channelId is string =>
-                        Boolean(channelId),
-                    )
-
-            next.onboarding.prompts = next.onboarding.prompts.map((prompt) => ({
-                ...prompt,
-                options: prompt.options.map((option) => ({
-                    ...option,
-                    channelIds: option.channelIds
-                        ?.map((channelId) => remapChannel(channelId))
-                        .filter((channelId): channelId is string =>
-                            Boolean(channelId),
-                        ),
-                    roleIds: option.roleIds
-                        ?.map((roleId) => remapRole(roleId))
-                        .filter((roleId): roleId is string => Boolean(roleId)),
-                })),
-            }))
-        }
-
-        if (next.moderation?.automod) {
-            next.moderation.automod.exemptRoles =
-                next.moderation.automod.exemptRoles
-                    ?.map((roleId) => remapRole(roleId))
-                    .filter((roleId): roleId is string => Boolean(roleId))
-
-            next.moderation.automod.exemptChannels =
-                next.moderation.automod.exemptChannels
-                    ?.map((channelId) => remapChannel(channelId))
-                    .filter((channelId): channelId is string =>
-                        Boolean(channelId),
-                    )
-        }
-
-        if (next.moderation?.moderationSettings) {
-            next.moderation.moderationSettings.muteRoleId =
-                remapRole(next.moderation.moderationSettings.muteRoleId) ?? null
-
-            next.moderation.moderationSettings.modRoleIds =
-                next.moderation.moderationSettings.modRoleIds
-                    ?.map((roleId) => remapRole(roleId))
-                    .filter((roleId): roleId is string => Boolean(roleId))
-
-            next.moderation.moderationSettings.adminRoleIds =
-                next.moderation.moderationSettings.adminRoleIds
-                    ?.map((roleId) => remapRole(roleId))
-                    .filter((roleId): roleId is string => Boolean(roleId))
-        }
-
-        if (next.automessages?.welcome) {
-            next.automessages.welcome.channelId =
-                remapChannel(next.automessages.welcome.channelId) ?? undefined
-        }
-
-        if (next.automessages?.leave) {
-            next.automessages.leave.channelId =
-                remapChannel(next.automessages.leave.channelId) ?? undefined
-        }
-
-        if (next.reactionroles) {
-            next.reactionroles.messages = next.reactionroles.messages?.map(
-                (message) => ({
-                    ...message,
-                    channelId: remapChannel(message.channelId) ?? undefined,
-                    mappings: message.mappings?.map((mapping) => ({
-                        ...mapping,
-                        roleId: remapRole(mapping.roleId) ?? mapping.roleId,
-                    })),
-                }),
-            )
-
-            next.reactionroles.exclusiveRoles =
-                next.reactionroles.exclusiveRoles?.map((item) => ({
-                    roleId: remapRole(item.roleId) ?? item.roleId,
-                    excludedRoleId:
-                        remapRole(item.excludedRoleId) ?? item.excludedRoleId,
-                }))
-        }
-
-        if (next.commandaccess) {
-            next.commandaccess.grants = next.commandaccess.grants.map(
-                (grant) => ({
-                    ...grant,
-                    roleId: remapRole(grant.roleId) ?? grant.roleId,
-                }),
-            )
-        }
+        remapRolesSection(next, remapRole, remapChannel)
+        remapOnboardingSection(next, remapRole, remapChannel)
+        remapModerationSection(next, remapRole, remapChannel)
+        remapAutoMessagesSection(next, remapChannel)
+        remapReactionRolesSection(next, remapRole, remapChannel)
+        remapCommandAccessSection(next, remapRole)
 
         return next
     }
@@ -574,6 +579,162 @@ class GuildAutomationExecutionService {
         })
     }
 
+    private async applyOneRole(params: {
+        token: string
+        guildId: string
+        role: ManifestRole
+        actualRoles: ManifestRole[]
+        usedActualRoleIds: Set<string>
+        roleRemap: RoleRemap
+    }): Promise<void> {
+        const { token, guildId, role, actualRoles, usedActualRoleIds, roleRemap } = params
+        const targetRoleId = this.resolveRoleTargetId({
+            desiredRoleId: role.id,
+            desiredRoleName: role.name,
+            actualRoles,
+            usedActualRoleIds,
+        })
+        const payload = {
+            name: role.name,
+            color: role.color,
+            hoist: role.hoist,
+            mentionable: role.mentionable,
+            permissions: role.permissions,
+        }
+        let resolvedRoleId = targetRoleId
+        if (targetRoleId) {
+            await this.discordRequest({
+                token,
+                endpoint: `/guilds/${guildId}/roles/${targetRoleId}`,
+                method: 'PATCH',
+                body: payload,
+            })
+        } else {
+            const created = await this.discordRequest<DiscordRoleResponse>({
+                token,
+                endpoint: `/guilds/${guildId}/roles`,
+                method: 'POST',
+                body: payload,
+            })
+            resolvedRoleId = created.id
+        }
+        if (!resolvedRoleId) return
+        usedActualRoleIds.add(resolvedRoleId)
+        if (resolvedRoleId !== role.id) {
+            roleRemap.set(role.id, resolvedRoleId)
+        }
+    }
+
+    private async applyOneChannel(params: {
+        token: string
+        guildId: string
+        channel: ManifestChannel
+        channelRemap: ChannelRemap
+        actualChannels: ManifestChannel[]
+        usedActualChannelIds: Set<string>
+    }): Promise<void> {
+        const { token, guildId, channel, channelRemap, actualChannels, usedActualChannelIds } = params
+        const remappedParentId =
+            (channel.parentId
+                ? channelRemap.get(channel.parentId)
+                : undefined) ?? channel.parentId
+        const targetChannelId = this.resolveChannelTargetId({
+            desiredChannelId: channel.id,
+            desiredChannelName: channel.name,
+            desiredChannelType: channel.type,
+            desiredParentId: remappedParentId,
+            actualChannels,
+            usedActualChannelIds,
+        })
+        const payload = {
+            name: channel.name,
+            type: toDiscordChannelType(channel.type),
+            parent_id: remappedParentId ?? null,
+            topic: channel.topic ?? null,
+        }
+        let resolvedChannelId = targetChannelId
+        if (targetChannelId) {
+            await this.discordRequest({
+                token,
+                endpoint: `/channels/${targetChannelId}`,
+                method: 'PATCH',
+                body: payload,
+            })
+        } else {
+            const created = await this.discordRequest<DiscordChannelResponse>({
+                token,
+                endpoint: `/guilds/${guildId}/channels`,
+                method: 'POST',
+                body: payload,
+            })
+            resolvedChannelId = created.id
+        }
+        if (!resolvedChannelId) return
+        usedActualChannelIds.add(resolvedChannelId)
+        if (resolvedChannelId !== channel.id) {
+            channelRemap.set(channel.id, resolvedChannelId)
+        }
+    }
+
+    private async pruneStaleRoles(
+        token: string,
+        guildId: string,
+        desiredRoles: ManifestRole[],
+        roleRemap: RoleRemap,
+    ): Promise<void> {
+        const latestRoles = await this.discordRequest<DiscordRoleResponse[]>({
+            token,
+            endpoint: `/guilds/${guildId}/roles`,
+        })
+        const desiredRoleIds = new Set(
+            desiredRoles.map((role) => roleRemap.get(role.id) ?? role.id),
+        )
+        for (const role of latestRoles) {
+            if (role.id === guildId || role.managed) continue
+            if (desiredRoleIds.has(role.id)) continue
+            try {
+                await this.discordRequest({
+                    token,
+                    endpoint: `/guilds/${guildId}/roles/${role.id}`,
+                    method: 'DELETE',
+                })
+            } catch (error) {
+                if (!isExpectedDeleteError(error)) throw error
+            }
+        }
+    }
+
+    private async pruneStaleChannels(
+        token: string,
+        guildId: string,
+        desiredChannels: ManifestChannel[],
+        channelRemap: ChannelRemap,
+    ): Promise<void> {
+        const latestChannels = await this.discordRequest<DiscordChannelResponse[]>(
+            {
+                token,
+                endpoint: `/guilds/${guildId}/channels`,
+            },
+        )
+        const desiredChannelIds = new Set(
+            desiredChannels.map(
+                (channel) => channelRemap.get(channel.id) ?? channel.id,
+            ),
+        )
+        for (const channel of latestChannels) {
+            if (desiredChannelIds.has(channel.id)) continue
+            try {
+                await this.discordRequest({
+                    token,
+                    endpoint: `/channels/${channel.id}`,
+                    method: 'DELETE',
+                })
+            } catch (error) {
+                if (!isExpectedDeleteError(error)) throw error
+            }
+        }
+    }
+
     private async applyRolesAndChannels(params: {
         token: string
         guildId: string
@@ -591,177 +752,49 @@ class GuildAutomationExecutionService {
         const usedActualChannelIds = new Set<string>()
 
         for (const role of desiredRoles) {
-            const targetRoleId = this.resolveRoleTargetId({
-                desiredRoleId: role.id,
-                desiredRoleName: role.name,
+            await this.applyOneRole({
+                token: params.token,
+                guildId: params.guildId,
+                role,
                 actualRoles,
                 usedActualRoleIds,
+                roleRemap: params.roleRemap,
             })
-
-            const payload = {
-                name: role.name,
-                color: role.color,
-                hoist: role.hoist,
-                mentionable: role.mentionable,
-                permissions: role.permissions,
-            }
-
-            let resolvedRoleId = targetRoleId
-            if (targetRoleId) {
-                await this.discordRequest({
-                    token: params.token,
-                    endpoint: `/guilds/${params.guildId}/roles/${targetRoleId}`,
-                    method: 'PATCH',
-                    body: payload,
-                })
-            } else {
-                const created = await this.discordRequest<DiscordRoleResponse>({
-                    token: params.token,
-                    endpoint: `/guilds/${params.guildId}/roles`,
-                    method: 'POST',
-                    body: payload,
-                })
-                resolvedRoleId = created.id
-            }
-
-            if (!resolvedRoleId) {
-                continue
-            }
-
-            usedActualRoleIds.add(resolvedRoleId)
-            if (resolvedRoleId !== role.id) {
-                params.roleRemap.set(role.id, resolvedRoleId)
-            }
         }
 
         const sortedChannels = [...desiredChannels].sort((a, b) => {
             const aPriority = a.type === 'GuildCategory' ? 0 : 1
             const bPriority = b.type === 'GuildCategory' ? 0 : 1
-            if (aPriority !== bPriority) {
-                return aPriority - bPriority
-            }
-
+            if (aPriority !== bPriority) return aPriority - bPriority
             return a.id.localeCompare(b.id)
         })
 
         for (const channel of sortedChannels) {
-            const remappedParentId =
-                (channel.parentId
-                    ? params.channelRemap.get(channel.parentId)
-                    : undefined) ?? channel.parentId
-
-            const targetChannelId = this.resolveChannelTargetId({
-                desiredChannelId: channel.id,
-                desiredChannelName: channel.name,
-                desiredChannelType: channel.type,
-                desiredParentId: remappedParentId,
+            await this.applyOneChannel({
+                token: params.token,
+                guildId: params.guildId,
+                channel,
+                channelRemap: params.channelRemap,
                 actualChannels,
                 usedActualChannelIds,
             })
-
-            const payload = {
-                name: channel.name,
-                type: toDiscordChannelType(channel.type),
-                parent_id: remappedParentId ?? null,
-                topic: channel.topic ?? null,
-            }
-
-            let resolvedChannelId = targetChannelId
-            if (targetChannelId) {
-                await this.discordRequest({
-                    token: params.token,
-                    endpoint: `/channels/${targetChannelId}`,
-                    method: 'PATCH',
-                    body: payload,
-                })
-            } else {
-                const created =
-                    await this.discordRequest<DiscordChannelResponse>({
-                        token: params.token,
-                        endpoint: `/guilds/${params.guildId}/channels`,
-                        method: 'POST',
-                        body: payload,
-                    })
-                resolvedChannelId = created.id
-            }
-
-            if (!resolvedChannelId) {
-                continue
-            }
-
-            usedActualChannelIds.add(resolvedChannelId)
-            if (resolvedChannelId !== channel.id) {
-                params.channelRemap.set(channel.id, resolvedChannelId)
-            }
         }
 
-        if (!params.allowProtected) {
-            return
-        }
+        if (!params.allowProtected) return
 
-        const latestRoles = await this.discordRequest<DiscordRoleResponse[]>({
-            token: params.token,
-            endpoint: `/guilds/${params.guildId}/roles`,
-        })
-        const desiredRoleIds = new Set(
-            desiredRoles.map(
-                (role) => params.roleRemap.get(role.id) ?? role.id,
-            ),
+        await this.pruneStaleRoles(
+            params.token,
+            params.guildId,
+            desiredRoles,
+            params.roleRemap,
         )
-
-        for (const role of latestRoles) {
-            if (role.id === params.guildId || role.managed) {
-                continue
-            }
-
-            if (desiredRoleIds.has(role.id)) {
-                continue
-            }
-
-            try {
-                await this.discordRequest({
-                    token: params.token,
-                    endpoint: `/guilds/${params.guildId}/roles/${role.id}`,
-                    method: 'DELETE',
-                })
-            } catch (error) {
-                if (!isExpectedDeleteError(error)) {
-                    throw error
-                }
-            }
-        }
-
-        const latestChannels = await this.discordRequest<
-            DiscordChannelResponse[]
-        >({
-            token: params.token,
-            endpoint: `/guilds/${params.guildId}/channels`,
-        })
-        const desiredChannelIds = new Set(
-            desiredChannels.map(
-                (channel) => params.channelRemap.get(channel.id) ?? channel.id,
-            ),
+        await this.pruneStaleChannels(
+            params.token,
+            params.guildId,
+            desiredChannels,
+            params.channelRemap,
         )
-
-        for (const channel of latestChannels) {
-            if (desiredChannelIds.has(channel.id)) {
-                continue
-            }
-
-            try {
-                await this.discordRequest({
-                    token: params.token,
-                    endpoint: `/channels/${channel.id}`,
-                    method: 'DELETE',
-                })
-            } catch (error) {
-                if (!isExpectedDeleteError(error)) {
-                    throw error
-                }
-            }
-        }
     }
-
     private async applyReactionRoleRules(
         guildId: string,
         desired: GuildAutomationManifestDocument,
@@ -936,6 +969,98 @@ class GuildAutomationExecutionService {
         }
     }
 
+    private async applyOnboardingModule(
+        token: string,
+        guildId: string,
+        desired: GuildAutomationManifestDocument,
+        appliedModules: string[],
+    ): Promise<void> {
+        const onboarding = desired.onboarding
+        if (!onboarding) return
+        await this.discordRequest({
+            token,
+            endpoint: `/guilds/${guildId}/onboarding`,
+            method: 'PUT',
+            body: {
+                enabled: onboarding.enabled,
+                mode: onboarding.mode,
+                default_channel_ids: onboarding.defaultChannelIds,
+                prompts: onboarding.prompts.map((prompt) => ({
+                    id: prompt.id,
+                    title: prompt.title,
+                    single_select: prompt.singleSelect,
+                    required: prompt.required,
+                    in_onboarding: prompt.inOnboarding,
+                    type: prompt.type,
+                    options: prompt.options.map((option) => ({
+                        id: option.id ?? null,
+                        title: option.title,
+                        description: option.description ?? null,
+                        channel_ids: option.channelIds,
+                        role_ids: option.roleIds,
+                        emoji: option.emoji ?? null,
+                    })),
+                })),
+            },
+        })
+        appliedModules.push('onboarding')
+    }
+
+    private async applyModerationModule(
+        guildId: string,
+        desired: GuildAutomationManifestDocument,
+        appliedModules: string[],
+    ): Promise<void> {
+        const automodPayload = toAutoModPayload(desired.moderation?.automod)
+        if (automodPayload) {
+            await autoModService.updateSettings(guildId, automodPayload)
+        }
+        const moderationPayload = toModerationPayload(
+            desired.moderation?.moderationSettings,
+        )
+        if (moderationPayload) {
+            await updateModerationSettings(guildId, moderationPayload)
+        }
+        appliedModules.push('moderation')
+    }
+
+    private async applyAutoMessagesModule(
+        guildId: string,
+        desired: GuildAutomationManifestDocument,
+        appliedModules: string[],
+    ): Promise<void> {
+        await this.upsertAutoMessage(guildId, 'welcome', desired.automessages?.welcome)
+        await this.upsertAutoMessage(guildId, 'leave', desired.automessages?.leave)
+        appliedModules.push('automessages')
+    }
+
+    private async applyReactionRolesModule(
+        guildId: string,
+        desired: GuildAutomationManifestDocument,
+        appliedModules: string[],
+        skippedModules: string[],
+    ): Promise<void> {
+        await this.applyReactionRoleRules(guildId, desired)
+        if ((desired.reactionroles?.messages?.length ?? 0) > 0) {
+            skippedModules.push(
+                'reactionroles.messages requires manual message-template publish',
+            )
+        }
+        appliedModules.push('reactionroles')
+    }
+
+    private async applyCommandAccessModule(
+        guildId: string,
+        desired: GuildAutomationManifestDocument,
+        appliedModules: string[],
+    ): Promise<void> {
+        await guildRoleAccessService.replaceRoleGrants(
+            guildId,
+            desired.commandaccess?.grants ?? [],
+        )
+        appliedModules.push('commandaccess')
+    }
+
     async executeApplyPlan(params: {
         guildId: string
         plan: GuildAutomationPlan
@@ -953,39 +1078,8 @@ class GuildAutomationExecutionService {
         const channelRemap: ChannelRemap = new Map()
         let effectiveDesired = params.desired
 
-        if (
-            shouldApplyModule(params.plan, 'onboarding', params.allowProtected)
-        ) {
-            const onboarding = effectiveDesired.onboarding
-            if (onboarding) {
-                await this.discordRequest({
-                    token,
-                    endpoint: `/guilds/${params.guildId}/onboarding`,
-                    method: 'PUT',
-                    body: {
-                        enabled: onboarding.enabled,
-                        mode: onboarding.mode,
-                        default_channel_ids: onboarding.defaultChannelIds,
-                        prompts: onboarding.prompts.map((prompt) => ({
-                            id: prompt.id,
-                            title: prompt.title,
-                            single_select: prompt.singleSelect,
-                            required: prompt.required,
-                            in_onboarding: prompt.inOnboarding,
-                            type: prompt.type,
-                            options: prompt.options.map((option) => ({
-                                id: option.id ?? null,
-                                title: option.title,
-                                description: option.description ?? null,
-                                channel_ids: option.channelIds,
-                                role_ids: option.roleIds,
-                                emoji: option.emoji ?? null,
-                            })),
-                        })),
-                    },
-                })
-                appliedModules.push('onboarding')
-            }
+        if (shouldApplyModule(params.plan, 'onboarding', params.allowProtected)) {
+            await this.applyOnboardingModule(token, params.guildId, effectiveDesired, appliedModules)
         }
 
         if (shouldApplyModule(params.plan, 'roles', params.allowProtected)) {
@@ -998,7 +1092,6 @@ class GuildAutomationExecutionService {
                 roleRemap,
                 channelRemap,
             })
-
             if (roleRemap.size > 0 || channelRemap.size > 0) {
                 effectiveDesired = this.remapManifestEntityIds({
                     manifest: effectiveDesired,
@@ -1006,86 +1099,23 @@ class GuildAutomationExecutionService {
                     channelRemap,
                 })
             }
-
             appliedModules.push('roles')
         }
 
-        if (
-            shouldApplyModule(params.plan, 'moderation', params.allowProtected)
-        ) {
-            const automodPayload = toAutoModPayload(
-                effectiveDesired.moderation?.automod,
-            )
-            if (automodPayload) {
-                await autoModService.updateSettings(
-                    params.guildId,
-                    automodPayload,
-                )
-            }
-
-            const moderationPayload = toModerationPayload(
-                effectiveDesired.moderation?.moderationSettings,
-            )
-            if (moderationPayload) {
-                await updateModerationSettings(
-                    params.guildId,
-                    moderationPayload,
-                )
-            }
-
-            appliedModules.push('moderation')
+        if (shouldApplyModule(params.plan, 'moderation', params.allowProtected)) {
+            await this.applyModerationModule(params.guildId, effectiveDesired, appliedModules)
         }
 
-        if (
-            shouldApplyModule(
-                params.plan,
-                'automessages',
-                params.allowProtected,
-            )
-        ) {
-            await this.upsertAutoMessage(
-                params.guildId,
-                'welcome',
-                effectiveDesired.automessages?.welcome,
-            )
-            await this.upsertAutoMessage(
-                params.guildId,
-                'leave',
-                effectiveDesired.automessages?.leave,
-            )
-            appliedModules.push('automessages')
+        if (shouldApplyModule(params.plan, 'automessages', params.allowProtected)) {
+            await this.applyAutoMessagesModule(params.guildId, effectiveDesired, appliedModules)
         }
 
-        if (
-            shouldApplyModule(
-                params.plan,
-                'reactionroles',
-                params.allowProtected,
-            )
-        ) {
-            await this.applyReactionRoleRules(params.guildId, effectiveDesired)
-
-            if ((effectiveDesired.reactionroles?.messages?.length ?? 0) > 0) {
-                skippedModules.push(
-                    'reactionroles.messages requires manual message-template publish',
-                )
-            }
-
-            appliedModules.push('reactionroles')
+        if (shouldApplyModule(params.plan, 'reactionroles', params.allowProtected)) {
+            await this.applyReactionRolesModule(params.guildId, effectiveDesired, appliedModules, skippedModules)
         }
 
-        if (
-            shouldApplyModule(
-                params.plan,
-                'commandaccess',
-                params.allowProtected,
-            )
-        ) {
-            await guildRoleAccessService.replaceRoleGrants(
-                params.guildId,
-                effectiveDesired.commandaccess?.grants ?? [],
-            )
-            appliedModules.push('commandaccess')
+        if (shouldApplyModule(params.plan, 'commandaccess', params.allowProtected)) {
+            await this.applyCommandAccessModule(params.guildId, effectiveDesired, appliedModules)
         }
 
         if (shouldApplyModule(params.plan, 'parity', params.allowProtected)) {

--- a/packages/backend/tests/unit/services/GuildAutomationExecutionService.test.ts
+++ b/packages/backend/tests/unit/services/GuildAutomationExecutionService.test.ts
@@ -1299,6 +1299,176 @@ describe('GuildAutomationExecutionService', () => {
             )
         })
 
+        test('should apply onboarding module with prompts containing options', async () => {
+            const desired = createMinimalManifest({
+                onboarding: {
+                    enabled: true,
+                    mode: 0,
+                    defaultChannelIds: [CHANNEL_ID_1],
+                    prompts: [
+                        {
+                            id: 'prompt-1',
+                            title: 'Pick a channel',
+                            singleSelect: true,
+                            required: false,
+                            inOnboarding: true,
+                            type: 0,
+                            options: [
+                                {
+                                    id: 'opt-1',
+                                    title: 'General',
+                                    description: null,
+                                    channelIds: [CHANNEL_ID_1],
+                                    roleIds: [ROLE_ID_1],
+                                    emoji: null,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            })
+            const actual = createMinimalManifest()
+            const plan = createMinimalPlan([
+                { module: 'onboarding', action: 'update', protected: false, description: 'Update' },
+            ])
+            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
+            const result = await guildAutomationExecutionService.executeApplyPlan({
+                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
+            })
+            expect(result.diagnostics.appliedModules).toContain('onboarding')
+            const body = JSON.parse((mockFetch.mock.calls[0] as any[])[1].body as string)
+            expect(body.prompts[0].options[0].channel_ids).toEqual([CHANNEL_ID_1])
+            expect(body.prompts[0].options[0].role_ids).toEqual([ROLE_ID_1])
+        })
+
+        test('should apply command access grants', async () => {
+            const desired = createMinimalManifest({
+                commandaccess: {
+                    grants: [
+                        { roleId: ROLE_ID_1, module: 'music', mode: 'allow' as any },
+                    ],
+                },
+            })
+            const actual = createMinimalManifest()
+            const plan = createMinimalPlan([
+                { module: 'commandaccess', action: 'update', protected: false, description: 'Update' },
+            ])
+            const { guildRoleAccessService } = await import('@lucky/shared/services')
+            ;(guildRoleAccessService.replaceRoleGrants as jest.Mock).mockResolvedValue(undefined)
+            const result = await guildAutomationExecutionService.executeApplyPlan({
+                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
+            })
+            expect(result.diagnostics.appliedModules).toContain('commandaccess')
+            expect(guildRoleAccessService.replaceRoleGrants as jest.Mock).toHaveBeenCalledWith(
+                GUILD_ID,
+                [{ roleId: ROLE_ID_1, module: 'music', mode: 'allow' }],
+            )
+        })
+
+        test('should update existing channel by ID', async () => {
+            const desired = createMinimalManifest({
+                roles: {
+                    roles: [],
+                    channels: [
+                        { id: CHANNEL_ID_1, name: 'updated-name', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                    ],
+                },
+            })
+            const actual = createMinimalManifest({
+                roles: {
+                    roles: [],
+                    channels: [
+                        { id: CHANNEL_ID_1, name: 'old-name', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                    ],
+                },
+            })
+            const plan = createMinimalPlan([
+                { module: 'roles', action: 'update', protected: false, description: 'Update channel' },
+            ])
+            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
+            const result = await guildAutomationExecutionService.executeApplyPlan({
+                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
+            })
+            expect(result.diagnostics.appliedModules).toContain('roles')
+            expect(mockFetch).toHaveBeenCalledWith(
+                expect.stringContaining(`/channels/${CHANNEL_ID_1}`),
+                expect.objectContaining({ method: 'PATCH' }),
+            )
+        })
+
+        test('should delete stale channels when allowProtected is true', async () => {
+            const desired = createMinimalManifest({
+                roles: {
+                    roles: [],
+                    channels: [
+                        { id: CHANNEL_ID_1, name: 'keep', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                    ],
+                },
+            })
+            const actual = createMinimalManifest({
+                roles: { roles: [], channels: [] },
+            })
+            const plan = createMinimalPlan([
+                { module: 'roles', action: 'delete', protected: true, description: 'Delete stale' },
+            ])
+            mockFetch
+                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: CHANNEL_ID_1, name: 'keep' }) })  // POST create channel
+                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })  // GET roles for prune
+                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [  // GET channels for prune
+                    { id: CHANNEL_ID_2, name: 'stale' },
+                ] })
+                .mockResolvedValueOnce({ ok: true, status: 204, json: async () => undefined })  // DELETE stale channel
+            const result = await guildAutomationExecutionService.executeApplyPlan({
+                guildId: GUILD_ID, plan, desired, actual, allowProtected: true,
+            })
+            expect(result.diagnostics.appliedModules).toContain('roles')
+            expect(mockFetch).toHaveBeenCalledWith(
+                expect.stringContaining(`/channels/${CHANNEL_ID_2}`),
+                expect.objectContaining({ method: 'DELETE' }),
+            )
+        })
+
+        test('should apply remapping through all manifest sections when roles/channels are remapped', async () => {
+            const OLD_ROLE = 'old-role-111'
+            const NEW_ROLE = 'new-role-222'
+            const OLD_CHANNEL = 'old-ch-111'
+            const NEW_CHANNEL = 'new-ch-222'
+
+            const desired = createMinimalManifest({
+                roles: {
+                    roles: [{ id: OLD_ROLE, name: 'Member', color: 0, hoist: false, mentionable: false }],
+                    channels: [{ id: OLD_CHANNEL, name: 'general', type: 'GuildText', parentId: null, topic: null, readonly: false }],
+                },
+                onboarding: { enabled: true, mode: 0, defaultChannelIds: [OLD_CHANNEL], prompts: [] },
+                moderation: {
+                    automod: { exemptRoles: [OLD_ROLE], exemptChannels: [OLD_CHANNEL] } as any,
+                    moderationSettings: { muteRoleId: OLD_ROLE, modRoleIds: [OLD_ROLE], adminRoleIds: [] } as any,
+                },
+                automessages: {
+                    welcome: { enabled: true, channelId: OLD_CHANNEL, message: 'hi' },
+                    leave: { enabled: true, channelId: OLD_CHANNEL, message: 'bye' },
+                },
+                reactionroles: {
+                    messages: [{ id: 'm1', messageId: 'dm1', channelId: OLD_CHANNEL, mappings: [{ roleId: OLD_ROLE, label: 'x', emoji: undefined, style: undefined }] }],
+                    exclusiveRoles: [{ roleId: OLD_ROLE, excludedRoleId: OLD_ROLE }],
+                },
+                commandaccess: { grants: [{ roleId: OLD_ROLE, module: 'music', mode: 'allow' as any }] },
+            })
+            const actual = createMinimalManifest({ roles: { roles: [], channels: [] } })
+            const plan = createMinimalPlan([
+                { module: 'roles', action: 'create', protected: false, description: 'Create' },
+            ])
+            mockFetch
+                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: NEW_ROLE, name: 'Member' }) })
+                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: NEW_CHANNEL, name: 'general' }) })
+            const result = await guildAutomationExecutionService.executeApplyPlan({
+                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
+            })
+            expect(result.remappedManifest).toBeDefined()
+            expect(result.diagnostics.roleIdRemaps).toEqual({ [OLD_ROLE]: NEW_ROLE })
+            expect(result.diagnostics.channelIdRemaps).toEqual({ [OLD_CHANNEL]: NEW_CHANNEL })
+        })
+
         test('should note when reactionroles messages require manual setup', async () => {
             const desired = createMinimalManifest({
                 reactionroles: {


### PR DESCRIPTION
## Summary

Reduces cyclomatic complexity in the three remaining high-complexity methods of `GuildAutomationExecutionService.ts` (all previously above the ESLint threshold of 15).

## Changes

**`remapManifestEntityIds` (22 → ~7)**
- Extracted 6 module-level section helpers: `remapRolesSection`, `remapOnboardingSection`, `remapModerationSection`, `remapAutoMessagesSection`, `remapReactionRolesSection`, `remapCommandAccessSection`
- Added `RemapFn` type alias for the remap function signature
- Main method now calls 6 focused helpers instead of containing 8+ nested if-blocks

**`applyRolesAndChannels` (32 → ~8)**
- Extracted `applyOneRole` — handles create-or-update for a single role
- Extracted `applyOneChannel` — handles create-or-update for a single channel
- Extracted `pruneStaleRoles` — deletes roles not in the desired manifest
- Extracted `pruneStaleChannels` — deletes channels not in the desired manifest
- Main method is now a clean orchestration loop

**`executeApplyPlan` (25 → ~10)**
- Extracted `applyOnboardingModule`, `applyModerationModule`, `applyAutoMessagesModule`, `applyReactionRolesModule`, `applyCommandAccessModule` as private methods
- Main method now has one `shouldApplyModule` check per extracted helper

No behavior changes — same Discord mutations, same service calls, same error handling.

## Verification

- [x] `npm run lint --workspace=packages/backend` — 0 GuildAutomation complexity warnings
- [x] `npm run type:check --workspace=packages/backend` — 0 errors  
- [x] `npm run test --workspace=packages/backend -- --ci` — 672/672 pass
- [ ] CI Quality Gates green

## Note

The remaining `buildAuthConfigHealth` complexity warning is addressed by the companion PR `refactor/backend-complexity-reduction` (#458).