### PR TITLE
fix(bot): version from package.json, play interaction guard, serversetupCriativaria loader noise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1868,42 +1868,28 @@
             "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
             "license": "(Apache-2.0 AND BSD-3-Clause)"
         },
-        "node_modules/@chevrotain/cst-dts-gen": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-            "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
+        "node_modules/@clack/core": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
+            "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
             "devOptional": true,
-            "license": "Apache-2.0",
+            "license": "MIT",
             "dependencies": {
-                "@chevrotain/gast": "10.5.0",
-                "@chevrotain/types": "10.5.0",
-                "lodash": "4.17.21"
+                "picocolors": "^1.0.0",
+                "sisteransi": "^1.0.5"
             }
         },
-        "node_modules/@chevrotain/gast": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-            "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
+        "node_modules/@clack/prompts": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
+            "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
             "devOptional": true,
-            "license": "Apache-2.0",
+            "license": "MIT",
             "dependencies": {
-                "@chevrotain/types": "10.5.0",
-                "lodash": "4.17.21"
+                "@clack/core": "0.5.0",
+                "picocolors": "^1.0.0",
+                "sisteransi": "^1.0.5"
             }
-        },
-        "node_modules/@chevrotain/types": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-            "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-            "devOptional": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/@chevrotain/utils": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-            "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-            "devOptional": true,
-            "license": "Apache-2.0"
         },
         "node_modules/@commitlint/cli": {
             "version": "20.5.0",
@@ -2556,33 +2542,33 @@
             }
         },
         "node_modules/@electric-sql/pglite": {
-            "version": "0.3.15",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
-            "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
+            "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
             "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@electric-sql/pglite-socket": {
-            "version": "0.0.20",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
-            "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
+            "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "pglite-server": "dist/scripts/server.js"
             },
             "peerDependencies": {
-                "@electric-sql/pglite": "0.3.15"
+                "@electric-sql/pglite": "0.4.1"
             }
         },
         "node_modules/@electric-sql/pglite-tools": {
-            "version": "0.2.20",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
-            "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
+            "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
             "devOptional": true,
             "license": "Apache-2.0",
             "peerDependencies": {
-                "@electric-sql/pglite": "0.3.15"
+                "@electric-sql/pglite": "0.4.1"
             }
         },
         "node_modules/@emnapi/core": {
@@ -3282,9 +3268,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.11",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-            "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+            "version": "1.19.12",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+            "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -4135,6 +4121,13 @@
                 "node": ">= 18"
             }
         },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "devOptional": true,
+            "license": "MIT"
+        },
         "node_modules/@lucky/backend": {
             "resolved": "packages/backend",
             "link": true
@@ -4146,20 +4139,6 @@
         "node_modules/@lucky/shared": {
             "resolved": "packages/shared",
             "link": true
-        },
-        "node_modules/@mrleebo/prisma-ast": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
-            "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
-            "devOptional": true,
-            "license": "MIT",
-            "dependencies": {
-                "chevrotain": "^10.5.0",
-                "lilconfig": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
         },
         "node_modules/@napi-rs/nice": {
             "version": "1.1.1",
@@ -5270,15 +5249,15 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/config": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.5.0.tgz",
-            "integrity": "sha512-1J/9YEX7A889xM46PYg9e8VAuSL1IUmXJW3tEhMv7XQHDWlfC9YSkIw9sTYRaq5GswGlxZ+GnnyiNsUZ9JJhSQ==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.6.0.tgz",
+            "integrity": "sha512-MuAz1MK4PeG5/03YzfzX3CnFVHQ6qePGwUpQRzPzX5tT0ffJ3Tzi9zJZbBc+VzEGFCM8ghW/gTVDR85Syjt+Yw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "c12": "3.1.0",
                 "deepmerge-ts": "7.1.5",
-                "effect": "3.18.4",
+                "effect": "3.20.0",
                 "empathic": "2.0.0"
             }
         },
