### PR TITLE
fix(bot): harden player retry and bridge fallbacks

### DIFF
--- a/packages/bot/src/handlers/player/errorHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.spec.ts
@@ -344,6 +344,22 @@ describe('setupErrorHandlers', () => {
         )
     })
 
+    it('logs when the error logger fails inside guarded handlers', () => {
+        const { playerHandlers } = createPlayerWithHandlers()
+        const logError = new Error('error logger failed')
+        errorLogMock.mockImplementationOnce(() => {
+            throw logError
+        })
+        ;(playerHandlers.error as TopLevelErrorHandler)(
+            new Error('Unhandled player error'),
+        )
+
+        expect(debugLogMock).toHaveBeenCalledWith({
+            message: 'errorHandlers: errorLog failed',
+            error: logError,
+        })
+    })
+
     it('skips when stream recovery has no requester, no tracks, no alternative, or no current track', async () => {
         const { queueHandlers } = createPlayerWithHandlers()
         const streamError = new Error('Could not extract stream')

--- a/packages/bot/src/handlers/player/errorHandlers.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.ts
@@ -74,7 +74,9 @@ function safeErrorLog(payload: {
 }): void {
     try {
         errorLog(payload)
-    } catch {}
+    } catch (error) {
+        debugLog({ message: 'errorHandlers: errorLog failed', error })
+    }
 }
 
 function logHandlerFailure(message: string, error: unknown): void {

--- a/packages/bot/src/handlers/player/errorHandlers.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.ts
@@ -1,5 +1,5 @@
 import { QueryType, type GuildQueue } from 'discord-player'
-import type { TextChannel, User } from 'discord.js'
+import type { User } from 'discord.js'
 import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
 import { createErrorEmbed } from '../../utils/general/embeds'
 import {
@@ -11,6 +11,7 @@ import {
     providerFromTrack,
     providerHealthService,
 } from '../../utils/music/search/providerHealth'
+import type { QueueMetadata } from '../../types/QueueMetadata'
 
 type PlayerEvents = {
     events: {
@@ -19,16 +20,11 @@ type PlayerEvents = {
     on?: (event: string, handler: Function) => void
 }
 
-interface IQueueMetadata {
-    requestedBy?: User | null
-    channel?: TextChannel | null
-}
-
 async function notifyChannelStreamFailed(
     queue: GuildQueue,
     trackTitle: string,
 ): Promise<void> {
-    const channel = (queue.metadata as IQueueMetadata)?.channel
+    const channel = (queue.metadata as QueueMetadata | undefined)?.channel
     if (!channel) return
     try {
         await channel.send({
@@ -187,7 +183,7 @@ function handleYouTubeParserError(
 ): void {
     const requestedBy: User | undefined =
         queue.currentTrack?.requestedBy ??
-        (queue.metadata as IQueueMetadata).requestedBy ??
+        (queue.metadata as QueueMetadata | undefined)?.requestedBy ??
         undefined
     logYouTubeError(
         error,
@@ -223,7 +219,7 @@ async function recoverFromStreamExtractionError(
 
     const requestedByUser: User | undefined =
         currentTrack.requestedBy ??
-        (queue.metadata as IQueueMetadata).requestedBy ??
+        (queue.metadata as QueueMetadata | undefined)?.requestedBy ??
         undefined
     if (!requestedByUser) {
         warnLog({

--- a/packages/bot/src/handlers/player/lifecycleHandlers.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.ts
@@ -5,7 +5,7 @@ import * as musicPresence from '../../services/MusicPresenceService'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 import { musicWatchdogService } from '../../utils/music/watchdog'
 import { musicSessionSnapshotService } from '../../utils/music/sessionSnapshots'
-import type { User } from 'discord.js'
+import type { QueueMetadata } from '../../types/QueueMetadata'
 
 export const setupLifecycleHandlers = (player: {
     events: { on: (event: string, handler: Function) => void }
@@ -33,9 +33,7 @@ export const setupLifecycleHandlers = (player: {
         }
 
         if (ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED) {
-            const metadata = queue.metadata as
-                | { requestedBy?: User | null }
-                | undefined
+            const metadata = queue.metadata as QueueMetadata | undefined
 
             await musicSessionSnapshotService.restoreSnapshot(
                 queue,

--- a/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
@@ -6,6 +6,7 @@ import type { Readable } from 'stream'
 const playdlSearchMock = jest.fn()
 const playdlStreamMock = jest.fn()
 const spawnMock = jest.fn()
+const providerIsAvailableMock = jest.fn()
 
 jest.mock('child_process', () => ({
     spawn: (...args: unknown[]) => spawnMock(...args),
@@ -37,6 +38,12 @@ jest.mock('@lucky/shared/utils', () => ({
     infoLog: jest.fn(),
     warnLog: jest.fn(),
     debugLog: jest.fn(),
+}))
+
+jest.mock('../../utils/music/search/providerHealth', () => ({
+    providerHealthService: {
+        isAvailable: (...args: unknown[]) => providerIsAvailableMock(...args),
+    },
 }))
 
 import {
@@ -363,6 +370,8 @@ describe('createResilientStream', () => {
         spawnMock.mockReset()
         playdlSearchMock.mockReset()
         playdlStreamMock.mockReset()
+        providerIsAvailableMock.mockReset()
+        providerIsAvailableMock.mockReturnValue(true)
     })
 
     it('streams via yt-dlp from source URL on first attempt', async () => {
@@ -396,6 +405,19 @@ describe('createResilientStream', () => {
         expect(result).toBe(fakeStream)
         expect(playdlSearchMock).toHaveBeenCalledTimes(1)
         expect(playdlStreamMock).toHaveBeenCalledWith('sc://primary')
+    })
+
+    it('skips SoundCloud stages when provider health is in cooldown', async () => {
+        spawnMock.mockReturnValue(makeSpawnError(1))
+        providerIsAvailableMock.mockReturnValue(false)
+
+        await expect(createResilientStream(makeTrack())).rejects.toThrow(
+            /bridge exhausted/i,
+        )
+
+        expect(providerIsAvailableMock).toHaveBeenCalledWith('soundcloud')
+        expect(playdlSearchMock).not.toHaveBeenCalled()
+        expect(playdlStreamMock).not.toHaveBeenCalled()
     })
 
     it('falls back to SoundCloud title-only when primary returns no validated match', async () => {

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -12,6 +12,7 @@ import {
     cleanAuthor,
     cleanSearchQuery,
 } from '../../utils/music/searchQueryCleaner'
+import { providerHealthService } from '../../utils/music/search/providerHealth'
 
 type CreatePlayerParams = {
     client: CustomClient
@@ -274,6 +275,19 @@ export async function createResilientStream(
                 },
             })
         }
+    }
+
+    if (!providerHealthService.isAvailable('soundcloud')) {
+        warnLog({
+            message:
+                'Bridge: SoundCloud circuit open, skipping fallback stages',
+            data: {
+                title: track.title,
+                cleanedTitle,
+                url: track.url,
+            },
+        })
+        throw new Error(`Bridge exhausted: no stream for "${track.title}"`)
     }
 
     try {

--- a/packages/bot/src/handlers/player/trackHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.spec.ts
@@ -28,6 +28,7 @@ const clearMusicPresenceMock = jest.fn()
 const infoLogMock = jest.fn()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
+const warnLogMock = jest.fn()
 
 jest.mock('discord-player', () => ({
     QueueRepeatMode: {
@@ -95,6 +96,7 @@ jest.mock('@lucky/shared/utils', () => ({
     infoLog: (...args: unknown[]) => infoLogMock(...args),
     debugLog: (...args: unknown[]) => debugLogMock(...args),
     errorLog: (...args: unknown[]) => errorLogMock(...args),
+    warnLog: (...args: unknown[]) => warnLogMock(...args),
 }))
 
 type PlayerEventHandler = (queue: GuildQueue, track?: Track) => Promise<void>
@@ -298,6 +300,29 @@ describe('trackHandlers autoplay replenishment', () => {
         expect(replenishQueueMock).toHaveBeenCalledTimes(2)
         expect(saveSnapshotMock).toHaveBeenCalledWith(autoplayQueue)
         expect(watchdogArmMock).toHaveBeenCalledWith(autoplayQueue)
+    })
+
+    it('logs a failed queue replenishment retry without retrying again', async () => {
+        jest.useFakeTimers()
+        const initialError = new Error('replenish failed')
+        const retryError = new Error('retry failed')
+        replenishQueueMock.mockRejectedValueOnce(initialError)
+        replenishQueueMock.mockRejectedValueOnce(retryError)
+
+        const handlers = setupHandlers()
+        const playerStart = handlers.playerStart
+        const autoplayQueue = createQueue(QueueRepeatMode.AUTOPLAY)
+
+        await playerStart(autoplayQueue, createAutoplayTrack('listener-14'))
+        jest.advanceTimersByTime(5000)
+        await Promise.resolve()
+
+        expect(replenishQueueMock).toHaveBeenCalledTimes(2)
+        expect(warnLogMock).toHaveBeenCalledWith({
+            message: 'Replenish retry failed',
+            error: retryError,
+            data: { guildId: 'guild-1' },
+        })
     })
 
     it('logs and exits gracefully when playerStart fails before now-playing updates', async () => {

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -1,6 +1,6 @@
 import type { Track, GuildQueue } from 'discord-player'
 import { QueueRepeatMode } from 'discord-player'
-import { infoLog, debugLog, errorLog } from '@lucky/shared/utils'
+import { infoLog, debugLog, errorLog, warnLog } from '@lucky/shared/utils'
 import { addTrackToHistory } from '../../utils/music/duplicateDetection'
 import { replenishQueue } from '../../utils/music/trackManagement/queueOperations'
 import { resetAutoplayCount } from '../../utils/music/autoplayManager'
@@ -15,7 +15,10 @@ import { musicWatchdogService } from '../../utils/music/watchdog'
 import { musicSessionSnapshotService } from '../../utils/music/sessionSnapshots'
 import * as voiceStatus from '../../services/VoiceChannelStatusService'
 import * as musicPresence from '../../services/MusicPresenceService'
-import { scheduleIdleDisconnect, clearIdleTimer } from '../../utils/music/idleDisconnect'
+import {
+    scheduleIdleDisconnect,
+    clearIdleTimer,
+} from '../../utils/music/idleDisconnect'
 import { clearVotes } from '../../utils/music/voteSkipStore'
 
 const MAX_GUILD_ENTRIES = 500
@@ -136,7 +139,13 @@ async function handleQueueReplenishment(
                 error: String(error),
             })
             setTimeout(() => {
-                replenishQueue(queue).catch(() => {})
+                replenishQueue(queue).catch((retryErr) => {
+                    warnLog({
+                        message: 'Replenish retry failed',
+                        error: retryErr,
+                        data: { guildId: queue.guild.id },
+                    })
+                })
             }, 5000)
         }
     } else {

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -1,22 +1,17 @@
 import type { Track, GuildQueue } from 'discord-player'
-import type { ColorResolvable, TextChannel, User } from 'discord.js'
+import type { ColorResolvable } from 'discord.js'
 import { debugLog, errorLog, warnLog } from '@lucky/shared/utils'
 import { createEmbed, EMBED_COLORS } from '../../utils/general/embeds'
 import { getAutoplayCount } from '../../utils/music/autoplayManager'
 import { constants } from '@lucky/shared/config'
 import { createMusicControlButtons } from '../../utils/music/buttonComponents'
+import type { QueueMetadata } from '../../types/QueueMetadata'
 import {
     isLastFmConfigured,
     getSessionKeyForUser,
     updateNowPlaying as lastFmUpdateNowPlaying,
     scrobble as lastFmScrobble,
 } from '../../lastfm'
-
-interface IQueueMetadata {
-    channel: TextChannel
-    client: unknown
-    requestedBy: User | undefined
-}
 
 const songInfoMessages = new Map<
     string,
@@ -45,7 +40,7 @@ function getLastFmRequesterId(
     const metadataRequester = (
         track.metadata as { requestedById?: unknown } | undefined
     )?.requestedById
-    const queueRequester = (queue.metadata as IQueueMetadata | undefined)
+    const queueRequester = (queue.metadata as QueueMetadata | undefined)
         ?.requestedBy?.id
     const fallbackRequester =
         typeof metadataRequester === 'string' ? metadataRequester : undefined
@@ -70,7 +65,7 @@ export async function sendNowPlayingEmbed(
     track: Track,
     isAutoplay: boolean,
 ): Promise<void> {
-    const metadata = queue.metadata as IQueueMetadata
+    const metadata = queue.metadata as QueueMetadata | undefined
     if (!metadata?.channel) return
 
     const requester = track.requestedBy

--- a/packages/bot/src/types/QueueMetadata.ts
+++ b/packages/bot/src/types/QueueMetadata.ts
@@ -1,0 +1,8 @@
+import type { TextChannel, User } from 'discord.js'
+import type { CustomClient } from './index'
+
+export interface QueueMetadata {
+    channel?: TextChannel | null
+    requestedBy?: User | null
+    client?: CustomClient | null
+}

--- a/packages/bot/src/types/index.ts
+++ b/packages/bot/src/types/index.ts
@@ -21,3 +21,5 @@ export type CommandType = {
     data: unknown
     execute: (_interaction: ChatInputCommandInteraction) => Promise<void>
 }
+
+export type { QueueMetadata } from './QueueMetadata'

--- a/packages/bot/src/utils/music/idleDisconnect.ts
+++ b/packages/bot/src/utils/music/idleDisconnect.ts
@@ -2,7 +2,7 @@ import type { GuildQueue } from 'discord-player'
 import { guildSettingsService } from '@lucky/shared/services'
 import { debugLog } from '@lucky/shared/utils'
 import { musicWatchdogService } from './watchdog'
-import type { TextChannel } from 'discord.js'
+import type { QueueMetadata } from '../../types/QueueMetadata'
 
 const idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
@@ -20,10 +20,13 @@ export function scheduleIdleDisconnect(queue: GuildQueue): void {
             data: { guildId, timeoutMinutes },
         })
 
-        const timer = setTimeout(() => {
-            idleTimers.delete(guildId)
-            void disconnectIdle(queue)
-        }, timeoutMinutes * 60 * 1000)
+        const timer = setTimeout(
+            () => {
+                idleTimers.delete(guildId)
+                void disconnectIdle(queue)
+            },
+            timeoutMinutes * 60 * 1000,
+        )
 
         idleTimers.set(guildId, timer)
     })()
@@ -42,12 +45,14 @@ async function disconnectIdle(queue: GuildQueue): Promise<void> {
     debugLog({ message: 'Idle disconnect triggered', data: { guildId } })
 
     try {
-        const metadata = queue.metadata as { channel?: TextChannel } | undefined
+        const metadata = queue.metadata as QueueMetadata | undefined
         musicWatchdogService.markIntentionalStop(guildId)
         queue.delete()
 
         if (metadata?.channel) {
-            await metadata.channel.send('👋 Left the voice channel due to inactivity.')
+            await metadata.channel.send(
+                '👋 Left the voice channel due to inactivity.',
+            )
         }
     } catch (error) {
         debugLog({

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -11,6 +11,7 @@ import { recommendationFeedbackService } from '../../services/musicRecommendatio
 import { trackHistoryService } from '@lucky/shared/services'
 import { getLastFmSeedTracks } from './autoplay/lastFmSeeds'
 import { cleanSearchQuery, cleanTitle, cleanAuthor } from './searchQueryCleaner'
+import type { QueueMetadata } from '../../types/QueueMetadata'
 
 const AUTOPLAY_BUFFER_SIZE = 8
 const HISTORY_SEED_LIMIT = 3
@@ -304,7 +305,7 @@ function randomJitter(max: number): number {
 }
 
 function getRequestedBy(queue: GuildQueue, currentTrack: Track): User | null {
-    const metadata = queue.metadata as { requestedBy?: User | null }
+    const metadata = queue.metadata as QueueMetadata | undefined
     return currentTrack.requestedBy ?? metadata?.requestedBy ?? null
 }
 

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -34,6 +34,12 @@ jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
 }))
 
+jest.mock('../../../src/utils/music/search/providerHealth', () => ({
+    providerHealthService: {
+        isAvailable: jest.fn(() => true),
+    },
+}))
+
 describe('playerFactory', () => {
     beforeEach(() => {
         jest.resetModules()


### PR DESCRIPTION
## Summary
- Log failed player replenishment retries and logger failures instead of swallowing them silently.
- Centralize queue metadata typing and replace local `IQueueMetadata` drift across player/music paths.
- Skip SoundCloud bridge fallback stages when provider health has SoundCloud in cooldown.

## Verification
- `npm run lint` exited 0.
- `npm run build` exited 0.
- `npm run test:all` exited 0 after rerun with local listener permissions: shared 257, backend 678, bot 1877, frontend 476 tests passed.
- `npm run audit:high` exited 0 with 0 vulnerabilities.

Note: the first sandboxed `npm run test:all` run failed in backend Supertest with `listen EPERM: operation not permitted 0.0.0.0`; rerunning with approved permissions passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added provider health checks to prevent fallback attempts when music providers are unavailable.

* **Bug Fixes**
  * Enhanced error logging to capture failures in error handlers and queue replenishment retries.
  * Improved stream creation resilience by short-circuiting unavailable provider fallbacks.

* **Tests**
  * Added test coverage for error-handler guards and provider availability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->