### PR TITLE
feat(bot): add purge, lockdown, and slowmode moderation commands

### DIFF
--- a/packages/bot/src/functions/moderation/commands/lockdown.spec.ts
+++ b/packages/bot/src/functions/moderation/commands/lockdown.spec.ts
@@ -1,0 +1,303 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import lockdownCommand from './lockdown.js'
+import { ChannelType, PermissionFlagsBits } from 'discord.js'
+
+const interactionReplyMock = jest.fn()
+const infoLogMock = jest.fn()
+const errorLogMock = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: (...args: unknown[]) => infoLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+}))
+
+jest.mock('../../../utils/general/interactionReply.js', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+function createPermissionOverwrite(sendMessagesDenied = false) {
+    return {
+        deny: {
+            has: jest.fn((perm) => {
+                if (perm === PermissionFlagsBits.SendMessages) {
+                    return sendMessagesDenied
+                }
+                return false
+            }),
+        },
+    } as any
+}
+
+function createChannel(id = 'channel-123', name = 'general') {
+    return {
+        id,
+        name,
+        type: ChannelType.GuildText,
+        toString: jest.fn(() => `<#${id}>`),
+        permissionOverwrites: {
+            cache: new Map(),
+            edit: jest.fn(async () => null),
+        },
+    } as any
+}
+
+function createGuild(id = 'guild-123', name = 'Test Guild') {
+    return {
+        id,
+        name,
+        roles: {
+            everyone: {
+                id: 'role-everyone',
+            },
+        },
+    } as any
+}
+
+function createInteraction({
+    guildId = 'guild-123',
+    guild = null as any,
+    channelId = 'channel-123',
+    channel = null as any,
+    userId = 'mod-123',
+    userTag = 'Moderator#5678',
+    selectedChannel = null as any,
+    reason = null as string | null,
+} = {}) {
+    const interaction = {
+        guild: guild || createGuild(guildId),
+        guildId,
+        channel: channel || createChannel(channelId),
+        channelId,
+        user: { id: userId, tag: userTag },
+        options: {
+            getChannel: jest.fn((name: string) => {
+                if (name === 'channel') return selectedChannel
+                return null
+            }),
+            getString: jest.fn((name: string) => {
+                if (name === 'reason') return reason
+                return null
+            }),
+        },
+    }
+
+    return interaction as any
+}
+
+describe('lockdown command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('rejects command outside of guild', async () => {
+        const interaction = {
+            guild: null,
+            channel: createChannel(),
+            options: {
+                getChannel: jest.fn(),
+                getString: jest.fn(),
+            },
+        } as any
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                content: '❌ This command can only be used in a server.',
+            },
+        })
+    })
+
+    test('locks unlocked channel', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel()
+        interaction.channel = channel
+        interaction.guild.roles.everyone.id = 'role-everyone'
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(channel.permissionOverwrites.edit).toHaveBeenCalledWith(
+            interaction.guild.roles.everyone,
+            { SendMessages: false },
+        )
+    })
+
+    test('unlocks locked channel', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel()
+        const overwrite = createPermissionOverwrite(true)
+        channel.permissionOverwrites.cache.set('role-everyone', overwrite)
+        interaction.channel = channel
+        interaction.guild.roles.everyone.id = 'role-everyone'
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(channel.permissionOverwrites.edit).toHaveBeenCalledWith(
+            interaction.guild.roles.everyone,
+            { SendMessages: null },
+        )
+    })
+
+    test('shows lock embed when locking', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel('channel-123', 'general')
+        interaction.channel = channel
+        interaction.guild.roles.everyone.id = 'role-everyone'
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                embeds: [
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            title: '🔒 Channel Locked',
+                            color: 0xf44336,
+                        }),
+                    }),
+                ],
+            },
+        })
+    })
+
+    test('shows unlock embed when unlocking', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel('channel-123', 'general')
+        const overwrite = createPermissionOverwrite(true)
+        channel.permissionOverwrites.cache.set('role-everyone', overwrite)
+        interaction.channel = channel
+        interaction.guild.roles.everyone.id = 'role-everyone'
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                embeds: [
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            title: '🔓 Channel Unlocked',
+                            color: 0x4caf50,
+                        }),
+                    }),
+                ],
+            },
+        })
+    })
+
+    test('includes channel info in embed', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel('channel-123', 'general')
+        interaction.channel = channel
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        const embedCall = interactionReplyMock.mock.calls[0][0]
+        const embed = embedCall.content.embeds[0]
+        const channelField = embed.data.fields.find(
+            (f: any) => f.name === 'Channel',
+        )
+
+        expect(channelField).toBeDefined()
+    })
+
+    test('includes reason in embed when provided', async () => {
+        const interaction = createInteraction({ reason: 'Spam attack' })
+        const channel = createChannel()
+        interaction.channel = channel
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        const embedCall = interactionReplyMock.mock.calls[0][0]
+        const embed = embedCall.content.embeds[0]
+        const reasonField = embed.data.fields.find(
+            (f: any) => f.name === 'Reason',
+        )
+
+        expect(reasonField).toBeDefined()
+        expect(reasonField.value).toBe('Spam attack')
+    })
+
+    test('includes moderator info in embed', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel()
+        interaction.channel = channel
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        const embedCall = interactionReplyMock.mock.calls[0][0]
+        const embed = embedCall.content.embeds[0]
+        const modField = embed.data.fields.find(
+            (f: any) => f.name === 'Moderator',
+        )
+
+        expect(modField).toBeDefined()
+        expect(modField.value).toBe('Moderator#5678')
+    })
+
+    test('uses selected channel when provided', async () => {
+        const interaction = createInteraction()
+        const selectedChannel = createChannel('channel-456', 'announcements')
+        interaction.options.getChannel.mockReturnValue(selectedChannel)
+        interaction.guild.roles.everyone.id = 'role-everyone'
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(selectedChannel.permissionOverwrites.edit).toHaveBeenCalled()
+    })
+
+    test('logs lock action', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel('channel-123', 'general')
+        interaction.channel = channel
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: expect.stringContaining('locked'),
+        })
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: expect.stringContaining('Moderator#5678'),
+        })
+    })
+
+    test('logs unlock action', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel('channel-123', 'general')
+        const overwrite = createPermissionOverwrite(true)
+        channel.permissionOverwrites.cache.set('role-everyone', overwrite)
+        interaction.channel = channel
+        interaction.guild.roles.everyone.id = 'role-everyone'
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: expect.stringContaining('unlocked'),
+        })
+    })
+
+    test('handles lockdown failure gracefully', async () => {
+        const interaction = createInteraction()
+        const channel = createChannel()
+        channel.permissionOverwrites.edit.mockRejectedValue(
+            new Error('Missing permissions'),
+        )
+        interaction.channel = channel
+
+        await lockdownCommand.execute({ interaction } as any)
+
+        expect(errorLogMock).toHaveBeenCalledWith({
+            message: 'Failed to toggle channel lockdown',
+            error: expect.any(Error),
+        })
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                content:
+                    '❌ Failed to toggle lockdown. Please check permissions and try again.',
+            },
+        })
+    })
+})

