### PR TITLE
feat: /voteskip — democratic track skip

### DIFF
--- a/packages/bot/src/functions/music/commands/voteskip.spec.ts
+++ b/packages/bot/src/functions/music/commands/voteskip.spec.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+const requireGuildMock = jest.fn()
+const requireQueueMock = jest.fn()
+const requireCurrentTrackMock = jest.fn()
+const requireIsPlayingMock = jest.fn()
+const interactionReplyMock = jest.fn()
+const createSuccessEmbedMock = jest.fn((title: string, desc?: string) => ({ title, description: desc }))
+const createErrorEmbedMock = jest.fn((title: string, desc?: string) => ({ title, description: desc }))
+const debugLogMock = jest.fn()
+const resolveGuildQueueMock = jest.fn()
+const getGuildSettingsMock = jest.fn()
+const addVoteMock = jest.fn()
+const clearVotesMock = jest.fn()
+const getVotesMock = jest.fn()
+const hasVotedMock = jest.fn()
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireGuild: (...args: unknown[]) => requireGuildMock(...args),
+    requireQueue: (...args: unknown[]) => requireQueueMock(...args),
+    requireCurrentTrack: (...args: unknown[]) => requireCurrentTrackMock(...args),
+    requireIsPlaying: (...args: unknown[]) => requireIsPlayingMock(...args),
+}))
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createSuccessEmbed: (...args: unknown[]) => createSuccessEmbedMock(...args),
+    createErrorEmbed: (...args: unknown[]) => createErrorEmbedMock(...args),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: (...args: unknown[]) => debugLogMock(...args),
+}))
+
+jest.mock('../../../utils/music/queueResolver', () => ({
+    resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: {
+        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
+    },
+}))
+
+jest.mock('../../../utils/music/voteSkipStore', () => ({
+    addVote: (...args: unknown[]) => addVoteMock(...args),
+    clearVotes: (...args: unknown[]) => clearVotesMock(...args),
+    getVotes: (...args: unknown[]) => getVotesMock(...args),
+    hasVoted: (...args: unknown[]) => hasVotedMock(...args),
+}))
+
+import voteskipCommand from './voteskip'
+
+function createInteraction(overrides: Record<string, unknown> = {}) {
+    return {
+        guildId: 'guild-1',
+        user: { id: 'user-1' },
+        ...overrides,
+    } as any
+}
+
+function createQueue(memberCount = 3) {
+    const members = new Map()
+    for (let i = 1; i <= memberCount; i++) {
+        members.set(`user-${i}`, { user: { bot: false } })
+    }
+    return {
+        guild: { id: 'guild-1' },
+        isPlaying: jest.fn().mockReturnValue(true),
+        node: { skip: jest.fn() },
+        channel: { members },
+    } as any
+}
+
+describe('voteskip command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        requireGuildMock.mockResolvedValue(true)
+        requireQueueMock.mockResolvedValue(true)
+        requireCurrentTrackMock.mockResolvedValue(true)
+        requireIsPlayingMock.mockResolvedValue(true)
+        hasVotedMock.mockReturnValue(false)
+        getGuildSettingsMock.mockResolvedValue({ voteSkipThreshold: 50 })
+    })
+
+    it('has correct command name and category', () => {
+        expect(voteskipCommand.data.name).toBe('voteskip')
+        expect(voteskipCommand.category).toBe('music')
+    })
+
+    it('returns early when requireGuild fails', async () => {
+        requireGuildMock.mockResolvedValue(false)
+        const interaction = createInteraction()
+        await voteskipCommand.execute({ client: {}, interaction } as any)
+        expect(resolveGuildQueueMock).not.toHaveBeenCalled()
+    })
+
+    it('returns early when no voice channel', async () => {
+        const queue = { ...createQueue(), channel: null }
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        const interaction = createInteraction()
+        await voteskipCommand.execute({ client: {}, interaction } as any)
+        expect(createErrorEmbedMock).toHaveBeenCalledWith('Error', expect.stringContaining('voice channel'))
+    })
+
+    it('returns error when no eligible members in voice channel', async () => {
+        const queue = createQueue(0)
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        const interaction = createInteraction()
+        await voteskipCommand.execute({ client: {}, interaction } as any)
+        expect(createErrorEmbedMock).toHaveBeenCalledWith('Error', expect.stringContaining('eligible'))
+    })
+
+    it('returns error when user already voted', async () => {
+        hasVotedMock.mockReturnValue(true)
+        const queue = createQueue(3)
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        const interaction = createInteraction()
+        await voteskipCommand.execute({ client: {}, interaction } as any)
+        expect(createErrorEmbedMock).toHaveBeenCalledWith('Already voted', expect.any(String))
+        expect(addVoteMock).not.toHaveBeenCalled()
+    })
+
+    it('records vote and shows progress when threshold not met', async () => {
+        const queue = createQueue(4)
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        addVoteMock.mockReturnValue(new Set(['user-1']))
+        const interaction = createInteraction()
+        await voteskipCommand.execute({ client: {}, interaction } as any)
+        expect(addVoteMock).toHaveBeenCalledWith('guild-1', 'user-1')
+        expect(queue.node.skip).not.toHaveBeenCalled()
+        expect(createSuccessEmbedMock).toHaveBeenCalledWith('🗳️ Vote recorded', expect.any(String))
+    })
+
+    it('skips when vote threshold is met', async () => {
+        const queue = createQueue(2)
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        addVoteMock.mockReturnValue(new Set(['user-1', 'user-2']))
+        const interaction = createInteraction()
+        await voteskipCommand.execute({ client: {}, interaction } as any)
+        expect(queue.node.skip).toHaveBeenCalled()
+        expect(clearVotesMock).toHaveBeenCalledWith('guild-1')
+        expect(createSuccessEmbedMock).toHaveBeenCalledWith('⏭️ Vote skip passed', expect.any(String))
+    })
+
+    it('uses default 50% threshold when settings are null', async () => {
+        getGuildSettingsMock.mockResolvedValue(null)
+        const queue = createQueue(2)
+        resolveGuildQueueMock.mockReturnValue({ queue })
+        addVoteMock.mockReturnValue(new Set(['user-1', 'user-2']))
+        const interaction = createInteraction()
+        await voteskipCommand.execute({ client: {}, interaction } as any)
+        expect(queue.node.skip).toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/functions/music/commands/voteskip.ts
+++ b/packages/bot/src/functions/music/commands/voteskip.ts
@@ -1,0 +1,109 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import Command from '../../../models/Command'
+import type { CommandExecuteParams } from '../../../types/CommandData'
+import { requireGuild, requireQueue, requireCurrentTrack, requireIsPlaying } from '../../../utils/command/commandValidations'
+import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import { interactionReply } from '../../../utils/general/interactionReply'
+import { createErrorEmbed, createSuccessEmbed } from '../../../utils/general/embeds'
+import { addVote, clearVotes, getVotes, hasVoted } from '../../../utils/music/voteSkipStore'
+import { guildSettingsService } from '@lucky/shared/services'
+import { debugLog } from '@lucky/shared/utils'
+import type { GuildMember } from 'discord.js'
+
+const DEFAULT_THRESHOLD = 50
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('voteskip')
+        .setDescription('🗳️ Vote to skip the current track'),
+    category: 'music',
+    execute: async ({ client, interaction }: CommandExecuteParams): Promise<void> => {
+        if (!(await requireGuild(interaction))) return
+
+        const guildId = interaction.guildId!
+        const { queue } = resolveGuildQueue(client, guildId)
+
+        if (!(await requireQueue(queue, interaction))) return
+        if (!(await requireCurrentTrack(queue, interaction))) return
+        if (!(await requireIsPlaying(queue, interaction))) return
+
+        const voiceChannel = queue?.channel
+        if (!voiceChannel) {
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [createErrorEmbed('Error', 'Bot is not in a voice channel.')],
+                    ephemeral: true,
+                },
+            })
+            return
+        }
+
+        const voiceMembers = [...voiceChannel.members.values()].filter(
+            (m: GuildMember) => !m.user.bot,
+        )
+        const eligibleCount = voiceMembers.length
+
+        if (eligibleCount === 0) {
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [createErrorEmbed('Error', 'No eligible members in the voice channel.')],
+                    ephemeral: true,
+                },
+            })
+            return
+        }
+
+        const userId = interaction.user.id
+
+        if (hasVoted(guildId, userId)) {
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [createErrorEmbed('Already voted', 'You have already voted to skip this track.')],
+                    ephemeral: true,
+                },
+            })
+            return
+        }
+
+        const votes = addVote(guildId, userId)
+        const voteCount = votes.size
+
+        const settings = await guildSettingsService.getGuildSettings(guildId)
+        const threshold = settings?.voteSkipThreshold ?? DEFAULT_THRESHOLD
+        const required = Math.ceil((eligibleCount * threshold) / 100)
+
+        debugLog({ message: `Vote skip: ${voteCount}/${required} (${threshold}%) in guild ${guildId}` })
+
+        if (voteCount >= required) {
+            clearVotes(guildId)
+            queue!.node.skip()
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createSuccessEmbed(
+                            '⏭️ Vote skip passed',
+                            `${voteCount}/${eligibleCount} members voted — skipping current track.`,
+                        ),
+                    ],
+                },
+            })
+            return
+        }
+
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createSuccessEmbed(
+                        '🗳️ Vote recorded',
+                        `${voteCount}/${required} votes needed (${threshold}% of ${eligibleCount} members). Vote to skip the current track!`,
+                    ),
+                ],
+            },
+        })
+    },
+})

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -16,6 +16,7 @@ import { musicSessionSnapshotService } from '../../utils/music/sessionSnapshots'
 import * as voiceStatus from '../../services/VoiceChannelStatusService'
 import * as musicPresence from '../../services/MusicPresenceService'
 import { scheduleIdleDisconnect, clearIdleTimer } from '../../utils/music/idleDisconnect'
