### PR TITLE
chore(release): v2.6.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.77] - 2026-04-10
+
+### Fixed
+
+- **Duplicate "Now Playing" message** — `/play` no longer sends two separate "Now Playing" embeds when the track starts immediately. The interaction reply is now registered as the guild's now-playing display; the `playerStart` handler edits it (refreshing buttons) instead of posting a second message.
+
 ## [2.6.76] - 2026-04-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.76",
+  "version": "2.6.77",
   "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/backend",
-  "version": "2.6.76",
+  "version": "2.6.77",
   "description": "Express API server for Lucky",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/bot",
-  "version": "2.6.76",
+  "version": "2.6.77",
   "description": "Discord bot application",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucky-webapp",
   "private": true,
-  "version": "2.6.76",
+  "version": "2.6.77",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/shared",
-  "version": "2.6.76",
+  "version": "2.6.77",
   "description": "Shared code for Lucky modular monolith",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
fix duplicate now-playing message from /play command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `/play` command sending duplicate "Now Playing" embeds when playback starts immediately.

* **Chores**
  * Version bump to 2.6.77.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->