### PR TITLE
chore(release): v2.6.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.71] - 2026-04-10
+
+### Added
+
+- **`/playtop <query>`** — queue a track at the front (plays next after current)
+- **`/playskip <query>`** — queue a track at the front and immediately skip the current track
+- **`/skipto <position>`** — skip all tracks before the given queue position
+- **`/seek <time>`** — seek to a position in the current track (`mm:ss` or raw seconds)
+- **`/replay`** — restart the current track from the beginning
+- **`/leavecleanup`** — remove all queued tracks requested by users who have left the voice channel
+- **`/nowplaying`** — alias for `/songinfo`; shows current track with rich embed
+- **`/effects bassboost <0-5>`** — apply bass boost via FFmpeg filter (levels map to `bassboost_low` → `bassboost_high`)
+- **`/effects nightcore`** — apply nightcore (speed + pitch up) FFmpeg filter
+- **`/effects reset`** — remove all active audio effects
+- **`/volume`** range extended to 1–200 (was 1–100)
+- **`/pause`** now toggles (pauses if playing, resumes if paused); `/resume` removed
+- **`/play`** optional `provider` parameter: `spotify` (default) | `youtube` | `soundcloud`
+- **`/purge <amount> [user] [contains]`** — bulk delete 1–100 messages; optional user and content filters
+- **`/lockdown [reason]`** — toggle `SendMessages` permission for `@everyone` in the current channel
+- **`/slowmode <seconds>`** — set channel slowmode (0 = off, max 21600s / 6h)
+- **`/autorole add <role> [delay_minutes]`** — assign a role to all new members on join, with optional delay up to 1440 minutes
+- **`/autorole remove <role>`** — remove a configured autorole
+- **`/autorole list`** — display all configured autoroles for the guild
+- **`/giveaway start <duration> <prize> [winners]`** — start a giveaway with 🎉 button entry; duration in `1h`/`30m`/`2d` format
+- **`/giveaway end <message_id>`** — end a giveaway early and pick winners
+- **`/giveaway reroll <message_id>`** — reroll winners for a completed giveaway
+- **Autoplay default ON** — guilds with no stored preference now default to autoplay enabled on new queues
+- **Cross-session autoplay deduplication** — `replenishQueue` fetches the last 20 played tracks from persistent history and excludes them from autoplay candidates, preventing recently-played songs from cycling back cross-session
+
 ## [2.6.70] - 2026-04-10
 
 ### Fixed

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # Lucky Implementation Status
 
-**Last Updated:** 2026-04-07  
-**Current Version:** v2.6.64
+**Last Updated:** 2026-04-10  
+**Current Version:** v2.6.71
 
 This document reflects what is currently shipped and running in production.
 
@@ -19,7 +19,7 @@ This document reflects what is currently shipped and running in production.
 
 ### Bot Commands
 
-#### Music (`/play`, `/queue`, `/skip`, `/stop`, `/pause`, `/resume`, `/volume`, etc.)
+#### Music (`/play`, `/queue`, `/skip`, `/stop`, `/pause`, `/volume`, etc.)
 
 - Full playback lifecycle with Discord Player v7
 - Queue management: `/queue show`, `/queue clear`, `/queue remove`, `/queue move`
@@ -27,8 +27,21 @@ This document reflects what is currently shipped and running in production.
 - `/queue smartshuffle` — energy-aware shuffle ordered by source/duration energy score, interleaved high/low buckets, per-requester streak limit (v2.6.24)
 - `/queue rescue` — probe-based detection and removal of unresolvable tracks (v2.6.20)
 - `/lyrics` — paginated lyrics via lyrics.ovh with smart query cleaning (v2.6.60)
-- `/repeat`, `/autoplay` — repeat mode and autoplay toggle; autoplay preference persists across sessions (v2.6.61)
+- `/repeat`, `/autoplay` — repeat mode and autoplay toggle; autoplay preference persists across sessions; **default ON** for new guilds (v2.6.61, v2.6.71)
 - `/session save|restore|list|delete <name>` — named queue snapshots, up to 10 per guild, 30-day TTL, autocomplete on restore/delete (v2.6.63)
