### PR TITLE
fix(bot): restore search fallback + default to AUTO_SEARCH

### DIFF
--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -150,14 +150,20 @@ export default new Command({
                     query,
                     playOptions,
                 )
-            } catch (spotifyError) {
-                // Only auto-fallback when the user did NOT explicitly specify a
-                // provider. If they chose spotify/youtube/soundcloud and it
-                // failed, surface the error so they can adjust their query.
-                if (searchEngine !== QueryType.AUTO && provider === null) {
-                    debugLog({
-                        message: 'Search failed, falling back to YouTube',
-                        data: { query, searchEngine },
+            } catch (primaryError) {
+                // Primary search failed — fall back through YouTube then AUTO.
+                // Always fall back regardless of which provider was requested;
+                // surfacing a hard error is worse than playing the song from a
+                // different source. We log the fallback so it shows up in traces.
+                if (searchEngine !== QueryType.AUTO) {
+                    warnLog({
+                        message:
+                            'Primary search failed, falling back to YouTube',
+                        data: {
+                            query,
+                            requestedProvider: provider ?? 'default',
+                            searchEngine: String(searchEngine),
+                        },
                     })
                     try {
                         result = await client.player.play(voiceChannel, query, {
@@ -165,9 +171,9 @@ export default new Command({
                             searchEngine: QueryType.YOUTUBE_SEARCH,
                         })
                     } catch (youtubeError) {
-                        debugLog({
+                        warnLog({
                             message:
-                                'YouTube search failed, falling back to auto',
+                                'YouTube search failed, falling back to AUTO',
                             data: { query },
                         })
                         result = await client.player.play(voiceChannel, query, {
@@ -176,7 +182,7 @@ export default new Command({
                         })
                     }
                 } else {
-                    throw spotifyError
+                    throw primaryError
                 }
             }
 

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -1,7 +1,10 @@
 import { QueryType } from 'discord-player'
 import type { ChatInputCommandInteraction, GuildMember } from 'discord.js'
 import type { CustomClient } from '../../../../types'
-import { requireVoiceChannel, requireDJRole } from '../../../../utils/command/commandValidations'
+import {
+    requireVoiceChannel,
+    requireDJRole,
+} from '../../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../../utils/music/queueResolver'
 import { buildPlayResponseEmbed } from '../../../../utils/music/nowPlayingEmbed'
 import { createMusicControlButtons } from '../../../../utils/music/buttonComponents'
@@ -25,7 +28,10 @@ export function isUrl(query: string): boolean {
     return query.startsWith('http://') || query.startsWith('https://')
 }
 
-export function resolveSearchEngine(query: string, provider?: string | null): QueryType {
+export function resolveSearchEngine(
+    query: string,
+    provider?: string | null,
+): QueryType {
     if (isUrl(query)) return QueryType.AUTO
 
     switch (provider) {
@@ -34,8 +40,9 @@ export function resolveSearchEngine(query: string, provider?: string | null): Qu
         case 'soundcloud':
             return QueryType.SOUNDCLOUD_SEARCH
         case 'spotify':
-        default:
             return QueryType.SPOTIFY_SEARCH
+        default:
+            return QueryType.AUTO_SEARCH
     }
 }
 
@@ -54,7 +61,12 @@ export async function executePlayAtTop({
 }: PlayAtTopOptions): Promise<void> {
     if (!interaction.guildId) {
         await interaction.reply({
-            embeds: [createErrorEmbed('Error', 'This command can only be used in a server')],
+            embeds: [
+                createErrorEmbed(
+                    'Error',
+                    'This command can only be used in a server',
+                ),
+            ],
             ephemeral: true,
         })
         return
@@ -77,7 +89,9 @@ export async function executePlayAtTop({
 
     try {
         const searchEngine = resolveSearchEngine(query)
-        const result = await client.player.play(voiceChannel, query, { searchEngine })
+        const result = await client.player.play(voiceChannel, query, {
+            searchEngine,
+        })
         const track = result.track
 
         const { queue } = resolveGuildQueue(client, interaction.guildId)
@@ -85,7 +99,9 @@ export async function executePlayAtTop({
             await interactionReply({
                 interaction,
                 content: {
-                    embeds: [createErrorEmbed('Error', 'Could not create queue')],
+                    embeds: [
+                        createErrorEmbed('Error', 'Could not create queue'),
+                    ],
                     ephemeral: true,
                 },
             })
@@ -102,16 +118,26 @@ export async function executePlayAtTop({
         const embed = buildPlayResponseEmbed(
             skipCurrent
                 ? { kind: 'nowPlaying', track, requestedBy: interaction.user }
-                : { kind: 'addedToQueue', track, requestedBy: interaction.user, queuePosition: 1 },
+                : {
+                      kind: 'addedToQueue',
+                      track,
+                      requestedBy: interaction.user,
+                      queuePosition: 1,
+                  },
         )
 
         await interactionReply({
             interaction,
-            content: { embeds: [embed], components: [createMusicControlButtons(queue)] },
+            content: {
+                embeds: [embed],
+                components: [createMusicControlButtons(queue)],
+            },
         })
 
         debugLog({
-            message: skipCurrent ? 'track added to top and current skipped' : 'track added to top of queue',
+            message: skipCurrent
+                ? 'track added to top and current skipped'
+                : 'track added to top of queue',
             data: { query, guildId: interaction.guildId },
         })
     } catch (error) {
@@ -123,13 +149,22 @@ export async function executePlayAtTop({
             return
         }
 
-        errorLog({ message: `${commandName} error:`, error, data: { query, guildId: interaction.guildId } })
+        errorLog({
+            message: `${commandName} error:`,
+            error,
+            data: { query, guildId: interaction.guildId },
+        })
 
         try {
             await interactionReply({
                 interaction,
                 content: {
-                    embeds: [createErrorEmbed('Play Error', createUserFriendlyError(error))],
+                    embeds: [
+                        createErrorEmbed(
+                            'Play Error',
+                            createUserFriendlyError(error),
+                        ),
+                    ],
                     ephemeral: true,
                 },
             })

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -217,10 +217,11 @@ export async function createResilientStream(
             })
             return stream
         } catch (ytdlpError) {
-            debugLog({
+            warnLog({
                 message: 'Bridge: yt-dlp failed, falling back to SoundCloud',
                 data: {
                     error: (ytdlpError as Error).message,
+                    url: track.url,
                     cleanedTitle,
                 },
             })
@@ -247,13 +248,15 @@ export async function createResilientStream(
         return await streamViaSoundCloud(cleanedTitle, track.duration)
     } catch {
         debugLog({
-            message: 'Bridge: title-only SoundCloud failed, retrying without parentheticals',
+            message:
+                'Bridge: title-only SoundCloud failed, retrying without parentheticals',
             data: { cleanedTitle },
         })
     }
 
     const openParen = cleanedTitle.indexOf('(')
-    const coreTitle = openParen > 0 ? cleanedTitle.slice(0, openParen).trim() : cleanedTitle
+    const coreTitle =
+        openParen > 0 ? cleanedTitle.slice(0, openParen).trim() : cleanedTitle
     if (coreTitle && coreTitle !== cleanedTitle) {
         try {
             return await streamViaSoundCloud(coreTitle, track.duration)
@@ -344,7 +347,9 @@ export function findMatchingSoundCloudResult(
         const resultNorm = normalizeForMatch(result.name)
         if (!resultNorm) return false
 
-        const matched = tokens.filter((token) => resultNorm.includes(token)).length
+        const matched = tokens.filter((token) =>
+            resultNorm.includes(token),
+        ).length
         const titleMatch = matched / tokens.length >= TITLE_MATCH_THRESHOLD
         if (!titleMatch) return false
 


### PR DESCRIPTION
## Problem

v2.6.74 introduced a regression: when `provider:spotify` is specified and the Spotify extractor fails, the fix correctly logged it but **threw an error instead of falling back** — meaning users got "Play Error" instead of music.

Additionally, the default search engine for plain text queries was `SPOTIFY_SEARCH`, which requires Spotify credentials/connectivity to succeed as the first attempt.

## Fix

**`queryUtils.ts`** — Default text search now uses `AUTO_SEARCH` instead of `SPOTIFY_SEARCH`. `AUTO_SEARCH` picks the best available extractor automatically, making `/play some song` work reliably without Spotify API needing to succeed first.

**`play/index.ts`** — Restore full fallback chain (primary → YOUTUBE_SEARCH → AUTO) for ALL cases, even when an explicit provider was specified. Playing from a fallback source is always better than an error. Fallback is now logged at WARN level so it shows in production traces.

**`playerFactory.ts`** — Escalate yt-dlp bridge failure from DEBUG to WARN so failed stream attempts appear in production logs.

## Test plan
- [x] 1853 tests, 0 failures
- [ ] Manual: `/play provider:spotify query:X` — plays music (may use YouTube audio backend), no error
- [ ] Manual: `/play query:X` (no provider) — plays via AUTO_SEARCH
- [ ] Logs: WARN lines appear when primary search falls back to YouTube

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced fallback search behavior in the music play command for improved result discovery when initial searches fail.

* **Bug Fixes**
  * Improved error logging visibility for music playback failures, now capturing original URLs and showing warnings for stream creation issues.

* **Chores**
  * Updated default search engine selection logic for music queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->