### PR TITLE
fix(bot): update discord-player-youtubei v3 extractor registration

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -1,4 +1,5 @@
 import { Player } from 'discord-player'
+import type { Track } from 'discord-player'
 import { DefaultExtractors } from '@discord-player/extractor'
 import * as playdl from 'play-dl'
 import type { Readable } from 'stream'
@@ -13,13 +14,6 @@ import {
 
 type CreatePlayerParams = {
     client: CustomClient
-}
-
-type BridgeTrack = {
-    title: string
-    author: string
-    duration?: string
-    url?: string
 }
 
 export const createPlayer = ({ client }: CreatePlayerParams): Player => {
@@ -74,29 +68,31 @@ const loadYoutubeExtractor = async (player: Player): Promise<void> => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const mod = (await import('discord-player-youtubei')) as any
 
-        const registered = await player.extractors.register(
-            mod.YoutubeiExtractor,
-            {
-                streamOptions: {
-                    useClient: 'IOS' as const,
-                    highWaterMark: 1 << 25,
-                },
-                generateWithPoToken: true,
-                createStream: createResilientStream,
-            },
-        )
+        // v3 renamed YoutubeiExtractor → YoutubeExtractor
+        const YoutubeExtractor = mod.YoutubeExtractor ?? mod.YoutubeiExtractor
+        if (!YoutubeExtractor) {
+            warnLog({
+                message:
+                    'discord-player-youtubei: no extractor export found — skipping YouTube extractor',
+            })
+            return
+        }
+
+        const registered = await player.extractors.register(YoutubeExtractor, {
+            createStream: createResilientStream,
+        })
 
         if (!registered) {
             warnLog({
                 message:
-                    'YoutubeiExtractor registration returned null — activation may have failed',
+                    'YoutubeExtractor registration returned null — activation may have failed',
             })
             return
         }
 
         infoLog({
             message:
-                'Registered YoutubeiExtractor (SoundCloud bridge + YouTube fallback)',
+                'Registered YoutubeExtractor (SoundCloud bridge + YouTube fallback)',
         })
     } catch (error) {
         warnLog({
@@ -107,7 +103,7 @@ const loadYoutubeExtractor = async (player: Player): Promise<void> => {
 }
 
 /**
- * Bridge fallback chain.
+ * Bridge fallback chain (discord-player-youtubei v3 createStream signature).
  *
  * 1. SoundCloud search with the cleaned "${title} ${author}" query
  * 2. SoundCloud search with cleaned title only (drops uploader-channel noise)
@@ -118,7 +114,8 @@ const loadYoutubeExtractor = async (player: Player): Promise<void> => {
  * context to understand WHY the bridge fell through.
  */
 export async function createResilientStream(
-    track: BridgeTrack,
+    track: Pick<Track, 'title' | 'author' | 'duration' | 'url'>,
+    _ext?: unknown,
 ): Promise<Readable> {
     const cleanedTitle = cleanTitle(track.title)
     const cleanedAuthor = cleanAuthor(track.author)

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -99,5 +99,55 @@ describe('playerFactory', () => {
             const [, options] = player.extractors.register.mock.calls[0]
             expect(typeof options.createStream).toBe('function')
         })
+
+        it('falls back to YoutubeiExtractor when YoutubeExtractor is absent (v2 compat)', async () => {
+            jest.resetModules()
+            jest.doMock('discord-player-youtubei', () => ({
+                YoutubeiExtractor: class MockYoutubeiExtractorV2 {},
+            }))
+
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+            const player = createPlayer({
+                client: { user: { id: '123' } } as any,
+            }) as unknown as { extractors: { register: jest.Mock } }
+
+            for (let i = 0; i < 50; i++) {
+                if (player.extractors.register.mock.calls.length > 0) break
+                await new Promise((resolve) => setTimeout(resolve, 10))
+            }
+
+            expect(player.extractors.register).toHaveBeenCalled()
+        })
+
+        it('logs warn and skips registration when no extractor export is found', async () => {
+            jest.resetModules()
+            jest.doMock('discord-player-youtubei', () => ({}))
+            jest.doMock('@lucky/shared/utils', () => ({
+                errorLog: jest.fn(),
+                infoLog: jest.fn(),
+                warnLog: jest.fn(),
+                debugLog: jest.fn(),
+            }))
+
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+            const { warnLog } = await import('@lucky/shared/utils')
+
+            const player = createPlayer({
+                client: { user: { id: '123' } } as any,
+            }) as unknown as { extractors: { register: jest.Mock } }
+
+            await new Promise((resolve) => setTimeout(resolve, 200))
+
+            expect(
+                (warnLog as jest.Mock).mock.calls.some((call) =>
+                    (call[0]?.message as string)?.includes(
+                        'no extractor export found',
+                    ),
+                ),
+            ).toBe(true)
+            expect(player.extractors.register).not.toHaveBeenCalled()
+        })
     })
 })

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -17,7 +17,7 @@ jest.mock('@discord-player/extractor', () => ({
 }))
 
 jest.mock('discord-player-youtubei', () => ({
-    YoutubeiExtractor: class MockYoutubeiExtractor {},
+    YoutubeExtractor: class MockYoutubeExtractor {},
 }))
 
 jest.mock('play-dl', () => ({
@@ -60,8 +60,8 @@ describe('playerFactory', () => {
         })
     })
 
-    describe('YoutubeiExtractor registration', () => {
-        it('registers YoutubeiExtractor with IOS client', async () => {
+    describe('YoutubeExtractor registration', () => {
+        it('registers YoutubeExtractor with createStream bridge', async () => {
             const { createPlayer } =
                 await import('../../../src/handlers/player/playerFactory')
 
@@ -77,9 +77,10 @@ describe('playerFactory', () => {
             expect(player.extractors.register).toHaveBeenCalled()
 
             const [, options] = player.extractors.register.mock.calls[0]
-            expect(options.streamOptions.useClient).toBe('IOS')
-            expect(options.streamOptions.highWaterMark).toBe(1 << 25)
-            expect(options.generateWithPoToken).toBe(true)
+            expect(typeof options.createStream).toBe('function')
+            // v3 API: streamOptions/generateWithPoToken removed
+            expect(options.streamOptions).toBeUndefined()
+            expect(options.generateWithPoToken).toBeUndefined()
         })
 
         it('sets a createStream override to route audio via SoundCloud', async () => {


### PR DESCRIPTION
## Root Cause

`discord-player-youtubei@3.0.0-beta.4` renamed the extractor from `YoutubeiExtractor` to `YoutubeExtractor` and removed `streamOptions.useClient` / `generateWithPoToken` from the registration options.

The old code resolved `mod.YoutubeiExtractor` → `undefined`, which caused `player.extractors.register(undefined, ...)` to throw `TypeError: Cannot read properties of undefined (reading 'identifier')`. This was silently caught, logging "YouTube extractor unavailable. Using SoundCloud/Spotify." on every bot startup.

**Effect**: No YouTube extractor was registered. All YouTube-backed tracks fell through to the SoundCloud extractor from `DefaultExtractors`. Tracks not available on SoundCloud (e.g. anime openings, niche tracks) failed with `NoResultError: Could not extract stream for this track` (Sentry LUCKY-2J, 4 events).

## Changes

- Resolve the extractor export with a v2 fallback: `mod.YoutubeExtractor ?? mod.YoutubeiExtractor`
- Explicit guard when neither export is found (logs warn, returns cleanly)
- Drop removed registration options (`streamOptions.useClient`, `generateWithPoToken`)
- Update `createResilientStream` signature to v3: `(track: Pick<Track, ...>, _ext?: unknown)`

## Test plan

- [ ] CI passes (66 player handler tests green)
- [ ] After deploy: bot logs should show `Registered YoutubeExtractor (SoundCloud bridge + YouTube fallback)` instead of `YouTube extractor unavailable`
- [ ] Verify `/play Ousama ranking Opening 2 Demo` now streams successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated YouTube extractor compatibility with the latest v3 release, including improved registration and error handling for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->