### PR TITLE
chore(release): v2.6.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.72] - 2026-04-10
+
+### Added
+
+- **`/djrole set <role>`** — restrict all music commands to users with a designated DJ role; server admins (ManageGuild) always bypass the check
+- **`/djrole clear`** — remove the DJ role restriction
+- **`/djrole show`** — display the currently configured DJ role
+- **`/voteskip`** — democratic skip: cast a vote to skip the current track; skips automatically when the threshold (default 50%) of eligible voice members vote. Threshold is configurable via `GuildSettings.voteSkipThreshold`. Vote state clears on track change.
+- **`/settings music idle-timeout <minutes>`** — configure how long (0–60 min, 0 = disabled) the bot waits in an empty voice channel before automatically disconnecting. Integrates with `MusicWatchdogService.markIntentionalStop` to prevent watchdog reconnect.
+
+### Fixed
+
+- **SoundCloud bridge matching (Sentry LUCKY-26/2P)** — Brazilian funk and tracks with compound DJ names (e.g. "DogDog" vs "Dog Dog" on SoundCloud) now match correctly. Changes:
+  - Token match changed from 100% (`every`) to 75% threshold, tolerating accent stripping and compound-word splits
+  - Duration tolerance relaxed from 15 s to 30 s
+  - `normalizeForMatch` regex uses literal space instead of `\s` (avoids Unicode edge cases)
+  - New 3rd fallback stage: strips content from first `(` in the cleaned title and retries SoundCloud search (e.g. "Bohemian Rhapsody (Official Music Live Session)" → "Bohemian Rhapsody")
+
 ## [2.6.71] - 2026-04-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.71",
+    "version": "2.6.72",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.71",
+    "version": "2.6.72",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.71",
+    "version": "2.6.72",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.71",
+    "version": "2.6.72",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.71",
+    "version": "2.6.72",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- DJ role system (`/djrole set|clear|show`) with music command guard
- `/voteskip` democratic skip (configurable threshold)
- `/settings music idle-timeout` auto-disconnect
- SoundCloud bridge fix (LUCKY-26/2P): 75% token match, 30s tolerance, core-title fallback

## Changelog

See [CHANGELOG.md](CHANGELOG.md) for full details.

## Test plan
- [ ] CI green (portability + SonarCloud + Security)
- [ ] Version bumped to 2.6.72 in all packages
- [ ] CHANGELOG updated with all PRs since v2.6.71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/djrole` commands to restrict music access by Discord role
  * Added `/voteskip` for community-driven track skipping with configurable threshold
  * Added `/settings music idle-timeout` to configure auto-disconnect timing for idle voice channels
  * Improved SoundCloud bridge matching accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->