### PR TITLE
fix(backend): fall back to commit label in health version endpoint

### DIFF
--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -35,6 +35,20 @@ export const resolveRequestOrigin = (req: Request): string | undefined => {
     }
 }
 
+const resolveRuntimeVersion = (): string | null => {
+    const semver = process.env.npm_package_version?.trim()
+    if (semver) {
+        return semver
+    }
+
+    const sha = process.env.COMMIT_SHA?.trim()
+    if (sha) {
+        return `commit ${sha.slice(0, 7)}`
+    }
+
+    return null
+}
+
 export function setupHealthRoutes(app: Express): void {
     app.get('/api/health', (_req: Request, res: Response) => {
         res.json({
@@ -47,7 +61,7 @@ export function setupHealthRoutes(app: Express): void {
     app.get('/api/health/version', (_req: Request, res: Response) => {
         res.json({
             commitSha: process.env.COMMIT_SHA ?? null,
-            version: process.env.npm_package_version ?? null,
+            version: resolveRuntimeVersion(),
         })
     })
 

--- a/packages/backend/tests/unit/routes/health.test.ts
+++ b/packages/backend/tests/unit/routes/health.test.ts
@@ -77,4 +77,17 @@ describe('GET /api/health/version', () => {
         expect(res.body.commitSha).toBeNull()
         expect(res.body.version).toBe('1.0.0')
     })
+
+    test('falls back to short commit label when npm_package_version is unset', async () => {
+        process.env.COMMIT_SHA = 'abc123def456'
+        delete process.env.npm_package_version
+
+        const res = await request(buildApp()).get('/api/health/version')
+
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({
+            commitSha: 'abc123def456',
+            version: 'commit abc123d',
+        })
+    })
 })


### PR DESCRIPTION
## Summary

- make `/api/health/version` return a meaningful fallback when `npm_package_version` is unavailable in production Docker
- align backend version reporting with the bot command’s existing runtime behavior: semver first, then short commit label

## Why

The live production endpoint currently returns:

```json
{"commitSha":"93b6310a...","version":null}
```

That happens because the backend container runs `node packages/backend/dist/index.js`, so `npm_package_version` is not set at runtime. Returning `null` weakens deploy observability even though `COMMIT_SHA` is available.

## Changes

- add `resolveRuntimeVersion()` in `packages/backend/src/routes/health.ts`
- keep semver when available
- otherwise return `commit <short-sha>` from `COMMIT_SHA`
- add a route test covering the fallback path

## Verification

- [x] `npm run test --workspace=packages/backend -- --ci --testPathPatterns="health.test"`
- [x] LSP diagnostics clean for `packages/backend/src/routes/health.ts`
- [ ] CI Quality Gates green