+- **`/playtop <query>`** — queue a track at position 1, plays next after current (v2.6.71)
+- **`/playskip <query>`** — queue at front and immediately skip current track (v2.6.71)
+- **`/skipto <position>`** — skip all tracks before the given queue position (v2.6.71)
+- **`/seek <time>`** — seek to `mm:ss` or raw seconds in current track (v2.6.71)
+- **`/replay`** — restart current track from the beginning (v2.6.71)
+- **`/leavecleanup`** — remove queued tracks from users who left the voice channel (v2.6.71)
+- **`/nowplaying`** — alias for `/songinfo`; shows current track rich embed (v2.6.71)
+- **`/volume`** — range extended to 1–200 (v2.6.71)
+- **`/pause`** — now toggles pause/resume; `/resume` removed (v2.6.71)
+- **`/play`** — optional `provider` parameter: `spotify` (default) | `youtube` | `soundcloud` (v2.6.71)
+- **`/effects bassboost <0-5>`** — bass boost via FFmpeg filter; levels map to `bassboost_low/bassboost/bassboost_high` (v2.6.71)
+- **`/effects nightcore`** — speed + pitch up FFmpeg filter (v2.6.71)
+- **`/effects reset`** — remove all active audio effects (v2.6.71)
 
 #### Music Intelligence
 
@@ -52,6 +65,9 @@ This document reflects what is currently shipped and running in production.
 - Full case management with case number tracking, DM notifications, evidence logging
 - **`/digest view`** — moderation activity digest with period-filtered stats and top 5 moderators (7d/30d/90d); date-bounded `getCasesSince` query backed by a composite index (v2.6.24, accuracy fix v2.6.64)
 - **`/digest schedule|unschedule`** — weekly automated digest posts to a chosen text channel; Redis-backed config, hourly in-process scheduler with single-flight guard, per-guild error isolation, env-validated interval/period, startup decoupled from the ready handler (v2.6.64)
+- **`/purge <amount> [user] [contains]`** — bulk delete 1–100 messages; optional user and content filters; respects Discord's 14-day message age limit (v2.6.71)
+- **`/lockdown [reason]`** — toggle `SendMessages` permission for `@everyone`; second invocation unlocks; requires `ManageChannels` (v2.6.71)
+- **`/slowmode <seconds>`** — set channel slowmode 0–21600s (6h); 0 disables; requires `ManageChannels` (v2.6.71)
 
 #### Auto-Moderation (`/automod`)
 
@@ -65,6 +81,15 @@ This document reflects what is currently shipped and running in production.
 - Embed builder (`/embed`), custom commands (`/customcommand`), auto-messages (`/automessage`)
 - Server logs (`/serverlog`), guild automation (RBAC-aware role assignment)
 - Reaction roles (`/reactionrole`)
+- **`/autorole add <role> [delay_minutes]`** — assign a role to new members on join; optional delay up to 1440 minutes (v2.6.71)
+- **`/autorole remove <role>`** — remove a configured autorole (v2.6.71)
+- **`/autorole list`** — list all configured autoroles for the guild (v2.6.71)
+
+#### Engagement
+
+- **`/giveaway start <duration> <prize> [winners]`** — giveaway with 🎉 button entry; duration in `1h`/`30m`/`2d` format; auto-picks winners on end (v2.6.71)
+- **`/giveaway end <message_id>`** — end a giveaway early and pick winners (v2.6.71)
+- **`/giveaway reroll <message_id>`** — reroll winners for a completed giveaway (v2.6.71)
 
 #### Download
 
@@ -123,6 +148,10 @@ This document reflects what is currently shipped and running in production.
 | Area                    | Description                                                                                      | Complexity |
 | ----------------------- | ------------------------------------------------------------------------------------------------ | ---------- |
 | Collaborative playlists | Shared curation surface (`/playlist`) on top of the existing per-user contribution limit service | L          |
+| DJ role restriction     | `/djrole set/clear/show` — restrict music commands to a configured role per guild                | M          |
+| Auto-disconnect         | Leave voice channel after configurable idle timeout (default 5 min)                              | M          |
+| Vote skip               | `/voteskip` — democratic skip requiring configurable % of voice members                          | M          |
+| Queue history view      | `/history` — paginated view of recently played tracks (leverages existing trackHistoryService)   | S          |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.70",
+    "version": "2.6.71",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.70",
+    "version": "2.6.71",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.70",
+    "version": "2.6.71",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.70",
+    "version": "2.6.71",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.70",
+    "version": "2.6.71",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump all packages `2.6.70 → 2.6.71`
- CHANGELOG: document all features from PRs #520–#526
- IMPLEMENTATION_STATUS: sync to v2.6.71 (was stale at v2.6.64)

### New commands documented
**Music**: `/playtop`, `/playskip`, `/skipto`, `/seek`, `/replay`, `/leavecleanup`, `/nowplaying` (alias), `/effects` (bassboost/nightcore/reset), `/volume` 1–200, `/pause` toggle, `/play` provider param, autoplay default-on + cross-session dedup

**Moderation**: `/purge`, `/lockdown`, `/slowmode`

**Management**: `/autorole` (add/remove/list), `/giveaway` (start/end/reroll)

## Test plan
- [ ] CI green (no code changes, version + docs only)