### PR TITLE
feat(bot): add autorole and giveaway commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.64",
+    "version": "2.6.70",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.64",
+            "version": "2.6.70",
             "license": "ISC",
             "workspaces": [
                 "packages/*"
@@ -24525,7 +24525,7 @@
         },
         "packages/backend": {
             "name": "@lucky/backend",
-            "version": "2.6.64",
+            "version": "2.6.70",
             "dependencies": {
                 "@lucky/shared": "file:../shared",
                 "connect-redis": "^9.0.0",
@@ -24579,7 +24579,7 @@
         },
         "packages/bot": {
             "name": "@lucky/bot",
-            "version": "2.6.64",
+            "version": "2.6.70",
             "dependencies": {
                 "@discord-player/extractor": "^7.2.0",
                 "@discordjs/builders": "^1.14.1",
@@ -24668,7 +24668,7 @@
         },
         "packages/frontend": {
             "name": "lucky-webapp",
-            "version": "2.6.64",
+            "version": "2.6.70",
             "dependencies": {
                 "@hookform/resolvers": "^5.0.0",
                 "@radix-ui/react-avatar": "^1.1.11",
@@ -25013,7 +25013,7 @@
         },
         "packages/shared": {
             "name": "@lucky/shared",
-            "version": "2.6.64",
+            "version": "2.6.70",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.3",
                 "@npmcli/agent": "^4.0.0",

--- a/packages/bot/src/functions/general/commands/giveaway.spec.ts
+++ b/packages/bot/src/functions/general/commands/giveaway.spec.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import giveawayCommand, { parseDuration } from './giveaway'
+
+const interactionReplyMock = jest.fn()
+const createSuccessEmbedMock = jest.fn((title: string, description: string) => ({ type: 'success', title, description }))
+const createErrorEmbedMock = jest.fn((title: string, description: string) => ({ type: 'error', title, description }))
+const requireGuildMock = jest.fn()
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createSuccessEmbed: (...args: unknown[]) => createSuccessEmbedMock(...args),
+    createErrorEmbed: (...args: unknown[]) => createErrorEmbedMock(...args),
+}))
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireGuild: (...args: unknown[]) => requireGuildMock(...args),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+}))
+
+function createInteraction(subcommand: string, opts: Record<string, unknown> = {}) {
+    return {
+        guild: { id: 'guild-1' },
+        channelId: 'channel-1',
+        channel: {
+            send: jest.fn().mockResolvedValue({
+                id: 'message-1',
+                url: 'https://discord.com/channels/guild-1/channel-1/message-1',
+                react: jest.fn().mockResolvedValue(undefined),
+            }),
+        },
+        options: {
+            getSubcommand: () => subcommand,
+            getString: () => opts.value ?? 'test-value',
+            getInteger: () => opts.winners ?? 1,
+        },
+    }
+}
+
+describe('giveaway command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        requireGuildMock.mockResolvedValue(true)
+    })
+
+    it('should be a valid command', () => {
+        expect(giveawayCommand.data.name).toBe('giveaway')
+    })
+
+    describe('parseDuration', () => {
+        it('should parse hours', () => {
+            expect(parseDuration('1h')).toBe(3600000)
+        })
+
+        it('should parse minutes', () => {
+            expect(parseDuration('30m')).toBe(1800000)
+        })
+
+        it('should parse days', () => {
+            expect(parseDuration('2d')).toBe(172800000)
+        })
+
+        it('should parse combined durations', () => {
+            expect(parseDuration('1h30m')).toBe(5400000)
+        })
+
+        it('should return 0 for invalid duration', () => {
+            expect(parseDuration('invalid')).toBe(0)
+        })
+    })
+
+    it('should start a giveaway', async () => {
+        const interaction = createInteraction('start', { value: '1h' }) as any
+        interaction.options.getString = jest.fn()
+            .mockReturnValueOnce('1h')
+            .mockReturnValueOnce('Discord Nitro')
+
+        await giveawayCommand.execute({
+            interaction,
+        })
+
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+
+    it('should reject invalid duration', async () => {
+        const interaction = createInteraction('start') as any
+        interaction.options.getString = jest.fn().mockReturnValueOnce('invalid')
+
+        await giveawayCommand.execute({
+            interaction,
+        })
+
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+
+    it('should handle end subcommand', async () => {
+        await giveawayCommand.execute({
+            interaction: createInteraction('end') as any,
+        })
+
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+
+    it('should handle reroll subcommand', async () => {
+        await giveawayCommand.execute({
+            interaction: createInteraction('reroll') as any,
+        })
+
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/functions/general/commands/giveaway.ts
+++ b/packages/bot/src/functions/general/commands/giveaway.ts
@@ -1,0 +1,314 @@
+import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders'
+import { PermissionFlagsBits, type TextChannel } from 'discord.js'
+import Command from '../../../models/Command'
+import { interactionReply } from '../../../utils/general/interactionReply'
+import { requireGuild } from '../../../utils/command/commandValidations'
+import { createSuccessEmbed, createErrorEmbed, createInfoEmbed } from '../../../utils/general/embeds'
+import { errorLog } from '@lucky/shared/utils'
+
+type GiveawayEntry = {
+    messageId: string
+    channelId: string
+    guildId: string
+    prize: string
+    winnersCount: number
+    endTime: number
+    entries: Set<string>
+    timeoutId: NodeJS.Timeout
+}
+
+const activeGiveaways = new Map<string, GiveawayEntry>()
+
+function parseDuration(durationStr: string): number {
+    const regex = /(\d+)([hmd])/g
+    let totalMs = 0
+    let match
+
+    while ((match = regex.exec(durationStr)) !== null) {
+        const value = parseInt(match[1], 10)
+        const unit = match[2]
+
+        switch (unit) {
+            case 'h':
+                totalMs += value * 3600000
+                break
+            case 'm':
+                totalMs += value * 60000
+                break
+            case 'd':
+                totalMs += value * 86400000
+                break
+        }
+    }
+
+    return totalMs
+}
+
+async function endGiveaway(messageId: string, isReroll = false, client?: any): Promise<void> {
+    const giveaway = activeGiveaways.get(messageId)
+    if (!isReroll) {
+        clearTimeout(giveaway?.timeoutId)
+    }
+
+    if (!giveaway) return
+
+    if (!client) {
+        try {
+            client = require('../../../client').default
+        } catch {
+            return
+        }
+    }
+
+    const guild = client.guilds.cache.get(giveaway.guildId)
+    if (!guild) return
+
+    const rawChannel = guild.channels.cache.get(giveaway.channelId)
+    if (!rawChannel || !rawChannel.isTextBased()) return
+
+    const channel = rawChannel as TextChannel
+    const message = await channel.messages.fetch(giveaway.messageId).catch(() => null)
+    if (!message) return
+
+    const entries = Array.from(giveaway.entries)
+    if (entries.length === 0) {
+        await channel.send({
+            embeds: [
+                new EmbedBuilder()
+                    .setTitle('🎉 Giveaway Ended 🎉')
+                    .setDescription(`**${giveaway.prize}** - No valid entries!`)
+                    .setColor(0xff0000),
+            ],
+        })
+        if (!isReroll) activeGiveaways.delete(messageId)
+        return
+    }
+
+    const winners: string[] = []
+    const selectedIndexes = new Set<number>()
+
+    for (let i = 0; i < Math.min(giveaway.winnersCount, entries.length); i++) {
+        let index = Math.floor(Math.random() * entries.length)
+        while (selectedIndexes.has(index)) {
+            index = Math.floor(Math.random() * entries.length)
+        }
+        selectedIndexes.add(index)
+        winners.push(entries[index])
+    }
+
+    const winnerMentions = winners.map((id) => `<@${id}>`).join(', ')
+
+    await channel.send({
+        embeds: [
+            new EmbedBuilder()
+                .setTitle(`🎉 Giveaway ${isReroll ? 'Rerolled' : 'Ended'} 🎉`)
+                .setDescription(`**${giveaway.prize}**\n\nWinner${giveaway.winnersCount > 1 ? 's' : ''}: ${winnerMentions}`)
+                .setColor(0x00ff00)
+                .setFooter({ text: `${giveaway.winnersCount} winner${giveaway.winnersCount > 1 ? 's' : ''}` }),
+        ],
+    })
+
+    if (!isReroll) activeGiveaways.delete(messageId)
+}
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('giveaway')
+        .setDescription('Run a giveaway')
+        .addSubcommand((sub) =>
+            sub
+                .setName('start')
+                .setDescription('Start a giveaway')
+                .addStringOption((o) =>
+                    o
+                        .setName('duration')
+                        .setDescription('Duration (e.g., 1h, 30m, 2d, 1h30m)')
+                        .setRequired(true),
+                )
+                .addStringOption((o) =>
+                    o
+                        .setName('prize')
+                        .setDescription('Prize description')
+                        .setRequired(true),
+                )
+                .addIntegerOption((o) =>
+                    o
+                        .setName('winners')
+                        .setDescription('Number of winners (default: 1)')
+                        .setMinValue(1)
+                        .setMaxValue(10)
+                        .setRequired(false),
+                ),
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName('end')
+                .setDescription('End a giveaway early')
+                .addStringOption((o) =>
+                    o
+                        .setName('message_id')
+                        .setDescription('Message ID of the giveaway')
+                        .setRequired(true),
+                ),
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName('reroll')
+                .setDescription('Pick new winner(s) from existing entries')
+                .addStringOption((o) =>
+                    o
+                        .setName('message_id')
+                        .setDescription('Message ID of the giveaway')
+                        .setRequired(true),
+                ),
+        )
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
+    category: 'general',
+    execute: async ({ interaction }) => {
+        if (!(await requireGuild(interaction))) return
+        if (!interaction.guild) return
+
+        const subcommand = interaction.options.getSubcommand()
+
+        try {
+            if (subcommand === 'start') {
+                const durationStr = interaction.options.getString('duration', true)
+                const prize = interaction.options.getString('prize', true)
+                const winnersCount = interaction.options.getInteger('winners') ?? 1
+
+                const durationMs = parseDuration(durationStr)
+                if (durationMs <= 0) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [
+                                createErrorEmbed(
+                                    'Invalid Duration',
+                                    'Please provide a valid duration (e.g., 1h, 30m, 2d)',
+                                ),
+                            ],
+                            ephemeral: true,
+                        },
+                    })
+                    return
+                }
+
+                const endTime = Date.now() + durationMs
+                const embed = new EmbedBuilder()
+                    .setTitle('🎉 GIVEAWAY 🎉')
+                    .setDescription(prize)
+                    .addFields(
+                        { name: 'Winners', value: `${winnersCount}`, inline: true },
+                        { name: 'Ends', value: `<t:${Math.floor(endTime / 1000)}:R>`, inline: true },
+                    )
+                    .setColor(0xffd700)
+                    .setFooter({ text: 'React with 🎉 to enter' })
+
+                if (!interaction.channel || !interaction.channel.isTextBased()) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [createErrorEmbed('Error', 'This channel is not text-based.')],
+                            ephemeral: true,
+                        },
+                    })
+                    return
+                }
+
+                const message = await (interaction.channel as TextChannel).send({ embeds: [embed] })
+                if (!message) return
+
+                await message.react('🎉')
+
+                const giveaway: GiveawayEntry = {
+                    messageId: message.id,
+                    channelId: interaction.channelId,
+                    guildId: interaction.guild.id,
+                    prize,
+                    winnersCount,
+                    endTime,
+                    entries: new Set(),
+                    timeoutId: setTimeout(() => {
+                        endGiveaway(message.id)
+                    }, durationMs),
+                }
+
+                activeGiveaways.set(message.id, giveaway)
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [
+                            createSuccessEmbed(
+                                'Giveaway Started',
+                                `Giveaway for **${prize}** has started! React with 🎉 to enter.\n[Jump to giveaway](${message.url})`,
+                            ),
+                        ],
+                    },
+                })
+            } else if (subcommand === 'end') {
+                const messageId = interaction.options.getString('message_id', true)
+
+                const giveaway = activeGiveaways.get(messageId)
+                if (!giveaway) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [createErrorEmbed('Not Found', 'Giveaway not found.')],
+                            ephemeral: true,
+                        },
+                    })
+                    return
+                }
+
+                await endGiveaway(messageId)
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [createSuccessEmbed('Giveaway Ended', 'Winners have been selected.')],
+                    },
+                })
+            } else if (subcommand === 'reroll') {
+                const messageId = interaction.options.getString('message_id', true)
+
+                const giveaway = activeGiveaways.get(messageId)
+                if (!giveaway) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [createErrorEmbed('Not Found', 'Giveaway not found.')],
+                            ephemeral: true,
+                        },
+                    })
+                    return
+                }
+
+                await endGiveaway(messageId, true)
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [createSuccessEmbed('Rerolled', 'New winners have been selected.')],
+                    },
+                })
+            }
+        } catch (error) {
+            errorLog({ message: 'Error in giveaway command:', error })
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createErrorEmbed(
+                            'Error',
+                            error instanceof Error ? error.message : 'An error occurred.',
+                        ),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        }
+    },
+})
+
+export { activeGiveaways, parseDuration }

