### PR TITLE
ci(deploy): skip docker-publish wait for non-image commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,13 +73,18 @@ jobs:
                     # docker-publish.yml only triggers on: packages/**, prisma/**, Dockerfile*,
                     # nginx/**, package*.json — if none of those changed, no rebuild is needed
                     # and deploying with the existing latest images is safe.
-                    changed_files=$(gh api \
-                      "repos/${{ github.repository }}/commits/${commit_sha}" \
-                      --jq '[.files[].filename] | join("\n")' 2>/dev/null || echo "")
+                    # Mirrors the exact path triggers from docker-publish.yml.
+                    docker_path_pattern='^(packages/|prisma/|Dockerfile|Dockerfile\.|nginx/|package\.json|package-lock\.json)'
 
-                    docker_relevant=$(echo "$changed_files" | grep -E \
-                      '^(packages/|prisma/|Dockerfile|Dockerfile\.|nginx/|package\.json|package-lock\.json)' \
-                      | head -1 || true)
+                    if ! changed_files=$(gh api \
+                      "repos/${{ github.repository }}/commits/${commit_sha}" \
+                      --jq '[.files[].filename] | join("\n")'); then
+                      echo "::warning::Failed to query commit file list — cannot determine if Docker rebuild is needed, proceeding with abort."
+                      echo "::error::No docker-publish run found for commit ${commit_sha} after ${detect_max}s — aborting deploy"
+                      exit 1
+                    fi
+
+                    docker_relevant=$(echo "$changed_files" | grep -E "$docker_path_pattern" | head -1 || true)
 
                     if [ -z "$docker_relevant" ]; then
                       echo "::notice::No Docker-relevant files changed in this commit — skipping image wait, deploying with existing images."
@@ -88,7 +93,7 @@ jobs:
 
                     echo "::error::No docker-publish run found for commit ${commit_sha} after ${detect_max}s — aborting deploy"
                     echo "Docker-relevant files changed:"
-                    echo "$changed_files" | grep -E '^(packages/|prisma/|Dockerfile|Dockerfile\.|nginx/|package\.json|package-lock\.json)' || true
+                    echo "$changed_files" | grep -E "$docker_path_pattern" || true
                     exit 1
                   fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,27 @@ jobs:
                       echo "::warning::No docker-publish run found for this commit — proceeding anyway (FORCE_UNVERIFIED_DEPLOY=true)"
                       exit 0
                     fi
+
+                    # Check if this commit touched Docker-relevant paths.
+                    # docker-publish.yml only triggers on: packages/**, prisma/**, Dockerfile*,
+                    # nginx/**, package*.json — if none of those changed, no rebuild is needed
+                    # and deploying with the existing latest images is safe.
+                    changed_files=$(gh api \
+                      "repos/${{ github.repository }}/commits/${commit_sha}" \
+                      --jq '[.files[].filename] | join("\n")' 2>/dev/null || echo "")
+
+                    docker_relevant=$(echo "$changed_files" | grep -E \
+                      '^(packages/|prisma/|Dockerfile|Dockerfile\.|nginx/|package\.json|package-lock\.json)' \
+                      | head -1 || true)
+
+                    if [ -z "$docker_relevant" ]; then
+                      echo "::notice::No Docker-relevant files changed in this commit — skipping image wait, deploying with existing images."
+                      exit 0
+                    fi
+
                     echo "::error::No docker-publish run found for commit ${commit_sha} after ${detect_max}s — aborting deploy"
+                    echo "Docker-relevant files changed:"
+                    echo "$changed_files" | grep -E '^(packages/|prisma/|Dockerfile|Dockerfile\.|nginx/|package\.json|package-lock\.json)' || true
                     exit 1
                   fi
 


### PR DESCRIPTION
## Problem

Deploy was failing on every commit that didn't touch Docker-relevant files.

`docker-publish.yml` only triggers when `packages/**`, `prisma/**`, `Dockerfile*`, `nginx/**`, or `package*.json` are changed. For docs, test, CI, or chore commits none of these paths change, so docker-publish never runs.

The "Wait for Docker images" step would poll for 60s, find nothing, and hard-abort:
```
No docker-publish run found for commit abc123 after 60s — aborting deploy
```

This broke deployment for:
- `docs: sync TESTING.md and README with current test matrix` (#457)
- `chore: add shared package test lane and wire into test:all` (#460)
- Any future docs/test/CI-only commit

## Fix

When no docker-publish run is found after the detection window, query the GitHub API to check which files the commit actually changed. If none of the changed files match the docker-publish trigger paths, the commit genuinely does not need new images — skip the wait and proceed with the existing `latest` images.

```
::notice::No Docker-relevant files changed in this commit — skipping image wait, deploying with existing images.
```

If Docker-relevant files **were** changed but no docker-publish run was found, the existing hard-abort is preserved (now with better diagnostic output showing which files triggered the expectation).

## What this does NOT change

- The `FORCE_UNVERIFIED_DEPLOY` escape hatch is unchanged
- docker-publish failure still aborts deploy (correct behaviour)  
- Wait logic for in-progress docker-publish runs is unchanged

## Verification

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI Quality Gates green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment pipeline verification to intelligently detect relevant code changes and optimize deployment timing, reducing unnecessary delays when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->