### PR TITLE
fix(bot): autoplay metadata, last.fm noise, soundcloud url params

### DIFF
--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -27,6 +27,7 @@ import {
     isUnknownInteractionError,
     isUrl,
     resolveSearchEngine,
+    normalizeSoundCloudUrl,
 } from './queryUtils'
 
 function isTrackAlreadyQueued(
@@ -98,7 +99,8 @@ export default new Command({
             throw error
         }
 
-        const query = interaction.options.getString('query', true)
+        const rawQuery = interaction.options.getString('query', true)
+        const query = normalizeSoundCloudUrl(rawQuery)
         const provider = interaction.options.getString('provider')
         const collaborativeCheck = collaborativePlaylistService.canAddTracks(
             interaction.guildId,

--- a/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
@@ -49,8 +49,14 @@ describe('normalizeSoundCloudUrl', () => {
         expect(normalizeSoundCloudUrl(query)).toBe(query)
     })
 
-    it('handles malformed URLs gracefully', () => {
+    it('handles non-URL strings gracefully', () => {
         const bad = 'not a url at all'
+        expect(normalizeSoundCloudUrl(bad)).toBe(bad)
+    })
+
+    it('handles malformed soundcloud URLs (no protocol) gracefully', () => {
+        // new URL('soundcloud.com/...') throws — catch block must return input
+        const bad = 'soundcloud.com/artist/track-no-protocol'
         expect(normalizeSoundCloudUrl(bad)).toBe(bad)
     })
 

--- a/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, jest } from '@jest/globals'
+
+jest.mock('discord-player', () => ({
+    QueryType: {
+        AUTO: 'auto',
+        AUTO_SEARCH: 'autoSearch',
+        YOUTUBE_SEARCH: 'youtubeSearch',
+        SOUNDCLOUD_SEARCH: 'soundcloudSearch',
+        SPOTIFY_SEARCH: 'spotifySearch',
+    },
+}))
+jest.mock('discord.js', () => ({}))
+jest.mock('../../../../utils/command/commandValidations', () => ({}))
+jest.mock('../../../../utils/music/queueResolver', () => ({}))
+jest.mock('../../../../utils/music/nowPlayingEmbed', () => ({}))
+jest.mock('../../../../utils/music/buttonComponents', () => ({}))
+jest.mock('../../../../utils/general/embeds', () => ({}))
+jest.mock('../../../../utils/general/interactionReply', () => ({}))
+jest.mock('../../../../utils/general/errorSanitizer', () => ({}))
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+    debugLog: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
+import { normalizeSoundCloudUrl, isUrl } from './queryUtils'
+
+describe('normalizeSoundCloudUrl', () => {
+    it('strips ?in= playlist context from SoundCloud track URLs', () => {
+        const url =
+            'https://soundcloud.com/akajuug/akajuug-inicio-remix?in=gabriel-mendesz/sets/plugzin'
+        expect(normalizeSoundCloudUrl(url)).toBe(
+            'https://soundcloud.com/akajuug/akajuug-inicio-remix',
+        )
+    })
+
+    it('leaves SoundCloud URLs without ?in= unchanged', () => {
+        const url = 'https://soundcloud.com/artist/track'
+        expect(normalizeSoundCloudUrl(url)).toBe(url)
+    })
+
+    it('leaves non-SoundCloud URLs unchanged', () => {
+        const url = 'https://www.youtube.com/watch?v=abc123&list=PLxxx'
+        expect(normalizeSoundCloudUrl(url)).toBe(url)
+    })
+
+    it('leaves plain text queries unchanged', () => {
+        const query = 'bohemian rhapsody queen'
+        expect(normalizeSoundCloudUrl(query)).toBe(query)
+    })
+
+    it('handles malformed URLs gracefully', () => {
+        const bad = 'not a url at all'
+        expect(normalizeSoundCloudUrl(bad)).toBe(bad)
+    })
+
+    it('preserves other SoundCloud query params while stripping ?in=', () => {
+        const url =
+            'https://soundcloud.com/artist/track?in=playlist&secret_token=abc'
+        const result = normalizeSoundCloudUrl(url)
+        expect(result).not.toContain('in=')
+        expect(result).toContain('secret_token=abc')
+    })
+})
+
+describe('isUrl', () => {
+    it('returns true for https URLs', () => {
+        expect(isUrl('https://example.com/path')).toBe(true)
+    })
+
+    it('returns true for http URLs', () => {
+        expect(isUrl('http://example.com')).toBe(true)
+    })
+
+    it('returns false for plain text', () => {
+        expect(isUrl('some song title')).toBe(false)
+    })
+})

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -28,6 +28,21 @@ export function isUrl(query: string): boolean {
     return query.startsWith('http://') || query.startsWith('https://')
 }
 
+/**
+ * Strips SoundCloud playlist-context query params (`?in=...`) that the
+ * SoundCloud extractor cannot resolve. The bare track URL resolves correctly.
+ */
+export function normalizeSoundCloudUrl(url: string): string {
+    if (!url.includes('soundcloud.com')) return url
+    try {
+        const parsed = new URL(url)
+        parsed.searchParams.delete('in')
+        return parsed.toString()
+    } catch {
+        return url
+    }
+}
+
 export function resolveSearchEngine(
     query: string,
     provider?: string | null,

--- a/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
@@ -16,9 +16,13 @@ const createMusicControlButtonsMock = jest.fn(() => ({
     toJSON: () => ({ type: 1, components: [] }),
 }))
 
+const warnLogMock = jest.fn()
+const errorLogMock = jest.fn()
+
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: (...args: unknown[]) => debugLogMock(...args),
-    errorLog: jest.fn(),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+    warnLog: (...args: unknown[]) => warnLogMock(...args),
 }))
 
 jest.mock('../../utils/general/embeds', () => ({
@@ -87,7 +91,10 @@ describe('trackNowPlaying', () => {
         getAutoplayCountMock.mockResolvedValue(7)
         isLastFmConfiguredMock.mockReturnValue(false)
         getSessionKeyForUserMock.mockResolvedValue(null)
-        createMusicControlButtonsMock.mockReturnValue({ type: 1, components: [] })
+        createMusicControlButtonsMock.mockReturnValue({
+            type: 1,
+            components: [],
+        })
     })
 
     it('adds autoplay reason field and footer progress for autoplay tracks', async () => {
@@ -245,5 +252,85 @@ describe('trackNowPlaying', () => {
         expect(getSessionKeyForUserMock).toHaveBeenNthCalledWith(2, undefined)
         expect(updateNowPlayingMock).not.toHaveBeenCalled()
         expect(scrobbleMock).not.toHaveBeenCalled()
+    })
+
+    it('warnLogs (not errorLogs) when updateNowPlaying returns 403', async () => {
+        isLastFmConfiguredMock.mockReturnValue(true)
+        getSessionKeyForUserMock.mockResolvedValue('session-key')
+        updateNowPlayingMock.mockRejectedValue(
+            new Error(
+                'Last.fm track.updateNowPlaying: 403 {"message":"Invalid session key"}',
+            ),
+        )
+
+        const { queue } = createQueue('guild-403-now')
+        const track = {
+            title: 'Song',
+            author: 'Artist',
+            durationMS: 0,
+            metadata: { requestedById: 'user-1' },
+            requestedBy: { id: 'user-1' },
+        }
+
+        await updateLastFmNowPlaying(queue as any, track as any)
+
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('session expired'),
+            }),
+        )
+        expect(errorLogMock).not.toHaveBeenCalled()
+    })
+
+    it('warnLogs (not errorLogs) when scrobble returns 403', async () => {
+        isLastFmConfiguredMock.mockReturnValue(true)
+        getSessionKeyForUserMock.mockResolvedValue('session-key')
+        scrobbleMock.mockRejectedValue(
+            new Error(
+                'Last.fm track.scrobble: 403 {"message":"Invalid session key"}',
+            ),
+        )
+
+        const { queue } = createQueue('guild-403-scrobble')
+        const track = {
+            title: 'Song',
+            author: 'Artist',
+            durationMS: 180000,
+            metadata: { requestedById: 'user-1' },
+            requestedBy: { id: 'user-1' },
+        }
+
+        await scrobbleCurrentTrackIfLastFm(queue as any, track as any)
+
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('session expired'),
+            }),
+        )
+        expect(errorLogMock).not.toHaveBeenCalled()
+    })
+
+    it('errorLogs non-403 Last.fm failures', async () => {
+        isLastFmConfiguredMock.mockReturnValue(true)
+        getSessionKeyForUserMock.mockResolvedValue('session-key')
+        scrobbleMock.mockRejectedValue(new Error('Network timeout'))
+
+        const { queue } = createQueue('guild-timeout-scrobble')
+        const track = {
+            title: 'Song',
+            author: 'Artist',
+            durationMS: 180000,
+            metadata: { requestedById: 'user-1' },
+            requestedBy: { id: 'user-1' },
+        }
+
+        await scrobbleCurrentTrackIfLastFm(queue as any, track as any)
+
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('scrobble failed'),
+            }),
+        )
+        expect(warnLogMock).not.toHaveBeenCalled()
     })
 })

