### PR TITLE
chore(release): v2.6.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.78] - 2026-04-10
+
+### Fixed
+
+- **Silent audio playback (critical)** — two root causes found and fixed:
+  1. `streamViaYtDlp` consumed the first chunk from yt-dlp's stdout (the WebM EBML header `1a 45 df a3`) via `once('data')` and discarded it. discord-player/ffmpeg received a headerless stream and could not decode the codec, resulting in silence. Fixed with a `PassThrough` that re-injects the first chunk before piping the remainder.
+  2. yt-dlp spawned without a JavaScript runtime (`node: unavailable`). Added `--js-runtimes node:/usr/local/bin/node` so YouTube extraction uses the full JS extractor and all audio formats are available.
+
 ## [2.6.77] - 2026-04-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.77",
+  "version": "2.6.78",
   "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/backend",
-  "version": "2.6.77",
+  "version": "2.6.78",
   "description": "Express API server for Lucky",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/bot",
-  "version": "2.6.77",
+  "version": "2.6.78",
   "description": "Discord bot application",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucky-webapp",
   "private": true,
-  "version": "2.6.77",
+  "version": "2.6.78",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/shared",
-  "version": "2.6.77",
+  "version": "2.6.78",
   "description": "Shared code for Lucky modular monolith",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
critical: silent audio fix — preserve first audio chunk, add node js-runtime to yt-dlp