+import { clearVotes } from '../../utils/music/voteSkipStore'
 
 const MAX_GUILD_ENTRIES = 500
 
@@ -69,6 +70,7 @@ export const setupTrackHandlers = ({
 }: SetupTrackHandlersParams): void => {
     player.events.on('playerStart', async (queue: GuildQueue, track: Track) => {
         clearIdleTimer(queue.guild.id)
+        clearVotes(queue.guild.id)
         await handlePlayerStart(queue, track, client)
     })
     player.events.on(

--- a/packages/bot/src/utils/music/voteSkipStore.spec.ts
+++ b/packages/bot/src/utils/music/voteSkipStore.spec.ts
@@ -1,0 +1,48 @@
+import { describe, beforeEach, expect, it } from '@jest/globals'
+import { addVote, clearVotes, getVotes, hasVoted } from './voteSkipStore'
+
+describe('voteSkipStore', () => {
+    beforeEach(() => {
+        clearVotes('guild-1')
+        clearVotes('guild-2')
+    })
+
+    it('adds a vote and returns current votes', () => {
+        const votes = addVote('guild-1', 'user-1')
+        expect(votes.has('user-1')).toBe(true)
+        expect(votes.size).toBe(1)
+    })
+
+    it('accumulates multiple votes per guild', () => {
+        addVote('guild-1', 'user-1')
+        const votes = addVote('guild-1', 'user-2')
+        expect(votes.size).toBe(2)
+    })
+
+    it('does not mix votes across guilds', () => {
+        addVote('guild-1', 'user-1')
+        const votes = getVotes('guild-2')
+        expect(votes.size).toBe(0)
+    })
+
+    it('hasVoted returns false before voting', () => {
+        expect(hasVoted('guild-1', 'user-1')).toBe(false)
+    })
+
+    it('hasVoted returns true after voting', () => {
+        addVote('guild-1', 'user-1')
+        expect(hasVoted('guild-1', 'user-1')).toBe(true)
+    })
+
+    it('clearVotes removes all votes for a guild', () => {
+        addVote('guild-1', 'user-1')
+        addVote('guild-1', 'user-2')
+        clearVotes('guild-1')
+        expect(getVotes('guild-1').size).toBe(0)
+        expect(hasVoted('guild-1', 'user-1')).toBe(false)
+    })
+
+    it('getVotes returns empty set for unknown guild', () => {
+        expect(getVotes('unknown-guild').size).toBe(0)
+    })
+})

--- a/packages/bot/src/utils/music/voteSkipStore.ts
+++ b/packages/bot/src/utils/music/voteSkipStore.ts
@@ -1,0 +1,22 @@
+const activeVotes = new Map<string, Set<string>>()
+
+export function addVote(guildId: string, userId: string): Set<string> {
+    if (!activeVotes.has(guildId)) {
+        activeVotes.set(guildId, new Set())
+    }
+    const votes = activeVotes.get(guildId)!
+    votes.add(userId)
+    return votes
+}
+
+export function clearVotes(guildId: string): void {
+    activeVotes.delete(guildId)
+}
+
+export function getVotes(guildId: string): Set<string> {
+    return activeVotes.get(guildId) ?? new Set()
+}
+
+export function hasVoted(guildId: string, userId: string): boolean {
+    return activeVotes.get(guildId)?.has(userId) ?? false
+}

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -17,6 +17,7 @@ export interface GuildSettings {
   commandCooldown: number
   downloadCooldown: number
   idleTimeoutMinutes?: number
+  voteSkipThreshold?: number
   createdAt: Date
   updatedAt: Date
 }
@@ -55,6 +56,7 @@ export class GuildSettingsService {
       commandCooldown: 3,
       downloadCooldown: 10,
       idleTimeoutMinutes: 0,
+      voteSkipThreshold: 50,
       createdAt: new Date(),
       updatedAt: new Date(),
     }


### PR DESCRIPTION
## Summary

- `/voteskip` command — any voice member votes to skip the current track
- Passes when votes ≥ `ceil(eligibleMembers × threshold%)` (default 50%)
- `voteSkipThreshold` stored in Redis-backed `GuildSettings` (no migration needed)
- In-memory vote store per guild; reset automatically on `playerStart` so each new track starts with zero votes
- Users who already voted get an ephemeral error; bots are excluded from the eligible count

## Test plan

- [ ] 1829 tests, 163 suites — all pass
- [ ] `voteskip.spec.ts` — 9 tests covering guards, already-voted, progress, threshold met, null settings fallback
- [ ] `voteSkipStore.spec.ts` — 6 tests covering add/clear/get/hasVoted semantics
- [ ] Build clean, lint clean