### PR TITLE
fix: route button interactions in eventHandler

### DIFF
--- a/packages/bot/src/handlers/eventHandler.spec.ts
+++ b/packages/bot/src/handlers/eventHandler.spec.ts
@@ -13,6 +13,8 @@ const handleMemberEventsMock = jest.fn()
 const handleAuditEventsMock = jest.fn()
 const handleExternalScrobblerMock = jest.fn()
 const handleReactionEventsMock = jest.fn()
+const handleMusicButtonInteractionMock = jest.fn()
+const handleButtonInteractionMock = jest.fn()
 const errorLogMock = jest.fn()
 const infoLogMock = jest.fn()
 const debugLogMock = jest.fn()
@@ -49,6 +51,18 @@ jest.mock('./externalScrobbler', () => ({
 jest.mock('./reactionHandler', () => ({
     handleReactionEvents: (...args: unknown[]) =>
         handleReactionEventsMock(...args),
+}))
+
+jest.mock('./musicButtonHandler', () => ({
+    handleMusicButtonInteraction: (...args: unknown[]) =>
+        handleMusicButtonInteractionMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    reactionRolesService: {
+        handleButtonInteraction: (...args: unknown[]) =>
+            handleButtonInteractionMock(...args),
+    },
 }))
 
 jest.mock('../utils/music/namedSessions', () => ({
@@ -106,10 +120,13 @@ function createAutocompleteInteraction(
         guildId: options.guildId === undefined ? 'guild-1' : options.guildId,
         commandName: options.commandName ?? 'session',
         options: {
-            getSubcommand: jest.fn().mockReturnValue(options.subcommand ?? 'restore'),
-            getFocused: jest
+            getSubcommand: jest
                 .fn()
-                .mockReturnValue({ name: options.focusedName ?? 'name', value: '' }),
+                .mockReturnValue(options.subcommand ?? 'restore'),
+            getFocused: jest.fn().mockReturnValue({
+                name: options.focusedName ?? 'name',
+                value: '',
+            }),
         },
         respond: respondMock,
     } as unknown as Interaction
@@ -136,6 +153,7 @@ describe('eventHandler', () => {
 
         interactionHandler?.({
             isAutocomplete: () => false,
+            isButton: () => false,
             isChatInputCommand: () => true,
             commandName: 'unknown',
             replied: false,
@@ -165,6 +183,7 @@ describe('eventHandler', () => {
 
         interactionHandler?.({
             isAutocomplete: () => false,
+            isButton: () => false,
             isChatInputCommand: () => true,
             commandName: 'broken',
             replied: true,
@@ -233,7 +252,9 @@ describe('eventHandler', () => {
 
         it('caps autocomplete response to the Discord limit of 25', async () => {
             namedSessionListMock.mockResolvedValue(
-                Array.from({ length: 40 }, (_, i) => ({ name: `session-${i}` })),
+                Array.from({ length: 40 }, (_, i) => ({
+                    name: `session-${i}`,
+                })),
             )
             const respondMock = jest.fn()
             const interaction = createAutocompleteInteraction({
@@ -288,6 +309,52 @@ describe('eventHandler', () => {
                     error: expect.any(Error),
                 }),
             )
+        })
+    })
+
+    describe('button interactions', () => {
+        function createButtonInteraction(customId: string): Interaction {
+            return {
+                isAutocomplete: () => false,
+                isChatInputCommand: () => false,
+                isButton: () => true,
+                customId,
+            } as unknown as Interaction
+        }
+
+        async function dispatchButton(customId: string): Promise<void> {
+            const { client, onMock } = createMockClient()
+            handleEvents(client as unknown as never)
+            const handler = getInteractionCreateHandler(onMock)
+            handler?.(createButtonInteraction(customId))
+            await flushAsyncHandlers()
+        }
+
+        beforeEach(() => {
+            handleMusicButtonInteractionMock.mockResolvedValue(undefined)
+            handleButtonInteractionMock.mockResolvedValue(undefined)
+        })
+
+        it('routes music_ buttons to handleMusicButtonInteraction', async () => {
+            await dispatchButton('music_pause_resume')
+            expect(handleMusicButtonInteractionMock).toHaveBeenCalledTimes(1)
+            expect(handleButtonInteractionMock).not.toHaveBeenCalled()
+        })
+
+        it('routes queue_page buttons to handleMusicButtonInteraction', async () => {
+            await dispatchButton('queue_page_2')
+            expect(handleMusicButtonInteractionMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('routes leaderboard_page buttons to handleMusicButtonInteraction', async () => {
+            await dispatchButton('leaderboard_page_0')
+            expect(handleMusicButtonInteractionMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('routes other buttons to reactionRolesService', async () => {
+            await dispatchButton('reaction_role_123')
+            expect(handleButtonInteractionMock).toHaveBeenCalledTimes(1)
+            expect(handleMusicButtonInteractionMock).not.toHaveBeenCalled()
         })
     })
 })

--- a/packages/bot/src/handlers/eventHandler.ts
+++ b/packages/bot/src/handlers/eventHandler.ts
@@ -18,6 +18,8 @@ import { handleMemberEvents } from './memberHandler'
 import { handleAuditEvents } from './auditHandler'
 import { handleExternalScrobbler } from './externalScrobbler'
 import { handleReactionEvents } from './reactionHandler'
+import { handleMusicButtonInteraction } from './musicButtonHandler'
+import { reactionRolesService } from '@lucky/shared/services'
 import { aiDevToolkitService } from '../services/AiDevToolkitService'
 import { namedSessionService } from '../utils/music/namedSessions'
 
@@ -102,9 +104,7 @@ async function handleInteractionError(
     }
 }
 
-async function handleAutocomplete(
-    interaction: Interaction,
-): Promise<void> {
+async function handleAutocomplete(interaction: Interaction): Promise<void> {
     try {
         if (!interaction.isAutocomplete()) return
         if (!interaction.guildId) {
@@ -121,9 +121,7 @@ async function handleAutocomplete(
             (subcommand === 'restore' || subcommand === 'delete') &&
             focusedOption.name === 'name'
         ) {
-            const sessions = await namedSessionService.list(
-                interaction.guildId,
-            )
+            const sessions = await namedSessionService.list(interaction.guildId)
             const choices = sessions
                 .map((s) => ({ name: s.name, value: s.name }))
                 .slice(0, 25)
@@ -145,6 +143,20 @@ async function handleInteractionCreate(
     try {
         if (interaction.isAutocomplete()) {
             await handleAutocomplete(interaction)
+            return
+        }
+
+        if (interaction.isButton()) {
+            const id = interaction.customId
+            if (
+                id.startsWith('music_') ||
+                id.startsWith('queue_page') ||
+                id.startsWith('leaderboard_page')
+            ) {
+                await handleMusicButtonInteraction(interaction)
+                return
+            }
+            await reactionRolesService.handleButtonInteraction(interaction)
             return
         }
 


### PR DESCRIPTION
## Summary

- Button interactions (pause, skip, queue, etc.) were silently dropped — `eventHandler.ts` hit the `!isChatInputCommand()` guard before any button routing logic
- Added button routing to `handleInteractionCreate`: `music_*` / `queue_page*` / `leaderboard_page*` → `handleMusicButtonInteraction`; everything else → `reactionRolesService.handleButtonInteraction`
- Added 4 new tests covering button routing; fixed existing tests that lacked `isButton` on their mocks

## Root cause

`interactionHandler.ts` already had correct button routing but was never called — `initializer.ts` registers `eventHandler.ts`. Fix adds the routing there instead of changing the registration.

## Test plan

- [x] `npm run test:bot -- --testPathPatterns="eventHandler|musicButton"` — 28 tests pass
- [x] `npm run verify` — 476 tests pass, 0 vulnerabilities