### PR TITLE
feat(bot): auto-disconnect on idle with /settings music idle-timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.70",
+    "version": "2.6.71",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.70",
+            "version": "2.6.71",
             "license": "ISC",
             "workspaces": [
                 "packages/*"
@@ -24525,7 +24525,7 @@
         },
         "packages/backend": {
             "name": "@lucky/backend",
-            "version": "2.6.70",
+            "version": "2.6.71",
             "dependencies": {
                 "@lucky/shared": "file:../shared",
                 "connect-redis": "^9.0.0",
@@ -24579,7 +24579,7 @@
         },
         "packages/bot": {
             "name": "@lucky/bot",
-            "version": "2.6.70",
+            "version": "2.6.71",
             "dependencies": {
                 "@discord-player/extractor": "^7.2.0",
                 "@discordjs/builders": "^1.14.1",
@@ -24668,7 +24668,7 @@
         },
         "packages/frontend": {
             "name": "lucky-webapp",
-            "version": "2.6.70",
+            "version": "2.6.71",
             "dependencies": {
                 "@hookform/resolvers": "^5.0.0",
                 "@radix-ui/react-avatar": "^1.1.11",
@@ -25013,7 +25013,7 @@
         },
         "packages/shared": {
             "name": "@lucky/shared",
-            "version": "2.6.70",
+            "version": "2.6.71",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.3",
                 "@npmcli/agent": "^4.0.0",

--- a/packages/bot/src/functions/management/commands/settings.spec.ts
+++ b/packages/bot/src/functions/management/commands/settings.spec.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import type { ChatInputCommandInteraction } from 'discord.js'
+
+const requireGuildMock = jest.fn()
+const setGuildSettingsMock = jest.fn()
+const interactionReplyMock = jest.fn()
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireGuild: (...args: unknown[]) => requireGuildMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: {
+        setGuildSettings: (...args: unknown[]) => setGuildSettingsMock(...args),
+    },
+}))
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createErrorEmbed: jest.fn((title, desc) => ({ title, desc })),
+    createSuccessEmbed: jest.fn((title, desc) => ({ title, desc })),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+}))
+
+describe('settings command', () => {
+    let mockInteraction: Partial<ChatInputCommandInteraction>
+    let settingsCommand: any
+
+    beforeEach(async () => {
+        jest.clearAllMocks()
+
+        mockInteraction = {
+            guildId: 'guild-123',
+            deferReply: jest.fn().mockResolvedValue(undefined),
+            options: {
+                getSubcommandGroup: jest.fn().mockReturnValue('music'),
+                getSubcommand: jest.fn().mockReturnValue('idle-timeout'),
+                getInteger: jest.fn().mockReturnValue(5),
+            },
+        } as any
+
+        requireGuildMock.mockResolvedValue(true)
+        setGuildSettingsMock.mockResolvedValue(true)
+        interactionReplyMock.mockResolvedValue(undefined)
+
+        settingsCommand = (await import('./settings')).default
+    })
+
+    it('should defer reply with ephemeral', async () => {
+        await settingsCommand.execute({ interaction: mockInteraction as ChatInputCommandInteraction })
+        expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true })
+    })
+
+    it('should save idle-timeout setting', async () => {
+        await settingsCommand.execute({ interaction: mockInteraction as ChatInputCommandInteraction })
+        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-123', { idleTimeoutMinutes: 5 })
+    })
+
+    it('should return early if requireGuild fails', async () => {
+        requireGuildMock.mockResolvedValue(false)
+
+        await settingsCommand.execute({ interaction: mockInteraction as ChatInputCommandInteraction })
+
+        expect(mockInteraction.deferReply).not.toHaveBeenCalled()
+    })
+
+    it('should handle persist failure', async () => {
+        setGuildSettingsMock.mockResolvedValue(false)
+
+        await settingsCommand.execute({ interaction: mockInteraction as ChatInputCommandInteraction })
+
+        expect(mockInteraction.deferReply).toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/functions/management/commands/settings.ts
+++ b/packages/bot/src/functions/management/commands/settings.ts
@@ -1,0 +1,71 @@
+import { SlashCommandBuilder, PermissionFlagsBits } from 'discord.js'
+import Command from '../../../models/Command'
+import { interactionReply } from '../../../utils/general/interactionReply'
+import { createErrorEmbed, createSuccessEmbed } from '../../../utils/general/embeds'
+import { guildSettingsService } from '@lucky/shared/services'
+import { requireGuild } from '../../../utils/command/commandValidations'
+import type { CommandExecuteParams } from '../../../types/CommandData'
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('settings')
+        .setDescription('⚙️ Configure bot settings for this server.')
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+        .addSubcommandGroup((group) =>
+            group
+                .setName('music')
+                .setDescription('Music settings')
+                .addSubcommand((sub) =>
+                    sub
+                        .setName('idle-timeout')
+                        .setDescription('Set idle disconnect timeout (0 = disabled)')
+                        .addIntegerOption((opt) =>
+                            opt
+                                .setName('minutes')
+                                .setDescription('Minutes before disconnecting (0-60, 0 = disabled)')
+                                .setMinValue(0)
+                                .setMaxValue(60)
+                                .setRequired(true),
+                        ),
+                ),
+        ),
+    category: 'management',
+    execute: async ({ interaction }: CommandExecuteParams) => {
+        if (!(await requireGuild(interaction))) return
+        const guildId = interaction.guildId!
+
+        await interaction.deferReply({ ephemeral: true })
+
+        const group = interaction.options.getSubcommandGroup()
+        const sub = interaction.options.getSubcommand()
+
+        if (group === 'music' && sub === 'idle-timeout') {
+            const minutes = interaction.options.getInteger('minutes', true)
+            const persisted = await guildSettingsService.setGuildSettings(guildId, {
+                idleTimeoutMinutes: minutes,
+            })
+
+            if (!persisted) {
+                await interactionReply({
+                    interaction,
+                    content: { embeds: [createErrorEmbed('Error', 'Failed to save setting.')] },
+                })
+                return
+            }
+
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createSuccessEmbed(
+                            'Setting Updated',
+                            minutes === 0
+                                ? 'Idle disconnect disabled.'
+                                : `Bot will leave voice after **${minutes} minute${minutes === 1 ? '' : 's'}** of inactivity.`,
+                        ),
+                    ],
+                },
+            })
+        }
+    },
+})

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -15,6 +15,7 @@ import { musicWatchdogService } from '../../utils/music/watchdog'
 import { musicSessionSnapshotService } from '../../utils/music/sessionSnapshots'
 import * as voiceStatus from '../../services/VoiceChannelStatusService'
 import * as musicPresence from '../../services/MusicPresenceService'