@@ -5289,22 +5268,22 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/dev": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
-            "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
+            "version": "0.24.3",
+            "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
+            "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
             "devOptional": true,
             "license": "ISC",
             "dependencies": {
-                "@electric-sql/pglite": "0.3.15",
-                "@electric-sql/pglite-socket": "0.0.20",
-                "@electric-sql/pglite-tools": "0.2.20",
-                "@hono/node-server": "1.19.9",
-                "@mrleebo/prisma-ast": "0.13.1",
+                "@electric-sql/pglite": "0.4.1",
+                "@electric-sql/pglite-socket": "0.1.1",
+                "@electric-sql/pglite-tools": "0.3.1",
+                "@hono/node-server": "1.19.11",
                 "@prisma/get-platform": "7.2.0",
                 "@prisma/query-plan-executor": "7.2.0",
+                "@prisma/streams-local": "0.1.2",
                 "foreground-child": "3.3.1",
                 "get-port-please": "3.2.0",
-                "hono": "4.11.4",
+                "hono": "^4.12.8",
                 "http-status-codes": "2.3.0",
                 "pathe": "2.0.3",
                 "proper-lockfile": "4.1.2",
@@ -5324,56 +5303,70 @@
             }
         },
         "node_modules/@prisma/engines": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.5.0.tgz",
-            "integrity": "sha512-ondGRhzoaVpRWvFaQ5wH5zS1BIbhzbKqczKjCn6j3L0Zfe/LInjcEg8+xtB49AuZBX30qyx1ZtGoootUohz2pw==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.6.0.tgz",
+            "integrity": "sha512-Sn5edRzhHqgRV2M+A0eIbY442B4mReWWf3pKs/LKreYgW7oa/up8JtK/s4iv/EQA097cyboZ08mmkpbLp+tZ3w==",
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.5.0",
-                "@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-                "@prisma/fetch-engine": "7.5.0",
-                "@prisma/get-platform": "7.5.0"
+                "@prisma/debug": "7.6.0",
+                "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+                "@prisma/fetch-engine": "7.6.0",
+                "@prisma/get-platform": "7.6.0"
             }
         },
         "node_modules/@prisma/engines-version": {
-            "version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e.tgz",
-            "integrity": "sha512-E+iRV/vbJLl8iGjVr6g/TEWokA+gjkV/doZkaQN1i/ULVdDwGnPJDfLUIFGS3BVwlG/m6L8T4x1x5isl8hGMxA==",
+            "version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711.tgz",
+            "integrity": "sha512-r51DLcJ8bDRSrBEJF3J4cinoWyGA7rfP2mG6lD90VqIbGNOkbfcLcXalSVjq5Y6brQS3vcjrq4GbyUb1Cb7vkw==",
+            "devOptional": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@prisma/engines/node_modules/@prisma/debug": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.6.0.tgz",
+            "integrity": "sha512-LpHr3qos4lQZ6sxwjStf59YBht7m9/QF7NSQsMH6qGENWZu2w3UkQUGn1h5iRkDjnWRj3VHykOu9qFhps4ADvA==",
             "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
-            "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.6.0.tgz",
+            "integrity": "sha512-ohZDwXvtmnbzOcutR2D13lDWpZP1wQjmPyztmt0AwXLzQI7q95EE7NYCvS+M6N6SivT+BM0NOqLmTH3wms4L3A==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.5.0"
+                "@prisma/debug": "7.6.0"
             }
         },
         "node_modules/@prisma/fetch-engine": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.5.0.tgz",
-            "integrity": "sha512-kZCl2FV54qnyrVdnII8MI6qvt7HfU6Cbiz8dZ8PXz4f4lbSw45jEB9/gEMK2SGdiNhBKyk/Wv95uthoLhGMLYA==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.6.0.tgz",
+            "integrity": "sha512-N575Ni95c3FkduWY/eKTHqNYgNbceZ1tQaSknVtJjpKmiiBXmniESn/GTxsDvICC4ZeiNrXxioGInzQrCdx16w==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.5.0",
-                "@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-                "@prisma/get-platform": "7.5.0"
+                "@prisma/debug": "7.6.0",
+                "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+                "@prisma/get-platform": "7.6.0"
             }
         },