--- a/packages/bot/src/functions/moderation/commands/lockdown.ts
+++ b/packages/bot/src/functions/moderation/commands/lockdown.ts
@@ -1,0 +1,126 @@
+import {
+    SlashCommandBuilder,
+    PermissionFlagsBits,
+    EmbedBuilder,
+    ChannelType,
+} from 'discord.js'
+import Command from '../../../models/Command.js'
+import { infoLog, errorLog } from '@lucky/shared/utils'
+import { interactionReply } from '../../../utils/general/interactionReply.js'
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('lockdown')
+        .setDescription('Toggle lockdown mode for a channel')
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+        .addChannelOption((option) =>
+            option
+                .setName('channel')
+                .setDescription('Channel to lock (defaults to current channel)')
+                .setRequired(false)
+                .addChannelTypes(ChannelType.GuildText),
+        )
+        .addStringOption((option) =>
+            option
+                .setName('reason')
+                .setDescription('Reason for lockdown')
+                .setRequired(false),
+        ),
+    category: 'moderation',
+    execute: async ({ interaction }) => {
+        if (!interaction.guild) {
+            await interactionReply({
+                interaction,
+                content: {
+                    content: '❌ This command can only be used in a server.',
+                },
+            })
+            return
+        }
+
+        const channel =
+            (interaction.options.getChannel('channel') as any) ||
+            interaction.channel
+        const reason =
+            interaction.options.getString('reason') || 'No reason provided'
+
+        if (!channel || channel.type !== ChannelType.GuildText) {
+            await interactionReply({
+                interaction,
+                content: {
+                    content: '❌ This command can only be used in text channels.',
+                },
+            })
+            return
+        }
+
+        try {
+            const everyone = interaction.guild.roles.everyone
+            const currentOverwrite = channel.permissionOverwrites.cache.get(
+                everyone.id,
+            )
+
+            const isSendMessagesBlocked =
+                currentOverwrite?.deny?.has(PermissionFlagsBits.SendMessages)
+
+            let isLocking: boolean
+            let action: string
+
+            if (isSendMessagesBlocked) {
+                await channel.permissionOverwrites.edit(everyone, {
+                    SendMessages: null,
+                })
+                isLocking = false
+                action = 'unlocked'
+            } else {
+                await channel.permissionOverwrites.edit(everyone, {
+                    SendMessages: false,
+                })
+                isLocking = true
+                action = 'locked'
+            }
+
+            const embed = new EmbedBuilder()
+                .setColor(isLocking ? 0xf44336 : 0x4caf50)
+                .setTitle(isLocking ? '🔒 Channel Locked' : '🔓 Channel Unlocked')
+                .addFields({
+                    name: 'Channel',
+                    value: `${channel}`,
+                })
+
+            if (reason) {
+                embed.addFields({
+                    name: 'Reason',
+                    value: reason,
+                })
+            }
+
+            embed.addFields({
+                name: 'Moderator',
+                value: interaction.user.tag,
+            }).setTimestamp()
+
+            await interactionReply({
+                interaction,
+                content: { embeds: [embed] },
+            })
+
+            infoLog({
+                message: `${interaction.user.tag} ${action} #${channel.name} in ${interaction.guild.name}${reason ? ` - Reason: ${reason}` : ''}`,
+            })
+        } catch (error) {
+            errorLog({
+                message: 'Failed to toggle channel lockdown',
+                error: error as Error,
+            })
+
+            await interactionReply({
+                interaction,
+                content: {
+                    content:
+                        '❌ Failed to toggle lockdown. Please check permissions and try again.',
+                },
+            })
+        }
+    },
+})