--- a/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
@@ -310,7 +310,31 @@ describe('trackNowPlaying', () => {
         expect(errorLogMock).not.toHaveBeenCalled()
     })
 
-    it('errorLogs non-403 Last.fm failures', async () => {
+    it('errorLogs non-403 Last.fm updateNowPlaying failures', async () => {
+        isLastFmConfiguredMock.mockReturnValue(true)
+        getSessionKeyForUserMock.mockResolvedValue('session-key')
+        updateNowPlayingMock.mockRejectedValue(new Error('Network timeout'))
+
+        const { queue } = createQueue('guild-timeout-now')
+        const track = {
+            title: 'Song',
+            author: 'Artist',
+            durationMS: 0,
+            metadata: { requestedById: 'user-1' },
+            requestedBy: { id: 'user-1' },
+        }
+
+        await updateLastFmNowPlaying(queue as any, track as any)
+
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('updateNowPlaying failed'),
+            }),
+        )
+        expect(warnLogMock).not.toHaveBeenCalled()
+    })
+
+    it('errorLogs non-403 Last.fm scrobble failures', async () => {
         isLastFmConfiguredMock.mockReturnValue(true)
         getSessionKeyForUserMock.mockResolvedValue('session-key')
         scrobbleMock.mockRejectedValue(new Error('Network timeout'))

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -1,6 +1,6 @@
 import type { Track, GuildQueue } from 'discord-player'
 import type { ColorResolvable, TextChannel, User } from 'discord.js'
-import { debugLog, errorLog } from '@lucky/shared/utils'
+import { debugLog, errorLog, warnLog } from '@lucky/shared/utils'
 import { createEmbed, EMBED_COLORS } from '../../utils/general/embeds'
 import { getAutoplayCount } from '../../utils/music/autoplayManager'
 import { constants } from '@lucky/shared/config'
@@ -163,7 +163,16 @@ export async function updateLastFmNowPlaying(
         )
         lastFmTrackStartTime.set(queue.guild.id, Math.floor(Date.now() / 1000))
     } catch (err) {
-        errorLog({ message: 'Last.fm updateNowPlaying failed', error: err })
+        const is403 = err instanceof Error && err.message.includes('403')
+        if (is403) {
+            warnLog({
+                message:
+                    'Last.fm updateNowPlaying: session expired, re-auth needed',
+                error: err,
+            })
+        } else {
+            errorLog({ message: 'Last.fm updateNowPlaying failed', error: err })
+        }
     }
 }
 
