### PR TITLE
feat(bot): persist autoplay preference so /autoplay works without active queue

### DIFF
--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -174,7 +174,7 @@ describe('autoplay command', () => {
         expect(interactionReplyMock).toHaveBeenCalled()
     })
 
-    it('saves preference and replies when no queue exists', async () => {
+    it('disables autoplay when no queue exists and settings are missing', async () => {
         const client = createClient({ directQueue: null })
         const interaction = createInteraction()
 
@@ -184,18 +184,15 @@ describe('autoplay command', () => {
         } as any)
 
         expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
-            autoPlayEnabled: true,
+            autoPlayEnabled: false,
         })
         expect(interactionReplyMock).toHaveBeenCalled()
-        const embedPayload = createEmbedMock.mock.calls[0]?.[0] as {
-            description: string
-        }
-        expect(embedPayload.description).toContain(
-            'Next time you use /play',
+        expect(createEmbedMock).toHaveBeenCalledWith(
+            expect.objectContaining({ title: 'Autoplay disabled' }),
         )
     })
 
-    it('shows an error when enabling autoplay without a queue fails to persist', async () => {
+    it('shows an error when disabling autoplay without a queue fails to persist', async () => {
         const client = createClient({ directQueue: null })
         const interaction = createInteraction()
         setGuildSettingsMock.mockResolvedValue(false)
@@ -207,7 +204,7 @@ describe('autoplay command', () => {
 
         expect(warnLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: 'Failed to persist autoplay enabled preference',
+                message: 'Failed to persist autoplay disabled preference',
             }),
         )
         expect(createEmbedMock).toHaveBeenCalledWith(

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -7,7 +7,6 @@ const QueueRepeatMode = {
 } as const
 
 const requireGuildMock = jest.fn()
-const requireQueueMock = jest.fn()
 const interactionReplyMock = jest.fn()
 const createEmbedMock = jest.fn((payload: unknown) => payload)
 const replenishQueueMock = jest.fn()
@@ -15,10 +14,11 @@ const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
 const warnLogMock = jest.fn()
 const resolveGuildQueueMock = jest.fn()
+const getGuildSettingsMock = jest.fn()
+const setGuildSettingsMock = jest.fn()
 
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireGuild: (...args: unknown[]) => requireGuildMock(...args),
-    requireQueue: (...args: unknown[]) => requireQueueMock(...args),
 }))
 
 jest.mock('discord-player', () => ({
@@ -56,6 +56,15 @@ jest.mock('@lucky/shared/utils', () => ({
     debugLog: (...args: unknown[]) => debugLogMock(...args),
     errorLog: (...args: unknown[]) => errorLogMock(...args),
     warnLog: (...args: unknown[]) => warnLogMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: {
+        getGuildSettings: (...args: unknown[]) =>
+            getGuildSettingsMock(...args),
+        setGuildSettings: (...args: unknown[]) =>
+            setGuildSettingsMock(...args),
+    },
 }))
 
 function createInteraction(guildId = 'guild-1') {
@@ -96,9 +105,8 @@ describe('autoplay command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireGuildMock.mockResolvedValue(true)
-        requireQueueMock.mockImplementation(async (queue: unknown) =>
-            Boolean(queue),
-        )
+        getGuildSettingsMock.mockResolvedValue(null)
+        setGuildSettingsMock.mockResolvedValue(true)
         resolveGuildQueueMock.mockReturnValue({
             queue: null,
             source: 'miss',
@@ -110,11 +118,9 @@ describe('autoplay command', () => {
         })
     })
 
-    it('uses resolved guild queue when fallback source recovers queue', async () => {
+    it('enables autoplay on active queue and persists preference', async () => {
         const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({
-            directQueue: null,
-        })
+        const client = createClient({ directQueue: null })
         const interaction = createInteraction()
         resolveGuildQueueMock.mockReturnValue({
             queue,
@@ -131,20 +137,19 @@ describe('autoplay command', () => {
             interaction,
         } as any)
 
-        expect(resolveGuildQueueMock).toHaveBeenCalledWith(client, 'guild-1')
-        expect(requireQueueMock).toHaveBeenCalledWith(queue, interaction)
         expect(queue.setRepeatMode).toHaveBeenCalledWith(
             QueueRepeatMode.AUTOPLAY,
         )
+        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
+            autoPlayEnabled: true,
+        })
         expect(replenishQueueMock).toHaveBeenCalledWith(queue)
         expect(interactionReplyMock).toHaveBeenCalled()
     })
 
     it('disables autoplay when already enabled', async () => {
         const queue = createQueue(QueueRepeatMode.AUTOPLAY)
-        const client = createClient({
-            directQueue: queue,
-        })
+        const client = createClient({ directQueue: queue })
         const interaction = createInteraction()
         resolveGuildQueueMock.mockReturnValue({
             queue,
@@ -162,15 +167,55 @@ describe('autoplay command', () => {
         } as any)
 
         expect(queue.setRepeatMode).toHaveBeenCalledWith(QueueRepeatMode.OFF)
+        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
+            autoPlayEnabled: false,
+        })
         expect(replenishQueueMock).not.toHaveBeenCalled()
         expect(interactionReplyMock).toHaveBeenCalled()
     })
 
+    it('saves preference and replies when no queue exists', async () => {
+        const client = createClient({ directQueue: null })
+        const interaction = createInteraction()
+
+        await autoplayCommand.execute({
+            client,
+            interaction,
+        } as any)
+
+        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
+            autoPlayEnabled: true,
+        })
+        expect(interactionReplyMock).toHaveBeenCalled()
+        const embedPayload = createEmbedMock.mock.calls[0]?.[0] as {
+            description: string
+        }
+        expect(embedPayload.description).toContain(
+            'Next time you use /play',
+        )
+    })
+
+    it('disables stored preference when no queue and was enabled', async () => {
+        const client = createClient({ directQueue: null })
+        const interaction = createInteraction()
+        getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: true })
+
+        await autoplayCommand.execute({
+            client,
+            interaction,
+        } as any)
+
+        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
+            autoPlayEnabled: false,
+        })
+        expect(createEmbedMock).toHaveBeenCalledWith(
+            expect.objectContaining({ title: 'Autoplay disabled' }),
+        )
+    })
+
     it('returns early when interaction guild id is missing', async () => {
         const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({
-            directQueue: queue,
-        })
+        const client = createClient({ directQueue: queue })
         const interaction = createInteraction(null as unknown as string)
 
         await autoplayCommand.execute({
@@ -178,56 +223,13 @@ describe('autoplay command', () => {
             interaction,
         } as any)
 
-        expect(interaction.deferReply).not.toHaveBeenCalled()
-        expect(requireQueueMock).not.toHaveBeenCalled()
         expect(interactionReplyMock).not.toHaveBeenCalled()
         expect(resolveGuildQueueMock).not.toHaveBeenCalled()
     })
 
-    it('passes null queue to validator when resolver misses', async () => {
-        const client = createClient({ directQueue: null })
-        const interaction = createInteraction()
-        requireQueueMock.mockResolvedValue(false)
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        expect(requireQueueMock).toHaveBeenCalledWith(null, interaction)
-        expect(interactionReplyMock).not.toHaveBeenCalled()
-    })
-
-    it('passes null queue to validator when resolver returns miss diagnostics', async () => {
-        const client = createClient({
-            directQueue: null,
-        })
-        const interaction = createInteraction('guild-1')
-        requireQueueMock.mockResolvedValue(false)
-        resolveGuildQueueMock.mockReturnValue({
-            queue: null,
-            source: 'miss',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 2,
-                cacheSampleKeys: ['guild-2', 'guild-3'],
-            },
-        })
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        expect(requireQueueMock).toHaveBeenCalledWith(null, interaction)
-        expect(interactionReplyMock).not.toHaveBeenCalled()
-    })
-
     it('replies before replenishment finishes', async () => {
         const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({
-            directQueue: queue,
-        })
+        const client = createClient({ directQueue: queue })
         const interaction = createInteraction()
         let resolveReplenish: () => void = () => {}
 
@@ -266,48 +268,12 @@ describe('autoplay command', () => {
         await executePromise
     })
 
-    it('logs error and still replies when queue replenish fails', async () => {
-        const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({
-            directQueue: queue,
-        })
-        const interaction = createInteraction()
-        replenishQueueMock.mockRejectedValue(new Error('replenish failed'))
-        resolveGuildQueueMock.mockReturnValue({
-            queue,
-            source: 'nodes.get',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 1,
-                cacheSampleKeys: ['guild-1'],
-            },
-        })
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        await Promise.resolve()
-        expect(queue.setRepeatMode).toHaveBeenCalledWith(
-            QueueRepeatMode.AUTOPLAY,
-        )
-        expect(errorLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: 'Error replenishing queue after enabling autoplay:',
-            }),
-        )
-        expect(interactionReplyMock).toHaveBeenCalled()
-    })
-
-    it('uses autoplay error response when execution throws unexpectedly', async () => {
+    it('uses autoplay error response when execution throws', async () => {
         const queue = createQueue(QueueRepeatMode.OFF)
         queue.setRepeatMode.mockImplementation(() => {
             throw new Error('unexpected')
         })
-        const client = createClient({
-            directQueue: queue,
-        })
+        const client = createClient({ directQueue: queue })
         const interaction = createInteraction()
         resolveGuildQueueMock.mockReturnValue({
             queue,
@@ -330,16 +296,7 @@ describe('autoplay command', () => {
             }),
         )
         expect(createEmbedMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                title: 'Error',
-            }),
-        )
-        expect(interactionReplyMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                content: expect.objectContaining({
-                    ephemeral: true,
-                }),
-            }),
+            expect.objectContaining({ title: 'Error' }),
         )
     })
 })

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -256,6 +256,42 @@ describe('autoplay command', () => {
         expect(replenishQueueMock).not.toHaveBeenCalled()
     })
 
+    it('shows a queue-only warning when enabling autoplay cannot persist', async () => {
+        const queue = createQueue(QueueRepeatMode.OFF)
+        const client = createClient({ directQueue: queue })
+        const interaction = createInteraction()
+        setGuildSettingsMock.mockResolvedValue(false)
+        resolveGuildQueueMock.mockReturnValue({
+            queue,
+            source: 'nodes.get',
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 1,
+                cacheSampleKeys: ['guild-1'],
+            },
+        })
+
+        await autoplayCommand.execute({
+            client,
+            interaction,
+        } as any)
+
+        expect(queue.setRepeatMode).toHaveBeenCalledWith(
+            QueueRepeatMode.AUTOPLAY,
+        )
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Failed to persist autoplay enabled preference',
+            }),
+        )
+        expect(createEmbedMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Autoplay enabled for current queue only',
+            }),
+        )
+        expect(replenishQueueMock).not.toHaveBeenCalled()
+    })
+
     it('disables stored preference when no queue and was enabled', async () => {
         const client = createClient({ directQueue: null })
         const interaction = createInteraction()
@@ -271,6 +307,24 @@ describe('autoplay command', () => {
         })
         expect(createEmbedMock).toHaveBeenCalledWith(
             expect.objectContaining({ title: 'Autoplay disabled' }),
+        )
+    })
+
+    it('enables stored preference when no queue and autoplay was disabled', async () => {
+        const client = createClient({ directQueue: null })
+        const interaction = createInteraction()
+        getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: false })
+
+        await autoplayCommand.execute({
+            client,
+            interaction,
+        } as any)
+
+        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
+            autoPlayEnabled: true,
+        })
+        expect(createEmbedMock).toHaveBeenCalledWith(
+            expect.objectContaining({ title: 'Autoplay enabled' }),
         )
     })
 

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -172,7 +172,7 @@ describe('autoplay command', () => {
         expect(interactionReplyMock).toHaveBeenCalled()
     })
 
