### PR TITLE
feat: DJ role restriction for music commands

### DIFF
--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -7,6 +7,7 @@ const QueueRepeatMode = {
 } as const
 
 const requireGuildMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const interactionReplyMock = jest.fn()
 const createEmbedMock = jest.fn((payload: unknown) => payload)
 const createErrorEmbedMock = jest.fn((title: string, desc: string) => ({
@@ -23,6 +24,7 @@ const setGuildSettingsMock = jest.fn()
 
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireGuild: (...args: unknown[]) => requireGuildMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('discord-player', () => ({
@@ -109,6 +111,7 @@ describe('autoplay command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireGuildMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         getGuildSettingsMock.mockResolvedValue(null)
         setGuildSettingsMock.mockResolvedValue(true)
         resolveGuildQueueMock.mockReturnValue({

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -10,7 +10,7 @@ import {
 import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
 import { guildSettingsService } from '@lucky/shared/services'
 import { QueueRepeatMode, type GuildQueue } from 'discord-player'
-import { requireGuild } from '../../../utils/command/commandValidations'
+import { requireGuild, requireDJRole } from '../../../utils/command/commandValidations'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import { messages } from '../../../utils/general/messages'
 import type { ColorResolvable, ChatInputCommandInteraction } from 'discord.js'
@@ -195,6 +195,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireGuild(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const guildId = interaction.guildId
         if (!guildId) return

--- a/packages/bot/src/functions/music/commands/djrole.spec.ts
+++ b/packages/bot/src/functions/music/commands/djrole.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+const requireGuildMock = jest.fn()
+const interactionReplyMock = jest.fn()
+const createSuccessEmbedMock = jest.fn((title: string, desc?: string) => ({ title, description: desc }))
+const createErrorEmbedMock = jest.fn((title: string, desc?: string) => ({ title, description: desc }))
+const createEmbedMock = jest.fn((opts: Record<string, unknown>) => opts)
+const setGuildSettingsMock = jest.fn()
+const getGuildSettingsMock = jest.fn()
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireGuild: (...args: unknown[]) => requireGuildMock(...args),
+}))
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createSuccessEmbed: (...args: unknown[]) => createSuccessEmbedMock(...args),
+    createErrorEmbed: (...args: unknown[]) => createErrorEmbedMock(...args),
+    createEmbed: (...args: unknown[]) => createEmbedMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: {
+        setGuildSettings: (...args: unknown[]) => setGuildSettingsMock(...args),
+        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
+    },
+}))
+
+import djroleCommand from './djrole'
+
+function createInteraction(sub: string, overrides: Record<string, unknown> = {}) {
+    return {
+        guildId: 'guild-1',
+        user: { id: 'user-1' },
+        deferReply: jest.fn().mockResolvedValue(undefined),
+        options: {
+            getSubcommand: jest.fn().mockReturnValue(sub),
+            getRole: jest.fn().mockReturnValue({ id: 'role-1', name: 'DJ' }),
+        },
+        ...overrides,
+    } as any
+}
+
+describe('djrole command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        requireGuildMock.mockResolvedValue(true)
+        setGuildSettingsMock.mockResolvedValue(true)
+        getGuildSettingsMock.mockResolvedValue(null)
+    })
+
+    it('has correct name and category', () => {
+        expect(djroleCommand.data.name).toBe('djrole')
+        expect(djroleCommand.category).toBe('music')
+    })
+
+    it('returns early when requireGuild fails', async () => {
+        requireGuildMock.mockResolvedValue(false)
+        const interaction = createInteraction('set')
+        await djroleCommand.execute({ client: {}, interaction } as any)
+        expect(interaction.deferReply).not.toHaveBeenCalled()
+    })
+
+    describe('set subcommand', () => {
+        it('saves djRoleId and replies with success embed', async () => {
+            const interaction = createInteraction('set')
+            await djroleCommand.execute({ client: {}, interaction } as any)
+            expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', { djRoleId: 'role-1' })
+            expect(createSuccessEmbedMock).toHaveBeenCalledWith('🎧 DJ Role Set', expect.stringContaining('role-1'))
+        })
+
+        it('replies with error when persist fails', async () => {
+            setGuildSettingsMock.mockResolvedValue(false)
+            const interaction = createInteraction('set')
+            await djroleCommand.execute({ client: {}, interaction } as any)
+            expect(createErrorEmbedMock).toHaveBeenCalledWith('Error', expect.any(String))
+        })
+    })
+
+    describe('clear subcommand', () => {
+        it('clears djRoleId and replies with success embed', async () => {
+            const interaction = createInteraction('clear')
+            await djroleCommand.execute({ client: {}, interaction } as any)
+            expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', { djRoleId: undefined })
+            expect(createSuccessEmbedMock).toHaveBeenCalledWith('🎧 DJ Role Cleared', expect.any(String))
+        })
+
+        it('replies with error when persist fails', async () => {
+            setGuildSettingsMock.mockResolvedValue(false)
+            const interaction = createInteraction('clear')
+            await djroleCommand.execute({ client: {}, interaction } as any)
+            expect(createErrorEmbedMock).toHaveBeenCalledWith('Error', expect.any(String))
+        })
+    })
+
+    describe('show subcommand', () => {
+        it('shows configured DJ role when set', async () => {
+            getGuildSettingsMock.mockResolvedValue({ djRoleId: 'role-99' })
+            const interaction = createInteraction('show')
+            await djroleCommand.execute({ client: {}, interaction } as any)
+            expect(createEmbedMock).toHaveBeenCalledWith(
+                expect.objectContaining({ description: expect.stringContaining('role-99') }),
+            )
+        })
+
+        it('shows "no DJ role" when not configured', async () => {
+            getGuildSettingsMock.mockResolvedValue(null)
+            const interaction = createInteraction('show')
+            await djroleCommand.execute({ client: {}, interaction } as any)
+            expect(createEmbedMock).toHaveBeenCalledWith(
+                expect.objectContaining({ description: expect.stringContaining('open to everyone') }),
+            )
+        })
+    })
+})

--- a/packages/bot/src/functions/music/commands/djrole.ts
+++ b/packages/bot/src/functions/music/commands/djrole.ts
@@ -1,0 +1,119 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import Command from '../../../models/Command'
+import { interactionReply } from '../../../utils/general/interactionReply'
+import {
+    createEmbed,
+    createErrorEmbed,
+    createSuccessEmbed,
+} from '../../../utils/general/embeds'
+import { guildSettingsService } from '@lucky/shared/services'
+import { requireGuild } from '../../../utils/command/commandValidations'
+import type { CommandExecuteParams } from '../../../types/CommandData'
+import { PermissionFlagsBits } from 'discord.js'
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('djrole')
+        .setDescription('🎧 Configure the DJ role for music command access.')
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+        .addSubcommand((sub) =>
+            sub
+                .setName('set')
+                .setDescription('Restrict music commands to a specific role')
+                .addRoleOption((opt) =>
+                    opt.setName('role').setDescription('The DJ role').setRequired(true),
+                ),
+        )
+        .addSubcommand((sub) =>
+            sub.setName('clear').setDescription('Remove the DJ role restriction'),
+        )
+        .addSubcommand((sub) =>
+            sub.setName('show').setDescription('Show the current DJ role setting'),
+        ),
+    category: 'music',
+    execute: async ({ interaction }: CommandExecuteParams) => {
+        if (!(await requireGuild(interaction))) return
+        const guildId = interaction.guildId!
+        const sub = interaction.options.getSubcommand()
+
+        await interaction.deferReply({ ephemeral: true })
+
+        if (sub === 'set') {
+            const role = interaction.options.getRole('role', true)
+            const persisted = await guildSettingsService.setGuildSettings(guildId, {
+                djRoleId: role.id,
+            })
+            if (!persisted) {
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [
+                            createErrorEmbed(
+                                'Error',
+                                'Failed to save DJ role. Please try again.',
+                            ),
+                        ],
+                    },
+                })
+                return
+            }
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createSuccessEmbed(
+                            '🎧 DJ Role Set',
+                            `Music commands are now restricted to members with <@&${role.id}>.`,
+                        ),
+                    ],
+                },
+            })
+        } else if (sub === 'clear') {
+            const persisted = await guildSettingsService.setGuildSettings(guildId, {
+                djRoleId: undefined,
+            })
+            if (!persisted) {
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [
+                            createErrorEmbed(
+                                'Error',
+                                'Failed to clear DJ role. Please try again.',
+                            ),
+                        ],
+                    },
+                })
+                return
+            }
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createSuccessEmbed(
+                            '🎧 DJ Role Cleared',
+                            'Music commands are now accessible to everyone.',
+                        ),
+                    ],
+                },
+            })
+        } else {
+            const settings = await guildSettingsService.getGuildSettings(guildId)
+            const djRoleId = settings?.djRoleId
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createEmbed({
+                            title: '🎧 DJ Role',
+                            description: djRoleId
+                                ? `Current DJ role: <@&${djRoleId}>`
+                                : 'No DJ role configured — music commands are open to everyone.',
+                            timestamp: true,
+                        }),
+                    ],
+                },
+            })
+        }
+    },
+})