@@ -192,6 +201,14 @@ export async function scrobbleCurrentTrackIfLastFm(
             sessionKey,
         )
     } catch (err) {
-        errorLog({ message: 'Last.fm scrobble failed', error: err })
+        const is403 = err instanceof Error && err.message.includes('403')
+        if (is403) {
+            warnLog({
+                message: 'Last.fm scrobble: session expired, re-auth needed',
+                error: err,
+            })
+        } else {
+            errorLog({ message: 'Last.fm scrobble failed', error: err })
+        }
     }
 }

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -1062,6 +1062,46 @@ describe('queueManipulation.replenishQueue', () => {
         expect(addedUrls).not.toContain('https://example.com/uprising')
     })
 
+    it('mutates existing metadata object when property is non-configurable (sealed tracks)', async () => {
+        const mutableMeta: Record<string, unknown> = { requestedById: 'user-1' }
+        const sealedTrack = Object.defineProperty(
+            {
+                title: 'Sealed Song',
+                author: 'Sealed Artist',
+                url: 'https://example.com/sealed',
+                source: 'spotify',
+                requestedBy: { id: 'user-1' },
+            },
+            'metadata',
+            {
+                get: () => mutableMeta,
+                configurable: false,
+                enumerable: true,
+            },
+        )
+
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: {
+                title: 'Current',
+                author: 'Artist',
+                url: 'https://example.com/current',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [sealedTrack],
+                }),
+            },
+        })
+
+        await expect(
+            replenishQueue(queue as unknown as GuildQueue),
+        ).resolves.not.toThrow()
+
+        expect(mutableMeta.isAutoplay).toBe(true)
+    })
+
     it('marks autoplay metadata on tracks with a read-only metadata getter (LUCKY-2K)', async () => {
         const trackWithReadOnlyMetadata = Object.defineProperty(
             {

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -877,6 +877,24 @@ function markAsAutoplayTrack(
     recommendationReason: string,
     requestedById?: string,
 ): void {
+    const descriptor = Object.getOwnPropertyDescriptor(track, 'metadata')
+
+    if (descriptor?.configurable === false) {
+        // discord-player seals metadata as a non-configurable property on some
+        // track objects — Object.defineProperty would throw `Cannot redefine`.
+        // Mutate the object the getter/value returns directly (stable reference).
+        const meta = (
+            track as unknown as { metadata?: Record<string, unknown> }
+        ).metadata
+        if (meta && typeof meta === 'object' && !Object.isFrozen(meta)) {
+            meta['isAutoplay'] = true
+            meta['recommendationReason'] = recommendationReason
+            if (requestedById !== undefined)
+                meta['requestedById'] = requestedById
+        }
+        return
+    }
+
     const existingMetadata =
         (track as unknown as { metadata?: Record<string, unknown> }).metadata ??
         {}


### PR DESCRIPTION
## What

Three Sentry-confirmed bugs fixed in a single PR.

### 1. `markAsAutoplayTrack` — `Object.defineProperty` fails for non-configurable metadata

discord-player seals the `metadata` property as non-configurable after first access on some tracks. `Object.defineProperty` throws `Cannot redefine property: metadata` in that case. Fix: detect `configurable === false`, then mutate the object the getter/value returns directly (discord-player's `_metadata` is a stable reference). For `configurable: true` properties (including getters), `Object.defineProperty` still runs as before.

### 2. Last.fm 403 "Invalid session key" → Sentry noise

Two `errorLog` calls (updateNowPlaying + scrobble) were sending to Sentry on every track play after a Last.fm session key expired. This is a user config issue (re-auth needed), not a code defect. Downgraded to `warnLog`.

### 3. SoundCloud `?in=` playlist context → `NoResultError`

SoundCloud URLs with `?in=<playlist>` parameter fail with `NoResultError: No results found` in the SoundCloud extractor. The param is a UI "in playlist" context that the extractor can't resolve. `normalizeSoundCloudUrl` strips it before the URL reaches the extractor.

## Test plan
- [x] 1853 tests, 0 failures
- [x] `markAsAutoplayTrack` test with `configurable: true` getter passes
- [ ] Verify Sentry: no more `markAsAutoplayTrack` TypeErrors or Last.fm 403 noise after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of SoundCloud URLs in the play command.

* **Bug Fixes**
  * Enhanced Last.fm session error detection with clearer warning messages.
  * Fixed track metadata handling in edge cases.

* **Tests**
  * Added test coverage for URL normalization utilities and Last.fm error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->