--- a/packages/bot/src/functions/moderation/commands/purge.spec.ts
+++ b/packages/bot/src/functions/moderation/commands/purge.spec.ts
@@ -1,0 +1,337 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import purgeCommand from './purge.js'
+import { ChannelType } from 'discord.js'
+
+const interactionReplyMock = jest.fn()
+const infoLogMock = jest.fn()
+const errorLogMock = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: (...args: unknown[]) => infoLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+}))
+
+jest.mock('../../../utils/general/interactionReply.js', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+function createUser(id = 'user-123', tag = 'TestUser#1234') {
+    return {
+        id,
+        tag,
+    } as any
+}
+
+function createMessage(
+    id = 'msg-123',
+    authorId = 'user-123',
+    content = 'test message',
+    createdTimestamp = Date.now(),
+) {
+    return {
+        id,
+        content,
+        author: {
+            id: authorId,
+            tag: 'MessageAuthor#1234',
+        },
+        createdTimestamp,
+    } as any
+}
+
+function createChannel(id = 'channel-123') {
+    return {
+        id,
+        type: ChannelType.GuildText,
+        messages: {
+            fetch: jest.fn(async () => new Map()),
+        },
+        bulkDelete: jest.fn(async () => []),
+    } as any
+}
+
+function createGuild(id = 'guild-123', name = 'Test Guild') {
+    return {
+        id,
+        name,
+    } as any
+}
+
+function createInteraction({
+    guildId = 'guild-123',
+    guild = null as any,
+    channelId = 'channel-123',
+    channel = null as any,
+    userId = 'mod-123',
+    userTag = 'Moderator#5678',
+    amount = 10,
+    filterUser = null as any,
+    filterText = null as string | null,
+} = {}) {
+    const interaction = {
+        guild: guild || createGuild(guildId),
+        guildId,
+        channel: channel || createChannel(channelId),
+        channelId,
+        user: { id: userId, tag: userTag },
+        options: {
+            getInteger: jest.fn((name: string) => {
+                if (name === 'amount') return amount
+                return null
+            }),
+            getUser: jest.fn((name: string) => {
+                if (name === 'user') return filterUser
+                return null
+            }),
+            getString: jest.fn((name: string) => {
+                if (name === 'contains') return filterText
+                return null
+            }),
+        },
+    }
+
+    return interaction as any
+}
+
+describe('purge command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('rejects command outside of guild', async () => {
+        const interaction = {
+            guild: null,
+            channel: createChannel(),
+            options: {
+                getInteger: jest.fn(),
+                getUser: jest.fn(),
+                getString: jest.fn(),
+            },
+        } as any
+
+        await purgeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                content: '❌ This command can only be used in a server.',
+            },
+        })
+    })
+
+    test('rejects command outside of text channel', async () => {
+        const interaction = createInteraction()
+        interaction.channel.type = ChannelType.GuildVoice
+
+        await purgeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                content: '❌ This command can only be used in text channels.',
+            },
+        })
+    })
+
+    test('purges specified number of messages', async () => {
+        const interaction = createInteraction({ amount: 5 })
+        const messages = new Map([
+            ['1', createMessage('1')],
+            ['2', createMessage('2')],
+            ['3', createMessage('3')],
+            ['4', createMessage('4')],
+            ['5', createMessage('5')],
+        ])
+        interaction.channel.messages.fetch.mockResolvedValue(messages)
+
+        await purgeCommand.execute({ interaction } as any)
+
+        expect(interaction.channel.bulkDelete).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({ id: '1' }),
+                expect.objectContaining({ id: '2' }),
+                expect.objectContaining({ id: '3' }),
+                expect.objectContaining({ id: '4' }),
+                expect.objectContaining({ id: '5' }),
+            ]),
+            true,
+        )
+    })
+
+    test('filters by user when specified', async () => {
+        const filterUser = createUser('user-target', 'TargetUser#9999')
+        const interaction = createInteraction({
+            amount: 10,
+            filterUser,
+        })
+        const messages = new Map([
+            ['1', createMessage('1', 'user-target', 'from target')],
+            ['2', createMessage('2', 'user-other', 'from other')],
+            ['3', createMessage('3', 'user-target', 'from target again')],
+        ])
+        interaction.channel.messages.fetch.mockResolvedValue(messages)
+
+        await purgeCommand.execute({ interaction } as any)
+
+        const deletedMessages = interaction.channel.bulkDelete.mock.calls[0][0]
+        expect(deletedMessages).toHaveLength(2)
+        expect(deletedMessages.every((m: any) => m.author.id === 'user-target')).toBe(
+            true,
+        )
+    })
+
+    test('filters by text content when specified', async () => {
+        const interaction = createInteraction({
+            amount: 10,
+            filterText: 'spam',
+        })
+        const messages = new Map([
+            ['1', createMessage('1', 'user-123', 'this is spam')],
+            ['2', createMessage('2', 'user-123', 'this is not related')],
+            ['3', createMessage('3', 'user-123', 'SPAM in caps')],
+        ])
+        interaction.channel.messages.fetch.mockResolvedValue(messages)
+
+        await purgeCommand.execute({ interaction } as any)
+
+        const deletedMessages = interaction.channel.bulkDelete.mock.calls[0][0]
+        expect(deletedMessages).toHaveLength(2)
+        expect(
+            deletedMessages.every((m: any) =>
+                m.content.toLowerCase().includes('spam'),
+            ),
+        ).toBe(true)
+    })
+
+    test('respects 14-day message age limit', async () => {
+        const interaction = createInteraction({ amount: 100 })
+        const now = Date.now()
+        const fifteenDaysMs = 15 * 24 * 60 * 60 * 1000
+        const messages = new Map([
+            ['1', createMessage('1', 'user-123', 'recent', now)],
+            ['2', createMessage('2', 'user-123', 'old', now - fifteenDaysMs)],
+            ['3', createMessage('3', 'user-123', 'recent', now - 1000)],
+        ])
+        interaction.channel.messages.fetch.mockResolvedValue(messages)
+
+        await purgeCommand.execute({ interaction } as any)
+
+        const deletedMessages = interaction.channel.bulkDelete.mock.calls[0][0]
+        expect(deletedMessages).toHaveLength(2)
+        expect(deletedMessages.map((m: any) => m.id)).not.toContain('2')
+    })
+
+    test('returns empty result message when no messages match', async () => {
+        const interaction = createInteraction()
+        const messages = new Map([
+            ['1', createMessage('1', 'user-other', 'other content')],
+        ])
+        const filterUser = createUser('user-target', 'TargetUser#9999')
+        interaction.options.getUser.mockReturnValue(filterUser)
+        interaction.channel.messages.fetch.mockResolvedValue(messages)
+
+        await purgeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                content: '❌ No messages found matching your criteria.',
+            },
+        })
+        expect(interaction.channel.bulkDelete).not.toHaveBeenCalled()
+    })
+
+    test('shows success embed with deleted count', async () => {
+        const interaction = createInteraction({ amount: 3 })
+        const messages = new Map([
+            ['1', createMessage('1')],
+            ['2', createMessage('2')],
+            ['3', createMessage('3')],
+        ])
+        interaction.channel.messages.fetch.mockResolvedValue(messages)
+
+        await purgeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                embeds: [
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            title: '🗑️ Messages Purged',
+                            fields: expect.arrayContaining([
+                                expect.objectContaining({
+                                    name: 'Deleted',
+                                    value: '3 messages',
+                                }),
+                            ]),
+                        }),
+                    }),
+                ],
+            },
+        })
+    })
+
+    test('includes filter info in embed', async () => {
+        const filterUser = createUser('user-target', 'TargetUser#9999')
+        const interaction = createInteraction({
+            amount: 1,
+            filterUser,
+        })
+        const messages = new Map([
+            ['1', createMessage('1', 'user-target')],
+        ])
+        interaction.channel.messages.fetch.mockResolvedValue(messages)
+
+        await purgeCommand.execute({ interaction } as any)
+
+        const embedCall = interactionReplyMock.mock.calls[0][0]
+        const embed = embedCall.content.embeds[0]
+        const filterField = embed.data.fields.find((f: any) => f.name === 'Filter')
+
+        expect(filterField).toBeDefined()
+        expect(filterField.value).toContain('TargetUser#9999')
+    })
+
+    test('handles purge failure gracefully', async () => {
+        const interaction = createInteraction()
+        interaction.channel.messages.fetch.mockRejectedValue(
+            new Error('Missing permissions'),
+        )
+
+        await purgeCommand.execute({ interaction } as any)
+
+        expect(errorLogMock).toHaveBeenCalledWith({
+            message: 'Failed to purge messages',
+            error: expect.any(Error),
+        })
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                content:
+                    '❌ Failed to purge messages. Please check permissions and try again.',
+            },
+        })
+    })
+
+    test('logs purge action', async () => {
+        const interaction = createInteraction({ amount: 5 })
+        const messages = new Map([
+            ['1', createMessage('1')],
+            ['2', createMessage('2')],
+            ['3', createMessage('3')],
+            ['4', createMessage('4')],
+            ['5', createMessage('5')],
+        ])
+        interaction.channel.messages.fetch.mockResolvedValue(messages)
+
+        await purgeCommand.execute({ interaction } as any)
+
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: expect.stringContaining('Moderator#5678'),
+        })
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: expect.stringContaining('5 messages'),
+        })
+    })
+})

