### PR TITLE
fix(bot): guard recordContribution against unexpected throws

### DIFF
--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -307,6 +307,28 @@ describe('play command', () => {
         )
     })
 
+    it('logs error when recordContribution throws but play still succeeds', async () => {
+        const interaction = createInteraction('guild-1')
+        const result = {
+            track: { title: 'Song A', author: 'Artist A' },
+            searchResult: { playlist: null, tracks: [] },
+        }
+        const client = createClient(async () => result, {
+            repeatMode: 3,
+            tracksSize: 2,
+        })
+        recordContributionMock.mockImplementation(() => {
+            throw new Error('state error')
+        })
+
+        await playCommand.execute({ client, interaction } as any)
+
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'Failed to record contribution' }),
+        )
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+
     it('applies stored autoplay preference to a queue', async () => {
         const interaction = createInteraction('guild-1')
         const queue = {

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -225,11 +225,15 @@ export default new Command({
                       queuePosition,
                   })
 
-            collaborativePlaylistService.recordContribution(
-                interaction.guildId,
-                interaction.user.id,
-                1,
-            )
+            try {
+                collaborativePlaylistService.recordContribution(
+                    interaction.guildId,
+                    interaction.user.id,
+                    1,
+                )
+            } catch (err) {
+                errorLog({ message: 'Failed to record contribution', error: err })
+            }
 
             // Attach the music control button row so the user can
             // pause/skip/shuffle/loop/previous directly from the /play


### PR DESCRIPTION
## Summary

- Wraps the `collaborativePlaylistService.recordContribution()` call in `/play` inside a `try/catch`
- Previously any unexpected synchronous throw would silently propagate or crash the command
- Error is now caught and logged via `errorLog` — play still succeeds
- Adds one new test covering the throw path

## Test plan

- [ ] CI: all bot tests pass
- [ ] New test `'logs error when recordContribution throws but play still succeeds'` passes
- [ ] Existing contribution recording test still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the play command to gracefully manage failures when recording contribution data. When contribution recording encounters an error, the command completes successfully and logs the error details for troubleshooting instead of failing the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->