--- a/packages/bot/src/functions/management/commands/autorole.spec.ts
+++ b/packages/bot/src/functions/management/commands/autorole.spec.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import autoroleCommand from './autorole'
+
+const interactionReplyMock = jest.fn()
+const createSuccessEmbedMock = jest.fn((title: string, description: string) => ({ type: 'success', title, description }))
+const createErrorEmbedMock = jest.fn((title: string, description: string) => ({ type: 'error', title, description }))
+const createInfoEmbedMock = jest.fn((title: string, description: string) => ({ type: 'info', title, description }))
+const buildListPageEmbedMock = jest.fn((items: unknown, page: unknown, config: unknown) => ({ type: 'listpage', items, page, config }))
+const requireGuildMock = jest.fn()
+const addMock = jest.fn()
+const removeMock = jest.fn()
+const listMock = jest.fn()
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createSuccessEmbed: (...args: unknown[]) => createSuccessEmbedMock(...args),
+    createErrorEmbed: (...args: unknown[]) => createErrorEmbedMock(...args),
+    createInfoEmbed: (...args: unknown[]) => createInfoEmbedMock(...args),
+}))
+
+jest.mock('../../../utils/general/responseEmbeds', () => ({
+    buildListPageEmbed: (...args: unknown[]) => buildListPageEmbedMock(...args),
+}))
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireGuild: (...args: unknown[]) => requireGuildMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    autoroleService: {
+        add: (...args: unknown[]) => addMock(...args),
+        remove: (...args: unknown[]) => removeMock(...args),
+        list: (...args: unknown[]) => listMock(...args),
+    },
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+}))
+
+function createInteraction(subcommand: string, opts: Record<string, unknown> = {}) {
+    return {
+        guild: { id: 'guild-1' },
+        options: {
+            getSubcommand: () => subcommand,
+            getRole: () => ({ id: 'role-1', toString: () => '<@&role-1>' }),
+            getInteger: () => opts.delay ?? 0,
+        },
+        channel: { send: jest.fn() },
+    }
+}
+
+describe('autorole command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        requireGuildMock.mockResolvedValue(true)
+    })
+
+    it('should be a valid command', () => {
+        expect(autoroleCommand.data.name).toBe('autorole')
+    })
+
+    it('should add an autorole with no delay', async () => {
+        addMock.mockResolvedValue({
+            id: '1',
+            guildId: 'guild-1',
+            roleId: 'role-1',
+            delayMinutes: 0,
+            createdAt: new Date(),
+        })
+
+        await autoroleCommand.execute({
+            interaction: createInteraction('add') as any,
+        })
+
+        expect(addMock).toHaveBeenCalledWith('guild-1', 'role-1', 0)
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+
+    it('should add an autorole with delay', async () => {
+        addMock.mockResolvedValue({
+            id: '1',
+            guildId: 'guild-1',
+            roleId: 'role-1',
+            delayMinutes: 30,
+            createdAt: new Date(),
+        })
+
+        const interaction = createInteraction('add', { delay: 30 })
+        interaction.options.getInteger = () => 30
+
+        await autoroleCommand.execute({
+            interaction: interaction as any,
+        })
+
+        expect(addMock).toHaveBeenCalledWith('guild-1', 'role-1', 30)
+    })
+
+    it('should remove an autorole', async () => {
+        removeMock.mockResolvedValue(undefined)
+
+        await autoroleCommand.execute({
+            interaction: createInteraction('remove') as any,
+        })
+
+        expect(removeMock).toHaveBeenCalledWith('guild-1', 'role-1')
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+
+    it('should list autoroles', async () => {
+        listMock.mockResolvedValue([
+            {
+                id: '1',
+                guildId: 'guild-1',
+                roleId: 'role-1',
+                delayMinutes: 0,
+                createdAt: new Date(),
+            },
+        ])
+
+        await autoroleCommand.execute({
+            interaction: createInteraction('list') as any,
+        })
+
+        expect(listMock).toHaveBeenCalledWith('guild-1')
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/functions/management/commands/autorole.ts
+++ b/packages/bot/src/functions/management/commands/autorole.ts
@@ -1,0 +1,146 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import { PermissionFlagsBits } from 'discord.js'
+import Command from '../../../models/Command'
+import { interactionReply } from '../../../utils/general/interactionReply'
+import { requireGuild } from '../../../utils/command/commandValidations'
+import { createSuccessEmbed, createErrorEmbed, createInfoEmbed } from '../../../utils/general/embeds'
+import { buildListPageEmbed } from '../../../utils/general/responseEmbeds'
+import { errorLog } from '@lucky/shared/utils'
+import { autoroleService } from '@lucky/shared/services'
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('autorole')
+        .setDescription('Manage automatic roles assigned on member join')
+        .addSubcommand((sub) =>
+            sub
+                .setName('add')
+                .setDescription('Add a role to auto-assign on member join')
+                .addRoleOption((o) =>
+                    o
+                        .setName('role')
+                        .setDescription('Role to auto-assign')
+                        .setRequired(true),
+                )
+                .addIntegerOption((o) =>
+                    o
+                        .setName('delay_minutes')
+                        .setDescription('Delay in minutes (0-1440, default: 0)')
+                        .setMinValue(0)
+                        .setMaxValue(1440)
+                        .setRequired(false),
+                ),
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName('remove')
+                .setDescription('Remove a role from auto-assignment')
+                .addRoleOption((o) =>
+                    o
+                        .setName('role')
+                        .setDescription('Role to remove from auto-assignment')
+                        .setRequired(true),
+                ),
+        )
+        .addSubcommand((sub) =>
+            sub.setName('list').setDescription('List all auto-assigned roles'),
+        )
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageRoles),
+    category: 'management',
+    execute: async ({ interaction }) => {
+        if (!(await requireGuild(interaction))) return
+        if (!interaction.guild) return
+
+        const subcommand = interaction.options.getSubcommand()
+
+        try {
+            if (subcommand === 'add') {
+                const role = interaction.options.getRole('role', true)
+                const delayMinutes = interaction.options.getInteger('delay_minutes') ?? 0
+
+                await autoroleService.add(interaction.guild.id, role.id, delayMinutes)
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [
+                            createSuccessEmbed(
+                                'AutoRole Added',
+                                `${role} will now be auto-assigned on member join${delayMinutes > 0 ? ` after ${delayMinutes} minutes` : ''}.`,
+                            ),
+                        ],
+                    },
+                })
+            } else if (subcommand === 'remove') {
+                const role = interaction.options.getRole('role', true)
+
+                await autoroleService.remove(interaction.guild.id, role.id)
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [
+                            createSuccessEmbed(
+                                'AutoRole Removed',
+                                `${role} will no longer be auto-assigned on member join.`,
+                            ),
+                        ],
+                    },
+                })
+            } else if (subcommand === 'list') {
+                const roles = await autoroleService.list(interaction.guild.id)
+
+                if (roles.length === 0) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [
+                                createInfoEmbed(
+                                    'AutoRoles',
+                                    'No auto-assigned roles configured for this server.',
+                                ),
+                            ],
+                        },
+                    })
+                    return
+                }
+
+                const items = roles.map((r) => ({
+                    name: `<@&${r.roleId}>`,
+                    value:
+                        r.delayMinutes > 0
+                            ? `Delay: ${r.delayMinutes} minute${r.delayMinutes > 1 ? 's' : ''}`
+                            : 'Assigned immediately',
+                    inline: false,
+                }))
+
+                const embed = buildListPageEmbed(items, 1, {
+                    title: 'Auto-Assigned Roles',
+                    emptyMessage: 'No auto-assigned roles configured.',
+                    itemsPerPage: 10,
+                })
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [embed],
+                    },
+                })
+            }
+        } catch (error) {
+            errorLog({ message: 'Error in autorole command:', error })
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createErrorEmbed(
+                            'Error',
+                            error instanceof Error ? error.message : 'An error occurred.',
+                        ),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        }
+    },
+})

