### PR TITLE
fix(ci): fix homelab deploy — COMMIT_SHA build arg + conditional SHA validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,8 @@ jobs:
                     exit 1
                   fi
 
-            - name: Wait for Docker images
+            - id: docker_wait
+              name: Wait for Docker images
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   GH_PAGER: cat
@@ -66,6 +67,7 @@ jobs:
                   if [ -z "$run_info" ]; then
                     if [ "${FORCE_UNVERIFIED_DEPLOY:-}" = "true" ]; then
                       echo "::warning::No docker-publish run found for this commit — proceeding anyway (FORCE_UNVERIFIED_DEPLOY=true)"
+                      echo "docker_rebuilt=false" >> "$GITHUB_OUTPUT"
                       exit 0
                     fi
 
@@ -88,6 +90,7 @@ jobs:
 
                     if [ -z "$docker_relevant" ]; then
                       echo "::notice::No Docker-relevant files changed in this commit — skipping image wait, deploying with existing images."
+                      echo "docker_rebuilt=false" >> "$GITHUB_OUTPUT"
                       exit 0
                     fi
 
@@ -104,6 +107,7 @@ jobs:
                   if [ "$status" = "completed" ]; then
                     if [ "$conclusion" = "success" ]; then
                       echo "==> Docker images already built successfully."
+                      echo "docker_rebuilt=true" >> "$GITHUB_OUTPUT"
                       exit 0
                     else
                       echo "::error::docker-publish failed (conclusion=$conclusion) — aborting deploy"
@@ -130,6 +134,7 @@ jobs:
                     if [ "$status" = "completed" ]; then
                       if [ "$conclusion" = "success" ]; then
                         echo "==> Docker images ready!"
+                        echo "docker_rebuilt=true" >> "$GITHUB_OUTPUT"
                         exit 0
                       else
                         echo "::error::docker-publish failed (conclusion=$conclusion) — aborting deploy"
@@ -242,12 +247,31 @@ jobs:
             - name: Validate deployed version
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+                  DOCKER_REBUILT: ${{ steps.docker_wait.outputs.docker_rebuilt }}
               run: |
                   set -euo pipefail
                   base_url=$(node -e 'const u = new URL(process.env.WEBHOOK_URL); console.log(`${u.protocol}//${u.host}`)')
-                  version_url="${base_url}/api/health/version"
                   expected="${{ github.sha }}"
 
+                  if [ "${DOCKER_REBUILT:-false}" != "true" ]; then
+                    health_url="${base_url}/api/health"
+                    echo "==> No Docker rebuild for this commit — verifying service health at $health_url..."
+                    for attempt in $(seq 1 20); do
+                      echo "Attempt ${attempt}/20..."
+                      response=$(curl -sS --max-time 20 -w "\n%{http_code}" "$health_url" || true)
+                      http_code=$(echo "$response" | tail -1)
+                      if [ "$http_code" = "200" ]; then
+                        echo "==> Service healthy after deploy. Done."
+                        exit 0
+                      fi
+                      echo "Not ready (HTTP $http_code). Waiting 15s..."
+                      sleep 15
+                    done
+                    echo "::error::Service did not become healthy after all attempts"
+                    exit 1
+                  fi
+
+                  version_url="${base_url}/api/health/version"
                   echo "==> Validating deployed SHA at $version_url (expected: $expected)..."
 
                   for attempt in $(seq 1 20); do

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -371,7 +371,10 @@ fi
 log "Pulling images..."
 if ! docker_compose pull bot backend frontend nginx; then
     log "WARN: Pull failed, falling back to local build..."
-    if ! docker_compose build --parallel bot backend frontend nginx; then
+    _build_commit_sha=$(git -C "$DEPLOY_DIR" rev-parse HEAD 2>/dev/null || echo "")
+    if ! docker_compose build --parallel \
+            --build-arg "COMMIT_SHA=${_build_commit_sha}" \
+            bot backend frontend nginx; then
         notify 16711680 "Deploy Failed" "Docker build failed"
         exit 1
     fi


### PR DESCRIPTION
## Summary

Two bugs caused the homelab deploy to always fail:

### Bug 1 — Local build fallback missing COMMIT_SHA (`scripts/deploy.sh`)

When `docker compose pull` fails (GHCR not authenticated), the deploy falls back to a local build. Previously that build had no `--build-arg COMMIT_SHA=` so `/api/health/version` returned `{"commitSha":""}` and validation failed with SHA mismatch.

Fix: resolve the SHA from `git rev-parse HEAD` (after `git reset --hard origin/main`) and pass it as `--build-arg COMMIT_SHA=` in the fallback build path.

### Bug 2 — SHA validation fires even when no Docker rebuild happened (`.github/workflows/deploy.yml`)

For non-Docker commits (docs, CI, workflow changes), `docker-publish` doesn't run — GHCR `latest` keeps the SHA from the last docker-relevant commit. The validation step was comparing `GITHUB_SHA` of the _triggering_ commit against the backend's `COMMIT_SHA` baked at docker-publish time → always a mismatch.

Root cause trace:
- PR #517 (readme/docs) merged → deploy triggered with `GITHUB_SHA=04488213`
- docker-publish skipped (no Docker-relevant files changed)
- Homelab pulled `latest` from GHCR → SHA `58afe7d9` (v2.6.70, previous Docker-publishing commit)
- Validation expected `04488213`, got `58afe7d9` → fail every 15s for 5 minutes

Fix: the "Wait for Docker images" step now sets a `docker_rebuilt` output (`true`/`false`). The "Validate deployed version" step checks commit SHA only when `docker_rebuilt=true`; otherwise it just verifies `/api/health` returns HTTP 200.

## Test plan

- [ ] CI passes on this PR
- [ ] Non-Docker commit merged to main → deploy succeeds with health-only validation
- [ ] Docker-relevant commit merged to main → deploy succeeds with SHA validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment validation with multi-step health verification to ensure services are fully ready before confirming successful deployment
  * Improved Docker image handling with robust fallback mechanisms that maintain consistency across deployment scenarios
  * Strengthened overall deployment reliability through better error handling and resilience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->