### PR TITLE
fix(bot): preserve first audio chunk and add node js-runtime to yt-dlp

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
@@ -124,7 +124,11 @@ describe('findMatchingSoundCloudResult', () => {
     it('accepts when duration is 16-30s off (relaxed tolerance)', () => {
         expect(
             findMatchingSoundCloudResult('Bohemian Rhapsody', '5:55', [
-                { name: 'Bohemian Rhapsody', url: 'sc://1', durationInSec: 374 },
+                {
+                    name: 'Bohemian Rhapsody',
+                    url: 'sc://1',
+                    durationInSec: 374,
+                },
             ])?.url,
         ).toBe('sc://1')
     })
@@ -171,9 +175,19 @@ describe('findMatchingSoundCloudResult', () => {
     })
 
     it('returns undefined when fewer than 75% of tokens match', () => {
-        const results = [{ name: 'Completely Different Song', url: 'sc://x', durationInSec: 180 }]
+        const results = [
+            {
+                name: 'Completely Different Song',
+                url: 'sc://x',
+                durationInSec: 180,
+            },
+        ]
         expect(
-            findMatchingSoundCloudResult('Bohemian Rhapsody Queen', '3:00', results),
+            findMatchingSoundCloudResult(
+                'Bohemian Rhapsody Queen',
+                '3:00',
+                results,
+            ),
         ).toBeUndefined()
     })
 })
@@ -222,18 +236,22 @@ describe('streamViaYtDlp', () => {
         spawnMock.mockReset()
     })
 
-    it('resolves with stdout when yt-dlp emits data', async () => {
+    it('resolves with a readable stream containing the first chunk when yt-dlp emits data', async () => {
         const proc = makeSpawnSuccess()
         spawnMock.mockReturnValue(proc)
 
         const stream = await streamViaYtDlp('https://youtube.com/watch?v=test')
-        expect(stream).toBe(proc.stdout)
+        // Now returns a PassThrough (not raw proc.stdout) to preserve first chunk
+        expect(stream).not.toBe(proc.stdout)
+        expect(stream.readable).toBe(true)
         expect(spawnMock).toHaveBeenCalledWith(
             'yt-dlp',
             expect.arrayContaining([
                 '--no-playlist',
                 '-o',
                 '-',
+                '--js-runtimes',
+                'node:/usr/local/bin/node',
                 'https://youtube.com/watch?v=test',
             ]),
             expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
@@ -307,7 +325,7 @@ describe('createResilientStream', () => {
         spawnMock.mockReturnValue(proc)
 
         const result = await createResilientStream(makeTrack())
-        expect(result).toBe(proc.stdout)
+        expect(result.readable).toBe(true)
         expect(spawnMock).toHaveBeenCalledWith(
             'yt-dlp',
             expect.arrayContaining([
@@ -366,15 +384,19 @@ describe('createResilientStream', () => {
                 author: 'Best Songs',
             }),
         )
-        expect(result).toBe(proc.stdout)
+        expect(result.readable).toBe(true)
         expect(playdlSearchMock).not.toHaveBeenCalled()
     })
 
     it('falls back to core title (stripped parentheticals) when title-only search fails', async () => {
         spawnMock.mockReturnValue(makeSpawnError(1))
         playdlSearchMock
-            .mockResolvedValueOnce([{ name: 'Unrelated', url: 'sc://miss', durationInSec: 180 }])
-            .mockResolvedValueOnce([{ name: 'Unrelated', url: 'sc://miss2', durationInSec: 180 }])
+            .mockResolvedValueOnce([
+                { name: 'Unrelated', url: 'sc://miss', durationInSec: 180 },
+            ])
+            .mockResolvedValueOnce([
+                { name: 'Unrelated', url: 'sc://miss2', durationInSec: 180 },
+            ])
             .mockResolvedValueOnce([
                 {
                     name: 'Bohemian Rhapsody',
@@ -385,7 +407,9 @@ describe('createResilientStream', () => {
         playdlStreamMock.mockResolvedValueOnce({ stream: fakeStream })
 
         const result = await createResilientStream(
-            makeTrack({ title: 'Bohemian Rhapsody (Official Music Live Session)' }),
+            makeTrack({
+                title: 'Bohemian Rhapsody (Official Music Live Session)',
+            }),
         )
         expect(result).toBe(fakeStream)
         expect(playdlSearchMock).toHaveBeenCalledTimes(3)

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -3,6 +3,7 @@ import type { Track } from 'discord-player'
 import { DefaultExtractors } from '@discord-player/extractor'
 import * as playdl from 'play-dl'
 import { spawn } from 'child_process'
+import { PassThrough } from 'stream'
 import type { Readable } from 'stream'
 import type { CustomClient } from '../../types'
 import { errorLog, infoLog, warnLog, debugLog } from '@lucky/shared/utils'
@@ -152,6 +153,11 @@ export function streamViaYtDlp(url: string): Promise<Readable> {
                 '--quiet',
                 '--no-warnings',
                 '--no-progress',
+                // Provide the Node.js runtime so yt-dlp can use the JS extractor
+                // for YouTube. Without it yt-dlp uses deprecated fallbacks and
+                // may produce incomplete/missing audio for certain formats.
+                '--js-runtimes',
+                'node:/usr/local/bin/node',
                 url,
             ],
             { stdio: ['ignore', 'pipe', 'pipe'] },
@@ -162,9 +168,15 @@ export function streamViaYtDlp(url: string): Promise<Readable> {
             reject(new Error('yt-dlp: timed out waiting for stream start'))
         }, 15_000)
 
-        proc.stdout!.once('data', () => {
+        proc.stdout!.once('data', (firstChunk: Buffer) => {
             clearTimeout(timeout)
-            resolve(proc.stdout!)
+            // The `once('data')` callback consumes the first chunk from the
+            // stream buffer (the WebM EBML header). We use a PassThrough to
+            // re-inject it so discord-player/ffmpeg receives a complete stream.
+            const through = new PassThrough()
+            through.write(firstChunk)
+            proc.stdout!.pipe(through)
+            resolve(through)
         })
 
         proc.once('error', (err) => {


### PR DESCRIPTION
## Root Cause — Silent Playback

Two bugs in `streamViaYtDlp` caused the audio to stream silently:

### Bug 1: First chunk (WebM header) was consumed and discarded

```typescript
// BEFORE — first chunk lost:
proc.stdout!.once('data', () => { resolve(proc.stdout!) })

// AFTER — first chunk preserved via PassThrough:
proc.stdout!.once('data', (firstChunk: Buffer) => {
    const through = new PassThrough()
    through.write(firstChunk)
    proc.stdout!.pipe(through)
    resolve(through)
})
```

yt-dlp outputs WebM/Opus (`1a 45 df a3` — EBML magic bytes). The `once('data')` callback consumed the first chunk (container header) without forwarding it. discord-player/ffmpeg received a stream starting mid-file → could not detect the codec → **silence** even though the bot appeared to be "playing".

### Bug 2: yt-dlp had no JavaScript runtime

yt-dlp logged: `JS Challenge Providers: node (unavailable)` even though `/usr/local/bin/node` exists. Without a JS runtime, YouTube extraction falls back to deprecated methods and misses certain audio formats. Fixed by passing `--js-runtimes node:/usr/local/bin/node` explicitly.

## Tests

- Updated 3 assertions that checked `result.toBe(proc.stdout)` → `result.readable === true` (the returned stream is now a PassThrough wrapping proc.stdout)
- Added `--js-runtimes` to the spawn args assertion
- 1869 tests, 0 failures