### PR TITLE
fix(bot): button interactions timeout + watchdog intentional stop

### DIFF
--- a/packages/bot/src/functions/music/commands/leave.spec.ts
+++ b/packages/bot/src/functions/music/commands/leave.spec.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import leaveCommand from './leave'
+
+const requireGuildMock = jest.fn()
+const requireQueueMock = jest.fn()
+const interactionReplyMock = jest.fn()
+const createSuccessEmbedMock = jest.fn()
+const createErrorEmbedMock = jest.fn()
+const resolveGuildQueueMock = jest.fn()
+const markIntentionalStopMock = jest.fn()
+const infoLogMock = jest.fn()
+const debugLogMock = jest.fn()
+const errorLogMock = jest.fn()
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireGuild: (...args: unknown[]) => requireGuildMock(...args),
+    requireQueue: (...args: unknown[]) => requireQueueMock(...args),
+}))
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createSuccessEmbed: (...args: unknown[]) => createSuccessEmbedMock(...args),
+    createErrorEmbed: (...args: unknown[]) => createErrorEmbedMock(...args),
+}))
+
+jest.mock('../../../utils/music/queueResolver', () => ({
+    resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
+}))
+
+jest.mock('../../../utils/music/watchdog', () => ({
+    musicWatchdogService: {
+        markIntentionalStop: (...args: unknown[]) =>
+            markIntentionalStopMock(...args),
+    },
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: (...args: unknown[]) => infoLogMock(...args),
+    debugLog: (...args: unknown[]) => debugLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+}))
+
+function createInteraction(guildId = 'guild-1') {
+    return { guildId, user: { tag: 'User#0001' } } as any
+}
+
+function createQueue(guildId = 'guild-1') {
+    return {
+        guild: { id: guildId },
+        delete: jest.fn(),
+    }
+}
+
+describe('leave command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        requireGuildMock.mockResolvedValue(true)
+        interactionReplyMock.mockResolvedValue(undefined)
+        createSuccessEmbedMock.mockReturnValue({ title: 'Goodbye!' })
+    })
+
+    it('marks intentional stop and deletes queue', async () => {
+        const queue = createQueue()
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        requireQueueMock.mockResolvedValue(true)
+
+        await leaveCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(markIntentionalStopMock).toHaveBeenCalledWith('guild-1')
+        expect(queue.delete).toHaveBeenCalled()
+    })
+
+    it('calls markIntentionalStop before queue.delete', async () => {
+        const queue = createQueue()
+        const callOrder: string[] = []
+        markIntentionalStopMock.mockImplementation(() => callOrder.push('mark'))
+        queue.delete.mockImplementation(() => callOrder.push('delete'))
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        requireQueueMock.mockResolvedValue(true)
+
+        await leaveCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(callOrder).toEqual(['mark', 'delete'])
+    })
+
+    it('replies with success embed after leaving', async () => {
+        const queue = createQueue()
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        requireQueueMock.mockResolvedValue(true)
+
+        await leaveCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.objectContaining({ embeds: expect.any(Array) }),
+            }),
+        )
+    })
+
+    it('returns early when guild check fails', async () => {
+        requireGuildMock.mockResolvedValue(false)
+
+        await leaveCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(markIntentionalStopMock).not.toHaveBeenCalled()
+    })
+
+    it('returns early when queue check fails', async () => {
+        resolveGuildQueueMock.mockReturnValue({ queue: null })
+        requireQueueMock.mockResolvedValue(false)
+
+        await leaveCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(markIntentionalStopMock).not.toHaveBeenCalled()
+    })
+
+    it('replies error embed when queue.delete throws', async () => {
+        const queue = createQueue()
+        queue.delete.mockImplementation(() => {
+            throw new Error('delete failed')
+        })
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        requireQueueMock.mockResolvedValue(true)
+        createErrorEmbedMock.mockReturnValue({ title: 'Error' })
+
+        await leaveCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(errorLogMock).toHaveBeenCalled()
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.objectContaining({ ephemeral: true }),
+            }),
+        )
+    })
+})