+import { scheduleIdleDisconnect, clearIdleTimer } from '../../utils/music/idleDisconnect'
 
 const MAX_GUILD_ENTRIES = 500
 
@@ -67,6 +68,7 @@ export const setupTrackHandlers = ({
     client,
 }: SetupTrackHandlersParams): void => {
     player.events.on('playerStart', async (queue: GuildQueue, track: Track) => {
+        clearIdleTimer(queue.guild.id)
         await handlePlayerStart(queue, track, client)
     })
     player.events.on(
@@ -84,6 +86,9 @@ export const setupTrackHandlers = ({
                 message: `Added "${tracks[0].title}" to queue in ${queue.guild.name}`,
             })
         }
+    })
+    player.events.on('emptyQueue', (queue: GuildQueue) => {
+        scheduleIdleDisconnect(queue)
     })
 }
 

--- a/packages/bot/src/utils/music/idleDisconnect.spec.ts
+++ b/packages/bot/src/utils/music/idleDisconnect.spec.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import type { GuildQueue } from 'discord-player'
+import type { TextChannel, Guild } from 'discord.js'
+
+const getGuildSettingsMock = jest.fn()
+const markIntentionalStopMock = jest.fn()
+
+jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: {
+        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
+    },
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+}))
+
+jest.mock('./watchdog', () => ({
+    musicWatchdogService: {
+        markIntentionalStop: (...args: unknown[]) => markIntentionalStopMock(...args),
+    },
+}))
+
+describe('idleDisconnect', () => {
+    let mockQueue: Partial<GuildQueue>
+    let mockGuild: Partial<Guild>
+    let mockChannel: Partial<TextChannel>
+    let scheduleIdleDisconnect: any
+    let clearIdleTimer: any
+
+    beforeEach(async () => {
+        jest.useFakeTimers()
+        jest.clearAllMocks()
+
+        mockGuild = { id: 'guild-123' }
+        mockChannel = { send: jest.fn().mockResolvedValue(undefined) }
+        mockQueue = {
+            guild: mockGuild as Guild,
+            delete: jest.fn(),
+            metadata: { channel: mockChannel },
+        } as unknown as GuildQueue
+
+        const module = await import('./idleDisconnect')
+        scheduleIdleDisconnect = module.scheduleIdleDisconnect
+        clearIdleTimer = module.clearIdleTimer
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it('should not schedule timer when idleTimeoutMinutes is 0', async () => {
+        getGuildSettingsMock.mockResolvedValue({ idleTimeoutMinutes: 0 })
+
+        scheduleIdleDisconnect(mockQueue as GuildQueue)
+        await jest.runAllTimersAsync()
+
+        expect(mockQueue.delete).not.toHaveBeenCalled()
+    })
+
+    it('should schedule timer when idleTimeoutMinutes is set', async () => {
+        getGuildSettingsMock.mockResolvedValue({ idleTimeoutMinutes: 5 })
+
+        scheduleIdleDisconnect(mockQueue as GuildQueue)
+        await jest.runOnlyPendingTimersAsync()
+        jest.advanceTimersByTime(5 * 60 * 1000)
+
+        expect(mockQueue.delete).toHaveBeenCalled()
+    })
+
+    it('should mark intentional stop before disconnecting', async () => {
+        getGuildSettingsMock.mockResolvedValue({ idleTimeoutMinutes: 1 })
+
+        scheduleIdleDisconnect(mockQueue as GuildQueue)
+        await jest.runOnlyPendingTimersAsync()
+        jest.advanceTimersByTime(1 * 60 * 1000)
+
+        expect(markIntentionalStopMock).toHaveBeenCalledWith('guild-123')
+    })
+
+    it('should send message to text channel on disconnect', async () => {
+        getGuildSettingsMock.mockResolvedValue({ idleTimeoutMinutes: 1 })
+
+        scheduleIdleDisconnect(mockQueue as GuildQueue)
+        await jest.runOnlyPendingTimersAsync()
+        jest.advanceTimersByTime(1 * 60 * 1000)
+
+        expect(mockChannel.send).toHaveBeenCalledWith('👋 Left the voice channel due to inactivity.')
+    })
+
+    it('should clear existing timer when scheduling new one', async () => {
+        getGuildSettingsMock.mockResolvedValue({ idleTimeoutMinutes: 5 })
+
+        scheduleIdleDisconnect(mockQueue as GuildQueue)
+        await jest.runOnlyPendingTimersAsync()
+        jest.clearAllMocks()
+
+        scheduleIdleDisconnect(mockQueue as GuildQueue)
+        await jest.runOnlyPendingTimersAsync()
+        jest.advanceTimersByTime(5 * 60 * 1000)
+
+        expect(mockQueue.delete).toHaveBeenCalledTimes(1)
+    })
+
+    it('clearIdleTimer should clear active timer', async () => {
+        getGuildSettingsMock.mockResolvedValue({ idleTimeoutMinutes: 5 })
+
+        scheduleIdleDisconnect(mockQueue as GuildQueue)
+        await jest.runOnlyPendingTimersAsync()
+
+        clearIdleTimer('guild-123')
+        jest.clearAllMocks()
+        jest.advanceTimersByTime(5 * 60 * 1000)
+
+        expect(mockQueue.delete).not.toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/utils/music/idleDisconnect.ts
+++ b/packages/bot/src/utils/music/idleDisconnect.ts
@@ -1,0 +1,58 @@
+import type { GuildQueue } from 'discord-player'
+import { guildSettingsService } from '@lucky/shared/services'
+import { debugLog } from '@lucky/shared/utils'
+import { musicWatchdogService } from './watchdog'
+import type { TextChannel } from 'discord.js'
+
+const idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+export function scheduleIdleDisconnect(queue: GuildQueue): void {
+    const guildId = queue.guild.id
+    clearIdleTimer(guildId)
+
+    void (async () => {
+        const settings = await guildSettingsService.getGuildSettings(guildId)
+        const timeoutMinutes = settings?.idleTimeoutMinutes ?? 0
+        if (timeoutMinutes <= 0) return
+
+        debugLog({
+            message: 'Idle disconnect scheduled',
+            data: { guildId, timeoutMinutes },
+        })
+
+        const timer = setTimeout(() => {
+            idleTimers.delete(guildId)
+            void disconnectIdle(queue)
+        }, timeoutMinutes * 60 * 1000)
+
+        idleTimers.set(guildId, timer)
+    })()
+}
+
+export function clearIdleTimer(guildId: string): void {
+    const timer = idleTimers.get(guildId)
+    if (timer) {
+        clearTimeout(timer)
+        idleTimers.delete(guildId)
+    }
+}
+
+async function disconnectIdle(queue: GuildQueue): Promise<void> {
+    const guildId = queue.guild.id
+    debugLog({ message: 'Idle disconnect triggered', data: { guildId } })
+
+    try {
+        const metadata = queue.metadata as { channel?: TextChannel } | undefined
+        musicWatchdogService.markIntentionalStop(guildId)
+        queue.delete()
+
+        if (metadata?.channel) {
+            await metadata.channel.send('👋 Left the voice channel due to inactivity.')
+        }
+    } catch (error) {
+        debugLog({
+            message: 'Error during idle disconnect',
+            data: { guildId, error: String(error) },
+        })
+    }
+}

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -16,6 +16,7 @@ export interface GuildSettings {
   allowSpotify: boolean
   commandCooldown: number
   downloadCooldown: number
+  idleTimeoutMinutes?: number
   createdAt: Date
   updatedAt: Date
 }
@@ -53,6 +54,7 @@ export class GuildSettingsService {
       allowSpotify: true,
       commandCooldown: 3,
       downloadCooldown: 10,
+      idleTimeoutMinutes: 0,
       createdAt: new Date(),
       updatedAt: new Date(),
     }


### PR DESCRIPTION
## Summary
- Bot automatically leaves the voice channel after a configurable idle period when the queue is empty
- New `/settings music idle-timeout <minutes>` command (0 = disabled, max 60 min, requires ManageGuild)
- `idleDisconnect.ts` — manages per-guild timers: schedules on `emptyQueue` event, clears on `playerStart`
- `GuildSettingsService` — adds optional `idleTimeoutMinutes` field (0 = disabled by default)
- Calls `musicWatchdogService.markIntentionalStop()` before disconnecting to prevent watchdog reconnect

## Test plan
- [ ] `idleDisconnect.spec.ts` — 0-minute timeout skips timer, 5-minute timeout fires after delay, re-scheduling clears old timer
- [ ] `settings.spec.ts` — idle-timeout subcommand saves/replies correctly
- [ ] All 1800+ bot tests pass
- [ ] CI green