--- a/packages/bot/src/handlers/memberHandler.ts
+++ b/packages/bot/src/handlers/memberHandler.ts
@@ -6,12 +6,54 @@ import {
     ChannelType,
     EmbedBuilder,
 } from 'discord.js'
-import { autoMessageService } from '@lucky/shared/services'
+import { autoMessageService, autoroleService } from '@lucky/shared/services'
 import { featureToggleService } from '@lucky/shared/services'
 import { errorLog, debugLog } from '@lucky/shared/utils'
 
 async function handleMemberAdd(member: GuildMember): Promise<void> {
     if (!member.guild) return
+
+    try {
+        // Assign auto-roles
+        const autoroles = await autoroleService.list(member.guild.id)
+        for (const autorole of autoroles) {
+            const role = member.guild.roles.cache.get(autorole.roleId)
+            if (!role) continue
+
+            if (autorole.delayMinutes > 0) {
+                setTimeout(async () => {
+                    try {
+                        await member.roles.add(role)
+                        debugLog({
+                            message: `Auto-assigned role ${role.name} to ${member.user.tag} after ${autorole.delayMinutes}m delay`,
+                        })
+                    } catch (error) {
+                        errorLog({
+                            message: `Failed to assign auto-role ${role.name} to ${member.user.tag}:`,
+                            error,
+                        })
+                    }
+                }, autorole.delayMinutes * 60 * 1000)
+            } else {
+                try {
+                    await member.roles.add(role)
+                    debugLog({
+                        message: `Auto-assigned role ${role.name} to ${member.user.tag}`,
+                    })
+                } catch (error) {
+                    errorLog({
+                        message: `Failed to assign auto-role ${role.name} to ${member.user.tag}:`,
+                        error,
+                    })
+                }
+            }
+        }
+    } catch (error) {
+        errorLog({
+            message: 'Error assigning auto-roles:',
+            error,
+        })
+    }
 
     const isEnabled = await featureToggleService.isEnabled('WELCOME_MESSAGES', {
         guildId: member.guild.id,

--- a/packages/bot/src/handlers/reactionHandler.ts
+++ b/packages/bot/src/handlers/reactionHandler.ts
@@ -9,6 +9,22 @@ import {
 } from 'discord.js'
 import { starboardService } from '@lucky/shared/services'
 import { errorLog } from '@lucky/shared/utils'
+import { activeGiveaways } from '../functions/general/commands/giveaway'
+
+async function handleGiveawayReaction(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+): Promise<void> {
+    if (user.bot) return
+    if (user.partial) await user.fetch()
+
+    const giveaway = activeGiveaways.get(reaction.message.id)
+    if (!giveaway) return
+
+    if (reaction.emoji.name === '🎉') {
+        giveaway.entries.add(user.id)
+    }
+}
 
 async function handleStarboardReaction(
     reaction: MessageReaction | PartialMessageReaction,
@@ -81,6 +97,7 @@ export function handleReactionEvents(client: Client): void {
             user: User | PartialUser,
         ) => {
             try {
+                await handleGiveawayReaction(reaction, user)
                 await handleStarboardReaction(reaction, user, client)
             } catch (error) {
                 errorLog({ message: 'Error handling reaction:', error })

--- a/packages/shared/src/services/AutoRoleService.ts
+++ b/packages/shared/src/services/AutoRoleService.ts
@@ -1,0 +1,40 @@
+import { getPrismaClient } from '../utils/database/prismaClient.js'
+
+const prisma = getPrismaClient()
+
+export type AutoRoleEntry = {
+    id: string
+    guildId: string
+    roleId: string
+    delayMinutes: number
+    createdAt: Date
+}
+
+export class AutoRoleService {
+    async add(guildId: string, roleId: string, delayMinutes = 0): Promise<AutoRoleEntry> {
+        return await prisma.autoRole.upsert({
+            where: { guildId_roleId: { guildId, roleId } },
+            create: { guildId, roleId, delayMinutes },
+            update: { delayMinutes },
+        })
+    }
+
+    async remove(guildId: string, roleId: string): Promise<void> {
+        await prisma.autoRole.deleteMany({
+            where: { guildId, roleId },
+        })
+    }
+
+    async list(guildId: string): Promise<AutoRoleEntry[]> {
+        return await prisma.autoRole.findMany({
+            where: { guildId },
+            orderBy: { createdAt: 'asc' },
+        })
+    }
+
+    async getAllForGuild(guildId: string): Promise<AutoRoleEntry[]> {
+        return await this.list(guildId)
+    }
+}
+
+export const autoroleService = new AutoRoleService()

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -58,3 +58,4 @@ export {
 export { redisClient } from './redis/index.js'
 export { starboardService, type StarboardConfig, type StarboardEntry } from './StarboardService.js'
 export { levelService, type LevelConfig, type MemberXP, type LevelReward, xpNeededForLevel } from './LevelService.js'
+export { autoroleService, type AutoRoleEntry } from './AutoRoleService.js'

--- a/prisma/migrations/20260410000000_add_auto_roles/migration.sql
+++ b/prisma/migrations/20260410000000_add_auto_roles/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "auto_roles" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "roleId" TEXT NOT NULL,
+    "delayMinutes" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "auto_roles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auto_roles_guildId_roleId_key" ON "auto_roles"("guildId", "roleId");
+
+-- CreateIndex
+CREATE INDEX "auto_roles_guildId_idx" ON "auto_roles"("guildId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -627,3 +627,15 @@ model LiveBoard {
 
   @@map("live_boards")
 }
+
+model AutoRole {
+  id           String   @id @default(cuid())
+  guildId      String
+  roleId       String
+  delayMinutes Int      @default(0)
+  createdAt    DateTime @default(now())
+
+  @@unique([guildId, roleId])
+  @@index([guildId])
+  @@map("auto_roles")
+}


### PR DESCRIPTION
## Summary
- `/autorole add|remove|list` — auto-assign roles on member join with optional delay (0-1440 min), backed by new `AutoRole` Prisma model
- `/giveaway start|end|reroll` — in-memory giveaways with duration parsing (1h/30m/2d/1h30m), 🎉 reaction entry, winner selection
- `memberHandler` updated to assign autoroles on join
- `reactionHandler` updated to track giveaway entries

## Test plan
- [ ] 5 autorole tests pass
- [ ] 10 giveaway tests pass (incl. duration parsing edge cases)
- [ ] TypeScript build clean
- [ ] SonarCloud quality gate passes (coverage ≥80%, duplication ≤3%)