### PR TITLE
chore(release): v2.6.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.81] - 2026-04-10
+
+### Fixed
+
+- **Player retry logging** — retry failures now emit `warnLog` with track title and guild ID instead of being silently swallowed.
+- **Shared `QueueMetadata` type** — created `packages/bot/src/types/QueueMetadata.ts`; replaced 6+ scattered `IQueueMetadata` interfaces across `errorHandlers`, `trackHandlers`, `trackNowPlaying`, and `queueManipulation` with a single typed import.
+- **Bridge fallback hardening** — unhealthy SoundCloud results are now skipped before they reach the extractor, reducing silent failures.
+
 ## [2.6.80] - 2026-04-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.78",
+  "version": "2.6.81",
   "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/backend",
-  "version": "2.6.78",
+  "version": "2.6.81",
   "description": "Express API server for Lucky",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/bot",
-  "version": "2.6.78",
+  "version": "2.6.81",
   "description": "Discord bot application",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucky-webapp",
   "private": true,
-  "version": "2.6.78",
+  "version": "2.6.81",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/shared",
-  "version": "2.6.78",
+  "version": "2.6.81",
   "description": "Shared code for Lucky modular monolith",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
player retry logging, shared QueueMetadata type, bridge fallback hardening (phases 3+4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Player retry failures now emit warnings with track title and guild information instead of being silently swallowed.
  * Improved SoundCloud bridge reliability by filtering unhealthy results before processing, reducing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->