--- a/packages/bot/src/functions/music/commands/leave.ts
+++ b/packages/bot/src/functions/music/commands/leave.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../utils/command/commandValidations'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import { musicWatchdogService } from '../../../utils/music/watchdog'
 
 export default new Command({
     data: new SlashCommandBuilder()
@@ -35,6 +36,7 @@ export default new Command({
                 message: 'Exiting voice channel',
                 data: { guildId: interaction.guildId },
             })
+            if (queue) musicWatchdogService.markIntentionalStop(queue.guild.id)
             queue?.delete()
             await interactionReply({
                 interaction,

--- a/packages/bot/src/functions/music/commands/stop.spec.ts
+++ b/packages/bot/src/functions/music/commands/stop.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import stopCommand from './stop'
+
+const requireQueueMock = jest.fn()
+const interactionReplyMock = jest.fn()
+const createSuccessEmbedMock = jest.fn()
+const resolveGuildQueueMock = jest.fn()
+const markIntentionalStopMock = jest.fn()
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireQueue: (...args: unknown[]) => requireQueueMock(...args),
+}))
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createSuccessEmbed: (...args: unknown[]) => createSuccessEmbedMock(...args),
+}))
+
+jest.mock('../../../utils/music/queueResolver', () => ({
+    resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
+}))
+
+jest.mock('../../../utils/music/watchdog', () => ({
+    musicWatchdogService: {
+        markIntentionalStop: (...args: unknown[]) =>
+            markIntentionalStopMock(...args),
+    },
+}))
+
+function createInteraction(guildId = 'guild-1') {
+    return { guildId } as any
+}
+
+function createQueue(guildId = 'guild-1') {
+    return {
+        guild: { id: guildId },
+        delete: jest.fn(),
+    }
+}
+
+describe('stop command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        interactionReplyMock.mockResolvedValue(undefined)
+        createSuccessEmbedMock.mockReturnValue({ title: 'Playback stopped' })
+    })
+
+    it('marks intentional stop and deletes queue', async () => {
+        const queue = createQueue()
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        requireQueueMock.mockResolvedValue(true)
+
+        const interaction = createInteraction()
+        await stopCommand.execute({ interaction, client: {} as any })
+
+        expect(markIntentionalStopMock).toHaveBeenCalledWith('guild-1')
+        expect(queue.delete).toHaveBeenCalled()
+    })
+
+    it('calls markIntentionalStop before queue.delete', async () => {
+        const queue = createQueue()
+        const callOrder: string[] = []
+        markIntentionalStopMock.mockImplementation(() => callOrder.push('mark'))
+        queue.delete.mockImplementation(() => callOrder.push('delete'))
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        requireQueueMock.mockResolvedValue(true)
+
+        await stopCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(callOrder).toEqual(['mark', 'delete'])
+    })
+
+    it('replies with success embed after stopping', async () => {
+        const queue = createQueue()
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        requireQueueMock.mockResolvedValue(true)
+        createSuccessEmbedMock.mockReturnValue({ title: 'Playback stopped' })
+
+        await stopCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.objectContaining({
+                    embeds: expect.any(Array),
+                }),
+            }),
+        )
+    })
+
+    it('returns early when queue check fails', async () => {
+        resolveGuildQueueMock.mockReturnValue({ queue: null })
+        requireQueueMock.mockResolvedValue(false)
+
+        await stopCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
+
+        expect(markIntentionalStopMock).not.toHaveBeenCalled()
+        expect(interactionReplyMock).not.toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/functions/music/commands/stop.ts
+++ b/packages/bot/src/functions/music/commands/stop.ts
@@ -1,10 +1,11 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
-import { interactionReply } from "../../../utils/general/interactionReply"
-import type { CommandExecuteParams } from "../../../types/CommandData"
-import { requireQueue } from "../../../utils/command/commandValidations"
+import { interactionReply } from '../../../utils/general/interactionReply'
+import type { CommandExecuteParams } from '../../../types/CommandData'
+import { requireQueue } from '../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 import { createSuccessEmbed } from '../../../utils/general/embeds'
+import { musicWatchdogService } from '../../../utils/music/watchdog'
 
 export default new Command({
     data: new SlashCommandBuilder()
@@ -16,6 +17,7 @@ export default new Command({
 
         if (!(await requireQueue(queue, interaction))) return
 
+        if (queue) musicWatchdogService.markIntentionalStop(queue.guild.id)
         queue?.delete()
 
         await interactionReply({

--- a/packages/bot/src/handlers/interactionHandler.ts
+++ b/packages/bot/src/handlers/interactionHandler.ts
@@ -99,7 +99,11 @@ export async function handleInteraction(
 
         if (interaction.isButton()) {
             const id = interaction.customId
-            if (id.startsWith('music_') || id.startsWith('queue_page')) {
+            if (
+                id.startsWith('music_') ||
+                id.startsWith('queue_page') ||
+                id.startsWith('leaderboard_page')
+            ) {
                 await handleMusicButtonInteraction(interaction)
                 return
             }

--- a/packages/bot/src/handlers/musicButtonHandler.spec.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.spec.ts
@@ -243,7 +243,7 @@ describe('handleMusicButtonInteraction', () => {
         )
     })
 
-    it('logs error and replies on unexpected exception', async () => {
+    it('logs error and replies on unexpected exception when not yet replied', async () => {
         const interaction = createInteraction(MUSIC_BUTTON_IDS.SKIP, {
             replied: false,
         })
@@ -257,6 +257,26 @@ describe('handleMusicButtonInteraction', () => {
         expect(interaction.reply).toHaveBeenCalledWith(
             expect.objectContaining({ ephemeral: true }),
         )
+    })
+
+    it('uses editReply on error when interaction is already deferred', async () => {
+        const queue = createMockQueue()
+        resolveGuildQueueMock.mockReturnValue({ queue, source: 'nodes.get' })
+        const interaction = createInteraction(MUSIC_BUTTON_IDS.PAUSE_RESUME, {
+            deferred: true,
+        })
+        interaction.editReply = jest.fn().mockResolvedValue(undefined)
+        createMusicControlButtonsMock.mockImplementation(() => {
+            throw new Error('render failed')
+        })
+
+        await handleMusicButtonInteraction(interaction as never)
+
+        expect(errorLogMock).toHaveBeenCalled()
+        expect(interaction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({ embeds: expect.any(Array) }),
+        )
+        expect(interaction.reply).not.toHaveBeenCalled()
     })
 
     it('uses resolver-backed queue lookup so music buttons still work after queue cache fallback', async () => {

--- a/packages/bot/src/handlers/musicButtonHandler.spec.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.spec.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import { handleMusicButtonInteraction } from './musicButtonHandler'
-import { MUSIC_BUTTON_IDS, QUEUE_BUTTON_PREFIX, LEADERBOARD_BUTTON_PREFIX } from '../types/musicButtons'
+import {
+    MUSIC_BUTTON_IDS,
+    QUEUE_BUTTON_PREFIX,
+    LEADERBOARD_BUTTON_PREFIX,
+} from '../types/musicButtons'
 
 const errorLogMock = jest.fn()
 const debugLogMock = jest.fn()
@@ -43,7 +47,9 @@ jest.mock('../utils/music/queueResolver', () => ({
     resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
 }))
 
-const buildListPageEmbedMock = jest.fn(() => ({ toJSON: () => ({ type: 'embed' }) }))
+const buildListPageEmbedMock = jest.fn(() => ({
+    toJSON: () => ({ type: 'embed' }),
+}))
 
 jest.mock('../utils/general/responseEmbeds', () => ({
     buildListPageEmbed: (...args: unknown[]) => buildListPageEmbedMock(...args),
@@ -79,6 +85,8 @@ function createInteraction(
         member: { voice: { channel: hasVoice ? { id: 'vc-1' } : null } },
         reply: jest.fn().mockResolvedValue(undefined),
         update: jest.fn().mockResolvedValue(undefined),
+        editReply: jest.fn().mockResolvedValue(undefined),
+        followUp: jest.fn().mockResolvedValue(undefined),
         deferUpdate: jest.fn().mockResolvedValue(undefined),
     }
 }
@@ -147,6 +155,7 @@ describe('handleMusicButtonInteraction', () => {
 
         expect(queue.history.back).toHaveBeenCalled()
         expect(interaction.deferUpdate).toHaveBeenCalled()
+        expect(interaction.editReply).not.toHaveBeenCalled()
     })
 
     it('pauses when PAUSE_RESUME and queue is playing', async () => {
@@ -160,7 +169,7 @@ describe('handleMusicButtonInteraction', () => {
 
         expect(queue.node.pause).toHaveBeenCalled()
         expect(createMusicControlButtonsMock).toHaveBeenCalledWith(queue)
-        expect(interaction.update).toHaveBeenCalledWith(
+        expect(interaction.editReply).toHaveBeenCalledWith(
             expect.objectContaining({ components: [buttons] }),
         )
     })
@@ -176,7 +185,7 @@ describe('handleMusicButtonInteraction', () => {
 
         expect(queue.node.resume).toHaveBeenCalled()
         expect(createMusicControlButtonsMock).toHaveBeenCalledWith(queue)
-        expect(interaction.update).toHaveBeenCalledWith(
+        expect(interaction.editReply).toHaveBeenCalledWith(
             expect.objectContaining({ components: [buttons] }),
         )
     })
@@ -190,6 +199,7 @@ describe('handleMusicButtonInteraction', () => {
 
         expect(queue.node.skip).toHaveBeenCalled()
         expect(interaction.deferUpdate).toHaveBeenCalled()
+        expect(interaction.editReply).not.toHaveBeenCalled()
     })
 
     it('shuffles queue for SHUFFLE button', async () => {
@@ -201,6 +211,7 @@ describe('handleMusicButtonInteraction', () => {
 
         expect(shuffleQueueMock).toHaveBeenCalledWith(queue)
         expect(interaction.deferUpdate).toHaveBeenCalled()
+        expect(interaction.editReply).not.toHaveBeenCalled()
     })
 
     it('cycles loop mode for LOOP button', async () => {
@@ -211,7 +222,7 @@ describe('handleMusicButtonInteraction', () => {
         await handleMusicButtonInteraction(interaction as never)
 
         expect(queue.setRepeatMode).toHaveBeenCalledWith(1)
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.followUp).toHaveBeenCalledWith(
             expect.objectContaining({ ephemeral: true }),
         )
     })
@@ -227,7 +238,7 @@ describe('handleMusicButtonInteraction', () => {
         await handleMusicButtonInteraction(interaction as never)
 
         expect(createQueueEmbedMock).toHaveBeenCalledWith(queue, undefined, 2)
-        expect(interaction.update).toHaveBeenCalledWith(
+        expect(interaction.editReply).toHaveBeenCalledWith(
             expect.objectContaining({ embeds: [embed], components }),
         )
     })
@@ -268,7 +279,7 @@ describe('handleMusicButtonInteraction', () => {
             'guild-1',
         )
         expect(queue.node.pause).toHaveBeenCalled()
-        expect(interaction.update).toHaveBeenCalled()
+        expect(interaction.editReply).toHaveBeenCalled()
     })
 
     describe('leaderboard page button', () => {
@@ -283,36 +294,50 @@ describe('handleMusicButtonInteraction', () => {
                 queue: createMockQueue(),
                 source: 'nodes.get',
             })
-            buildListPageEmbedMock.mockReturnValue({ data: { title: 'XP Leaderboard' } })
+            buildListPageEmbedMock.mockReturnValue({
+                data: { title: 'XP Leaderboard' },
+            })
             createLeaderboardPaginationButtonsMock.mockReturnValue(null)
         })
 
         it('renders page 0 and calls buildListPageEmbed with correct args', async () => {
             getLeaderboardMock.mockResolvedValue(fakeEntries)
-            const interaction = createInteraction(`${LEADERBOARD_BUTTON_PREFIX}_0`)
+            const interaction = createInteraction(
+                `${LEADERBOARD_BUTTON_PREFIX}_0`,
+            )
 
             await handleMusicButtonInteraction(interaction as never)
 
             expect(getLeaderboardMock).toHaveBeenCalledWith('guild-1', 50)
             expect(buildListPageEmbedMock).toHaveBeenCalledWith(
                 expect.arrayContaining([
-                    expect.objectContaining({ name: '#1', value: expect.stringContaining('user-0') }),
+                    expect.objectContaining({
+                        name: '#1',
+                        value: expect.stringContaining('user-0'),
+                    }),
                 ]),
                 1,
-                expect.objectContaining({ title: 'XP Leaderboard', itemsPerPage: 5 }),
+                expect.objectContaining({
+                    title: 'XP Leaderboard',
+                    itemsPerPage: 5,
+                }),
             )
-            expect(interaction.update).toHaveBeenCalled()
+            expect(interaction.editReply).toHaveBeenCalled()
         })
 
         it('includes pagination row when createLeaderboardPaginationButtons returns a row', async () => {
             getLeaderboardMock.mockResolvedValue(fakeEntries)
             const paginationRow = { type: 1, components: [] }
-            createLeaderboardPaginationButtonsMock.mockReturnValue(paginationRow)
-            const interaction = createInteraction(`${LEADERBOARD_BUTTON_PREFIX}_0`)
+            createLeaderboardPaginationButtonsMock.mockReturnValue(
+                paginationRow,
+            )
+            const interaction = createInteraction(
+                `${LEADERBOARD_BUTTON_PREFIX}_0`,
+            )
 
             await handleMusicButtonInteraction(interaction as never)
 
-            expect(interaction.update).toHaveBeenCalledWith(
+            expect(interaction.editReply).toHaveBeenCalledWith(
                 expect.objectContaining({
                     components: [paginationRow],
                 }),
@@ -321,11 +346,13 @@ describe('handleMusicButtonInteraction', () => {
 
         it('shows error embed and empty components when leaderboard is empty', async () => {
             getLeaderboardMock.mockResolvedValue([])
-            const interaction = createInteraction(`${LEADERBOARD_BUTTON_PREFIX}_0`)
+            const interaction = createInteraction(
+                `${LEADERBOARD_BUTTON_PREFIX}_0`,
+            )
 
             await handleMusicButtonInteraction(interaction as never)
 
-            expect(interaction.update).toHaveBeenCalledWith(
+            expect(interaction.editReply).toHaveBeenCalledWith(
                 expect.objectContaining({ components: [] }),
             )
             expect(createErrorEmbedMock).toHaveBeenCalledWith(

--- a/packages/bot/src/handlers/musicButtonHandler.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.ts
@@ -2,8 +2,15 @@ import { type ButtonInteraction, type GuildMember } from 'discord.js'
 import { QueueRepeatMode } from 'discord-player'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import { createErrorEmbed } from '../utils/general/embeds'
-import { MUSIC_BUTTON_IDS, QUEUE_BUTTON_PREFIX, LEADERBOARD_BUTTON_PREFIX } from '../types/musicButtons'
-import { createMusicControlButtons, createLeaderboardPaginationButtons } from '../utils/music/buttonComponents'
+import {
+    MUSIC_BUTTON_IDS,
+    QUEUE_BUTTON_PREFIX,
+    LEADERBOARD_BUTTON_PREFIX,
+} from '../types/musicButtons'
+import {
+    createMusicControlButtons,
+    createLeaderboardPaginationButtons,
+} from '../utils/music/buttonComponents'
 import { createQueueEmbed } from '../functions/music/commands/queue/queueEmbed'
 import { shuffleQueue } from '../utils/music/queueManipulation'
 import type { GuildQueue } from 'discord-player'
@@ -58,6 +65,7 @@ export async function handleMusicButtonInteraction(
             return
         }
 
+        await interaction.deferUpdate()
         await routeButtonAction(interaction, queue)
     } catch (error) {
         errorLog({
@@ -69,6 +77,12 @@ export async function handleMusicButtonInteraction(
                 .reply({
                     embeds: [createErrorEmbed('Error', 'Something went wrong')],
                     ephemeral: true,
+                })
+                .catch(() => {})
+        } else if (interaction.deferred) {
+            await interaction
+                .editReply({
+                    embeds: [createErrorEmbed('Error', 'Something went wrong')],
                 })
                 .catch(() => {})
         }
@@ -108,7 +122,6 @@ async function handlePrevious(
 ): Promise<void> {
     await queue.history.back()
     debugLog({ message: 'Previous track via button' })
-    await interaction.deferUpdate()
 }
 
 async function handlePauseResume(
@@ -121,7 +134,7 @@ async function handlePauseResume(
         queue.node.pause()
     }
 
-    await interaction.update({
+    await interaction.editReply({
         components: [createMusicControlButtons(queue)],
     })
 }
@@ -132,7 +145,6 @@ async function handleSkip(
 ): Promise<void> {
     queue.node.skip()
     debugLog({ message: 'Track skipped via button' })
-    await interaction.deferUpdate()
 }
 
 async function handleShuffle(
@@ -141,7 +153,6 @@ async function handleShuffle(
 ): Promise<void> {
     await shuffleQueue(queue)
     debugLog({ message: 'Queue shuffled via button' })
-    await interaction.deferUpdate()
 }
 
 const LOOP_MODE_NAMES: Record<number, string> = {
@@ -168,7 +179,7 @@ async function handleLoop(
     queue.setRepeatMode(newMode)
 
     const modeName = LOOP_MODE_NAMES[newMode] ?? 'Off'
-    await interaction.reply({
+    await interaction.followUp({
         content: `\u{1F501} Loop mode: **${modeName}**`,
         ephemeral: true,
     })
@@ -184,7 +195,7 @@ async function handleQueuePage(
     const page = parseInt(pageMatch[1], 10)
     const { embed, components } = await createQueueEmbed(queue, undefined, page)
 
-    await interaction.update({
+    await interaction.editReply({
         embeds: [embed],
         components,
     })
@@ -199,11 +210,16 @@ async function handleLeaderboardPage(
         if (!pageMatch?.[1] || !interaction.guildId) return
 
         const page = parseInt(pageMatch[1], 10)
-        const entries = await levelService.getLeaderboard(interaction.guildId, 50)
+        const entries = await levelService.getLeaderboard(
+            interaction.guildId,
+            50,
+        )
 
         if (entries.length === 0) {
-            await interaction.update({
-                embeds: [createErrorEmbed('Leaderboard', 'No XP recorded yet.')],
+            await interaction.editReply({
+                embeds: [
+                    createErrorEmbed('Leaderboard', 'No XP recorded yet.'),
+                ],
                 components: [],
             })
             return
@@ -225,12 +241,15 @@ async function handleLeaderboardPage(
         })
 
         const components = []
-        const paginationRow = createLeaderboardPaginationButtons(page, totalPages)
+        const paginationRow = createLeaderboardPaginationButtons(
+            page,
+            totalPages,
+        )
         if (paginationRow) {
             components.push(paginationRow)
         }
 
-        await interaction.update({
+        await interaction.editReply({
             embeds: [embed],
             components,
         })
@@ -240,13 +259,11 @@ async function handleLeaderboardPage(
             message: 'Error handling leaderboard page interaction',
             error,
         })
-        if (!interaction.replied && !interaction.deferred) {
-            await interaction
-                .reply({
-                    embeds: [createErrorEmbed('Error', 'Something went wrong')],
-                    ephemeral: true,
-                })
-                .catch(() => {})
-        }
+        await interaction
+            .followUp({
+                embeds: [createErrorEmbed('Error', 'Something went wrong')],
+                ephemeral: true,
+            })
+            .catch(() => {})
     }
 }

--- a/packages/bot/src/utils/music/watchdog.ts
+++ b/packages/bot/src/utils/music/watchdog.ts
@@ -40,6 +40,7 @@ export class MusicWatchdogService {
     private scanTimer: ReturnType<typeof setInterval> | null = null
     private readonly timers = new Map<string, ReturnType<typeof setTimeout>>()
     private readonly states = new Map<string, WatchdogGuildState>()
+    private readonly intentionalStops = new Set<string>()
     private orphanMonitorInterval: ReturnType<typeof setInterval> | null = null
 
     constructor(options: MusicWatchdogOptions = {}) {
@@ -101,6 +102,12 @@ export class MusicWatchdogService {
         state.lastActivityAt = now
     }
 
+    markIntentionalStop(guildId: string): void {
+        this.intentionalStops.add(guildId)
+        this.clear(guildId)
+        setTimeout(() => this.intentionalStops.delete(guildId), 5_000)
+    }
+
     clear(guildId: string): void {
         const timer = this.timers.get(guildId)
         if (timer) {
@@ -123,6 +130,12 @@ export class MusicWatchdogService {
     async checkAndRecover(queue: GuildQueue): Promise<RecoveryAction> {
         const guildId = queue.guild.id
         const state = this.ensureState(guildId)
+
+        if (this.intentionalStops.has(guildId)) {
+            state.lastRecoveryAction = 'none'
+            state.lastRecoveryDetail = 'intentional_stop'
+            return 'none'
+        }
 
         if (queue.node.isPlaying()) {
             state.lastRecoveryAction = 'none'

--- a/packages/bot/tests/handlers/interactionHandler.test.ts
+++ b/packages/bot/tests/handlers/interactionHandler.test.ts
@@ -135,6 +135,18 @@ describe('handleInteraction', () => {
         )
     })
 
+    it('calls handleMusicButtonInteraction for leaderboard_page prefixed buttons', async () => {
+        const interaction = createButtonInteraction('leaderboard_page_1')
+        const client = createClient()
+
+        await handleInteraction(interaction, client)
+
+        expect(handleMusicButtonInteractionMock).toHaveBeenCalledWith(
+            interaction,
+        )
+        expect(handleButtonInteractionMock).not.toHaveBeenCalled()
+    })
+
     it('calls reactionRolesService for non-music buttons', async () => {
         const interaction = createButtonInteraction('role_123')
         const client = createClient()

--- a/packages/bot/tests/utils/music/watchdog.test.ts
+++ b/packages/bot/tests/utils/music/watchdog.test.ts
@@ -1,0 +1,124 @@
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+    errorLog: jest.fn(),
+    infoLog: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    redisClient: {
+        isHealthy: jest.fn().mockReturnValue(false),
+        keys: jest.fn().mockResolvedValue([]),
+    },
+}))
+
+jest.mock('../../../src/utils/music/sessionSnapshots', () => ({
+    musicSessionSnapshotService: {
+        getSnapshot: jest.fn(),
+        restoreSnapshot: jest.fn(),
+        saveSnapshot: jest.fn(),
+        deleteSnapshot: jest.fn(),
+    },
+}))
+
+import { MusicWatchdogService } from '../../../src/utils/music/watchdog'
+
+function makeQueue(
+    overrides: Partial<{
+        guildId: string
+        isPlaying: boolean
+        connectionStatus: string
+        currentTrack: unknown
+        tracksSize: number
+    }> = {},
+): any {
+    const opts = {
+        guildId: 'guild-1',
+        isPlaying: false,
+        connectionStatus: 'ready',
+        currentTrack: null,
+        tracksSize: 0,
+        ...overrides,
+    }
+    return {
+        guild: { id: opts.guildId, name: 'Test Guild' },
+        node: {
+            isPlaying: jest.fn().mockReturnValue(opts.isPlaying),
+            play: jest.fn().mockResolvedValue(undefined),
+        },
+        connection: {
+            state: { status: opts.connectionStatus },
+            rejoin: jest.fn(),
+        },
+        currentTrack: opts.currentTrack,
+        tracks: { size: opts.tracksSize },
+    }
+}
+
+describe('MusicWatchdogService', () => {
+    let service: MusicWatchdogService
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        service = new MusicWatchdogService({ timeoutMs: 100 })
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    describe('markIntentionalStop', () => {
+        it('causes checkAndRecover to return none without attempting recovery', async () => {
+            const queue = makeQueue()
+            service.markIntentionalStop('guild-1')
+
+            const result = await service.checkAndRecover(queue)
+
+            expect(result).toBe('none')
+            expect(queue.node.play).not.toHaveBeenCalled()
+            expect(queue.connection.rejoin).not.toHaveBeenCalled()
+        })
+
+        it('clears any active watchdog timer', () => {
+            const queue = makeQueue()
+            service.arm(queue)
+            expect(service['timers'].has('guild-1')).toBe(true)
+
+            service.markIntentionalStop('guild-1')
+            expect(service['timers'].has('guild-1')).toBe(false)
+        })
+
+        it('removes the intentional stop flag after 5 seconds', async () => {
+            const queue = makeQueue()
+            service.markIntentionalStop('guild-1')
+
+            jest.advanceTimersByTime(5_000)
+
+            expect(service['intentionalStops'].has('guild-1')).toBe(false)
+        })
+
+        it('does not block recovery for a different guild', async () => {
+            const queue2 = makeQueue({ guildId: 'guild-2', isPlaying: true })
+            service.markIntentionalStop('guild-1')
+
+            const result = await service.checkAndRecover(queue2)
+            expect(result).toBe('none')
+            expect(queue2.node.isPlaying).toHaveBeenCalled()
+        })
+    })
+
+    describe('checkAndRecover', () => {
+        it('returns none when queue is playing', async () => {
+            const queue = makeQueue({ isPlaying: true })
+            const result = await service.checkAndRecover(queue)
+            expect(result).toBe('none')
+        })
+
+        it('requeues current track when connection is ready and track exists', async () => {
+            const queue = makeQueue({ currentTrack: { title: 'Song' } })
+            const result = await service.checkAndRecover(queue)
+            expect(result).toBe('requeue_current')
+            expect(queue.node.play).toHaveBeenCalled()
+        })
+    })
+})


### PR DESCRIPTION
## Summary

- **Leaderboard buttons silently failing**: `leaderboard_page_*` buttons were not matched in `interactionHandler.ts` routing, falling through to `reactionRolesService` which sent no response — Discord showed "This interaction failed"
- **All music buttons at risk of 3-second timeout**: `deferUpdate()` was called per-handler (and missing from some). Moved it centrally in `handleMusicButtonInteraction` after voice + queue guards. Handlers that update the message now use `editReply()`, ephemeral responses use `followUp()`
- **Bot reconnecting after `/stop` and `/leave`**: `connectionDestroyed` and `disconnect` lifecycle events both called `checkAndRecover()`, which rejoined the voice channel and restored the session. Added `MusicWatchdogService.markIntentionalStop(guildId)` — sets a 5-second flag that short-circuits recovery. `/stop` and `/leave` call it before `queue.delete()`

## Changes

- `interactionHandler.ts`: add `leaderboard_page` to music button routing predicate
- `musicButtonHandler.ts`: centralize `deferUpdate()`, `update()` → `editReply()`, `reply()` (loop/error) → `followUp()`
- `watchdog.ts`: `markIntentionalStop()` + `intentionalStops` set + guard in `checkAndRecover()`
- `stop.ts` / `leave.ts`: call `markIntentionalStop()` before `queue.delete()`
- `musicButtonHandler.spec.ts`: update assertions to `editReply`/`followUp`
- `tests/handlers/interactionHandler.test.ts`: add `leaderboard_page_` routing test
- `tests/utils/music/watchdog.test.ts`: new — covers `markIntentionalStop` behaviour

## Test plan

- [ ] 1663 tests green (`npx jest --no-coverage`)
- [ ] Lint + build clean
- [ ] Click a leaderboard pagination button — no "This interaction failed"
- [ ] Click pause/resume/skip/shuffle — buttons respond immediately
- [ ] `/stop` — bot leaves, does not rejoin, song does not resume
- [ ] `/leave` — same
- [ ] Manual disconnect from Discord — bot still recovers (watchdog not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for leaderboard pagination button interactions.

* **Bug Fixes**
  * Improved music command handling to properly distinguish between intentional stops and unexpected disconnections.
  * Fixed interaction response flow for pause/resume, queue pages, and leaderboard navigation.

* **Tests**
  * Added comprehensive test coverage for music watchdog service and leaderboard pagination routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->