### PR TITLE
fix(bot): defer autoplay/buttons, non-blocking play, dedup versions

### DIFF
--- a/.agents/plans/lucky-v2.6.66-command-polish.md
+++ b/.agents/plans/lucky-v2.6.66-command-polish.md
@@ -1,0 +1,108 @@
+# Lucky v2.6.66 — command response polish wave
+
+## Goal
+
+After PR #501 ships v2.6.65 (play bridge fix + now-playing embed + music control buttons), apply the new embed/button standard across the rest of the slash command surface so every reply is consistent, rich, and visually complete.
+
+## What I already audited (source of truth for this plan)
+
+- 52 top-level commands, 95+ subcommands across music / moderation / management / engagement / general / automod.
+- Gold standard: `buildPlayResponseEmbed` (new in v2.6.65) + `createMusicControlButtons` + `detectSource`.
+- No P0 command crashes found by the audit. One near-P0: `/level leaderboard` crams rows into `description` → will silently truncate past ~1024 chars on busy servers.
+- Error handling fragmented: only ~6 commands route through `createUserFriendlyError`; the rest use hard-coded strings.
+
+## Phases
+
+Each phase is independently shippable. Ship each as its own small PR so a bad change is cheap to revert.
+
+### Phase 1 — Reusable embed builders (~2.5 h, foundation)
+
+Create four shared helpers that every subsequent phase depends on. Put them in `packages/bot/src/utils/music/embeds/` (or a fresh `packages/bot/src/utils/general/responseEmbeds/` if they're used outside music).
+
+1. **`buildTrackEmbed(track, kind, requestedBy?)`** — general-purpose track display.
+    - Re-uses `detectSource` + source badge color pattern from `nowPlayingEmbed`.
+    - Kinds: `'queued' | 'playing' | 'recommended' | 'history'`.
+    - **Consumers**: `/queue show` (per track), `/songinfo`, `/history`, `/recommendation show`.
+
+2. **`buildUserProfileEmbed(user, stats?)`** — user stat snapshot.
+    - Avatar thumbnail, fields for XP / level / rank / progress bar.
+    - **Consumers**: `/level rank`, `/lastfm status`.
+
+3. **`buildListPageEmbed(items, page, config)`** — paginated list helper.
+    - Fields-per-item (not one jumbo description).
+    - Footer with `Page N/M`.
+    - **Consumers**: `/level leaderboard`, `/cases`, `/starboard top`, `/twitch list`, `/history` list view.
+
+4. **`buildPlatformAttribEmbed(platform, body)`** — external-service branding.
+    - Platform color + icon + label injection for Last.fm / Spotify / YouTube.
+    - **Consumers**: `/lastfm link|status`, `/songinfo` source field when URL is external.
+
+**Verification**: unit tests for each helper (mirror `nowPlayingEmbed.spec.ts` structure — ~10–15 tests each). `npm run test:bot` passes. tsc + lint clean.
+
+**Ship**: single PR `feat/bot-reusable-embeds`.
+
+### Phase 2 — Fix the near-P0: `/level leaderboard` truncation (~1 h)
+
+- Replace the "10 rows in one description" pattern with `buildListPageEmbed`.
+- Add pagination buttons (reuse `createQueuePaginationButtons` from `buttonComponents.ts`).
+- Cap each page at 5 users with avatar thumbnails rendered as field icons (via the header/author slot if inline avatars aren't possible).
+- Test the truncation edge case explicitly: generate 50 fake users, assert no field body exceeds 1024 chars.
+
+**Ship**: single PR `fix/level-leaderboard-pagination`.
+
+### Phase 3 — Music command consistency (~2.5 h)
+
+Apply `buildTrackEmbed` + source badges to the remaining music commands so every "here's a track" response looks uniform.
+
+- `/queue show` — per-track rendering gains source badges, track duration, requester avatar (existing pagination stays).
+- `/queue show` — also attach `createMusicControlButtons(queue)` to the rendered message so users can pause/skip from the queue view.
+- `/songinfo` — migrate from `musicEmbed` to `buildTrackEmbed`; adds thumbnail + source badge.
+- `/skip` / `/pause` / `/resume` — migrate from flat `successEmbed` to a 2-field "now" mini-embed ("Just skipped:" + track chip).
+- `/history` case-list renderer — use `buildListPageEmbed`; unify pagination with `/cases` once Phase 1 lands.
+
+**Ship**: single PR `feat/music-command-embed-consistency`.
+
+### Phase 4 — Engagement + external service polish (~2 h)
+
+- `/level rank` — `buildUserProfileEmbed` with XP progress bar.
+- `/lastfm status` — `buildPlatformAttribEmbed` + last scrobbled track thumbnail.
+- `/lastfm link` — Last.fm color + iconography.
+- `/starboard top` — embed preview of starred messages (fetch original message embed/thumbnail when available; fall back to text snippet).
+
+**Ship**: single PR `feat/engagement-command-polish`.
+
+### Phase 5 — Cross-cutting quality pass (~1.5 h)
+
+- Audit all embed builders and add `setTimestamp()` to every terminal reply (currently only 19 of ~52 commands call it).
+- Migrate hard-coded catch-block error strings to `createUserFriendlyError`. Prioritize high-traffic commands (`/play`, `/queue`, `/ban`, `/warn`, `/level`).
+- Unify `/autoplay` from `createEmbed({...})` to the new shared helpers.
+
+**Ship**: single PR `chore/command-response-quality-pass`.
+
+### Phase 6 — Release v2.6.66 (~30 m)
+
+- `chore(release): v2.6.66` — bump × 5, CHANGELOG entry, tag, deploy, verify.
+- Update `lucky-bot.md` memory.
+
+## Out of scope (explicit)
+
+- **`/digest` case-detail buttons** — UX improvement, but requires routing work that's bigger than polish. Park for a later PR.
+- **`/playlist collaborative` contribution meter** — cosmetic; ship after v2.6.66.
+- **`/help` usage examples** — lower-priority; the audit called it already well-structured.
+- **`/cases` type-specific color coding** — nice-to-have, minor impact.
+- **Full error-handler standardization across ALL commands** — too much scope for one polish wave. Phase 5 covers the high-traffic subset only.
+- **Any rewrite of `/queue show`'s pagination logic** — the current `createQueuePaginationButtons` is fine; only the per-track rendering needs updating.
+
+## Sequencing notes
+
+- Phase 1 is a dependency for Phases 2-4. Do it first, ship it independently so the rest can build on a merged foundation.
+- Phase 2 is standalone and ships next regardless (near-P0).
+- Phases 3 and 4 can run in parallel worktrees if session bandwidth allows.
+- Phase 5 must wait for Phases 2-4 to merge (it's a cleanup pass over the migrated code).
+- Phase 6 runs only after all preceding phases are merged and CI green.
+
+## State at the start of this plan (2026-04-08)
+
+- PR #501 (fix/play-stream-bridge) in flight; CI re-running after 463c318 addressed 3 CodeRabbit comments + the Sonar quality gate blockers.
+- v2.6.65 release PR will follow once #501 merges.
+- This plan runs AFTER v2.6.65 ships to prod.

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -9,7 +9,10 @@ const QueueRepeatMode = {
 const requireGuildMock = jest.fn()
 const interactionReplyMock = jest.fn()
 const createEmbedMock = jest.fn((payload: unknown) => payload)
-const createErrorEmbedMock = jest.fn((title: string, desc: string) => ({ title, description: desc }))
+const createErrorEmbedMock = jest.fn((title: string, desc: string) => ({
+    title,
+    description: desc,
+}))
 const replenishQueueMock = jest.fn()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
@@ -35,7 +38,8 @@ jest.mock('../../../utils/general/interactionReply', () => ({
 
 jest.mock('../../../utils/general/embeds', () => ({
     createEmbed: (payload: unknown) => createEmbedMock(payload),
-    createErrorEmbed: (title: string, desc: string) => createErrorEmbedMock(title, desc),
+    createErrorEmbed: (title: string, desc: string) =>
+        createErrorEmbedMock(title, desc),
     EMBED_COLORS: {
         AUTOPLAY: '#00BFFF',
         ERROR: '#FF0000',
@@ -190,9 +194,7 @@ describe('autoplay command', () => {
         const embedPayload = createEmbedMock.mock.calls[0]?.[0] as {
             description: string
         }
-        expect(embedPayload.description).toContain(
-            'Next time you use /play',
-        )
+        expect(embedPayload.description).toContain('Next time you use /play')
     })
 
     it('shows an error when enabling autoplay without a queue fails to persist', async () => {
@@ -412,6 +414,56 @@ describe('autoplay command', () => {
                 message: 'Error replenishing queue after enabling autoplay:',
             }),
         )
+    })
+
+    it('returns silently when deferReply throws unknown interaction error (10062)', async () => {
+        const interaction = createInteraction()
+        interaction.deferReply = jest
+            .fn()
+            .mockRejectedValue(
+                Object.assign(new Error('Unknown interaction'), {
+                    code: 10062,
+                }),
+            )
+        resolveGuildQueueMock.mockReturnValue({
+            queue: null,
+            source: 'miss',
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 0,
+                cacheSampleKeys: [],
+            },
+        })
+
+        await autoplayCommand.execute({
+            client: createClient({ directQueue: null }),
+            interaction,
+        } as any)
+
+        expect(interactionReplyMock).not.toHaveBeenCalled()
+        expect(getGuildSettingsMock).not.toHaveBeenCalled()
+    })
+
+    it('re-throws when deferReply fails with a non-10062 error', async () => {
+        const interaction = createInteraction()
+        const boom = new Error('network error')
+        interaction.deferReply = jest.fn().mockRejectedValue(boom)
+        resolveGuildQueueMock.mockReturnValue({
+            queue: null,
+            source: 'miss',
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 0,
+                cacheSampleKeys: [],
+            },
+        })
+
+        await expect(
+            autoplayCommand.execute({
+                client: createClient({ directQueue: null }),
+                interaction,
+            } as any),
+        ).rejects.toThrow('network error')
     })
 
     it('uses autoplay error response when execution throws', async () => {

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -169,9 +169,7 @@ async function handleAutoplayError(
     await interactionReply({
         interaction,
         content: {
-            embeds: [
-                createErrorEmbed('Error', messages.error.notPlaying),
-            ],
+            embeds: [createErrorEmbed('Error', messages.error.notPlaying)],
             ephemeral: true,
         },
     })
@@ -216,6 +214,18 @@ export default new Command({
                     cacheSampleKeys: diagnostics.cacheSampleKeys,
                 },
             })
+        }
+
+        try {
+            await interaction.deferReply()
+        } catch (error) {
+            const isUnknownInteraction =
+                typeof error === 'object' &&
+                error !== null &&
+                'code' in error &&
+                (error as { code?: number }).code === 10062
+            if (isUnknownInteraction) return
+            throw error
         }
 
         try {

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 
+const flushPromises = () =>
+    new Promise<void>((resolve) => setImmediate(resolve))
+
 const requireVoiceChannelMock =
     jest.fn<(interaction: unknown) => Promise<boolean>>()
 const errorLogMock = jest.fn<(payload: unknown) => void>()
@@ -47,6 +50,8 @@ const moveUserTrackToPriorityMock =
 const blendAutoplayTracksMock =
     jest.fn<(queue: unknown, track: unknown) => Promise<void>>()
 const interactionReplyMock = jest.fn<(payload: unknown) => Promise<void>>()
+const buildPlayResponseEmbedMock = jest.fn<(payload: unknown) => unknown>()
+const createMusicControlButtonsMock = jest.fn<(queue: unknown) => unknown>()
 
 jest.mock('discord-player', () => ({
     QueueRepeatMode: { OFF: 0, AUTOPLAY: 3 },
@@ -112,6 +117,20 @@ jest.mock('../../../../utils/general/interactionReply', () => ({
     interactionReply: (payload: unknown) => interactionReplyMock(payload),
 }))
 
+jest.mock('../../../../utils/music/nowPlayingEmbed', () => ({
+    buildPlayResponseEmbed: (payload: unknown) =>
+        buildPlayResponseEmbedMock(payload),
+}))
+
+jest.mock('../../../../utils/music/buttonComponents', () => ({
+    createMusicControlButtons: (queue: unknown) =>
+        createMusicControlButtonsMock(queue),
+}))
+
+jest.mock('../../../../utils/general/errorSanitizer', () => ({
+    createUserFriendlyError: (error: unknown) => 'User friendly error',
+}))
+
 import playCommand from './index'
 
 function createInteraction(guildId: string | null) {
@@ -165,6 +184,15 @@ describe('play command', () => {
         })
         getGuildSettingsMock.mockResolvedValue(null)
         resolveGuildQueueMock.mockReturnValue({ queue: null })
+        interactionReplyMock.mockResolvedValue(undefined)
+        buildPlayResponseEmbedMock.mockReturnValue({
+            title: 'Now Playing',
+            description: 'test track',
+        })
+        createMusicControlButtonsMock.mockReturnValue({
+            type: 1,
+            components: [],
+        })
     })
 
     it('rejects command outside guilds', async () => {
@@ -300,6 +328,9 @@ describe('play command', () => {
             interaction,
         } as any)
 
+        // Wait for background operations to complete
+        await flushPromises()
+
         expect(queue.setRepeatMode).toHaveBeenCalledWith(3)
         expect(debugLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -358,6 +389,9 @@ describe('play command', () => {
             client: createClient(async () => result),
             interaction,
         } as any)
+
+        // Wait for background operations to complete
+        await flushPromises()
 
         expect(queue.setRepeatMode).not.toHaveBeenCalled()
         expect(warnLogMock).toHaveBeenCalledWith(
@@ -428,6 +462,9 @@ describe('play command', () => {
             })),
             interaction,
         } as any)
+
+        // Wait for background operations to complete
+        await flushPromises()
 
         expect(moveUserTrackToPriorityMock).not.toHaveBeenCalled()
         expect(blendAutoplayTracksMock).toHaveBeenCalledWith(
@@ -636,13 +673,17 @@ describe('play command', () => {
             interaction,
         } as any)
 
+        // Wait for background operations to complete
+        await flushPromises()
+
         expect(blendAutoplayTracksMock).toHaveBeenCalledWith(
             expect.anything(),
             track,
         )
+        // Blending error is now logged as "Post-play background ops failed" in background task
         expect(errorLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: 'Play command error:',
+                message: 'Post-play background ops failed',
             }),
         )
         expect(interactionReplyMock).toHaveBeenCalledWith(

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -171,16 +171,9 @@ export default new Command({
                 interaction.guildId ?? '',
             )
 
-            if (!hadQueueBeforePlay && queue) {
-                await applyStoredAutoplayPreference(queue, interaction.guildId)
-            }
-
             if (!isPlaylist && queue) {
                 if (!isTrackAlreadyQueued(queue, track)) {
                     moveUserTrackToPriority(queue, track)
-                }
-                if (queue.repeatMode === QueueRepeatMode.AUTOPLAY) {
-                    await blendAutoplayTracks(queue, track)
                 }
             }
 
@@ -235,6 +228,35 @@ export default new Command({
                 interaction,
                 content: { embeds: [embed], components },
             })
+
+            // Start background ops (apply autoplay pref then blend) without awaiting.
+            // This lets the response reach the user immediately.
+            // The Promise is not awaited, allowing the command handler to return while
+            // these operations continue processing in the background.
+            const bgOps = (async () => {
+                try {
+                    if (!hadQueueBeforePlay && queue) {
+                        await applyStoredAutoplayPreference(
+                            queue,
+                            interaction.guildId!,
+                        )
+                    }
+                    if (
+                        !isPlaylist &&
+                        queue &&
+                        queue.repeatMode === QueueRepeatMode.AUTOPLAY
+                    ) {
+                        await blendAutoplayTracks(queue, track)
+                    }
+                } catch (bgError) {
+                    errorLog({
+                        message: 'Post-play background ops failed',
+                        error: bgError,
+                        data: { guildId: interaction.guildId },
+                    })
+                }
+            })()
+            void bgOps
         } catch (error) {
             if (isUnknownInteractionError(error)) {
                 debugLog({
@@ -283,20 +305,22 @@ async function applyStoredAutoplayPreference(
 ): Promise<void> {
     try {
         const settings = await guildSettingsService.getGuildSettings(guildId)
-        if (typeof settings?.autoPlayEnabled === 'boolean') {
-            const repeatMode = settings.autoPlayEnabled
+        const repeatMode =
+            (settings?.autoPlayEnabled ?? true)
                 ? QueueRepeatMode.AUTOPLAY
                 : QueueRepeatMode.OFF
 
-            if (queue.repeatMode !== repeatMode) {
-                queue.setRepeatMode(repeatMode)
-            }
-
-            debugLog({
-                message: 'Applied stored autoplay preference to queue',
-                data: { guildId, autoPlayEnabled: settings.autoPlayEnabled },
-            })
+        if (queue.repeatMode !== repeatMode) {
+            queue.setRepeatMode(repeatMode)
         }
+
+        debugLog({
+            message: 'Applied stored autoplay preference to queue',
+            data: {
+                guildId,
+                autoPlayEnabled: settings?.autoPlayEnabled ?? true,
+            },
+        })
     } catch (error) {
         warnLog({
             message: 'Failed to apply stored autoplay preference',

--- a/packages/bot/src/handlers/musicButtonHandler.spec.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.spec.ts
@@ -130,7 +130,8 @@ describe('handleMusicButtonInteraction', () => {
 
         await handleMusicButtonInteraction(interaction as never)
 
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.deferUpdate).toHaveBeenCalled()
+        expect(interaction.followUp).toHaveBeenCalledWith(
             expect.objectContaining({ ephemeral: true }),
         )
     })
@@ -141,7 +142,8 @@ describe('handleMusicButtonInteraction', () => {
 
         await handleMusicButtonInteraction(interaction as never)
 
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.deferUpdate).toHaveBeenCalled()
+        expect(interaction.followUp).toHaveBeenCalledWith(
             expect.objectContaining({ ephemeral: true }),
         )
     })
@@ -254,7 +256,8 @@ describe('handleMusicButtonInteraction', () => {
         await handleMusicButtonInteraction(interaction as never)
 
         expect(errorLogMock).toHaveBeenCalled()
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.deferUpdate).toHaveBeenCalled()
+        expect(interaction.followUp).toHaveBeenCalledWith(
             expect.objectContaining({ ephemeral: true }),
         )
     })

--- a/packages/bot/src/handlers/musicButtonHandler.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.ts
@@ -25,9 +25,11 @@ export async function handleMusicButtonInteraction(
     interaction: ButtonInteraction,
 ): Promise<void> {
     try {
+        await interaction.deferUpdate()
+
         const member = interaction.member as GuildMember
         if (!member.voice.channel) {
-            await interaction.reply({
+            await interaction.followUp({
                 embeds: [
                     createErrorEmbed(
                         'Not in Voice',
@@ -53,7 +55,7 @@ export async function handleMusicButtonInteraction(
                     diagnostics,
                 },
             })
-            await interaction.reply({
+            await interaction.followUp({
                 embeds: [
                     createErrorEmbed(
                         'No Music',
@@ -65,24 +67,23 @@ export async function handleMusicButtonInteraction(
             return
         }
 
-        await interaction.deferUpdate()
         await routeButtonAction(interaction, queue)
     } catch (error) {
         errorLog({
             message: 'Music button interaction error',
             error,
         })
-        if (!interaction.replied && !interaction.deferred) {
-            await interaction
-                .reply({
-                    embeds: [createErrorEmbed('Error', 'Something went wrong')],
-                    ephemeral: true,
-                })
-                .catch(() => {})
-        } else if (interaction.deferred) {
+        if (interaction.deferred) {
             await interaction
                 .editReply({
                     embeds: [createErrorEmbed('Error', 'Something went wrong')],
+                })
+                .catch(() => {})
+        } else if (!interaction.replied) {
+            await interaction
+                .followUp({
+                    embeds: [createErrorEmbed('Error', 'Something went wrong')],
+                    ephemeral: true,
                 })
                 .catch(() => {})
         }

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -9,7 +9,7 @@ import type { User } from 'discord.js'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import { recommendationFeedbackService } from '../../services/musicRecommendation/feedbackService'
 import { getLastFmSeedTracks } from './autoplay/lastFmSeeds'
-import { cleanSearchQuery } from './searchQueryCleaner'
+import { cleanSearchQuery, cleanTitle, cleanAuthor } from './searchQueryCleaner'
 
 const AUTOPLAY_BUFFER_SIZE = 8
 const HISTORY_SEED_LIMIT = 3
@@ -743,7 +743,9 @@ function getHistoryTracks(queue: GuildQueue): Track[] {
 }
 
 function normalizeTrackKey(title?: string, author?: string): string {
-    return `${normalizeText(title)}::${normalizeText(author)}`
+    const cleanedTitle = title ? cleanTitle(title) : ''
+    const cleanedAuthor = author ? cleanAuthor(author) : ''
+    return `${normalizeText(cleanedTitle)}::${normalizeText(cleanedAuthor)}`
 }
 
 function normalizeText(value?: string): string {

--- a/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
@@ -138,3 +138,45 @@ describe('isSpamChannel', () => {
         expect(isSpamChannel('   ')).toBe(false)
     })
 })
+
+describe('cleanTitle — version variant noise patterns', () => {
+    it('strips (Live) and (Live Version)', () => {
+        expect(cleanTitle('Bohemian Rhapsody (Live)')).toBe('Bohemian Rhapsody')
+        expect(cleanTitle('Bohemian Rhapsody (Live Version)')).toBe(
+            'Bohemian Rhapsody',
+        )
+    })
+
+    it('strips (Acoustic) and (Acoustic Version)', () => {
+        expect(cleanTitle('Creep (Acoustic)')).toBe('Creep')
+        expect(cleanTitle('Creep (Acoustic Version)')).toBe('Creep')
+    })
+
+    it('strips (Cover) and (Cover Version)', () => {
+        expect(cleanTitle('Hallelujah (Cover)')).toBe('Hallelujah')
+    })
+
+    it('strips (Remix) and [Remix]', () => {
+        expect(cleanTitle('Blinding Lights (Remix)')).toBe('Blinding Lights')
+        expect(cleanTitle('Blinding Lights [Remix]')).toBe('Blinding Lights')
+    })
+
+    it('strips (Instrumental)', () => {
+        expect(cleanTitle('Shape of You (Instrumental)')).toBe('Shape of You')
+    })
+
+    it('strips (Explicit Version) and (Clean Version)', () => {
+        expect(cleanTitle('Track (Explicit Version)')).toBe('Track')
+        expect(cleanTitle('Track (Clean Version)')).toBe('Track')
+    })
+
+    it('strips (Deluxe Edition) and (Album Version)', () => {
+        expect(cleanTitle('Song (Deluxe Edition)')).toBe('Song')
+        expect(cleanTitle('Song (Album Version)')).toBe('Song')
+    })
+
+    it('strips (Single Version) and (Bonus Track)', () => {
+        expect(cleanTitle('Track (Single Version)')).toBe('Track')
+        expect(cleanTitle('Track (Bonus Track)')).toBe('Track')
+    })
+})

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -47,6 +47,25 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     /\[download\]/gi,
     /\[free\s{0,3}download\]/gi,
 
+    // Version variants: live, acoustic, cover, remix, etc.
+    /\(live(?:\s{0,3}(?:version|session|performance|at\s[^)]+))?\)/gi,
+    /\[live(?:\s{0,3}(?:version|session|performance|at\s[^\]]+))?\]/gi,
+    /\(acoustic(?:\s{0,3}version)?\)/gi,
+    /\[acoustic(?:\s{0,3}version)?\]/gi,
+    /\(cover(?:\s{0,3}version)?\)/gi,
+    /\[cover(?:\s{0,3}version)?\]/gi,
+    /\(remix(?:\s{0,3}(?:version|edit))?\)/gi,
+    /\[remix(?:\s{0,3}(?:version|edit))?\]/gi,
+    /\(instrumental(?:\s{0,3}version)?\)/gi,
+    /\[instrumental(?:\s{0,3}version)?\]/gi,
+    /\(karaoke(?:\s{0,3}version)?\)/gi,
+    /\(explicit(?:\s{0,3}version)?\)/gi,
+    /\(clean(?:\s{0,3}version)?\)/gi,
+    /\(single(?:\s{0,3}version)?\)/gi,
+    /\(album\s{0,3}version\)/gi,
+    /\(deluxe(?:\s{0,3}(?:version|edition))?\)/gi,
+    /\(bonus\s{0,3}track\)/gi,
+
     // Bare decorators that weren't wrapped in brackets
     /\bofficial\s{0,3}music\s{0,3}video\b/gi,
     /\bofficial\s{0,3}video\b/gi,


### PR DESCRIPTION
## Summary

- **`/autoplay` 5-10s lag**: added `deferReply()` before DB calls — Discord was timing out waiting for the initial acknowledgement
- **Buttons "This interaction failed"**: `deferUpdate()` is now the very first operation in `handleMusicButtonInteraction` (before voice/queue checks). Error messages use `followUp({ ephemeral: true })` since the interaction is already deferred
- **`/play` slow reply**: `applyStoredAutoplayPreference` (DB) and `blendAutoplayTracks` (Spotify API) now run fire-and-forget after `interactionReply` — user gets the "Now Playing" embed immediately
- **Autoplay default ON**: guilds without a stored preference now default to autoplay enabled on new queues (`?? true`)
- **Repeated songs in autoplay**: `normalizeTrackKey` now uses `cleanTitle`/`cleanAuthor` before hashing, so "(Live)", "(Acoustic)", "(Cover)", "(Remix)", "(Instrumental)", etc. are stripped before comparison — versions of the same song are caught as duplicates. Also added 17 new version-variant noise patterns to `searchQueryCleaner.ts`

## Test plan

- [ ] 1674 tests green
- [ ] `/autoplay` responds immediately (no "thinking..." lag)
- [ ] All music buttons (pause/resume/skip/shuffle/loop/queue/leaderboard) work without "This interaction failed"  
- [ ] `/play` sends "Now Playing" embed immediately; autoplay queue fills in background
- [ ] New guilds get autoplay ON by default
- [ ] Autoplay queue doesn't add "Song (Live)" when "Song" is already in history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better music-title cleaning to strip version/format modifiers (live, acoustic, cover, remix, instrumental, karaoke, explicit, clean, single, album, deluxe, bonus).

* **Bug Fixes**
  * Fixed leaderboard truncation.
  * Improved button interaction handling for more reliable responses.
  * Hardened autoplay error handling for edge-case interaction failures.

* **Improvements**
  * Post-play tasks now run in background for snappier play responses.
  * Added timestamps and friendlier error messages in music commands.

* **Documentation**
  * Added a staged rollout plan for command response polish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->