### PR TITLE
fix(shared): handle last.fm unlink p2025 as successful cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **external Last.fm scrobbler**: Invalid Last.fm sessions (`error: 9`, "Invalid session key") are now auto-unlinked per user when detected during `updateNowPlaying`/`scrobble`, preventing repeated log/error spam from stale credentials.
+- **Last.fm unlink resilience**: unlink operations now treat Prisma `P2025` (already absent link) as a successful cleanup path, preventing repeated error spam when invalid-session cleanup races or records are already removed.
 - **voice connection hardening (`/play`)**: `player.play` now receives `nodeOptions.connectionTimeout` from environment config, and watchdog recovery performs one additional rejoin wait cycle before failing.
 
 ### Changed

--- a/packages/shared/src/services/LastFmLinkService/index.spec.ts
+++ b/packages/shared/src/services/LastFmLinkService/index.spec.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { LastFmLinkService } from './index'
+
+const deleteMock =
+    jest.fn<(args: { where: { discordId: string } }) => Promise<unknown>>()
+const debugLogMock = jest.fn<(payload: unknown) => void>()
+const errorLogMock = jest.fn<(payload: unknown) => void>()
+
+jest.mock('../../utils/database/prismaClient', () => ({
+    getPrismaClient: () => ({
+        lastFmLink: {
+            delete: (args: { where: { discordId: string } }) =>
+                deleteMock(args),
+        },
+    }),
+}))
+
+jest.mock('../../utils/general/log', () => ({
+    debugLog: (payload: unknown) => debugLogMock(payload),
+    errorLog: (payload: unknown) => errorLogMock(payload),
+}))
+
+describe('LastFmLinkService.unlink', () => {
+    const service = new LastFmLinkService()
+
+    beforeEach(() => {
+        deleteMock.mockReset()
+        debugLogMock.mockReset()
+        errorLogMock.mockReset()
+    })
+
+    it('returns true when delete succeeds', async () => {
+        deleteMock.mockResolvedValue({})
+
+        const result = await service.unlink('123')
+
+        expect(result).toBe(true)
+        expect(deleteMock).toHaveBeenCalledWith({ where: { discordId: '123' } })
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'Last.fm link removed' }),
+        )
+        expect(errorLogMock).not.toHaveBeenCalled()
+    })
+
+    it('returns true when record is already absent (P2025)', async () => {
+        deleteMock.mockRejectedValue({ code: 'P2025' })
+
+        const result = await service.unlink('456')
+
+        expect(result).toBe(true)
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'Last.fm link already absent' }),
+        )
+        expect(errorLogMock).not.toHaveBeenCalled()
+    })
+
+    it('returns false and logs error on unexpected failures', async () => {
+        const dbError = new Error('db unavailable')
+        deleteMock.mockRejectedValue(dbError)
+
+        const result = await service.unlink('789')
+
+        expect(result).toBe(false)
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'Failed to unlink Last.fm' }),
+        )
+    })
+})

--- a/packages/shared/src/services/LastFmLinkService/index.ts
+++ b/packages/shared/src/services/LastFmLinkService/index.ts
@@ -82,6 +82,22 @@ export class LastFmLinkService {
             })
             return true
         } catch (error) {
+            const code =
+                typeof error === 'object' &&
+                error !== null &&
+                'code' in error &&
+                typeof (error as { code?: unknown }).code === 'string'
+                    ? (error as { code: string }).code
+                    : null
+
+            if (code === 'P2025') {
+                debugLog({
+                    message: 'Last.fm link already absent',
+                    data: { discordId },
+                })
+                return true
+            }
+
             errorLog({
                 message: 'Failed to unlink Last.fm',
                 error,

--- a/packages/shared/src/services/LastFmLinkService/index.ts
+++ b/packages/shared/src/services/LastFmLinkService/index.ts
@@ -91,6 +91,9 @@ export class LastFmLinkService {
                     : null
 
             if (code === 'P2025') {
+                // Prisma P2025 = record not found:
+                // https://www.prisma.io/docs/orm/reference/error-reference
+                // Treat delete of a missing link as idempotent success.
                 debugLog({
                     message: 'Last.fm link already absent',
                     data: { discordId },


### PR DESCRIPTION
## Summary
- treat Prisma `P2025` during `LastFmLinkService.unlink` as an idempotent success case (record already absent)
- stop escalating already-removed Last.fm links as hard unlink failures, reducing production error spam under invalid-session cleanup races
- add focused unit coverage for unlink success, `P2025` success path, and unexpected-error failure path

## Verification
- `npm test --workspace=packages/shared -- src/services/LastFmLinkService/index.spec.ts`
- `npm test --workspace=packages/bot -- src/handlers/externalScrobbler.spec.ts src/lastfm/lastFmApi.spec.ts`
- `npm run type:check --workspace=packages/shared`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Last.fm unlinking resilience to gracefully handle cases where the link is already absent, preventing repeated error messages during cleanup operations.

* **Tests**
  * Added comprehensive test coverage for Last.fm unlinking behavior across success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->