### PR TITLE
fix(bot): log player recovery catch errors

### DIFF
--- a/packages/bot/src/handlers/player/errorHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.spec.ts
@@ -531,6 +531,48 @@ describe('setupErrorHandlers', () => {
         )
     })
 
+    it('logs Discord notification failures during stream recovery', async () => {
+        const { queueHandlers } = createPlayerWithHandlers()
+        providerFromTrackMock.mockReturnValue('youtube')
+        analyzeYouTubeErrorMock.mockReturnValue({ isParserError: false })
+
+        const sendError = new Error('missing access')
+        const queue = {
+            guild: { id: 'guild-notify-fail', name: 'Guild Notify Fail' },
+            metadata: {
+                requestedBy: { id: 'user-1' },
+                channel: {
+                    id: 'ch-1',
+                    send: jest.fn().mockRejectedValue(sendError),
+                },
+            },
+            currentTrack: {
+                url: 'https://example.com/current',
+                title: 'Unavailable Song',
+                requestedBy: { id: 'user-1' },
+            },
+            player: { search: jest.fn().mockResolvedValue({ tracks: [] }) },
+            insertTrack: jest.fn(),
+            node: { skip: jest.fn() },
+        }
+
+        ;(queueHandlers.playerError as PlayerErrorHandler)(
+            queue as any,
+            new Error('Could not extract stream'),
+        )
+        await flushPromises()
+
+        expect(debugLogMock).toHaveBeenCalledWith({
+            message: 'Failed to notify channel about stream failure',
+            error: sendError,
+            data: {
+                guildId: 'guild-notify-fail',
+                trackTitle: 'Unavailable Song',
+            },
+        })
+        expect(queue.node.skip).toHaveBeenCalled()
+    })
+
     it('sends Discord error embed when no requestedBy user', async () => {
         const { queueHandlers } = createPlayerWithHandlers()
         providerFromTrackMock.mockReturnValue('youtube')

--- a/packages/bot/src/handlers/player/errorHandlers.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.ts
@@ -35,8 +35,12 @@ async function notifyChannelStreamFailed(
                 ),
             ],
         })
-    } catch {
-        // non-critical — don't crash if we can't notify
+    } catch (error) {
+        debugLog({
+            message: 'Failed to notify channel about stream failure',
+            error,
+            data: { guildId: queue.guild.id, trackTitle },
+        })
     }
 }
 

--- a/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import { EventEmitter } from 'events'
 import { PassThrough } from 'stream'
 import type { Readable } from 'stream'
+import { debugLog } from '@lucky/shared/utils'
 
 const playdlSearchMock = jest.fn()
 const playdlStreamMock = jest.fn()
@@ -286,6 +287,22 @@ describe('streamViaYtDlp', () => {
         expect(spawnMock).not.toHaveBeenCalled()
     })
 
+    it('preserves invalid URL parse failures as the rejection cause', async () => {
+        let rejection: unknown
+
+        try {
+            await streamViaYtDlp('not a url')
+        } catch (error) {
+            rejection = error
+        }
+
+        expect(rejection).toBeInstanceOf(Error)
+        expect((rejection as Error).message).toMatch(/invalid URL/i)
+        expect((rejection as Error).cause).toBeDefined()
+        expect(((rejection as Error).cause as Error).name).toBe('TypeError')
+        expect(spawnMock).not.toHaveBeenCalled()
+    })
+
     it('accepts all allowed domains', async () => {
         const allowedUrls = [
             'https://youtube.com/watch?v=test',
@@ -481,6 +498,18 @@ describe('createResilientStream', () => {
         expect(result).toBe(fakeStream)
         expect(playdlSearchMock).toHaveBeenCalledTimes(3)
         expect(playdlStreamMock).toHaveBeenCalledWith('sc://core')
+        expect(debugLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining(
+                    'title-only SoundCloud failed',
+                ),
+                data: expect.objectContaining({
+                    error: expect.stringContaining('no validated match'),
+                    cleanedTitle:
+                        'Bohemian Rhapsody (Official Music Live Session)',
+                }),
+            }),
+        )
     })
 
     it('throws "Bridge exhausted" when track has no URL and SoundCloud fails', async () => {

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -143,8 +143,8 @@ function validateYtDlpUrl(url: string): void {
     let parsed: URL
     try {
         parsed = new URL(url)
-    } catch {
-        throw new Error(`yt-dlp: invalid URL`)
+    } catch (error) {
+        throw new Error(`yt-dlp: invalid URL`, { cause: error })
     }
     if (parsed.protocol !== 'https:') {
         throw new Error(`yt-dlp: only https URLs are allowed`)
@@ -308,11 +308,14 @@ export async function createResilientStream(
 
     try {
         return await streamViaSoundCloud(cleanedTitle, track.duration)
-    } catch {
+    } catch (titleOnlyError) {
         debugLog({
             message:
                 'Bridge: title-only SoundCloud failed, retrying without parentheticals',
-            data: { cleanedTitle },
+            data: {
+                error: (titleOnlyError as Error).message,
+                cleanedTitle,
+            },
         })
     }
 

--- a/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
@@ -160,6 +160,31 @@ describe('trackNowPlaying', () => {
         )
     })
 
+    it('logs stale now-playing message fetch failures before sending a new one', async () => {
+        const { queue, channel } = createQueue('guild-fetch-fails')
+        const fetchError = new Error('message missing')
+        channel.messages.fetch.mockRejectedValueOnce(fetchError)
+        const track = {
+            title: 'Song B2',
+            author: 'Artist B2',
+            url: 'https://example.com/b2',
+            duration: '2:41',
+            thumbnail: null,
+            requestedBy: { username: 'user-b' },
+            metadata: {},
+        }
+
+        await sendNowPlayingEmbed(queue as any, track as any, false)
+        await sendNowPlayingEmbed(queue as any, track as any, false)
+
+        expect(debugLogMock).toHaveBeenCalledWith({
+            message: 'Failed to update existing now playing message',
+            error: fetchError,
+            data: { guildId: 'guild-fetch-fails', messageId: 'message-1' },
+        })
+        expect(channel.send).toHaveBeenCalledTimes(2)
+    })
+
     it.each([
         {
             name: 'track requester id over metadata and queue fallback',

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -131,7 +131,15 @@ export async function sendNowPlayingEmbed(
                 },
             })
             return
-        } catch {
+        } catch (error) {
+            debugLog({
+                message: 'Failed to update existing now playing message',
+                error,
+                data: {
+                    guildId: queue.guild.id,
+                    messageId: previousMessage.messageId,
+                },
+            })
             songInfoMessages.delete(queue.guild.id)
         }
     }


### PR DESCRIPTION
## Summary
- log previously swallowed player recovery notification failures with guild and track context
- log stale now-playing message fetch failures before deleting the cached message id
- preserve invalid URL parse failures as Error.cause and include title-only SoundCloud fallback errors in debug logs
- add regression coverage for the player recovery and stream bridge fallback paths

## Verification
- npm run lint
- npm run type:check --workspace=packages/bot
- npm run test:bot
- npm run build:bot
- npm run audit:high
- rg -n "catch \\{" packages/bot/src/handlers/player --glob '!**/*.spec.ts' (no matches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging when stream recovery fails to notify Discord channels, capturing diagnostic context for troubleshooting.
  * Enhanced error handling for URL validation, preserving underlying error information for better diagnostics.
  * Added diagnostic logging when now-playing message updates fail, including relevant error details and guild identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->