-    it('disables autoplay when no queue exists and settings are missing', async () => {
+    it('enables autoplay when no queue exists and settings are missing', async () => {
         const client = createClient({ directQueue: null })
         const interaction = createInteraction()
 
@@ -182,15 +182,18 @@ describe('autoplay command', () => {
         } as any)
 
         expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
-            autoPlayEnabled: false,
+            autoPlayEnabled: true,
         })
         expect(interactionReplyMock).toHaveBeenCalled()
-        expect(createEmbedMock).toHaveBeenCalledWith(
-            expect.objectContaining({ title: 'Autoplay disabled' }),
+        const embedPayload = createEmbedMock.mock.calls[0]?.[0] as {
+            description: string
+        }
+        expect(embedPayload.description).toContain(
+            'Next time you use /play',
         )
     })
 
-    it('shows an error when disabling autoplay without a queue fails to persist', async () => {
+    it('shows an error when enabling autoplay without a queue fails to persist', async () => {
         const client = createClient({ directQueue: null })
         const interaction = createInteraction()
         setGuildSettingsMock.mockResolvedValue(false)
@@ -202,7 +205,7 @@ describe('autoplay command', () => {
 
         expect(warnLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: 'Failed to persist autoplay disabled preference',
+                message: 'Failed to persist autoplay enabled preference',
             }),
         )
         expect(createEmbedMock).toHaveBeenCalledWith(
@@ -287,7 +290,7 @@ describe('autoplay command', () => {
                 title: 'Autoplay enabled for current queue only',
             }),
         )
-        expect(replenishQueueMock).not.toHaveBeenCalled()
+        expect(replenishQueueMock).toHaveBeenCalledWith(queue)
     })
 
     it('disables stored preference when no queue and was enabled', async () => {

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -60,10 +60,8 @@ jest.mock('@lucky/shared/utils', () => ({
 
 jest.mock('@lucky/shared/services', () => ({
     guildSettingsService: {
-        getGuildSettings: (...args: unknown[]) =>
-            getGuildSettingsMock(...args),
-        setGuildSettings: (...args: unknown[]) =>
-            setGuildSettingsMock(...args),
+        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
+        setGuildSettings: (...args: unknown[]) => setGuildSettingsMock(...args),
     },
 }))
 
@@ -381,6 +379,34 @@ describe('autoplay command', () => {
 
         resolveReplenish()
         await executePromise
+    })
+
+    it('logs replenish failures after enabling autoplay', async () => {
+        const queue = createQueue(QueueRepeatMode.OFF)
+        const client = createClient({ directQueue: queue })
+        const interaction = createInteraction()
+        replenishQueueMock.mockRejectedValue(new Error('replenish failed'))
+        resolveGuildQueueMock.mockReturnValue({
+            queue,
+            source: 'nodes.get',
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 1,
+                cacheSampleKeys: ['guild-1'],
+            },
+        })
+
+        await autoplayCommand.execute({
+            client,
+            interaction,
+        } as any)
+
+        await Promise.resolve()
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Error replenishing queue after enabling autoplay:',
+            }),
+        )
     })
 
     it('uses autoplay error response when execution throws', async () => {

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -195,6 +195,70 @@ describe('autoplay command', () => {
         )
     })
 
+    it('shows an error when enabling autoplay without a queue fails to persist', async () => {
+        const client = createClient({ directQueue: null })
+        const interaction = createInteraction()
+        setGuildSettingsMock.mockResolvedValue(false)
+
+        await autoplayCommand.execute({
+            client,
+            interaction,
+        } as any)
+
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Failed to persist autoplay enabled preference',
+            }),
+        )
+        expect(createEmbedMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Autoplay preference not saved',
+            }),
+        )
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.objectContaining({
+                    ephemeral: true,
+                }),
+            }),
+        )
+        expect(replenishQueueMock).not.toHaveBeenCalled()
+    })
+
+    it('shows a queue-only warning when disabling autoplay cannot persist', async () => {
+        const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+        const client = createClient({ directQueue: queue })
+        const interaction = createInteraction()
+        setGuildSettingsMock.mockResolvedValue(false)
+        resolveGuildQueueMock.mockReturnValue({
+            queue,
+            source: 'nodes.get',
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 1,
+                cacheSampleKeys: ['guild-1'],
+            },
+        })
+
+        await autoplayCommand.execute({
+            client,
+            interaction,
+        } as any)
+
+        expect(queue.setRepeatMode).toHaveBeenCalledWith(QueueRepeatMode.OFF)
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Failed to persist autoplay disabled preference',
+            }),
+        )
+        expect(createEmbedMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Autoplay disabled for current queue only',
+            }),
+        )
+        expect(replenishQueueMock).not.toHaveBeenCalled()
+    })
+
     it('disables stored preference when no queue and was enabled', async () => {
         const client = createClient({ directQueue: null })
         const interaction = createInteraction()

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -7,25 +7,24 @@ import {
     EMOJIS,
 } from '../../../utils/general/embeds'
 import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
+import { guildSettingsService } from '@lucky/shared/services'
 import { QueueRepeatMode, type GuildQueue } from 'discord-player'
-import {
-    requireGuild,
-    requireQueue,
-} from '../../../utils/command/commandValidations'
+import { requireGuild } from '../../../utils/command/commandValidations'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import { messages } from '../../../utils/general/messages'
 import type { ColorResolvable, ChatInputCommandInteraction } from 'discord.js'
 import { replenishQueue } from '../../../utils/music/trackManagement/queueOperations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 
-/**
- * Handle disabling autoplay
- */
 async function handleDisableAutoplay(
     queue: GuildQueue | null,
     interaction: ChatInputCommandInteraction,
+    guildId: string,
 ): Promise<void> {
     queue?.setRepeatMode(QueueRepeatMode.OFF)
+    await guildSettingsService.setGuildSettings(guildId, {
+        autoPlayEnabled: false,
+    })
 
     await interactionReply({
         interaction,
@@ -44,14 +43,15 @@ async function handleDisableAutoplay(
     })
 }
 
-/**
- * Handle enabling autoplay and populating queue
- */
 async function handleEnableAutoplay(
     queue: GuildQueue | null,
     interaction: ChatInputCommandInteraction,
+    guildId: string,
 ): Promise<void> {
     queue?.setRepeatMode(QueueRepeatMode.AUTOPLAY)
+    await guildSettingsService.setGuildSettings(guildId, {
+        autoPlayEnabled: true,
+    })
 
     await interactionReply({
         interaction,
@@ -59,8 +59,9 @@ async function handleEnableAutoplay(
             embeds: [
                 createEmbed({
                     title: 'Autoplay enabled',
-                    description:
-                        'Autoplay has been enabled. The bot will automatically add related songs when the queue is empty.',
+                    description: queue
+                        ? 'Autoplay has been enabled. The bot will automatically add related songs when the queue is empty.'
+                        : 'Autoplay preference saved. Next time you use /play, autoplay will be enabled automatically.',
                     color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
                     emoji: EMOJIS.AUTOPLAY,
                     timestamp: true,
@@ -74,9 +75,6 @@ async function handleEnableAutoplay(
     }
 }
 
-/**
- * Populate queue with related tracks
- */
 async function populateQueueWithRelatedTracks(
     queue: GuildQueue,
     interaction: ChatInputCommandInteraction,
@@ -107,9 +105,6 @@ async function populateQueueWithRelatedTracks(
     }
 }
 
-/**
- * Handle autoplay errors
- */
 async function handleAutoplayError(
     error: unknown,
     interaction: ChatInputCommandInteraction,
@@ -129,6 +124,17 @@ async function handleAutoplayError(
             ephemeral: true,
         },
     })
+}
+
+async function resolveCurrentAutoplayState(
+    queue: GuildQueue | null,
+    guildId: string,
+): Promise<boolean> {
+    if (queue) {
+        return queue.repeatMode === QueueRepeatMode.AUTOPLAY
+    }
+    const settings = await guildSettingsService.getGuildSettings(guildId)
+    return settings?.autoPlayEnabled ?? false
 }
 
 export default new Command({
@@ -160,16 +166,17 @@ export default new Command({
                 },
             })
         }
-        if (!(await requireQueue(queue, interaction))) return
 
         try {
-            const isAutoplayEnabled =
-                queue?.repeatMode === QueueRepeatMode.AUTOPLAY
+            const isAutoplayEnabled = await resolveCurrentAutoplayState(
+                queue,
+                guildId,
+            )
 
             if (isAutoplayEnabled) {
-                await handleDisableAutoplay(queue, interaction)
+                await handleDisableAutoplay(queue, interaction, guildId)
             } else {
-                await handleEnableAutoplay(queue, interaction)
+                await handleEnableAutoplay(queue, interaction, guildId)
             }
         } catch (error) {
             await handleAutoplayError(error, interaction)

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -101,6 +101,9 @@ async function handleEnableAutoplay(
             message: 'Failed to persist autoplay enabled preference',
             data: { guildId, hasQueue: Boolean(queue) },
         })
+        if (queue?.currentTrack) {
+            void populateQueueWithRelatedTracks(queue, interaction)
+        }
         await replyAutoplayPersistenceFailure(interaction, queue, true)
         return
     }
@@ -186,7 +189,7 @@ async function resolveCurrentAutoplayState(
         return queue.repeatMode === QueueRepeatMode.AUTOPLAY
     }
     const settings = await guildSettingsService.getGuildSettings(guildId)
-    return settings?.autoPlayEnabled ?? true
+    return settings?.autoPlayEnabled ?? false
 }
 
 export default new Command({

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -16,15 +16,58 @@ import type { ColorResolvable, ChatInputCommandInteraction } from 'discord.js'
 import { replenishQueue } from '../../../utils/music/trackManagement/queueOperations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 
+async function replyAutoplayPersistenceFailure(
+    interaction: ChatInputCommandInteraction,
+    queue: GuildQueue | null,
+    enabled: boolean,
+): Promise<void> {
+    await interactionReply({
+        interaction,
+        content: {
+            embeds: [
+                createEmbed({
+                    title: enabled
+                        ? queue
+                            ? 'Autoplay enabled for current queue only'
+                            : 'Autoplay preference not saved'
+                        : queue
+                          ? 'Autoplay disabled for current queue only'
+                          : 'Autoplay preference not saved',
+                    description: enabled
+                        ? queue
+                            ? 'Autoplay was enabled on the active queue, but the preference could not be saved for future sessions.'
+                            : 'Could not save autoplay preference. Please try again.'
+                        : queue
+                          ? 'Autoplay was disabled on the active queue, but the preference could not be saved for future sessions.'
+                          : 'Could not update autoplay preference. Please try again.',
+                    color: EMBED_COLORS.ERROR as ColorResolvable,
+                    emoji: EMOJIS.ERROR,
+                    timestamp: true,
+                }),
+            ],
+            ephemeral: true,
+        },
+    })
+}
+
 async function handleDisableAutoplay(
     queue: GuildQueue | null,
     interaction: ChatInputCommandInteraction,
     guildId: string,
 ): Promise<void> {
     queue?.setRepeatMode(QueueRepeatMode.OFF)
-    await guildSettingsService.setGuildSettings(guildId, {
+    const persisted = await guildSettingsService.setGuildSettings(guildId, {
         autoPlayEnabled: false,
     })
+
+    if (!persisted) {
+        warnLog({
+            message: 'Failed to persist autoplay disabled preference',
+            data: { guildId, hasQueue: Boolean(queue) },
+        })
+        await replyAutoplayPersistenceFailure(interaction, queue, false)
+        return
+    }
 
     await interactionReply({
         interaction,
@@ -49,9 +92,18 @@ async function handleEnableAutoplay(
     guildId: string,
 ): Promise<void> {
     queue?.setRepeatMode(QueueRepeatMode.AUTOPLAY)
-    await guildSettingsService.setGuildSettings(guildId, {
+    const persisted = await guildSettingsService.setGuildSettings(guildId, {
         autoPlayEnabled: true,
     })
+
+    if (!persisted) {
+        warnLog({
+            message: 'Failed to persist autoplay enabled preference',
+            data: { guildId, hasQueue: Boolean(queue) },
+        })
+        await replyAutoplayPersistenceFailure(interaction, queue, true)
+        return
+    }
 
     await interactionReply({
         interaction,
@@ -134,7 +186,7 @@ async function resolveCurrentAutoplayState(
         return queue.repeatMode === QueueRepeatMode.AUTOPLAY
     }
     const settings = await guildSettingsService.getGuildSettings(guildId)
-    return settings?.autoPlayEnabled ?? false
+    return settings?.autoPlayEnabled ?? true
 }
 
 export default new Command({

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -178,7 +178,7 @@ describe('play command', () => {
         expect(createSuccessEmbedMock).toHaveBeenCalled()
     })
 
-    it('applies stored autoplay preference to a new queue', async () => {
+    it('applies stored autoplay preference to a queue', async () => {
         const interaction = createInteraction('guild-1')
         const queue = {
             repeatMode: 0,
@@ -200,7 +200,36 @@ describe('play command', () => {
         expect(queue.setRepeatMode).toHaveBeenCalledWith(3)
         expect(debugLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: 'Applied stored autoplay preference to new queue',
+                message: 'Applied stored autoplay preference to queue',
+                data: expect.objectContaining({ autoPlayEnabled: true }),
+            }),
+        )
+    })
+
+    it('applies stored autoplay disabled preference to a fresh autoplay queue', async () => {
+        const interaction = createInteraction('guild-1')
+        const queue = {
+            repeatMode: 3,
+            tracks: { size: 0 },
+            setRepeatMode: jest.fn(),
+        }
+        const result = {
+            track: { title: 'Song A', author: 'Artist A' },
+            searchResult: { playlist: null, tracks: [] },
+        }
+        getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: false })
+        resolveGuildQueueMock.mockReturnValue({ queue })
+
+        await playCommand.execute({
+            client: createClient(async () => result),
+            interaction,
+        } as any)
+
+        expect(queue.setRepeatMode).toHaveBeenCalledWith(0)
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Applied stored autoplay preference to queue',
+                data: expect.objectContaining({ autoPlayEnabled: false }),
             }),
         )
     })

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -305,6 +305,68 @@ describe('play command', () => {
         )
     })
 
+    it('does not reinsert a manual track already queued by matching url', async () => {
+        const interaction = createInteraction('guild-1')
+        const track = {
+            url: 'https://example.com/url-match',
+            title: 'Song A',
+            author: 'Artist A',
+        }
+
+        resolveGuildQueueMock.mockReturnValue({
+            queue: {
+                repeatMode: 3,
+                tracks: {
+                    size: 1,
+                    toArray: () => [
+                        {
+                            url: 'https://example.com/url-match',
+                            title: 'Queued',
+                        },
+                    ],
+                },
+            },
+        })
+
+        await playCommand.execute({
+            client: createClient(async () => ({
+                track,
+                searchResult: { playlist: null, tracks: [] },
+            })),
+            interaction,
+        } as any)
+
+        expect(moveUserTrackToPriorityMock).not.toHaveBeenCalled()
+    })
+
+    it('does not reinsert the same track object already queued', async () => {
+        const interaction = createInteraction('guild-1')
+        const track = {
+            title: 'Song A',
+            author: 'Artist A',
+        }
+
+        resolveGuildQueueMock.mockReturnValue({
+            queue: {
+                repeatMode: 3,
+                tracks: {
+                    size: 1,
+                    toArray: () => [track],
+                },
+            },
+        })
+
+        await playCommand.execute({
+            client: createClient(async () => ({
+                track,
+                searchResult: { playlist: null, tracks: [] },
+            })),
+            interaction,
+        } as any)
+
+        expect(moveUserTrackToPriorityMock).not.toHaveBeenCalled()
+    })
+
     it('stops when voice channel validation fails', async () => {
         requireVoiceChannelMock.mockResolvedValue(false)
         const interaction = createInteraction('guild-1')
@@ -338,6 +400,25 @@ describe('play command', () => {
         expect(createErrorEmbedMock).toHaveBeenCalledWith(
             'Play Error',
             expect.stringContaining('Could not find'),
+        )
+    })
+
+    it('logs a warning when sending the play error reply also fails', async () => {
+        const interaction = createInteraction('guild-1')
+        interaction.editReply.mockRejectedValue(new Error('reply failed'))
+
+        await playCommand.execute({
+            client: createClient(async () => {
+                throw Object.assign(new Error('Search failed'), { code: 123 })
+            }),
+            interaction,
+        } as any)
+
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Failed to send play command error reply',
+                data: expect.objectContaining({ guildId: 'guild-1' }),
+            }),
         )
     })
 })

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 
 const requireVoiceChannelMock = jest.fn()
 const errorLogMock = jest.fn()
+const debugLogMock = jest.fn()
+const getGuildSettingsMock = jest.fn()
 const createErrorEmbedMock = jest.fn((title: string, message: string) => ({
     type: 'error',
     title,
@@ -40,6 +42,13 @@ jest.mock('../../../../utils/command/commandValidations', () => ({
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: (...args: unknown[]) => errorLogMock(...args),
+    debugLog: (...args: unknown[]) => debugLogMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: {
+        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
+    },
 }))
 
 jest.mock('../../../../utils/general/embeds', () => ({
@@ -102,6 +111,7 @@ describe('play command', () => {
             allowed: true,
             limit: 3,
         })
+        getGuildSettingsMock.mockResolvedValue(null)
         resolveGuildQueueMock.mockReturnValue({ queue: null })
     })
 
@@ -164,6 +174,33 @@ describe('play command', () => {
         )
         expect(interaction.editReply).toHaveBeenCalled()
         expect(createSuccessEmbedMock).toHaveBeenCalled()
+    })
+
+    it('applies stored autoplay preference to a new queue', async () => {
+        const interaction = createInteraction('guild-1')
+        const queue = {
+            repeatMode: 0,
+            tracks: { size: 0 },
+            setRepeatMode: jest.fn(),
+        }
+        const result = {
+            track: { title: 'Song A', author: 'Artist A' },
+            searchResult: { playlist: null, tracks: [] },
+        }
+        getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: true })
+        resolveGuildQueueMock.mockReturnValue({ queue })
+
+        await playCommand.execute({
+            client: createClient(async () => result),
+            interaction,
+        } as any)
+
+        expect(queue.setRepeatMode).toHaveBeenCalledWith(3)
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Applied stored autoplay preference to new queue',
+            }),
+        )
     })
 
     it('does not reinsert a manual track already queued by player.play in autoplay mode', async () => {

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -262,6 +262,31 @@ describe('play command', () => {
         )
     })
 
+    it('does not overwrite repeat mode on an already active queue', async () => {
+        const interaction = createInteraction('guild-1')
+        const queue = {
+            repeatMode: 3,
+            tracks: {
+                size: 1,
+                toArray: () => [],
+            },
+            setRepeatMode: jest.fn(),
+        }
+        const result = {
+            track: { title: 'Song A', author: 'Artist A' },
+            searchResult: { playlist: null, tracks: [] },
+        }
+        getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: false })
+        resolveGuildQueueMock.mockReturnValue({ queue })
+
+        await playCommand.execute({
+            client: createClient(async () => result),
+            interaction,
+        } as any)
+
+        expect(queue.setRepeatMode).not.toHaveBeenCalled()
+    })
+
     it('does not reinsert a manual track already queued by player.play in autoplay mode', async () => {
         const interaction = createInteraction('guild-1')
         const track = {

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -22,7 +22,7 @@ const moveUserTrackToPriorityMock = jest.fn()
 const blendAutoplayTracksMock = jest.fn().mockResolvedValue(undefined)
 
 jest.mock('discord-player', () => ({
-    QueueRepeatMode: { AUTOPLAY: 3 },
+    QueueRepeatMode: { OFF: 0, AUTOPLAY: 3 },
 }))
 
 jest.mock('../../../../utils/music/queueManipulation', () => ({
@@ -201,12 +201,12 @@ describe('play command', () => {
         expect(debugLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 message: 'Applied stored autoplay preference to queue',
-                data: expect.objectContaining({ autoPlayEnabled: true }),
+                data: expect.objectContaining({ guildId: 'guild-1' }),
             }),
         )
     })
 
-    it('applies stored autoplay disabled preference to a fresh autoplay queue', async () => {
+    it('does not override an active autoplay queue when stored preference is disabled', async () => {
         const interaction = createInteraction('guild-1')
         const queue = {
             repeatMode: 3,
@@ -225,11 +225,10 @@ describe('play command', () => {
             interaction,
         } as any)
 
-        expect(queue.setRepeatMode).toHaveBeenCalledWith(0)
-        expect(debugLogMock).toHaveBeenCalledWith(
+        expect(queue.setRepeatMode).not.toHaveBeenCalled()
+        expect(debugLogMock).not.toHaveBeenCalledWith(
             expect.objectContaining({
                 message: 'Applied stored autoplay preference to queue',
-                data: expect.objectContaining({ autoPlayEnabled: false }),
             }),
         )
     })

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -225,10 +225,11 @@ describe('play command', () => {
             interaction,
         } as any)
 
-        expect(queue.setRepeatMode).not.toHaveBeenCalled()
-        expect(debugLogMock).not.toHaveBeenCalledWith(
+        expect(queue.setRepeatMode).toHaveBeenCalledWith(0)
+        expect(debugLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 message: 'Applied stored autoplay preference to queue',
+                data: expect.objectContaining({ autoPlayEnabled: false }),
             }),
         )
     })

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -190,7 +190,9 @@ describe('play command', () => {
             searchResult: { playlist: null, tracks: [] },
         }
         getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: true })
-        resolveGuildQueueMock.mockReturnValue({ queue })
+        resolveGuildQueueMock
+            .mockReturnValueOnce({ queue: null })
+            .mockReturnValueOnce({ queue })
 
         await playCommand.execute({
             client: createClient(async () => result),
@@ -218,18 +220,19 @@ describe('play command', () => {
             searchResult: { playlist: null, tracks: [] },
         }
         getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: false })
-        resolveGuildQueueMock.mockReturnValue({ queue })
+        resolveGuildQueueMock
+            .mockReturnValueOnce({ queue })
+            .mockReturnValueOnce({ queue })
 
         await playCommand.execute({
             client: createClient(async () => result),
             interaction,
         } as any)
 
-        expect(queue.setRepeatMode).toHaveBeenCalledWith(0)
-        expect(debugLogMock).toHaveBeenCalledWith(
+        expect(queue.setRepeatMode).not.toHaveBeenCalled()
+        expect(debugLogMock).not.toHaveBeenCalledWith(
             expect.objectContaining({
                 message: 'Applied stored autoplay preference to queue',
-                data: expect.objectContaining({ autoPlayEnabled: false }),
             }),
         )
     })
@@ -246,7 +249,9 @@ describe('play command', () => {
             searchResult: { playlist: null, tracks: [] },
         }
         getGuildSettingsMock.mockRejectedValue(new Error('redis unavailable'))
-        resolveGuildQueueMock.mockReturnValue({ queue })
+        resolveGuildQueueMock
+            .mockReturnValueOnce({ queue: null })
+            .mockReturnValueOnce({ queue })
 
         await playCommand.execute({
             client: createClient(async () => result),

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 const requireVoiceChannelMock = jest.fn()
 const errorLogMock = jest.fn()
 const debugLogMock = jest.fn()
+const warnLogMock = jest.fn()
 const getGuildSettingsMock = jest.fn()
 const createErrorEmbedMock = jest.fn((title: string, message: string) => ({
     type: 'error',
@@ -43,6 +44,7 @@ jest.mock('../../../../utils/command/commandValidations', () => ({
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: (...args: unknown[]) => errorLogMock(...args),
     debugLog: (...args: unknown[]) => debugLogMock(...args),
+    warnLog: (...args: unknown[]) => warnLogMock(...args),
 }))
 
 jest.mock('@lucky/shared/services', () => ({
@@ -199,6 +201,34 @@ describe('play command', () => {
         expect(debugLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 message: 'Applied stored autoplay preference to new queue',
+            }),
+        )
+    })
+
+    it('logs a warning when stored autoplay preference lookup fails', async () => {
+        const interaction = createInteraction('guild-1')
+        const queue = {
+            repeatMode: 0,
+            tracks: { size: 0 },
+            setRepeatMode: jest.fn(),
+        }
+        const result = {
+            track: { title: 'Song A', author: 'Artist A' },
+            searchResult: { playlist: null, tracks: [] },
+        }
+        getGuildSettingsMock.mockRejectedValue(new Error('redis unavailable'))
+        resolveGuildQueueMock.mockReturnValue({ queue })
+
+        await playCommand.execute({
+            client: createClient(async () => result),
+            interaction,
+        } as any)
+
+        expect(queue.setRepeatMode).not.toHaveBeenCalled()
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Failed to apply stored autoplay preference',
+                data: expect.objectContaining({ guildId: 'guild-1' }),
             }),
         )
     })

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -4,7 +4,7 @@ import { requireVoiceChannel } from '../../../../utils/command/commandValidation
 import type { CommandExecuteParams } from '../../../../types/CommandData'
 import type { CustomClient } from '../../../../types'
 import Command from '../../../../models/Command'
-import { errorLog, debugLog } from '@lucky/shared/utils'
+import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
 import { guildSettingsService } from '@lucky/shared/services'
 import { createErrorEmbed } from '../../../../utils/general/embeds'
 import { createSuccessEmbed } from '../../../../utils/general/embeds'
@@ -163,8 +163,12 @@ export default new Command({
                         ),
                     ],
                 })
-            } catch {
-                // interaction already dead — nothing to do
+            } catch (replyError) {
+                warnLog({
+                    message: 'Failed to send play command error reply',
+                    error: replyError,
+                    data: { guildId: interaction.guildId },
+                })
             }
         }
     },
@@ -177,20 +181,27 @@ async function applyStoredAutoplayPreference(
     },
     guildId: string,
 ): Promise<void> {
-    if (queue.repeatMode === QueueRepeatMode.AUTOPLAY) return
-
     try {
-        const settings =
-            await guildSettingsService.getGuildSettings(guildId)
-        if (settings?.autoPlayEnabled) {
-            queue.setRepeatMode(QueueRepeatMode.AUTOPLAY)
+        const settings = await guildSettingsService.getGuildSettings(guildId)
+        if (typeof settings?.autoPlayEnabled === 'boolean') {
+            const repeatMode = settings.autoPlayEnabled
+                ? QueueRepeatMode.AUTOPLAY
+                : QueueRepeatMode.OFF
+
+            if (queue.repeatMode !== repeatMode) {
+                queue.setRepeatMode(repeatMode)
+            }
+
             debugLog({
-                message:
-                    'Applied stored autoplay preference to new queue',
-                data: { guildId },
+                message: 'Applied stored autoplay preference to queue',
+                data: { guildId, autoPlayEnabled: settings.autoPlayEnabled },
             })
         }
-    } catch {
-        // non-critical — autoplay preference is best-effort
+    } catch (error) {
+        warnLog({
+            message: 'Failed to apply stored autoplay preference',
+            error,
+            data: { guildId },
+        })
     }
 }

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -4,7 +4,8 @@ import { requireVoiceChannel } from '../../../../utils/command/commandValidation
 import type { CommandExecuteParams } from '../../../../types/CommandData'
 import type { CustomClient } from '../../../../types'
 import Command from '../../../../models/Command'
-import { errorLog } from '@lucky/shared/utils'
+import { errorLog, debugLog } from '@lucky/shared/utils'
+import { guildSettingsService } from '@lucky/shared/services'
 import { createErrorEmbed } from '../../../../utils/general/embeds'
 import { createSuccessEmbed } from '../../../../utils/general/embeds'
 import { collaborativePlaylistService } from '../../../../utils/music/collaborativePlaylist'
@@ -109,6 +110,14 @@ export default new Command({
                 client,
                 interaction.guildId ?? '',
             )
+
+            if (queue) {
+                await applyStoredAutoplayPreference(
+                    queue,
+                    interaction.guildId,
+                )
+            }
+
             if (!isPlaylist && queue) {
                 if (!isTrackAlreadyQueued(queue, track)) {
                     moveUserTrackToPriority(queue, track)
@@ -142,8 +151,6 @@ export default new Command({
                 data: { query, guildId: interaction.guildId },
             })
 
-            // DiscordAPIError[10062] = Unknown Interaction — token expired or bot
-            // restarted between deferReply and editReply. No reply is possible.
             const code = (error as { code?: number })?.code
             if (code === DISCORD_UNKNOWN_INTERACTION_CODE) return
 
@@ -162,3 +169,25 @@ export default new Command({
         }
     },
 })
+
+async function applyStoredAutoplayPreference(
+    queue: { repeatMode: number; setRepeatMode: (mode: number) => void },
+    guildId: string,
+): Promise<void> {
+    if (queue.repeatMode === QueueRepeatMode.AUTOPLAY) return
+
+    try {
+        const settings =
+            await guildSettingsService.getGuildSettings(guildId)
+        if (settings?.autoPlayEnabled) {
+            queue.setRepeatMode(QueueRepeatMode.AUTOPLAY)
+            debugLog({
+                message:
+                    'Applied stored autoplay preference to new queue',
+                data: { guildId },
+            })
+        }
+    } catch {
+        // non-critical — autoplay preference is best-effort
+    }
+}

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -89,6 +89,10 @@ export default new Command({
         }
 
         try {
+            const hadQueueBeforePlay = Boolean(
+                resolveGuildQueue(client, interaction.guildId ?? '').queue,
+            )
+
             const result = await client.player.play(voiceChannel, query, {
                 nodeOptions: {
                     metadata: {
@@ -111,7 +115,7 @@ export default new Command({
                 interaction.guildId ?? '',
             )
 
-            if (queue) {
+            if (!hadQueueBeforePlay && queue) {
                 await applyStoredAutoplayPreference(
                     queue,
                     interaction.guildId,

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -171,7 +171,10 @@ export default new Command({
 })
 
 async function applyStoredAutoplayPreference(
-    queue: { repeatMode: number; setRepeatMode: (mode: number) => void },
+    queue: {
+        repeatMode: QueueRepeatMode
+        setRepeatMode: (mode: QueueRepeatMode) => void
+    },
     guildId: string,
 ): Promise<void> {
     if (queue.repeatMode === QueueRepeatMode.AUTOPLAY) return


### PR DESCRIPTION
## Problem

`/autoplay` requires an active queue (`requireQueue` gate). After `/leave` or bot restart, the queue is gone — `/autoplay` returns "❌ No Queue" and users can't pre-enable autoplay before starting music.

## Fix

### `/autoplay` — works with or without a queue

- **With queue**: sets `QueueRepeatMode.AUTOPLAY` on the queue AND persists `autoPlayEnabled: true` to guild settings (Redis)
- **Without queue**: persists the preference to guild settings and tells the user "Next time you use /play, autoplay will be enabled automatically"
- Toggle works both ways — disabling saves `autoPlayEnabled: false`
- Reads current state from queue (if active) or guild settings (if no queue)

### `/play` — applies stored autoplay preference

After `client.player.play()` creates a new queue, reads guild settings and auto-enables `QueueRepeatMode.AUTOPLAY` if `autoPlayEnabled` is `true`. This means:
1. User enables autoplay → leaves → comes back → `/play` → autoplay is already on

### Infrastructure already existed

`GuildSettingsService` already had `autoPlayEnabled: boolean` in its schema and Redis storage. This change just wires it into the command flow.

## Test changes

- Removed `requireQueue` mock from autoplay spec (no longer used)
- Added `guildSettingsService` mock (getGuildSettings / setGuildSettings)
- New test: "saves preference and replies when no queue exists"
- New test: "disables stored preference when no queue and was enabled"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autoplay preferences now persist across sessions and are applied to playback automatically.
  * You can toggle autoplay at any time, even without an active queue; messaging reflects queue vs. preference behavior.
* **Bug Fixes**
  * Improved handling and user feedback when saving or applying autoplay preferences fails.
* **Tests**
  * Test suite expanded to cover persistence, toggling without a queue, applying stored preferences, and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->