### PR TITLE
fix(bot): relax SoundCloud match threshold — fixes NoResultError on Brazilian funk tracks

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
@@ -115,10 +115,18 @@ describe('findMatchingSoundCloudResult', () => {
         ).toBe('sc://1')
     })
 
-    it('rejects when duration is > 15s off', () => {
+    it('rejects when duration is > 30s off', () => {
         expect(
             findMatchingSoundCloudResult('Bohemian Rhapsody', '10:00', results),
         ).toBeUndefined()
+    })
+
+    it('accepts when duration is 16-30s off (relaxed tolerance)', () => {
+        expect(
+            findMatchingSoundCloudResult('Bohemian Rhapsody', '5:55', [
+                { name: 'Bohemian Rhapsody', url: 'sc://1', durationInSec: 374 },
+            ])?.url,
+        ).toBe('sc://1')
     })
 
     it('accepts when track has no duration', () => {
@@ -144,6 +152,28 @@ describe('findMatchingSoundCloudResult', () => {
             findMatchingSoundCloudResult('夜に駆ける', '4:07', [
                 { name: '夜に駆ける', url: 'sc://3', durationInSec: 247 },
             ]),
+        ).toBeUndefined()
+    })
+
+    it('matches Brazilian funk track when result is missing 1 compound token (75% threshold)', () => {
+        const query =
+            'MC Ryan SP MC Jacara e MC Meno K - Posso Ate Nao Te Dar Flores (DJ Japa NK e DJ Davi DogDog)'
+        const results = [
+            {
+                name: 'MC Ryan SP, MC Jacaré e MC Meno K - Posso Até Não Te Dar Flores (DJ Japa NK e DJ Davi Dog Dog)',
+                url: 'sc://funk',
+                durationInSec: 194,
+            },
+        ]
+        expect(findMatchingSoundCloudResult(query, '3:14', results)?.url).toBe(
+            'sc://funk',
+        )
+    })
+
+    it('returns undefined when fewer than 75% of tokens match', () => {
+        const results = [{ name: 'Completely Different Song', url: 'sc://x', durationInSec: 180 }]
+        expect(
+            findMatchingSoundCloudResult('Bohemian Rhapsody Queen', '3:00', results),
         ).toBeUndefined()
     })
 })
@@ -338,6 +368,28 @@ describe('createResilientStream', () => {
         )
         expect(result).toBe(proc.stdout)
         expect(playdlSearchMock).not.toHaveBeenCalled()
+    })
+
+    it('falls back to core title (stripped parentheticals) when title-only search fails', async () => {
+        spawnMock.mockReturnValue(makeSpawnError(1))
+        playdlSearchMock
+            .mockResolvedValueOnce([{ name: 'Unrelated', url: 'sc://miss', durationInSec: 180 }])
+            .mockResolvedValueOnce([{ name: 'Unrelated', url: 'sc://miss2', durationInSec: 180 }])
+            .mockResolvedValueOnce([
+                {
+                    name: 'Bohemian Rhapsody',
+                    url: 'sc://core',
+                    durationInSec: 354,
+                },
+            ])
+        playdlStreamMock.mockResolvedValueOnce({ stream: fakeStream })
+
+        const result = await createResilientStream(
+            makeTrack({ title: 'Bohemian Rhapsody (Official Music Live Session)' }),
+        )
+        expect(result).toBe(fakeStream)
+        expect(playdlSearchMock).toHaveBeenCalledTimes(3)
+        expect(playdlStreamMock).toHaveBeenCalledWith('sc://core')
     })
 
     it('throws "Bridge exhausted" when track has no URL and SoundCloud fails', async () => {

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -252,7 +252,7 @@ export async function createResilientStream(
         })
     }
 
