### PR TITLE
fix(bot): respect explicit provider and fix stream recovery

### DIFF
--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -1,6 +1,9 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import type { GuildMember, ChatInputCommandInteraction } from 'discord.js'
-import { requireVoiceChannel, requireDJRole } from '../../../../utils/command/commandValidations'
+import {
+    requireVoiceChannel,
+    requireDJRole,
+} from '../../../../utils/command/commandValidations'
 import type { CommandExecuteParams } from '../../../../types/CommandData'
 import type { CustomClient } from '../../../../types'
 import Command from '../../../../models/Command'
@@ -148,11 +151,13 @@ export default new Command({
                     playOptions,
                 )
             } catch (spotifyError) {
-                if (searchEngine !== QueryType.AUTO) {
+                // Only auto-fallback when the user did NOT explicitly specify a
+                // provider. If they chose spotify/youtube/soundcloud and it
+                // failed, surface the error so they can adjust their query.
+                if (searchEngine !== QueryType.AUTO && provider === null) {
                     debugLog({
-                        message:
-                            'Spotify search failed, falling back to YouTube',
-                        data: { query },
+                        message: 'Search failed, falling back to YouTube',
+                        data: { query, searchEngine },
                     })
                     try {
                         result = await client.player.play(voiceChannel, query, {
@@ -231,7 +236,10 @@ export default new Command({
                     1,
                 )
             } catch (err) {
-                errorLog({ message: 'Failed to record contribution', error: err })
+                errorLog({
+                    message: 'Failed to record contribution',
+                    error: err,
+                })
             }
 
             // Attach the music control button row so the user can

--- a/packages/bot/src/handlers/player/errorHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.spec.ts
@@ -149,11 +149,8 @@ describe('setupErrorHandlers', () => {
                     tracks: [alternativeTrack],
                 }),
             },
-            removeTrack: jest.fn(),
-            addTrack: jest.fn(),
+            insertTrack: jest.fn(),
             node: {
-                isPlaying: jest.fn(() => false),
-                play: jest.fn().mockResolvedValue(undefined),
                 skip: jest.fn(),
             },
         }
@@ -172,8 +169,8 @@ describe('setupErrorHandlers', () => {
             'Could not extract stream',
         )
         expect(queue.player.search).toHaveBeenCalled()
-        expect(queue.removeTrack).toHaveBeenCalledWith(0)
-        expect(queue.addTrack).toHaveBeenCalledWith(alternativeTrack)
+        expect(queue.insertTrack).toHaveBeenCalledWith(alternativeTrack, 0)
+        expect(queue.node.skip).toHaveBeenCalled()
         expect(recordSuccessMock).toHaveBeenCalledWith('youtube')
     })
 

--- a/packages/bot/src/handlers/player/errorHandlers.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.ts
@@ -221,15 +221,15 @@ async function recoverFromStreamExtractionError(
     )
 
     if (alternativeTrack) {
-        queue.removeTrack(0)
-        queue.addTrack(alternativeTrack)
-        if (!queue.node.isPlaying()) {
-            await queue.node.play()
-            providerHealthService.recordSuccess(providerFromTrack(currentTrack))
-            debugLog({
-                message: 'Successfully recovered from stream extraction error',
-            })
-        }
+        // Insert at the front of the queue so the alternative plays immediately
+        // after we skip the failing current track. Using insertTrack(0) avoids
+        // accidentally removing a legitimately queued user track.
+        queue.insertTrack(alternativeTrack, 0)
+        queue.node.skip()
+        providerHealthService.recordSuccess(providerFromTrack(currentTrack))
+        debugLog({
+            message: 'Successfully recovered from stream extraction error',
+        })
     } else {
         queue.node.skip()
     }


### PR DESCRIPTION
## Problem

Two bugs causing `/play` failures:

### 1. Explicit `provider` choice silently ignored
When the user runs `/play query:... provider:spotify`, if the Spotify extractor throws, the bot was silently falling back to YouTube and returning a YouTube video — ignoring the user's explicit choice. Root: the fallback catch in `play/index.ts` didn't check whether the user had explicitly set a provider.

### 2. `NoResultError: Could not extract stream` — recovery replays the failing track
`recoverFromStreamExtractionError` in `errorHandlers.ts` had two logic bugs:
- `queue.removeTrack(0)` removes the **next queued track**, not the failing current one
- `queue.node.play()` after that **replays the same failing track**, causing the same error again (visible in Sentry as recurring `NoResultError` from `_SoundCloudExtractor.stream`)

## Fix

**`play/index.ts`**: Only auto-fallback to YouTube when `provider === null` (user didn't specify). If they explicitly chose a provider and it fails, surface the error.

**`errorHandlers.ts`**: Replace `removeTrack(0) + addTrack + node.play()` with `insertTrack(alternativeTrack, 0) + node.skip()` — inserts the YouTube alternative at the front of the queue and skips the failing track so it actually plays.

## Test plan
- [x] `errorHandlers.spec.ts` — updated to assert `insertTrack(alt, 0)` + `node.skip()`
- [x] `commands/play/index.spec.ts` — passes unchanged (no provider-specific tests added)
- [x] Full suite: **1853 tests, 0 failures**
- [ ] Manual: `/play query:Bohemian Rhapsody provider:spotify` → must play Spotify result or error, never silently switch to YouTube
- [ ] Manual: play a track that fails stream → bot should recover to YouTube alt instead of looping the same failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved music search fallback logic to Spotify alternative sources with more precise conditions.
  * Enhanced stream extraction error recovery to better handle alternative track substitution and playback resumption.
  * Refined error logging to provide clearer debugging information during search and recovery operations.

* **Tests**
  * Updated test fixtures to reflect changes in queue recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->