### PR TITLE
fix(bot): fix autoplay metadata write failing on read-only getter

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -271,8 +271,7 @@ describe('queueManipulation.replenishQueue', () => {
             name: 'when Spotify and AUTO search throw',
             spotifySearch: () =>
                 Promise.reject(new Error('Spotify unavailable')),
-            autoSearch: () =>
-                Promise.reject(new Error('AUTO parser failed')),
+            autoSearch: () => Promise.reject(new Error('AUTO parser failed')),
             fallbackUrl: 'https://example.com/fallback',
         },
         {
@@ -888,9 +887,8 @@ describe('queueManipulation.replenishQueue', () => {
                 url: 'https://example.com/broad',
                 metadata: expect.objectContaining({
                     isAutoplay: true,
-                    recommendationReason: expect.stringContaining(
-                        'artist fallback',
-                    ),
+                    recommendationReason:
+                        expect.stringContaining('artist fallback'),
                 }),
             }),
         )
@@ -1046,6 +1044,48 @@ describe('queueManipulation.replenishQueue', () => {
         )
         expect(addedUrls).toContain('https://example.com/seed')
         expect(addedUrls).not.toContain('https://example.com/uprising')
+    })
+
+    it('marks autoplay metadata on tracks with a read-only metadata getter (LUCKY-2K)', async () => {
+        const trackWithReadOnlyMetadata = Object.defineProperty(
+            {
+                title: 'Getter Song',
+                author: 'Getter Artist',
+                url: 'https://example.com/getter',
+                source: 'spotify',
+                requestedBy: { id: 'user-1' },
+            },
+            'metadata',
+            {
+                get: () => ({ requestedById: 'user-1' }),
+                configurable: true,
+            },
+        )
+
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: {
+                title: 'Current',
+                author: 'Artist',
+                url: 'https://example.com/current',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [trackWithReadOnlyMetadata],
+                }),
+            },
+        })
+
+        await expect(
+            replenishQueue(queue as unknown as GuildQueue),
+        ).resolves.not.toThrow()
+
+        expect(queue.addTrack).toHaveBeenCalledTimes(1)
+        const added = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect((added?.metadata as Record<string, unknown>)?.isAutoplay).toBe(
+            true,
+        )
     })
 })
 

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -862,21 +862,25 @@ function markAsAutoplayTrack(
     recommendationReason: string,
     requestedById?: string,
 ): void {
-    const trackWithMetadata = track as unknown as {
-        metadata?: Record<string, unknown>
-    }
-    const metadata = trackWithMetadata.metadata ?? {}
+    const existingMetadata =
+        (track as unknown as { metadata?: Record<string, unknown> }).metadata ??
+        {}
     const existingRequestedById =
-        typeof metadata.requestedById === 'string'
-            ? metadata.requestedById
+        typeof existingMetadata.requestedById === 'string'
+            ? existingMetadata.requestedById
             : undefined
 
-    trackWithMetadata.metadata = {
-        ...metadata,
-        isAutoplay: true,
-        recommendationReason,
-        requestedById: requestedById ?? existingRequestedById,
-    }
+    Object.defineProperty(track, 'metadata', {
+        value: {
+            ...existingMetadata,
+            isAutoplay: true,
+            recommendationReason,
+            requestedById: requestedById ?? existingRequestedById,
+        },
+        writable: true,
+        configurable: true,
+        enumerable: true,
+    })
 }
 
 export function moveUserTrackToPriority(queue: GuildQueue, track: Track): void {


### PR DESCRIPTION
## Summary

- **Root cause (Sentry LUCKY-2K, 9 events in 24h):** `discord-player` Track objects expose `metadata` as a getter-only property. `markAsAutoplayTrack` was doing direct assignment (`track.metadata = { ... }`), which throws `TypeError: Cannot set property metadata of [object Object] which has only a getter`. This silently crashed every autoplay replenishment call since v2.6.65.
- **Fix:** Replace direct assignment with `Object.defineProperty(track, 'metadata', { value: ..., writable: true, configurable: true, enumerable: true })`. This overrides the property descriptor entirely rather than trying to set a value through a getter.
- **Regression test:** Added a test that creates a track with an explicit read-only metadata getter and verifies `replenishQueue` resolves without throwing and marks `isAutoplay: true`.

## Test plan

- [x] `queueManipulation.spec.ts` — 37 tests pass (new LUCKY-2K regression test included)
- [x] Full bot test suite — 1685 tests, 146 suites, all green
- [x] Lint passes