+        "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.6.0.tgz",
+            "integrity": "sha512-LpHr3qos4lQZ6sxwjStf59YBht7m9/QF7NSQsMH6qGENWZu2w3UkQUGn1h5iRkDjnWRj3VHykOu9qFhps4ADvA==",
+            "devOptional": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
-            "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.6.0.tgz",
+            "integrity": "sha512-ohZDwXvtmnbzOcutR2D13lDWpZP1wQjmPyztmt0AwXLzQI7q95EE7NYCvS+M6N6SivT+BM0NOqLmTH3wms4L3A==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.5.0"
+                "@prisma/debug": "7.6.0"
             }
         },
         "node_modules/@prisma/get-platform": {
@@ -5453,14 +5446,48 @@
             "devOptional": true,
             "license": "Apache-2.0"
         },
-        "node_modules/@prisma/studio-core": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.21.1.tgz",
-            "integrity": "sha512-bOGqG/eMQtKC0XVvcVLRmhWWzm/I+0QUWqAEhEBtetpuS3k3V4IWqKGUONkAIT223DNXJMxMtZp36b1FmcdPeg==",
+        "node_modules/@prisma/streams-local": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
+            "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "ajv": "^8.12.0",
+                "better-result": "^2.7.0",
+                "env-paths": "^3.0.0",
+                "proper-lockfile": "^4.1.2"
+            },
             "engines": {
-                "node": "^20.19 || ^22.12 || ^24.0",
+                "bun": ">=1.3.6",
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/@prisma/streams-local/node_modules/env-paths": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+            "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+            "devOptional": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@prisma/studio-core": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
+            "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@radix-ui/react-toggle": "1.1.10",
+                "chart.js": "4.5.1"
+            },
+            "engines": {
+                "node": "^20.19 || ^22.12 || >=24.0",
                 "pnpm": "8"
             },
             "peerDependencies": {
@@ -6986,6 +7013,75 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
             "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toggle": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+            "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@radix-ui/react-compose-refs": "1.1.2"
@@ -11412,7 +11508,7 @@
             "version": "8.18.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -11913,6 +12009,19 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/better-result": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.7.0.tgz",
+            "integrity": "sha512-7zrmXjAK8u8Z6SOe4R65XObOR5X+Y2I/VVku3t5cPOGQ8/WsBcfFmfnIPiEl5EBMDOzPHRwbiPbMtQBKYdw7RA==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@clack/prompts": "^0.11.0"
+            },
+            "bin": {
+                "better-result": "bin/cli.mjs"
             }
         },
         "node_modules/bgutils-js": {
@@ -12633,19 +12742,17 @@
                 "node": ">=10"
             }
         },
-        "node_modules/chevrotain": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-            "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
+        "node_modules/chart.js": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "devOptional": true,
-            "license": "Apache-2.0",
+            "license": "MIT",
             "dependencies": {
-                "@chevrotain/cst-dts-gen": "10.5.0",
-                "@chevrotain/gast": "10.5.0",
-                "@chevrotain/types": "10.5.0",
-                "@chevrotain/utils": "10.5.0",
-                "lodash": "4.17.21",
-                "regexp-to-ast": "0.5.0"
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
         },
         "node_modules/chokidar": {
@@ -13387,9 +13494,9 @@
             }
         },
         "node_modules/defu": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-            "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+            "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -14891,7 +14998,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
             "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -15885,9 +15992,9 @@
             "license": "ISC"
         },
         "node_modules/hono": {
-            "version": "4.12.7",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-            "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+            "version": "4.12.9",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+            "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -17975,7 +18082,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
@@ -18348,16 +18455,6 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/lilconfig": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-            "devOptional": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -18390,9 +18487,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.camelcase": {
@@ -19402,9 +19499,9 @@
             }
         },
         "node_modules/nypm/node_modules/citty": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-            "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -20304,17 +20401,17 @@
             }
         },
         "node_modules/prisma": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.5.0.tgz",