--- a/packages/bot/src/functions/moderation/commands/purge.ts
+++ b/packages/bot/src/functions/moderation/commands/purge.ts
@@ -1,0 +1,146 @@
+import {
+    SlashCommandBuilder,
+    PermissionFlagsBits,
+    EmbedBuilder,
+    ChannelType,
+} from 'discord.js'
+import Command from '../../../models/Command.js'
+import { infoLog, errorLog } from '@lucky/shared/utils'
+import { interactionReply } from '../../../utils/general/interactionReply.js'
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('purge')
+        .setDescription('Delete messages from the channel')
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+        .addIntegerOption((option) =>
+            option
+                .setName('amount')
+                .setDescription('Number of messages to delete (1-100)')
+                .setRequired(true)
+                .setMinValue(1)
+                .setMaxValue(100),
+        )
+        .addUserOption((option) =>
+            option
+                .setName('user')
+                .setDescription('Filter by user (optional)')
+                .setRequired(false),
+        )
+        .addStringOption((option) =>
+            option
+                .setName('contains')
+                .setDescription('Filter by text content (case-insensitive, optional)')
+                .setRequired(false),
+        ),
+    category: 'moderation',
+    execute: async ({ interaction }) => {
+        if (!interaction.guild || !interaction.channel) {
+            await interactionReply({
+                interaction,
+                content: {
+                    content: '❌ This command can only be used in a server.',
+                },
+            })
+            return
+        }
+
+        if (interaction.channel.type !== ChannelType.GuildText) {
+            await interactionReply({
+                interaction,
+                content: {
+                    content: '❌ This command can only be used in text channels.',
+                },
+            })
+            return
+        }
+
+        const amount = interaction.options.getInteger('amount', true)
+        const filterUser = interaction.options.getUser('user')
+        const filterText = interaction.options.getString('contains')?.toLowerCase()
+
+        try {
+            const messages = await interaction.channel.messages.fetch({
+                limit: 100,
+            })
+
+            const now = Date.now()
+            const fourteenDaysMs = 14 * 24 * 60 * 60 * 1000
+
+            let filtered = Array.from(messages.values()).filter((msg) => {
+                if (now - msg.createdTimestamp > fourteenDaysMs) {
+                    return false
+                }
+
+                if (filterUser && msg.author.id !== filterUser.id) {
+                    return false
+                }
+
+                if (filterText && !msg.content.toLowerCase().includes(filterText)) {
+                    return false
+                }
+
+                return true
+            })
+
+            filtered = filtered.slice(0, amount)
+
+            if (filtered.length === 0) {
+                await interactionReply({
+                    interaction,
+                    content: {
+                        content: '❌ No messages found matching your criteria.',
+                    },
+                })
+                return
+            }
+
+            await interaction.channel.bulkDelete(filtered, true)
+
+            const embed = new EmbedBuilder()
+                .setColor(0x9c27b0)
+                .setTitle('🗑️ Messages Purged')
+                .addFields({
+                    name: 'Deleted',
+                    value: `${filtered.length} message${filtered.length !== 1 ? 's' : ''}`,
+                })
+                .setTimestamp()
+
+            if (filterUser) {
+                embed.addFields({
+                    name: 'Filter',
+                    value: `From ${filterUser.tag}`,
+                })
+            }
+
+            if (filterText) {
+                embed.addFields({
+                    name: 'Text Filter',
+                    value: filterText,
+                })
+            }
+
+            await interactionReply({
+                interaction,
+                content: { embeds: [embed] },
+            })
+
+            infoLog({
+                message: `${interaction.user.tag} purged ${filtered.length} messages in ${interaction.guild.name}`,
+            })
+        } catch (error) {
+            errorLog({
+                message: 'Failed to purge messages',
+                error: error as Error,
+            })
+
+            await interactionReply({
+                interaction,
+                content: {
+                    content:
+                        '❌ Failed to purge messages. Please check permissions and try again.',
+                },
+            })
+        }
+    },
+})