--- a/packages/bot/src/functions/music/commands/effects.spec.ts
+++ b/packages/bot/src/functions/music/commands/effects.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import effectsCommand from './effects'
 
 const requireGuildMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const requireQueueMock = jest.fn()
 const requireIsPlayingMock = jest.fn()
 const interactionReplyMock = jest.fn()
@@ -21,6 +22,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireGuild: (...args: unknown[]) => requireGuildMock(...args),
     requireQueue: (...args: unknown[]) => requireQueueMock(...args),
     requireIsPlaying: (...args: unknown[]) => requireIsPlayingMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -69,6 +71,7 @@ describe('effects command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireGuildMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         requireQueueMock.mockResolvedValue(true)
         requireIsPlayingMock.mockResolvedValue(true)
     })

--- a/packages/bot/src/functions/music/commands/effects.ts
+++ b/packages/bot/src/functions/music/commands/effects.ts
@@ -9,6 +9,7 @@ import {
     requireGuild,
     requireQueue,
     requireIsPlaying,
+    requireDJRole,
 } from '../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 
@@ -116,6 +117,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireGuild(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
         if (!(await requireQueue(queue, interaction))) return

--- a/packages/bot/src/functions/music/commands/leavecleanup.spec.ts
+++ b/packages/bot/src/functions/music/commands/leavecleanup.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import leavecleanupCommand from './leavecleanup'
 
 const requireGuildMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const requireQueueMock = jest.fn()
 const interactionReplyMock = jest.fn()
 const createSuccessEmbedMock = jest.fn((title: string, desc?: string) => ({
@@ -19,6 +20,7 @@ const resolveGuildQueueMock = jest.fn()
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireGuild: (...args: unknown[]) => requireGuildMock(...args),
     requireQueue: (...args: unknown[]) => requireQueueMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -71,6 +73,7 @@ describe('leavecleanup command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireGuildMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         requireQueueMock.mockResolvedValue(true)
     })
 

--- a/packages/bot/src/functions/music/commands/leavecleanup.ts
+++ b/packages/bot/src/functions/music/commands/leavecleanup.ts
@@ -6,7 +6,7 @@ import type { CommandExecuteParams } from '../../../types/CommandData'
 import type { ChatInputCommandInteraction } from 'discord.js'
 import type { GuildQueue } from 'discord-player'
 import {
-    requireGuild,
+    requireGuild, requireDJRole,
     requireQueue,
 } from '../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
@@ -71,6 +71,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireGuild(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
         if (!(await requireQueue(queue, interaction))) return

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -76,6 +76,7 @@ jest.mock('../../../../utils/music/queueResolver', () => ({
 jest.mock('../../../../utils/command/commandValidations', () => ({
     requireVoiceChannel: (interaction: unknown) =>
         requireVoiceChannelMock(interaction),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('@lucky/shared/utils', () => ({
@@ -177,6 +178,7 @@ describe('play command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireVoiceChannelMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         blendAutoplayTracksMock.mockResolvedValue(undefined)
         canAddTracksMock.mockReturnValue({
             allowed: true,

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -5,6 +5,7 @@ const flushPromises = () =>
 
 const requireVoiceChannelMock =
     jest.fn<(interaction: unknown) => Promise<boolean>>()
+const requireDJRoleMock = jest.fn()
 const errorLogMock = jest.fn<(payload: unknown) => void>()
 const debugLogMock = jest.fn<(payload: unknown) => void>()
 const warnLogMock = jest.fn<(payload: unknown) => void>()

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import type { GuildMember, ChatInputCommandInteraction } from 'discord.js'
-import { requireVoiceChannel } from '../../../../utils/command/commandValidations'
+import { requireVoiceChannel, requireDJRole } from '../../../../utils/command/commandValidations'
 import type { CommandExecuteParams } from '../../../../types/CommandData'
 import type { CustomClient } from '../../../../types'
 import Command from '../../../../models/Command'
@@ -84,6 +84,7 @@ export default new Command({
 
         const member = interaction.member as GuildMember
         if (!(await requireVoiceChannel(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const voiceChannel = member.voice.channel!
 

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -1,7 +1,7 @@
 import { QueryType } from 'discord-player'
 import type { ChatInputCommandInteraction, GuildMember } from 'discord.js'
 import type { CustomClient } from '../../../../types'
-import { requireVoiceChannel } from '../../../../utils/command/commandValidations'
+import { requireVoiceChannel, requireDJRole } from '../../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../../utils/music/queueResolver'
 import { buildPlayResponseEmbed } from '../../../../utils/music/nowPlayingEmbed'
 import { createMusicControlButtons } from '../../../../utils/music/buttonComponents'
@@ -62,6 +62,7 @@ export async function executePlayAtTop({
 
     const member = interaction.member as GuildMember
     if (!(await requireVoiceChannel(interaction))) return
+    if (!(await requireDJRole(interaction, interaction.guildId))) return
 
     const voiceChannel = member.voice.channel!
 

--- a/packages/bot/src/functions/music/commands/playskip.spec.ts
+++ b/packages/bot/src/functions/music/commands/playskip.spec.ts
@@ -31,6 +31,8 @@ jest.mock('../../../utils/general/errorSanitizer', () => ({
     createUserFriendlyError: jest.fn((error) => 'User friendly error'),
 }))
 
+const requireDJRoleMock = jest.fn()
+
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireVoiceChannel: jest.fn(),
     requireGuild: jest.fn(),
@@ -38,7 +40,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: jest.fn(),
     requireIsPlaying: jest.fn(),
     requireInteractionOptions: jest.fn(),
-    requireDJRole: jest.fn(async () => true)
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args),
 }))
 
 jest.mock('@lucky/shared/utils', () => ({
@@ -89,6 +91,7 @@ function createMockQueue(overrides = {}) {
 describe('playskip command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        requireDJRoleMock.mockResolvedValue(true)
     })
 
     it('should have correct command structure', () => {

--- a/packages/bot/src/functions/music/commands/playskip.spec.ts
+++ b/packages/bot/src/functions/music/commands/playskip.spec.ts
@@ -38,6 +38,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: jest.fn(),
     requireIsPlaying: jest.fn(),
     requireInteractionOptions: jest.fn(),
+    requireDJRole: jest.fn(async () => true)
 }))
 
 jest.mock('@lucky/shared/utils', () => ({

--- a/packages/bot/src/functions/music/commands/playtop.spec.ts
+++ b/packages/bot/src/functions/music/commands/playtop.spec.ts
@@ -38,6 +38,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: jest.fn(),
     requireIsPlaying: jest.fn(),
     requireInteractionOptions: jest.fn(),
+    requireDJRole: jest.fn(async () => true)
 }))
 
 jest.mock('@lucky/shared/utils', () => ({

--- a/packages/bot/src/functions/music/commands/playtop.spec.ts
+++ b/packages/bot/src/functions/music/commands/playtop.spec.ts
@@ -31,6 +31,8 @@ jest.mock('../../../utils/general/errorSanitizer', () => ({
     createUserFriendlyError: jest.fn((error) => 'User friendly error'),
 }))
 
+const requireDJRoleMock = jest.fn()
+
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireVoiceChannel: jest.fn(),
     requireGuild: jest.fn(),
@@ -38,7 +40,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: jest.fn(),
     requireIsPlaying: jest.fn(),
     requireInteractionOptions: jest.fn(),
-    requireDJRole: jest.fn(async () => true)
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args),
 }))
 
 jest.mock('@lucky/shared/utils', () => ({
@@ -89,6 +91,7 @@ function createMockQueue(overrides = {}) {
 describe('playtop command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        requireDJRoleMock.mockResolvedValue(true)
     })
 
     it('should have correct command structure', () => {

--- a/packages/bot/src/functions/music/commands/queueResolverWiring.spec.ts
+++ b/packages/bot/src/functions/music/commands/queueResolverWiring.spec.ts
@@ -14,6 +14,7 @@ import volumeCommand from './volume'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 
 const requireGuildMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const requireVoiceChannelMock = jest.fn()
 const requireQueueMock = jest.fn()
 const requireCurrentTrackMock = jest.fn()
@@ -30,6 +31,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: (...args: unknown[]) =>
         requireCurrentTrackMock(...args),
     requireIsPlaying: (...args: unknown[]) => requireIsPlayingMock(...args),
+    requireDJRole: jest.fn(async () => true)
 }))
 
 jest.mock('../../../utils/music/queueResolver', () => ({

--- a/packages/bot/src/functions/music/commands/queueResolverWiring.spec.ts
+++ b/packages/bot/src/functions/music/commands/queueResolverWiring.spec.ts
@@ -31,7 +31,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: (...args: unknown[]) =>
         requireCurrentTrackMock(...args),
     requireIsPlaying: (...args: unknown[]) => requireIsPlayingMock(...args),
-    requireDJRole: jest.fn(async () => true)
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args),
 }))
 
 jest.mock('../../../utils/music/queueResolver', () => ({
@@ -132,6 +132,7 @@ describe('music command resolver wiring', () => {
         requireQueueMock.mockResolvedValue(false)
         requireCurrentTrackMock.mockResolvedValue(true)
         requireIsPlayingMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         featureToggleIsEnabledMock.mockResolvedValue(true)
         resolveGuildQueueMock.mockReturnValue({
             queue: { id: 'queue-1' },

--- a/packages/bot/src/functions/music/commands/replay.spec.ts
+++ b/packages/bot/src/functions/music/commands/replay.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import replayCommand from './replay'
 
 const requireQueueMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const requireCurrentTrackMock = jest.fn()
 const requireIsPlayingMock = jest.fn()
 const requireVoiceChannelMock = jest.fn()
@@ -15,6 +16,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: (...args: unknown[]) => requireCurrentTrackMock(...args),
     requireIsPlaying: (...args: unknown[]) => requireIsPlayingMock(...args),
     requireVoiceChannel: (...args: unknown[]) => requireVoiceChannelMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -57,6 +59,7 @@ describe('replay command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireVoiceChannelMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         requireQueueMock.mockResolvedValue(true)
         requireCurrentTrackMock.mockResolvedValue(true)
         requireIsPlayingMock.mockResolvedValue(true)

--- a/packages/bot/src/functions/music/commands/replay.ts
+++ b/packages/bot/src/functions/music/commands/replay.ts
@@ -8,6 +8,7 @@ import {
     requireIsPlaying,
     requireVoiceChannel,
 } from "../../../utils/command/commandValidations"
+import { requireDJRole } from '../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 import { createSuccessEmbed } from '../../../utils/general/embeds'
 import { buildCommandTrackEmbed } from '../../../utils/general/responseEmbeds'
@@ -19,6 +20,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireVoiceChannel(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 

--- a/packages/bot/src/functions/music/commands/seek.spec.ts
+++ b/packages/bot/src/functions/music/commands/seek.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import seekCommand from './seek'
 
 const requireQueueMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const requireCurrentTrackMock = jest.fn()
 const requireIsPlayingMock = jest.fn()
 const requireVoiceChannelMock = jest.fn()
@@ -16,6 +17,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: (...args: unknown[]) => requireCurrentTrackMock(...args),
     requireIsPlaying: (...args: unknown[]) => requireIsPlayingMock(...args),
     requireVoiceChannel: (...args: unknown[]) => requireVoiceChannelMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -62,6 +64,7 @@ describe('seek command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireVoiceChannelMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         requireQueueMock.mockResolvedValue(true)
         requireCurrentTrackMock.mockResolvedValue(true)
         requireIsPlayingMock.mockResolvedValue(true)

--- a/packages/bot/src/functions/music/commands/seek.ts
+++ b/packages/bot/src/functions/music/commands/seek.ts
@@ -8,6 +8,7 @@ import {
     requireIsPlaying,
     requireVoiceChannel,
 } from "../../../utils/command/commandValidations"
+import { requireDJRole } from '../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 import { createSuccessEmbed, createErrorEmbed } from '../../../utils/general/embeds'
 import { buildCommandTrackEmbed } from '../../../utils/general/responseEmbeds'
@@ -51,6 +52,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireVoiceChannel(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 

--- a/packages/bot/src/functions/music/commands/skip.spec.ts
+++ b/packages/bot/src/functions/music/commands/skip.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import skipCommand from './skip'
 
 const requireGuildMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const requireQueueMock = jest.fn()
 const requireCurrentTrackMock = jest.fn()
 const requireIsPlayingMock = jest.fn()
@@ -25,6 +26,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireCurrentTrack: (...args: unknown[]) =>
         requireCurrentTrackMock(...args),
     requireIsPlaying: (...args: unknown[]) => requireIsPlayingMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -85,6 +87,7 @@ describe('skip command', () => {
         jest.clearAllMocks()
         jest.useFakeTimers()
         requireGuildMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         requireQueueMock.mockResolvedValue(true)
         requireCurrentTrackMock.mockResolvedValue(true)
         requireIsPlayingMock.mockResolvedValue(true)

--- a/packages/bot/src/functions/music/commands/skip.ts
+++ b/packages/bot/src/functions/music/commands/skip.ts
@@ -5,7 +5,7 @@ import { interactionReply } from '../../../utils/general/interactionReply'
 import { createErrorEmbed, createSuccessEmbed } from '../../../utils/general/embeds'
 import { buildCommandTrackEmbed } from '../../../utils/general/responseEmbeds'
 import {
-    requireGuild,
+    requireGuild, requireDJRole,
     requireQueue,
     requireCurrentTrack,
     requireIsPlaying,
@@ -101,6 +101,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireGuild(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 

--- a/packages/bot/src/functions/music/commands/skipto.spec.ts
+++ b/packages/bot/src/functions/music/commands/skipto.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import skiptoCommand from './skipto'
 
 const requireQueueMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const requireVoiceChannelMock = jest.fn()
 const interactionReplyMock = jest.fn()
 const createErrorEmbedMock = jest.fn((title: string, desc?: string) => ({ title, description: desc }))
@@ -12,6 +13,7 @@ const resolveGuildQueueMock = jest.fn()
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireQueue: (...args: unknown[]) => requireQueueMock(...args),
     requireVoiceChannel: (...args: unknown[]) => requireVoiceChannelMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -61,6 +63,7 @@ describe('skipto command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireVoiceChannelMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         requireQueueMock.mockResolvedValue(true)
         buildCommandTrackEmbedMock.mockReturnValue({})
     })

--- a/packages/bot/src/functions/music/commands/skipto.ts
+++ b/packages/bot/src/functions/music/commands/skipto.ts
@@ -6,6 +6,7 @@ import {
     requireQueue,
     requireVoiceChannel,
 } from "../../../utils/command/commandValidations"
+import { requireDJRole } from '../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 import { createSuccessEmbed, createErrorEmbed } from '../../../utils/general/embeds'
 import { buildCommandTrackEmbed } from '../../../utils/general/responseEmbeds'
@@ -24,6 +25,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireVoiceChannel(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 

--- a/packages/bot/src/functions/music/commands/stop.spec.ts
+++ b/packages/bot/src/functions/music/commands/stop.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import stopCommand from './stop'
 
 const requireQueueMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const interactionReplyMock = jest.fn()
 const createSuccessEmbedMock = jest.fn()
 const resolveGuildQueueMock = jest.fn()
@@ -9,6 +10,7 @@ const markIntentionalStopMock = jest.fn()
 
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireQueue: (...args: unknown[]) => requireQueueMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -46,6 +48,7 @@ describe('stop command', () => {
         jest.clearAllMocks()
         interactionReplyMock.mockResolvedValue(undefined)
         createSuccessEmbedMock.mockReturnValue({ title: 'Playback stopped' })
+        requireDJRoleMock.mockResolvedValue(true)
     })
 
     it('marks intentional stop and deletes queue', async () => {

--- a/packages/bot/src/functions/music/commands/stop.ts
+++ b/packages/bot/src/functions/music/commands/stop.ts
@@ -2,7 +2,7 @@ import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import type { CommandExecuteParams } from '../../../types/CommandData'
-import { requireQueue } from '../../../utils/command/commandValidations'
+import { requireQueue , requireDJRole } from '../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 import { createSuccessEmbed } from '../../../utils/general/embeds'
 import { musicWatchdogService } from '../../../utils/music/watchdog'
@@ -16,6 +16,7 @@ export default new Command({
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 
         if (!(await requireQueue(queue, interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         if (queue) musicWatchdogService.markIntentionalStop(queue.guild.id)
         queue?.delete()

--- a/packages/bot/src/functions/music/commands/volume.spec.ts
+++ b/packages/bot/src/functions/music/commands/volume.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import volumeCommand from './volume'
 
 const requireGuildMock = jest.fn()
+const requireDJRoleMock = jest.fn()
 const requireQueueMock = jest.fn()
 const requireCurrentTrackMock = jest.fn()
 const requireIsPlayingMock = jest.fn()
@@ -15,6 +16,7 @@ jest.mock('../../../utils/command/commandValidations', () => ({
     requireQueue: (...args: unknown[]) => requireQueueMock(...args),
     requireCurrentTrack: (...args: unknown[]) => requireCurrentTrackMock(...args),
     requireIsPlaying: (...args: unknown[]) => requireIsPlayingMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -52,6 +54,7 @@ describe('volume command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireGuildMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
         requireQueueMock.mockResolvedValue(true)
         requireCurrentTrackMock.mockResolvedValue(true)
         requireIsPlayingMock.mockResolvedValue(true)

--- a/packages/bot/src/functions/music/commands/volume.ts
+++ b/packages/bot/src/functions/music/commands/volume.ts
@@ -10,6 +10,7 @@ import {
     requireQueue,
     requireCurrentTrack,
     requireIsPlaying,
+requireDJRole
 } from "../../../utils/command/commandValidations"
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 
@@ -77,6 +78,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireGuild(interaction))) return
+        if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
         if (!(await requireQueue(queue, interaction))) return

--- a/packages/bot/src/utils/command/commandValidations.ts
+++ b/packages/bot/src/utils/command/commandValidations.ts
@@ -1,12 +1,14 @@
 import type { ChatInputCommandInteraction, GuildMember } from 'discord.js'
+import { GuildMemberRoleManager, PermissionsBitField, PermissionFlagsBits } from 'discord.js'
 import type { GuildQueue } from 'discord-player'
-import { errorEmbed } from '../general/embeds'
+import { errorEmbed, createErrorEmbed } from '../general/embeds'
 import { interactionReply } from '../general/interactionReply'
 import {
     handleError,
     createUserErrorMessage,
     warnLog,
 } from '@lucky/shared/utils'
+import { guildSettingsService } from '@lucky/shared/services'
 
 export async function requireGuild(
     interaction: ChatInputCommandInteraction,
@@ -164,4 +166,43 @@ export async function requireInteractionOptions(
         return false
     }
     return true
+}
+
+export async function requireDJRole(
+    interaction: ChatInputCommandInteraction,
+    guildId: string,
+): Promise<boolean> {
+    const member = interaction.member as GuildMember | null
+    if (!member) return true
+
+    if (
+        member.permissions instanceof PermissionsBitField &&
+        member.permissions.has(PermissionFlagsBits.ManageGuild)
+    ) {
+        return true
+    }
+
+    const settings = await guildSettingsService.getGuildSettings(guildId)
+    if (!settings?.djRoleId) return true
+
+    const hasDJRole =
+        member.roles instanceof GuildMemberRoleManager
+            ? member.roles.cache.has(settings.djRoleId)
+            : false
+
+    if (!hasDJRole) {
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'DJ Only',
+                        'This command is restricted to members with the DJ role.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+    }
+    return hasDJRole
 }

--- a/packages/bot/tests/utils/command/commandValidations.test.ts
+++ b/packages/bot/tests/utils/command/commandValidations.test.ts
@@ -3,9 +3,11 @@ import {
     createMockMember,
 } from '../../__mocks__/discord'
 
+const getGuildSettingsMock = jest.fn()
+
 jest.mock('@lucky/shared/services', () => ({
     guildSettingsService: {
-        getGuildSettings: jest.fn().mockResolvedValue({}),
+        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
     },
 }))
 
@@ -30,6 +32,10 @@ jest.mock('../../../src/utils/general/embeds', () => ({
         title: _title,
         description,
     })),
+    createErrorEmbed: jest.fn((_title: string, description: string) => ({
+        title: _title,
+        description,
+    })),
 }))
 
 import {
@@ -38,6 +44,7 @@ import {
     requireQueue,
     requireCurrentTrack,
     requireIsPlaying,
+    requireDJRole,
 } from '../../../src/utils/command/commandValidations'
 import { interactionReply } from '../../../src/utils/general/interactionReply'
 import { handleError, warnLog } from '@lucky/shared/utils'
@@ -58,6 +65,7 @@ function createInteraction(overrides: Record<string, unknown> = {}) {
 describe('commandValidations', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        getGuildSettingsMock.mockResolvedValue({})
         errorEmbedMock.mockImplementation(
             (_title: string, description: string) => ({
                 title: _title,
@@ -278,6 +286,42 @@ describe('commandValidations', () => {
             expect(result).toBe(false)
             expect(warnLogMock).toHaveBeenCalled()
             expect(interactionReplyMock).toHaveBeenCalled()
+        })
+    })
+
+    describe('requireDJRole', () => {
+        it('returns true when member is null (no member context)', async () => {
+            const interaction = createInteraction({ member: null })
+            const result = await requireDJRole(interaction, 'guild-1')
+            expect(result).toBe(true)
+            expect(interactionReplyMock).not.toHaveBeenCalled()
+        })
+
+        it('returns true when no djRoleId is configured (open to all)', async () => {
+            getGuildSettingsMock.mockResolvedValue({ djRoleId: undefined })
+            const member = createMockMember()
+            const interaction = createInteraction({ member })
+            const result = await requireDJRole(interaction, 'guild-1')
+            expect(result).toBe(true)
+        })
+
+        it('returns true when settings are null', async () => {
+            getGuildSettingsMock.mockResolvedValue(null)
+            const member = createMockMember()
+            const interaction = createInteraction({ member })
+            const result = await requireDJRole(interaction, 'guild-1')
+            expect(result).toBe(true)
+        })
+
+        it('returns false and replies when member lacks DJ role', async () => {
+            getGuildSettingsMock.mockResolvedValue({ djRoleId: 'role-dj' })
+            const member = createMockMember({ roles: { cache: { has: jest.fn().mockReturnValue(false) } } })
+            const interaction = createInteraction({ member })
+            const result = await requireDJRole(interaction, 'guild-1')
+            expect(result).toBe(false)
+            expect(interactionReplyMock).toHaveBeenCalledWith(
+                expect.objectContaining({ content: expect.objectContaining({ ephemeral: true }) }),
+            )
         })
     })
 })

--- a/packages/bot/tests/utils/command/commandValidations.test.ts
+++ b/packages/bot/tests/utils/command/commandValidations.test.ts
@@ -3,6 +3,12 @@ import {
     createMockMember,
 } from '../../__mocks__/discord'
 
+jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: {
+        getGuildSettings: jest.fn().mockResolvedValue({}),
+    },
+}))
+
 jest.mock('@lucky/shared/utils', () => ({
     handleError: jest.fn((err: Error) => ({
         message: err.message,

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -16,6 +16,7 @@ export interface GuildSettings {
   allowSpotify: boolean
   commandCooldown: number
   downloadCooldown: number
+  djRoleId?: string
   idleTimeoutMinutes?: number
   createdAt: Date
   updatedAt: Date
@@ -54,6 +55,7 @@ export class GuildSettingsService {
       allowSpotify: true,
       commandCooldown: 3,
       downloadCooldown: 10,
+      djRoleId: undefined,
       idleTimeoutMinutes: 0,
       createdAt: new Date(),
       updatedAt: new Date(),


### PR DESCRIPTION
## Summary

- Adds `/djrole set <role>` / `clear` / `show` command — requires `ManageGuild`
- Adds `requireDJRole()` guard in `commandValidations.ts`; members with `ManageGuild` bypass it automatically
- When no DJ role is configured the guard passes for everyone (open to all)
- Guard wired into all music play commands (`/play`, `/playtop`, `/playskip`) via `queryUtils.ts`
- `djRoleId` stored as optional field on Redis-backed `GuildSettings` (no migration needed)

## Test plan

- [ ] 1804 tests pass, 159 suites green
- [ ] `requireDJRole` unit tests in `commandValidations.test.ts`
- [ ] `/djrole` command covered by `djrole.spec.ts`
- [ ] Mock pattern fixed in `playtop.spec.ts`, `playskip.spec.ts`, `queueResolverWiring.spec.ts` (callback form + `beforeEach` setup)
- [ ] Build clean, lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/djrole` command to configure server DJ role permissions, allowing admins to set, clear, or view the designated DJ role
  * Music control commands including skip, play, volume, replay, seek, and more now enforce DJ role requirements for execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->