-            "integrity": "sha512-n30qZpWehaYQzigLjmuPisyEsvOzHt7bZeRyg8gZ5DvJo9FGjD+gNaY59Ns3hlLD5/jZH5GBeftIss0jDbUoLg==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.6.0.tgz",
+            "integrity": "sha512-OKJIPT81K3+F+AayIkY/Y3mkF2NWoFh7lZApaaqPYy7EHILKdO0VsmGkP+hDKYTySHsFSyLWXm/JgcR1B8fY1Q==",
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/config": "7.5.0",
-                "@prisma/dev": "0.20.0",
-                "@prisma/engines": "7.5.0",
-                "@prisma/studio-core": "0.21.1",
+                "@prisma/config": "7.6.0",
+                "@prisma/dev": "0.24.3",
+                "@prisma/engines": "7.6.0",
+                "@prisma/studio-core": "0.27.3",
                 "mysql2": "3.15.3",
                 "postgres": "3.4.7"
             },
@@ -20827,13 +20924,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/regexp-to-ast": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-            "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-            "devOptional": true,
-            "license": "MIT"
-        },
         "node_modules/remeda": {
             "version": "2.33.4",
             "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
@@ -20858,7 +20948,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -21499,6 +21589,13 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
+        },
+        "node_modules/sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/slash": {
             "version": "3.0.0",

--- a/packages/bot/src/functions/general/commands/version.spec.ts
+++ b/packages/bot/src/functions/general/commands/version.spec.ts
@@ -7,7 +7,7 @@ const createInfoEmbedMock = jest.fn((title: string, message: string) => ({
     message,
 }))
 
-jest.mock('../../../../../package.json', () => ({ version: '9.9.9' }))
+jest.mock('../../../../package.json', () => ({ version: '9.9.9' }))
 
 jest.mock('../../../utils/general/embeds', () => ({
     createInfoEmbed: (...args: unknown[]) =>

--- a/packages/bot/src/functions/general/commands/version.spec.ts
+++ b/packages/bot/src/functions/general/commands/version.spec.ts
@@ -7,6 +7,8 @@ const createInfoEmbedMock = jest.fn((title: string, message: string) => ({
     message,
 }))
 
+jest.mock('../../../../../package.json', () => ({ version: '9.9.9' }))
+
 jest.mock('../../../utils/general/embeds', () => ({
     createInfoEmbed: (...args: unknown[]) =>
         createInfoEmbedMock(...(args as [string, string])),
@@ -22,16 +24,8 @@ function createInteraction() {
 }
 
 describe('version command', () => {
-    const originalNpmVersion = process.env.npm_package_version
-    const originalCommitSha = process.env.COMMIT_SHA
-
     beforeEach(() => {
         jest.clearAllMocks()
-    })
-
-    afterEach(() => {
-        process.env.npm_package_version = originalNpmVersion
-        process.env.COMMIT_SHA = originalCommitSha
     })
 
     it('defers reply as ephemeral', async () => {
@@ -40,36 +34,12 @@ describe('version command', () => {
         expect(deferReplyMock).toHaveBeenCalledWith({ ephemeral: true })
     })
 
-    it('replies with semver when npm_package_version is set', async () => {
-        process.env.npm_package_version = '2.6.60'
-        delete process.env.COMMIT_SHA
+    it('replies with version from package.json', async () => {
         const interaction = createInteraction()
         await versionCommand.execute({ interaction } as any)
         expect(createInfoEmbedMock).toHaveBeenCalledWith(
             'Bot Version',
-            'v2.6.60',
-        )
-    })
-
-    it('replies with commit sha when npm_package_version is unset', async () => {
-        delete process.env.npm_package_version
-        process.env.COMMIT_SHA = 'abc1234567890'
-        const interaction = createInteraction()
-        await versionCommand.execute({ interaction } as any)
-        expect(createInfoEmbedMock).toHaveBeenCalledWith(
-            'Bot Version',
-            'commit abc1234',
-        )
-    })
-
-    it('replies with unknown when neither env var is set', async () => {
-        delete process.env.npm_package_version
-        delete process.env.COMMIT_SHA
-        const interaction = createInteraction()
-        await versionCommand.execute({ interaction } as any)
-        expect(createInfoEmbedMock).toHaveBeenCalledWith(
-            'Bot Version',
-            'unknown',
+            'v9.9.9',
         )
     })
 })

--- a/packages/bot/src/functions/general/commands/version.ts
+++ b/packages/bot/src/functions/general/commands/version.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
 import { createInfoEmbed } from '../../../utils/general/embeds'
-import { version } from '../../../../../package.json'
+import { version } from '../../../../package.json'
 
 function resolveVersion(): string {
     return `v${version}`

--- a/packages/bot/src/functions/general/commands/version.ts
+++ b/packages/bot/src/functions/general/commands/version.ts
@@ -1,13 +1,10 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
 import { createInfoEmbed } from '../../../utils/general/embeds'
+import { version } from '../../../../../package.json'
 
 function resolveVersion(): string {
-    const semver = process.env.npm_package_version
-    if (semver) return `v${semver}`
-    const sha = process.env.COMMIT_SHA
-    if (sha) return `commit ${sha.slice(0, 7)}`
-    return 'unknown'
+    return `v${version}`
 }
 
 export default new Command({

--- a/packages/bot/src/functions/management/commands/helpers/serversetupCriativaria.spec.ts
+++ b/packages/bot/src/functions/management/commands/helpers/serversetupCriativaria.spec.ts
@@ -59,11 +59,11 @@ jest.mock('@lucky/shared/utils', () => ({
     getPrismaClient: getPrismaClientMock,
 }))
 
-jest.mock('../../../twitch/twitchApi', () => ({
+jest.mock('../../../../twitch/twitchApi', () => ({
     getTwitchUserByLogin: getTwitchUserByLoginMock,
 }))
 
-jest.mock('../../../twitch', () => ({
+jest.mock('../../../../twitch', () => ({
     refreshTwitchSubscriptions: refreshTwitchSubscriptionsMock,
 }))
 

--- a/packages/bot/src/functions/management/commands/helpers/serversetupCriativaria.ts
+++ b/packages/bot/src/functions/management/commands/helpers/serversetupCriativaria.ts
@@ -17,8 +17,8 @@ import {
     twitchNotificationService,
 } from '@lucky/shared/services'
 import { getPrismaClient } from '@lucky/shared/utils'
-import { getTwitchUserByLogin } from '../../../twitch/twitchApi'
-import { refreshTwitchSubscriptions } from '../../../twitch'
+import { getTwitchUserByLogin } from '../../../../twitch/twitchApi'
+import { refreshTwitchSubscriptions } from '../../../../twitch'
 
 export type SetupMode = 'dry-run' | 'apply'
 

--- a/packages/bot/src/functions/management/commands/serversetup.spec.ts
+++ b/packages/bot/src/functions/management/commands/serversetup.spec.ts
@@ -5,7 +5,7 @@ import {
     formatCriativariaSummary,
     resolveSetupMode,
     runCriativariaSetup,
-} from './serversetupCriativaria'
+} from './helpers/serversetupCriativaria'
 
 jest.mock('../../../utils/general/interactionReply', () => ({
     interactionReply: jest.fn(),
@@ -16,7 +16,7 @@ jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
 }))
 
-jest.mock('./serversetupCriativaria', () => ({
+jest.mock('./helpers/serversetupCriativaria', () => ({
     resolveSetupMode: jest.fn(),
     runCriativariaSetup: jest.fn(),
     formatCriativariaSummary: jest.fn(),

--- a/packages/bot/src/functions/management/commands/serversetup.ts
+++ b/packages/bot/src/functions/management/commands/serversetup.ts
@@ -16,7 +16,7 @@ import {
     formatCriativariaSummary,
     resolveSetupMode,
     runCriativariaSetup,
-} from './serversetupCriativaria.js'
+} from './helpers/serversetupCriativaria.js'
 
 interface ChannelDef {
     name: string

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -140,14 +140,23 @@ export default new Command({
                 data: { query, guildId: interaction.guildId },
             })
 
-            await interaction.editReply({
-                embeds: [
-                    createErrorEmbed(
-                        'Play Error',
-                        'Could not find or play the requested track',
-                    ),
-                ],
-            })
+            // DiscordAPIError[10062] = Unknown Interaction — token expired or bot
+            // restarted between deferReply and editReply. No reply is possible.
+            const code = (error as { code?: number })?.code
+            if (code === 10062) return
+
+            try {
+                await interaction.editReply({
+                    embeds: [
+                        createErrorEmbed(
+                            'Play Error',
+                            'Could not find or play the requested track',
+                        ),
+                    ],
+                })
+            } catch {
+                // interaction already dead — nothing to do
+            }
         }
     },
 })

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -15,6 +15,8 @@ import {
     blendAutoplayTracks,
 } from '../../../../utils/music/queueManipulation'
 
+const DISCORD_UNKNOWN_INTERACTION_CODE = 10062
+
 function isTrackAlreadyQueued(
     queue: { tracks: { toArray?: () => Array<{ id?: string; url?: string }> } },
     track: { id?: string; url?: string },
@@ -143,7 +145,7 @@ export default new Command({
             // DiscordAPIError[10062] = Unknown Interaction — token expired or bot
             // restarted between deferReply and editReply. No reply is possible.
             const code = (error as { code?: number })?.code
-            if (code === 10062) return
+            if (code === DISCORD_UNKNOWN_INTERACTION_CODE) return
 
             try {
                 await interaction.editReply({


### PR DESCRIPTION
## Problem

Three issues surfaced in Sentry:

1. **`/version` shows `commit abc1234`** instead of `v2.6.60` in production
2. **`DiscordAPIError[10062]`** on `/play` — a second Sentry error thrown from the catch block trying to `editReply` on an already-expired interaction token
3. **`Command in serversetupCriativaria.js is not a valid Command instance`** — command loader error fired on every bot start

## Root Causes & Fixes

### Fix A — `/version` reads from `package.json` directly

```diff
-const semver = process.env.npm_package_version
-if (semver) return `v${semver}`
-const sha = process.env.COMMIT_SHA
-if (sha) return `commit ${sha.slice(0, 7)}`
-return 'unknown'
+import { version } from '../../../../../package.json'
+return `v${version}`
```

Docker starts the bot with `node dist/index.js`, not via `npm`, so `npm_package_version` is never injected → fell through to the `COMMIT_SHA` build arg. Importing from `package.json` is baked at build time and always correct. `tsconfig.json` already has `resolveJsonModule: true`.

### Fix B — `/play` guard against `DiscordAPIError[10062]`

```diff
+const code = (error as { code?: number })?.code
+if (code === 10062) return  // interaction expired, nothing to reply to
+try {
     await interaction.editReply({ ... })
+} catch { /* interaction dead */ }
```

During the crash-loop period the bot restarted mid-interaction. The deferred token expired, and the catch block then tried `editReply` on it — triggering a second `DiscordAPIError[10062]` in Sentry. Now silently dropped for code 10062; other errors still show the user-facing error embed.

### Fix C — Move `serversetupCriativaria` to `commands/helpers/`

The command loader scans `management/commands/` for flat `.js` files. `serversetupCriativaria.js` is a helper module with no `data`/`execute` — it failed `isValidCommand` and fired an `errorLog` on every bot start. Moved to `commands/helpers/serversetupCriativaria.ts`. The loader only picks up `helpers/index.js`, which doesn't exist, so the subdirectory is silently skipped. Relative import paths updated in both the source and spec; import in `serversetup.ts` updated to `./helpers/serversetupCriativaria.js`.

## Checklist
- [x] LSP diagnostics clean on all 4 changed files — zero errors
- [x] Git detected renames correctly (`R` status for both moved files)
- [x] No logic changes to `serversetupCriativaria` — only relative import path depth updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Play command now handles expired Discord interactions gracefully to avoid cascading errors.

* **Chores**
  * Version reporting standardized to use package metadata for consistent output.
  * Internal module references corrected for reliable server-setup behavior.

* **Tests**
  * Updated tests to use a deterministic version source for stable, reproducible results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->