--- a/packages/bot/src/functions/moderation/commands/slowmode.spec.ts
+++ b/packages/bot/src/functions/moderation/commands/slowmode.spec.ts
@@ -1,0 +1,285 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import slowmodeCommand from './slowmode.js'
+
+const interactionReplyMock = jest.fn()
+const infoLogMock = jest.fn()
+const errorLogMock = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: (...args: unknown[]) => infoLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+}))
+
+jest.mock('../../../utils/general/interactionReply.js', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+function createChannel(id = 'channel-123', name = 'general') {
+    return {
+        id,
+        name,
+        setRateLimitPerUser: jest.fn(async () => null),
+    } as any
+}
+
+function createGuild(id = 'guild-123', name = 'Test Guild') {
+    return {
+        id,
+        name,
+    } as any
+}
+
+function createInteraction({
+    guildId = 'guild-123',
+    guild = null as any,
+    channelId = 'channel-123',
+    channel = null as any,
+    userId = 'mod-123',
+    userTag = 'Moderator#5678',
+    seconds = 10,
+} = {}) {
+    const interaction = {
+        guild: guild || createGuild(guildId),
+        guildId,
+        channel: channel || createChannel(channelId),
+        channelId,
+        user: { id: userId, tag: userTag },
+        options: {
+            getInteger: jest.fn((name: string) => {
+                if (name === 'seconds') return seconds
+                return null
+            }),
+        },
+    }
+
+    return interaction as any
+}
+
+describe('slowmode command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('rejects command outside of guild', async () => {
+        const interaction = {
+            guild: null,
+            channel: createChannel(),
+            options: {
+                getInteger: jest.fn(),
+            },
+        } as any
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                content: '❌ This command can only be used in a server.',
+            },
+        })
+    })
+
+    test('sets slowmode with 10 second duration', async () => {
+        const interaction = createInteraction({ seconds: 10 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interaction.channel.setRateLimitPerUser).toHaveBeenCalledWith(10)
+    })
+
+    test('disables slowmode with 0 seconds', async () => {
+        const interaction = createInteraction({ seconds: 0 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interaction.channel.setRateLimitPerUser).toHaveBeenCalledWith(0)
+    })
+
+    test('sets slowmode with 1 minute (60 seconds)', async () => {
+        const interaction = createInteraction({ seconds: 60 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interaction.channel.setRateLimitPerUser).toHaveBeenCalledWith(60)
+    })
+
+    test('sets slowmode with 1 hour (3600 seconds)', async () => {
+        const interaction = createInteraction({ seconds: 3600 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interaction.channel.setRateLimitPerUser).toHaveBeenCalledWith(3600)
+    })
+
+    test('shows enabled embed with seconds format', async () => {
+        const interaction = createInteraction({ seconds: 30 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                embeds: [
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            title: '⏱️ Slowmode Enabled',
+                            color: 0xff9800,
+                            fields: expect.arrayContaining([
+                                expect.objectContaining({
+                                    name: 'Duration',
+                                    value: '30s',
+                                }),
+                            ]),
+                        }),
+                    }),
+                ],
+            },
+        })
+    })
+
+    test('shows enabled embed with minutes format', async () => {
+        const interaction = createInteraction({ seconds: 120 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                embeds: [
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            title: '⏱️ Slowmode Enabled',
+                            fields: expect.arrayContaining([
+                                expect.objectContaining({
+                                    name: 'Duration',
+                                    value: '2m',
+                                }),
+                            ]),
+                        }),
+                    }),
+                ],
+            },
+        })
+    })
+
+    test('shows enabled embed with hours format', async () => {
+        const interaction = createInteraction({ seconds: 7200 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                embeds: [
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            title: '⏱️ Slowmode Enabled',
+                            fields: expect.arrayContaining([
+                                expect.objectContaining({
+                                    name: 'Duration',
+                                    value: '2h',
+                                }),
+                            ]),
+                        }),
+                    }),
+                ],
+            },
+        })
+    })
+
+    test('shows disabled embed when setting to 0', async () => {
+        const interaction = createInteraction({ seconds: 0 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                embeds: [
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            title: '⏱️ Slowmode Disabled',
+                            color: 0x4caf50,
+                            fields: expect.arrayContaining([
+                                expect.objectContaining({
+                                    name: 'Duration',
+                                    value: 'disabled',
+                                }),
+                            ]),
+                        }),
+                    }),
+                ],
+            },
+        })
+    })
+
+    test('includes moderator info in embed', async () => {
+        const interaction = createInteraction({ seconds: 10 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        const embedCall = interactionReplyMock.mock.calls[0][0]
+        const embed = embedCall.content.embeds[0]
+        const modField = embed.data.fields.find(
+            (f: any) => f.name === 'Moderator',
+        )
+
+        expect(modField).toBeDefined()
+        expect(modField.value).toBe('Moderator#5678')
+    })
+
+    test('logs slowmode enable action', async () => {
+        const interaction = createInteraction({ seconds: 60 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: expect.stringContaining('set slowmode'),
+        })
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: expect.stringContaining('Moderator#5678'),
+        })
+    })
+
+    test('logs slowmode disable action', async () => {
+        const interaction = createInteraction({ seconds: 0 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: expect.stringContaining('disabled slowmode'),
+        })
+    })
+
+    test('handles slowmode failure gracefully', async () => {
+        const interaction = createInteraction({ seconds: 10 })
+        interaction.channel.setRateLimitPerUser.mockRejectedValue(
+            new Error('Missing permissions'),
+        )
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(errorLogMock).toHaveBeenCalledWith({
+            message: 'Failed to set slowmode',
+            error: expect.any(Error),
+        })
+        expect(interactionReplyMock).toHaveBeenCalledWith({
+            interaction,
+            content: {
+                content:
+                    '❌ Failed to set slowmode. Please check permissions and try again.',
+            },
+        })
+    })
+
+    test('handles maximum slowmode duration (6 hours)', async () => {
+        const interaction = createInteraction({ seconds: 21600 })
+
+        await slowmodeCommand.execute({ interaction } as any)
+
+        expect(interaction.channel.setRateLimitPerUser).toHaveBeenCalledWith(
+            21600,
+        )
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/functions/moderation/commands/slowmode.ts
+++ b/packages/bot/src/functions/moderation/commands/slowmode.ts
@@ -2,6 +2,7 @@ import {
     SlashCommandBuilder,
     PermissionFlagsBits,
     EmbedBuilder,
+    TextChannel,
 } from 'discord.js'
 import Command from '../../../models/Command.js'
 import { infoLog, errorLog } from '@lucky/shared/utils'
@@ -35,7 +36,7 @@ export default new Command({
         const seconds = interaction.options.getInteger('seconds', true)
 
         try {
-            await interaction.channel.setRateLimitPerUser(seconds)
+            await (interaction.channel as TextChannel).setRateLimitPerUser(seconds)
 
             const formatDuration = (sec: number): string => {
                 if (sec === 0) return 'disabled'

--- a/packages/bot/src/functions/moderation/commands/slowmode.ts
+++ b/packages/bot/src/functions/moderation/commands/slowmode.ts
@@ -66,8 +66,9 @@ export default new Command({
             })
 
             const action = seconds === 0 ? 'disabled slowmode' : `set slowmode to ${formatDuration(seconds)}`
+            const channelName = (interaction.channel as TextChannel).name
             infoLog({
-                message: `${interaction.user.tag} ${action} in #${interaction.channel.name} (${interaction.guild.name})`,
+                message: `${interaction.user.tag} ${action} in #${channelName} (${interaction.guild.name})`,
             })
         } catch (error) {
             errorLog({

--- a/packages/bot/src/functions/moderation/commands/slowmode.ts
+++ b/packages/bot/src/functions/moderation/commands/slowmode.ts
@@ -1,0 +1,86 @@
+import {
+    SlashCommandBuilder,
+    PermissionFlagsBits,
+    EmbedBuilder,
+} from 'discord.js'
+import Command from '../../../models/Command.js'
+import { infoLog, errorLog } from '@lucky/shared/utils'
+import { interactionReply } from '../../../utils/general/interactionReply.js'
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('slowmode')
+        .setDescription('Set slowmode for the current channel')
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+        .addIntegerOption((option) =>
+            option
+                .setName('seconds')
+                .setDescription('Slowmode duration in seconds (0 to disable)')
+                .setRequired(true)
+                .setMinValue(0)
+                .setMaxValue(21600),
+        ),
+    category: 'moderation',
+    execute: async ({ interaction }) => {
+        if (!interaction.guild || !interaction.channel) {
+            await interactionReply({
+                interaction,
+                content: {
+                    content: '❌ This command can only be used in a server.',
+                },
+            })
+            return
+        }
+
+        const seconds = interaction.options.getInteger('seconds', true)
+
+        try {
+            await interaction.channel.setRateLimitPerUser(seconds)
+
+            const formatDuration = (sec: number): string => {
+                if (sec === 0) return 'disabled'
+                if (sec < 60) return `${sec}s`
+                if (sec < 3600) return `${Math.floor(sec / 60)}m`
+                return `${Math.floor(sec / 3600)}h`
+            }
+
+            const embed = new EmbedBuilder()
+                .setColor(seconds === 0 ? 0x4caf50 : 0xff9800)
+                .setTitle(
+                    seconds === 0 ? '⏱️ Slowmode Disabled' : '⏱️ Slowmode Enabled',
+                )
+                .addFields({
+                    name: 'Duration',
+                    value: formatDuration(seconds),
+                })
+                .addFields({
+                    name: 'Moderator',
+                    value: interaction.user.tag,
+                })
+                .setTimestamp()
+
+            await interactionReply({
+                interaction,
+                content: { embeds: [embed] },
+            })
+
+            const action = seconds === 0 ? 'disabled slowmode' : `set slowmode to ${formatDuration(seconds)}`
+            infoLog({
+                message: `${interaction.user.tag} ${action} in #${interaction.channel.name} (${interaction.guild.name})`,
+            })
+        } catch (error) {
+            errorLog({
+                message: 'Failed to set slowmode',
+                error: error as Error,
+            })
+
+            await interactionReply({
+                interaction,
+                content: {
+                    content:
+                        '❌ Failed to set slowmode. Please check permissions and try again.',
+                },
+            })
+        }
+    },
+})


### PR DESCRIPTION
## Summary

Implements 3 moderation commands from Dyno bot parity analysis:

- **`/purge <amount> [user] [contains]`** — bulk delete 1-100 messages with optional user/content filters. Respects Discord's 14-day limit for bulk delete.
- **`/lockdown [channel] [reason]`** — toggles `SendMessages` for `@everyone` (lock/unlock). Second invocation unlocks.
- **`/slowmode <seconds>`** — sets channel slowmode 0-21600s (0 = disable). Formats display as s/m/h.

## Test plan

- [x] 37 new tests across 3 spec files (purge: 11, lockdown: 12, slowmode: 12)
- [x] 1722 total bot tests passing
- [x] `npm run verify` passes