-    const coreTitle = cleanedTitle.replace(/\s*\([^)]*\)\s*/g, ' ').replace(/\s{2,}/g, ' ').trim()
+    const coreTitle = cleanedTitle.replace(/ *\([^)]*\) */g, ' ').replace(/ {2,}/g, ' ').trim()
     if (coreTitle && coreTitle !== cleanedTitle) {
         try {
             return await streamViaSoundCloud(coreTitle, track.duration)

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -334,7 +334,7 @@ export function findMatchingSoundCloudResult(
     const queryNorm = normalizeForMatch(query)
     if (!queryNorm) return undefined
 
-    const tokens = queryNorm.split(/\s+/).filter(Boolean)
+    const tokens = queryNorm.split(/ +/).filter(Boolean)
     if (tokens.length === 0) return undefined
 
     const trackSec = parseDurationString(trackDuration)
@@ -355,8 +355,8 @@ export function findMatchingSoundCloudResult(
 function normalizeForMatch(value: string): string {
     return value
         .toLowerCase()
-        .replace(/[^a-z0-9\s]/g, '')
-        .replace(/\s{2,}/g, ' ')
+        .replace(/[^a-z0-9 ]/g, '')
+        .replace(/ {2,}/g, ' ')
         .trim()
 }
 

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -245,10 +245,27 @@ export async function createResilientStream(
 
     try {
         return await streamViaSoundCloud(cleanedTitle, track.duration)
-    } catch (titleOnlyError) {
+    } catch {
+        debugLog({
+            message: 'Bridge: title-only SoundCloud failed, retrying without parentheticals',
+            data: { cleanedTitle },
+        })
+    }
+
+    const coreTitle = cleanedTitle.replace(/\s*\(.*?\)\s*/g, ' ').replace(/\s{2,}/g, ' ').trim()
+    if (coreTitle && coreTitle !== cleanedTitle) {
+        try {
+            return await streamViaSoundCloud(coreTitle, track.duration)
+        } catch (coreError) {
+            errorLog({
+                message: 'Bridge: all stages exhausted',
+                error: coreError,
+                data: { title: track.title, coreTitle },
+            })
+        }
+    } else {
         errorLog({
             message: 'Bridge: all stages exhausted',
-            error: titleOnlyError,
             data: { title: track.title },
         })
     }
@@ -295,13 +312,19 @@ type SoundCloudSearchResult = {
 }
 
 /**
+ * Minimum fraction of query tokens that must appear in the result name.
+ * Using 0.75 instead of 1.0 tolerates minor title differences:
+ *   - Accent stripping ("Jacaré" → "jacar" vs "Jacare" → "jacare")
+ *   - Compound word splits ("DogDog" vs "Dog Dog" → "dog dog")
+ *   - DJ credits missing or abbreviated on SoundCloud
+ */
+const TITLE_MATCH_THRESHOLD = 0.75
+
+/**
  * Pure match logic, exported so tests can cover it without spinning up play-dl.
  *
- * Matches a candidate result iff every non-empty token in the cleaned query
- * appears in the normalized result name. This is tighter than the previous
- * symmetric substring check, which allowed short candidate names (e.g. a
- * 4-character remix title) to match a long query because
- * `queryNorm.includes(resultNorm)` was true.
+ * Requires at least TITLE_MATCH_THRESHOLD fraction of query tokens to appear
+ * in the result name, and duration within 30 seconds when available.
  */
 export function findMatchingSoundCloudResult(
     query: string,
@@ -320,11 +343,12 @@ export function findMatchingSoundCloudResult(
         const resultNorm = normalizeForMatch(result.name)
         if (!resultNorm) return false
 
-        const titleMatch = tokens.every((token) => resultNorm.includes(token))
+        const matched = tokens.filter((token) => resultNorm.includes(token)).length
+        const titleMatch = matched / tokens.length >= TITLE_MATCH_THRESHOLD
         if (!titleMatch) return false
 
         if (trackSec === null || !result.durationInSec) return true
-        return Math.abs(result.durationInSec - trackSec) <= 15
+        return Math.abs(result.durationInSec - trackSec) <= 30
     })
 }
 
@@ -332,6 +356,7 @@ function normalizeForMatch(value: string): string {
     return value
         .toLowerCase()
         .replace(/[^a-z0-9\s]/g, '')
+        .replace(/\s{2,}/g, ' ')
         .trim()
 }
 

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -252,7 +252,8 @@ export async function createResilientStream(
         })
     }
 
-    const coreTitle = cleanedTitle.replace(/\([^)]*\)/g, ' ').replace(/ {2,}/g, ' ').trim()
+    const openParen = cleanedTitle.indexOf('(')
+    const coreTitle = openParen > 0 ? cleanedTitle.slice(0, openParen).trim() : cleanedTitle
     if (coreTitle && coreTitle !== cleanedTitle) {
         try {
             return await streamViaSoundCloud(coreTitle, track.duration)

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -252,7 +252,7 @@ export async function createResilientStream(
         })
     }
 
-    const coreTitle = cleanedTitle.replace(/\s*\(.*?\)\s*/g, ' ').replace(/\s{2,}/g, ' ').trim()
+    const coreTitle = cleanedTitle.replace(/\s*\([^)]*\)\s*/g, ' ').replace(/\s{2,}/g, ' ').trim()
     if (coreTitle && coreTitle !== cleanedTitle) {
         try {
             return await streamViaSoundCloud(coreTitle, track.duration)

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -252,7 +252,7 @@ export async function createResilientStream(
         })
     }
 
-    const coreTitle = cleanedTitle.replace(/ *\([^)]*\) */g, ' ').replace(/ {2,}/g, ' ').trim()
+    const coreTitle = cleanedTitle.replace(/\([^)]*\)/g, ' ').replace(/ {2,}/g, ' ').trim()
     if (coreTitle && coreTitle !== cleanedTitle) {
         try {
             return await streamViaSoundCloud(coreTitle, track.duration)


### PR DESCRIPTION
## Root Cause

Fixes LUCKY-26 / LUCKY-2P (both unresolved in Sentry, last seen ~3h ago).

**Track**: `MC Ryan SP, MC Jacaré e MC Meno K - Posso Até Não Te Dar Flores (DJ Japa NK e DJ Davi DogDog)`

The bridge `findMatchingSoundCloudResult` required **100% of query tokens** to appear in the SoundCloud result name. Two failure modes:

1. **Compound word split**: `DogDog` → token `"dogdog"` not found when SoundCloud stores it as `"Dog Dog"` → space makes it `"dog dog"` which doesn't contain the substring `"dogdog"`
2. **Accent stripping drops chars**: `Jacaré` → `"jacar"` (é stripped), `Até` → `"at"` (é stripped) — minor differences between how our code and SoundCloud normalize accents

## Changes

- `findMatchingSoundCloudResult`: changed from `tokens.every` (100%) to **75% match threshold** — tolerates 1–2 token mismatches in long titles
- Duration tolerance: **15s → 30s** — handles different track versions
- `createResilientStream`: added **3rd fallback stage** that strips all parenthetical content (`(DJ Japa NK e DJ Davi DogDog)`) before retrying SoundCloud search

## Test plan

- [ ] 1818 tests, all pass
- [ ] New test: Brazilian funk track with compound-name mismatch → 75% threshold matches
- [ ] New test: duration 16–30s off → now accepted
- [ ] New test: core-title fallback stage triggered when title-only fails on parenthetical title
- [ ] Build clean, lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced music track matching with more flexible search criteria and increased duration tolerance (30-second window) for better search accuracy and improved track discovery.
  - Improved fallback mechanism that attempts simplified title-based searches when standard SoundCloud lookups fail to find matches, enhancing overall streaming reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->