### PR TITLE
fix(bot): ignore expired play interactions in sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **play command Sentry noise reduction**: `/play` now treats `DiscordAPIError[10062]` (`Unknown interaction`) as an interaction-expired path before logging command failures, and safely exits when `deferReply` already expired. This prevents recurring false-positive production error reports for already-handled interaction expiry events.
+
 ## [2.6.61] - 2026-04-03
 
 ### Fixed

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -190,6 +190,33 @@ describe('play command', () => {
         )
     })
 
+    it('silently exits when collaborative-limit reply hits unknown interaction', async () => {
+        const interaction = createInteraction('guild-1')
+        interaction.editReply.mockRejectedValue(
+            Object.assign(new Error('Unknown interaction'), { code: 10062 }),
+        )
+        canAddTracksMock.mockReturnValue({
+            allowed: false,
+            limit: 1,
+        })
+
+        await playCommand.execute({
+            client: createClient(async () => ({})),
+            interaction,
+        } as any)
+
+        expect(errorLogMock).not.toHaveBeenCalled()
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Play command interaction expired before editReply',
+                data: expect.objectContaining({
+                    stage: 'collaborative-limit',
+                    guildId: 'guild-1',
+                }),
+            }),
+        )
+    })
+
     it('plays track and records contribution', async () => {
         const interaction = createInteraction('guild-1')
         const result = {

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -480,6 +480,40 @@ describe('play command', () => {
         )
     })
 
+    it('ignores unknown interaction errors thrown during deferReply', async () => {
+        const interaction = createInteraction('guild-1')
+        interaction.deferReply.mockRejectedValue(
+            Object.assign(new Error('Unknown interaction'), { code: 10062 }),
+        )
+
+        await playCommand.execute({
+            client: createClient(async () => ({
+                track: { title: 'Song A', author: 'Artist A' },
+                searchResult: { playlist: null, tracks: [] },
+            })),
+            interaction,
+        } as any)
+
+        expect(errorLogMock).not.toHaveBeenCalled()
+        expect(interaction.editReply).not.toHaveBeenCalled()
+    })
+
+    it('ignores unknown interaction errors thrown during play flow', async () => {
+        const interaction = createInteraction('guild-1')
+
+        await playCommand.execute({
+            client: createClient(async () => {
+                throw Object.assign(new Error('Unknown interaction'), {
+                    code: 10062,
+                })
+            }),
+            interaction,
+        } as any)
+
+        expect(errorLogMock).not.toHaveBeenCalled()
+        expect(interaction.editReply).not.toHaveBeenCalled()
+    })
+
     it('logs a warning when sending the play error reply also fails', async () => {
         const interaction = createInteraction('guild-1')
         interaction.editReply.mockRejectedValue(new Error('reply failed'))

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -46,6 +46,7 @@ const moveUserTrackToPriorityMock =
     jest.fn<(queue: unknown, track: unknown) => void>()
 const blendAutoplayTracksMock =
     jest.fn<(queue: unknown, track: unknown) => Promise<void>>()
+const interactionReplyMock = jest.fn<(payload: unknown) => Promise<void>>()
 
 jest.mock('discord-player', () => ({
     QueueRepeatMode: { OFF: 0, AUTOPLAY: 3 },
@@ -101,6 +102,10 @@ jest.mock('../../../../utils/music/collaborativePlaylist', () => ({
         recordContribution: (guildId: string, userId: string, amount: number) =>
             recordContributionMock(guildId, userId, amount),
     },
+}))
+
+jest.mock('../../../../utils/general/interactionReply', () => ({
+    interactionReply: (payload: unknown) => interactionReplyMock(payload),
 }))
 
 import playCommand from './index'
@@ -185,16 +190,17 @@ describe('play command', () => {
         } as any)
 
         expect(interaction.deferReply).toHaveBeenCalled()
-        expect(interaction.editReply).toHaveBeenCalledWith(
-            expect.objectContaining({ embeds: expect.any(Array) }),
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                interaction,
+                content: expect.objectContaining({ embeds: expect.any(Array) }),
+            }),
         )
+        expect(interaction.editReply).not.toHaveBeenCalled()
     })
 
-    it('silently exits when collaborative-limit reply hits unknown interaction', async () => {
+    it('uses interactionReply for collaborative-limit replies', async () => {
         const interaction = createInteraction('guild-1')
-        interaction.editReply.mockRejectedValue(
-            Object.assign(new Error('Unknown interaction'), { code: 10062 }),
-        )
         canAddTracksMock.mockReturnValue({
             allowed: false,
             limit: 1,
@@ -206,13 +212,17 @@ describe('play command', () => {
         } as any)
 
         expect(errorLogMock).not.toHaveBeenCalled()
-        expect(debugLogMock).toHaveBeenCalledWith(
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                interaction,
+                content: expect.objectContaining({
+                    embeds: expect.any(Array),
+                }),
+            }),
+        )
+        expect(debugLogMock).not.toHaveBeenCalledWith(
             expect.objectContaining({
                 message: 'Play command interaction expired before editReply',
-                data: expect.objectContaining({
-                    stage: 'collaborative-limit',
-                    guildId: 'guild-1',
-                }),
             }),
         )
     })
@@ -239,7 +249,13 @@ describe('play command', () => {
             'user-1',
             1,
         )
-        expect(interaction.editReply).toHaveBeenCalled()
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                interaction,
+                content: expect.objectContaining({ embeds: expect.any(Array) }),
+            }),
+        )
+        expect(interaction.editReply).not.toHaveBeenCalled()
         expect(createSuccessEmbedMock).toHaveBeenCalled()
         expect(client.player.play).toHaveBeenCalledWith(
             expect.anything(),
@@ -500,7 +516,15 @@ describe('play command', () => {
                 data: expect.objectContaining({ guildId: 'guild-1' }),
             }),
         )
-        expect(interaction.editReply).toHaveBeenCalled()
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                interaction,
+                content: expect.objectContaining({
+                    embeds: expect.any(Array),
+                }),
+            }),
+        )
+        expect(interaction.editReply).not.toHaveBeenCalled()
         expect(createErrorEmbedMock).toHaveBeenCalledWith(
             'Play Error',
             expect.stringContaining('Could not find'),
@@ -541,9 +565,8 @@ describe('play command', () => {
         expect(interaction.editReply).not.toHaveBeenCalled()
     })
 
-    it('logs a warning when sending the play error reply also fails', async () => {
+    it('uses interactionReply for play error replies', async () => {
         const interaction = createInteraction('guild-1')
-        interaction.editReply.mockRejectedValue(new Error('reply failed'))
 
         await playCommand.execute({
             client: createClient(async () => {
@@ -552,10 +575,15 @@ describe('play command', () => {
             interaction,
         } as any)
 
-        expect(warnLogMock).toHaveBeenCalledWith(
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                interaction,
+                content: expect.objectContaining({ embeds: expect.any(Array) }),
+            }),
+        )
+        expect(warnLogMock).not.toHaveBeenCalledWith(
             expect.objectContaining({
                 message: 'Failed to send play command error reply',
-                data: expect.objectContaining({ guildId: 'guild-1' }),
             }),
         )
     })

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -19,6 +19,15 @@ import {
 
 const DISCORD_UNKNOWN_INTERACTION_CODE = 10062
 
+function isUnknownInteractionError(error: unknown): boolean {
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error as { code?: number }).code === DISCORD_UNKNOWN_INTERACTION_CODE
+    )
+}
+
 function isTrackAlreadyQueued(
     queue: { tracks: { toArray?: () => Array<{ id?: string; url?: string }> } },
     track: { id?: string; url?: string },
@@ -69,7 +78,12 @@ export default new Command({
 
         const voiceChannel = member.voice.channel!
 
-        await interaction.deferReply()
+        try {
+            await interaction.deferReply()
+        } catch (error) {
+            if (isUnknownInteractionError(error)) return
+            throw error
+        }
 
         const query = interaction.options.getString('query', true)
         const collaborativeCheck = collaborativePlaylistService.canAddTracks(
@@ -149,14 +163,19 @@ export default new Command({
 
             await interaction.editReply({ embeds: [embed] })
         } catch (error) {
+            if (isUnknownInteractionError(error)) {
+                debugLog({
+                    message: 'Play command interaction expired before reply',
+                    data: { query, guildId: interaction.guildId },
+                })
+                return
+            }
+
             errorLog({
                 message: 'Play command error:',
                 error,
                 data: { query, guildId: interaction.guildId },
             })
-
-            const code = (error as { code?: number })?.code
-            if (code === DISCORD_UNKNOWN_INTERACTION_CODE) return
 
             try {
                 await interaction.editReply({

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -28,6 +28,29 @@ function isUnknownInteractionError(error: unknown): boolean {
     )
 }
 
+async function safeEditReply(
+    interaction: ChatInputCommandInteraction,
+    payload: {
+        embeds: unknown[]
+    },
+    context: { stage: string; guildId: string | null; query?: string },
+): Promise<boolean> {
+    try {
+        await interaction.editReply(payload)
+        return true
+    } catch (error) {
+        if (isUnknownInteractionError(error)) {
+            debugLog({
+                message: 'Play command interaction expired before editReply',
+                data: context,
+            })
+            return false
+        }
+
+        throw error
+    }
+}
+
 function isTrackAlreadyQueued(
     queue: { tracks: { toArray?: () => Array<{ id?: string; url?: string }> } },
     track: { id?: string; url?: string },
@@ -92,14 +115,22 @@ export default new Command({
             1,
         )
         if (!collaborativeCheck.allowed) {
-            await interaction.editReply({
-                embeds: [
-                    createErrorEmbed(
-                        'Contribution limit reached',
-                        `Collaborative mode limit reached (${collaborativeCheck.limit} track requests per user).`,
-                    ),
-                ],
-            })
+            await safeEditReply(
+                interaction,
+                {
+                    embeds: [
+                        createErrorEmbed(
+                            'Contribution limit reached',
+                            `Collaborative mode limit reached (${collaborativeCheck.limit} track requests per user).`,
+                        ),
+                    ],
+                },
+                {
+                    stage: 'collaborative-limit',
+                    guildId: interaction.guildId,
+                    query,
+                },
+            )
             return
         }
 
@@ -161,7 +192,15 @@ export default new Command({
                 1,
             )
 
-            await interaction.editReply({ embeds: [embed] })
+            await safeEditReply(
+                interaction,
+                { embeds: [embed] },
+                {
+                    stage: 'success',
+                    guildId: interaction.guildId,
+                    query,
+                },
+            )
         } catch (error) {
             if (isUnknownInteractionError(error)) {
                 debugLog({
@@ -178,14 +217,22 @@ export default new Command({
             })
 
             try {
-                await interaction.editReply({
-                    embeds: [
-                        createErrorEmbed(
-                            'Play Error',
-                            'Could not find or play the requested track',
-                        ),
-                    ],
-                })
+                await safeEditReply(
+                    interaction,
+                    {
+                        embeds: [
+                            createErrorEmbed(
+                                'Play Error',
+                                'Could not find or play the requested track',
+                            ),
+                        ],
+                    },
+                    {
+                        stage: 'error-reply',
+                        guildId: interaction.guildId,
+                        query,
+                    },
+                )
             } catch (replyError) {
                 warnLog({
                     message: 'Failed to send play command error reply',

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -9,6 +9,7 @@ import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
 import { guildSettingsService } from '@lucky/shared/services'
 import { createErrorEmbed } from '../../../../utils/general/embeds'
 import { createSuccessEmbed } from '../../../../utils/general/embeds'
+import { interactionReply } from '../../../../utils/general/interactionReply'
 import { collaborativePlaylistService } from '../../../../utils/music/collaborativePlaylist'
 import { QueueRepeatMode } from 'discord-player'
 import { resolveGuildQueue } from '../../../../utils/music/queueResolver'
@@ -26,29 +27,6 @@ function isUnknownInteractionError(error: unknown): boolean {
         'code' in error &&
         (error as { code?: number }).code === DISCORD_UNKNOWN_INTERACTION_CODE
     )
-}
-
-async function safeEditReply(
-    interaction: ChatInputCommandInteraction,
-    payload: {
-        embeds: unknown[]
-    },
-    context: { stage: string; guildId: string | null; query?: string },
-): Promise<boolean> {
-    try {
-        await interaction.editReply(payload)
-        return true
-    } catch (error) {
-        if (isUnknownInteractionError(error)) {
-            debugLog({
-                message: 'Play command interaction expired before editReply',
-                data: context,
-            })
-            return false
-        }
-
-        throw error
-    }
 }
 
 function isTrackAlreadyQueued(
@@ -115,9 +93,9 @@ export default new Command({
             1,
         )
         if (!collaborativeCheck.allowed) {
-            await safeEditReply(
+            await interactionReply({
                 interaction,
-                {
+                content: {
                     embeds: [
                         createErrorEmbed(
                             'Contribution limit reached',
@@ -125,12 +103,7 @@ export default new Command({
                         ),
                     ],
                 },
-                {
-                    stage: 'collaborative-limit',
-                    guildId: interaction.guildId,
-                    query,
-                },
-            )
+            })
             return
         }
 
@@ -192,15 +165,10 @@ export default new Command({
                 1,
             )
 
-            await safeEditReply(
+            await interactionReply({
                 interaction,
-                { embeds: [embed] },
-                {
-                    stage: 'success',
-                    guildId: interaction.guildId,
-                    query,
-                },
-            )
+                content: { embeds: [embed] },
+            })
         } catch (error) {
             if (isUnknownInteractionError(error)) {
                 debugLog({
@@ -217,9 +185,9 @@ export default new Command({
             })
 
             try {
-                await safeEditReply(
+                await interactionReply({
                     interaction,
-                    {
+                    content: {
                         embeds: [
                             createErrorEmbed(
                                 'Play Error',
@@ -227,12 +195,7 @@ export default new Command({
                             ),
                         ],
                     },
-                    {
-                        stage: 'error-reply',
-                        guildId: interaction.guildId,
-                        query,
-                    },
-                )
+                })
             } catch (replyError) {
                 warnLog({
                     message: 'Failed to send play command error reply',


### PR DESCRIPTION
## Summary
- treat `DiscordAPIError[10062]` (`Unknown interaction`) in `/play` as an interaction-expired path before error logging
- guard `deferReply()` in `/play` and exit safely when the interaction already expired
- add regression tests to ensure unknown interaction errors are ignored (no noisy error logs) in both defer and play-flow paths

## Context
- Addresses recurring Sentry issue LUCKY-1Y (`DiscordAPIError[10062]`) seen in production event `f7c60a8f996642b9bfe014fe0c716ff6`

## Verification
- `node /Volumes/External HD/Desenvolvimento/Lucky/node_modules/.bin/jest --config packages/bot/jest.config.cjs packages/bot/src/functions/music/commands/play/index.spec.ts --runInBand` ✅
- `node /Volumes/External HD/Desenvolvimento/Lucky/node_modules/.bin/jest --config packages/bot/jest.config.cjs packages/bot/src/functions/music/commands/autoplay.spec.ts --runInBand` ✅
- `npm run type:check --workspace=packages/bot` ❌ fails in shared preflight with existing env/toolchain issue: `tsconfig.json(26,31): error TS5103: Invalid value for '--ignoreDeprecations'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The /play command now treats expired/unknown interactions as non-actionable, avoiding repeated error reports and performing a safe early exit when replies have already expired.

* **Tests**
  * Added test coverage for expired/unknown interaction scenarios to ensure no unnecessary error logging or reply attempts.

* **Documentation**
  * Updated changelog with the fixed interaction-expired behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->