### PR TITLE
fix(bot): spotify-first, no duplicate play msg, soundcloud last

### DIFF
--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -59,6 +59,8 @@ jest.mock('discord-player', () => ({
     QueryType: {
         AUTO: 'auto',
         SPOTIFY_SEARCH: 'spotifySearch',
+        YOUTUBE_SEARCH: 'youtubeSearch',
+        SOUNDCLOUD_SEARCH: 'soundcloudSearch',
     },
 }))
 
@@ -716,6 +718,86 @@ describe('play command', () => {
                 message: 'Post-play background ops failed',
             }),
         )
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                interaction,
+                content: expect.objectContaining({ embeds: expect.any(Array) }),
+            }),
+        )
+    })
+
+    it('falls back through YouTube to SoundCloud when both Spotify and YouTube fail', async () => {
+        const interaction = createInteraction('guild-1')
+        const result = {
+            track: { title: 'Song A', author: 'Artist A' },
+            searchResult: { playlist: null, tracks: [] },
+        }
+
+        let playCallCount = 0
+        const playImpl = async (...args: unknown[]) => {
+            playCallCount++
+            if (playCallCount === 1) {
+                // First call (Spotify) fails
+                throw new Error('Spotify search failed')
+            } else if (playCallCount === 2) {
+                // Second call (YouTube) fails
+                throw new Error('YouTube search failed')
+            } else {
+                // Third call (SoundCloud) succeeds
+                return result
+            }
+        }
+
+        const client = createClient(playImpl, {
+            repeatMode: 3,
+            tracksSize: 2,
+        })
+
+        await playCommand.execute({
+            client,
+            interaction,
+        } as any)
+
+        expect(client.player.play).toHaveBeenCalledTimes(3)
+        // First attempt with default provider (SPOTIFY_SEARCH)
+        expect(client.player.play).toHaveBeenNthCalledWith(
+            1,
+            expect.anything(),
+            'test query',
+            expect.objectContaining({
+                searchEngine: 'spotifySearch',
+            }),
+        )
+        // Second attempt with YouTube
+        expect(client.player.play).toHaveBeenNthCalledWith(
+            2,
+            expect.anything(),
+            'test query',
+            expect.objectContaining({
+                searchEngine: 'youtubeSearch',
+            }),
+        )
+        // Third attempt with SoundCloud
+        expect(client.player.play).toHaveBeenNthCalledWith(
+            3,
+            expect.anything(),
+            'test query',
+            expect.objectContaining({
+                searchEngine: 'soundcloudSearch',
+            }),
+        )
+        // Should log warnings for first two failures
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringMatching(/Primary search failed/i),
+            }),
+        )
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringMatching(/YouTube search failed/i),
+            }),
+        )
+        // Should still reply with success
         expect(interactionReplyMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 interaction,

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -133,12 +133,6 @@ jest.mock('../../../../utils/general/errorSanitizer', () => ({
     createUserFriendlyError: (error: unknown) => 'User friendly error',
 }))
 
-const registerNowPlayingMessageMock = jest.fn()
-jest.mock('../../../../handlers/player/trackNowPlaying', () => ({
-    registerNowPlayingMessage: (...args: unknown[]) =>
-        registerNowPlayingMessageMock(...args),
-}))
-
 import playCommand from './index'
 
 function createInteraction(guildId: string | null) {
@@ -727,55 +721,6 @@ describe('play command', () => {
                 interaction,
                 content: expect.objectContaining({ embeds: expect.any(Array) }),
             }),
-        )
-    })
-
-    it('registers interaction reply as now-playing message to prevent duplicate (queuePosition=0)', async () => {
-        // When the track starts immediately (no pre-existing queue), the /play
-        // interaction reply shows "Now Playing". Without registration, the
-        // playerStart handler sends a second "Now Playing" message. This test
-        // verifies the registration happens so the handler edits instead.
-        const interaction = createInteraction('guild-1')
-        const track = {
-            id: 'track-1',
-            url: 'https://youtube.com/watch?v=abc',
-            title: 'Test Song',
-            author: 'Test Artist',
-            duration: '3:30',
-            thumbnail: null,
-            requestedBy: { id: 'user-1' },
-            metadata: {},
-        }
-
-        resolveGuildQueueMock.mockReturnValue({ queue: null }) // no pre-existing queue
-        const queue = {
-            tracks: { size: 0, toArray: jest.fn(() => []) },
-            repeatMode: 0,
-        }
-        resolveGuildQueueMock
-            .mockReturnValueOnce({ queue: null })
-            .mockReturnValue({ queue })
-
-        await playCommand.execute({
-            client: createClient(
-                async () => ({
-                    track,
-                    searchResult: { playlist: null, tracks: [track] },
-                }),
-                { tracksSize: 0 },
-            ),
-            interaction,
-        } as any)
-
-        await flushPromises()
-
-        // fetchReply must be called and registerNowPlayingMessage invoked with
-        // the reply's id and channelId — this prevents the duplicate embed.
-        expect(interaction.fetchReply).toHaveBeenCalled()
-        expect(registerNowPlayingMessageMock).toHaveBeenCalledWith(
-            'guild-1',
-            'msg-123',
-            'channel-1',
         )
     })
 })

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -22,7 +22,6 @@ import {
 } from '../../../../utils/music/queueManipulation'
 import { buildPlayResponseEmbed } from '../../../../utils/music/nowPlayingEmbed'
 import { createMusicControlButtons } from '../../../../utils/music/buttonComponents'
-import { registerNowPlayingMessage } from '../../../../handlers/player/trackNowPlaying'
 import {
     DISCORD_UNKNOWN_INTERACTION_CODE,
     isUnknownInteractionError,
@@ -176,12 +175,12 @@ export default new Command({
                     } catch (youtubeError) {
                         warnLog({
                             message:
-                                'YouTube search failed, falling back to AUTO',
+                                'YouTube search failed, falling back to SoundCloud',
                             data: { query },
                         })
                         result = await client.player.play(voiceChannel, query, {
                             ...playOptions,
-                            searchEngine: QueryType.AUTO,
+                            searchEngine: QueryType.SOUNDCLOUD_SEARCH,
                         })
                     }
                 } else {
@@ -232,7 +231,7 @@ export default new Command({
                       },
                   })
                 : buildPlayResponseEmbed({
-                      kind: queuePosition === 0 ? 'nowPlaying' : 'addedToQueue',
+                      kind: 'addedToQueue',
                       track,
                       requestedBy: interaction.user,
                       queuePosition,
@@ -251,33 +250,10 @@ export default new Command({
                 })
             }
 
-            // Attach the music control button row so the user can
-            // pause/skip/shuffle/loop/previous directly from the /play
-            // response. The row is queue-state-aware (disables Previous
-            // when there's no history, disables Shuffle on small queues).
-            const components = queue ? [createMusicControlButtons(queue)] : []
-
             await interactionReply({
                 interaction,
-                content: { embeds: [embed], components },
+                content: { embeds: [embed] },
             })
-
-            // When the track starts playing immediately (queuePosition === 0),
-            // register the interaction reply as the "now playing" message so
-            // the playerStart handler edits it (adding buttons) rather than
-            // sending a second "Now Playing" message in the channel.
-            if (queuePosition === 0 && interaction.guildId) {
-                try {
-                    const reply = await interaction.fetchReply()
-                    registerNowPlayingMessage(
-                        interaction.guildId,
-                        reply.id,
-                        reply.channelId,
-                    )
-                } catch {
-                    // non-critical — worst case playerStart sends a fresh message
-                }
-            }
 
             // Start background ops (apply autoplay pref then blend) without awaiting.
             // This lets the response reach the user immediately.

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -57,7 +57,9 @@ export function resolveSearchEngine(
         case 'spotify':
             return QueryType.SPOTIFY_SEARCH
         default:
-            return QueryType.AUTO_SEARCH
+            // Spotify first: best metadata (titles, artwork, artist).
+            // Fallback chain in play/index.ts tries YouTube then AUTO if Spotify throws.
+            return QueryType.SPOTIFY_SEARCH
     }
 }
 

--- a/packages/bot/src/functions/music/commands/queue/queueEmbed.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueEmbed.ts
@@ -64,7 +64,7 @@ async function addUpcomingTracks(
         const trackList = await createTrackListDisplay(allTracks, options, page)
         embed.addFields({
             name: `\u{1F4CB} Upcoming Tracks (${allTracks.length})`,
-            value: trackList,
+            value: trackList || 'No displayable tracks',
             inline: false,
         })
     } else {

--- a/packages/bot/src/handlers/player/index.ts
+++ b/packages/bot/src/handlers/player/index.ts
@@ -2,7 +2,10 @@ import type { Player } from 'discord-player'
 import type { CustomClient } from '../../types'
 import { createPlayer } from './playerFactory'
 import { setupErrorHandlers } from './errorHandlers'
-import { setupLifecycleHandlers } from './lifecycleHandlers'
+import {
+    setupLifecycleHandlers,
+    setupVoiceKickDetection,
+} from './lifecycleHandlers'
 import { setupTrackHandlers } from './trackHandlers'
 
 type CreatePlayerParams = {
@@ -16,9 +19,23 @@ export const createPlayerWithHandlers = ({
 
     player.events.removeAllListeners()
 
-    setupErrorHandlers(player as unknown as { events: { on: (event: string, handler: Function) => void } })
-    setupLifecycleHandlers(player as unknown as { events: { on: (event: string, handler: Function) => void } })
-    setupTrackHandlers({ player: player as unknown as { events: { on: (event: string, handler: Function) => void } }, client })
+    setupErrorHandlers(
+        player as unknown as {
+            events: { on: (event: string, handler: Function) => void }
+        },
+    )
+    setupLifecycleHandlers(
+        player as unknown as {
+            events: { on: (event: string, handler: Function) => void }
+        },
+    )
+    setupTrackHandlers({
+        player: player as unknown as {
+            events: { on: (event: string, handler: Function) => void }
+        },
+        client,
+    })
+    setupVoiceKickDetection(client)
 
     return player
 }

--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -34,7 +34,10 @@ jest.mock('../../utils/music/watchdog', () => ({
     },
 }))
 
-import { setupLifecycleHandlers } from './lifecycleHandlers'
+import {
+    setupLifecycleHandlers,
+    setupVoiceKickDetection,
+} from './lifecycleHandlers'
 
 type PlayerEventHandler = (queue: GuildQueue, message?: string) => Promise<void>
 
@@ -164,5 +167,123 @@ describe('setupLifecycleHandlers', () => {
         await handlers.emptyQueue(queue)
 
         expect(watchdogMarkIntentionalStopMock).toHaveBeenCalledWith('guild-5')
+    })
+})
+
+describe('setupVoiceKickDetection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('marks intentional stop when bot is kicked from voice channel', () => {
+        const voiceStateUpdateListeners: Array<
+            (oldState: any, newState: any) => void
+        > = []
+        const client = {
+            user: { id: 'bot-user-id' },
+            on: jest.fn(
+                (
+                    event: string,
+                    handler: (oldState: any, newState: any) => void,
+                ) => {
+                    if (event === 'voiceStateUpdate') {
+                        voiceStateUpdateListeners.push(handler)
+                    }
+                },
+            ),
+        }
+
+        setupVoiceKickDetection(client)
+
+        expect(voiceStateUpdateListeners.length).toBe(1)
+
+        const oldState = {
+            member: { id: 'bot-user-id' },
+            channelId: 'voice-channel-1',
+            guild: { id: 'guild-1', name: 'Test Guild' },
+        }
+        const newState = {
+            member: { id: 'bot-user-id' },
+            channelId: null,
+        }
+
+        voiceStateUpdateListeners[0](oldState, newState)
+
+        expect(watchdogMarkIntentionalStopMock).toHaveBeenCalledWith('guild-1')
+        expect(infoLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringMatching(/disconnected from voice/i),
+            }),
+        )
+    })
+
+    it('ignores voiceStateUpdate for non-bot members', () => {
+        const voiceStateUpdateListeners: Array<
+            (oldState: any, newState: any) => void
+        > = []
+        const client = {
+            user: { id: 'bot-user-id' },
+            on: jest.fn(
+                (
+                    event: string,
+                    handler: (oldState: any, newState: any) => void,
+                ) => {
+                    if (event === 'voiceStateUpdate') {
+                        voiceStateUpdateListeners.push(handler)
+                    }
+                },
+            ),
+        }
+
+        setupVoiceKickDetection(client)
+
+        const oldState = {
+            member: { id: 'other-user-id' },
+            channelId: 'voice-channel-1',
+            guild: { id: 'guild-1', name: 'Test Guild' },
+        }
+        const newState = {
+            member: { id: 'other-user-id' },
+            channelId: null,
+        }
+
+        voiceStateUpdateListeners[0](oldState, newState)
+
+        expect(watchdogMarkIntentionalStopMock).not.toHaveBeenCalled()
+    })
+
+    it('ignores bot moving between channels (not a disconnect)', () => {
+        const voiceStateUpdateListeners: Array<
+            (oldState: any, newState: any) => void
+        > = []
+        const client = {
+            user: { id: 'bot-user-id' },
+            on: jest.fn(
+                (
+                    event: string,
+                    handler: (oldState: any, newState: any) => void,
+                ) => {
+                    if (event === 'voiceStateUpdate') {
+                        voiceStateUpdateListeners.push(handler)
+                    }
+                },
+            ),
+        }
+
+        setupVoiceKickDetection(client)
+
+        const oldState = {
+            member: { id: 'bot-user-id' },
+            channelId: 'voice-channel-1',
+            guild: { id: 'guild-1', name: 'Test Guild' },
+        }
+        const newState = {
+            member: { id: 'bot-user-id' },
+            channelId: 'voice-channel-2',
+        }
+
+        voiceStateUpdateListeners[0](oldState, newState)
+
+        expect(watchdogMarkIntentionalStopMock).not.toHaveBeenCalled()
     })
 })

--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -28,6 +28,8 @@ jest.mock('../../utils/music/watchdog', () => ({
         checkAndRecover: (...args: unknown[]) =>
             watchdogCheckRecoverMock(...args),
         clear: (...args: unknown[]) => watchdogClearMock(...args),
+        isIntentionalStop: () => false,
+        markIntentionalStop: jest.fn(),
     },
 }))
 

--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import type { GuildQueue } from 'discord-player'
-import { setupLifecycleHandlers } from './lifecycleHandlers'
 
 const debugLogMock = jest.fn()
 const infoLogMock = jest.fn()
@@ -9,6 +8,8 @@ const saveSnapshotMock = jest.fn()
 const watchdogArmMock = jest.fn()
 const watchdogCheckRecoverMock = jest.fn()
 const watchdogClearMock = jest.fn()
+const watchdogMarkIntentionalStopMock = jest.fn()
+const watchdogIsIntentionalStopMock = jest.fn(() => false)
 
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: (...args: unknown[]) => debugLogMock(...args),
@@ -28,10 +29,12 @@ jest.mock('../../utils/music/watchdog', () => ({
         checkAndRecover: (...args: unknown[]) =>
             watchdogCheckRecoverMock(...args),
         clear: (...args: unknown[]) => watchdogClearMock(...args),
-        isIntentionalStop: () => false,
-        markIntentionalStop: jest.fn(),
+        isIntentionalStop: watchdogIsIntentionalStopMock,
+        markIntentionalStop: watchdogMarkIntentionalStopMock,
     },
 }))
+
+import { setupLifecycleHandlers } from './lifecycleHandlers'
 
 type PlayerEventHandler = (queue: GuildQueue, message?: string) => Promise<void>
 
@@ -41,6 +44,7 @@ describe('setupLifecycleHandlers', () => {
         restoreSnapshotMock.mockResolvedValue({ restoredCount: 0 })
         saveSnapshotMock.mockResolvedValue(null)
         watchdogCheckRecoverMock.mockResolvedValue('none')
+        watchdogIsIntentionalStopMock.mockReturnValue(false)
     })
 
     it('restores snapshot and arms watchdog on connection', async () => {
@@ -93,5 +97,72 @@ describe('setupLifecycleHandlers', () => {
 
         expect(saveSnapshotMock).toHaveBeenCalledWith(queue)
         expect(watchdogCheckRecoverMock).toHaveBeenCalledWith(queue)
+    })
+
+    it('does NOT call checkAndRecover when connectionDestroyed', async () => {
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-3', name: 'Guild 3' },
+        } as unknown as GuildQueue
+
+        await handlers.connectionDestroyed(queue)
+
+        expect(saveSnapshotMock).toHaveBeenCalled()
+        expect(watchdogCheckRecoverMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call checkAndRecover when disconnect is intentional stop', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-4', name: 'Guild 4' },
+        } as unknown as GuildQueue
+
+        await handlers.disconnect(queue)
+
+        expect(saveSnapshotMock).toHaveBeenCalledWith(queue)
+        expect(watchdogCheckRecoverMock).not.toHaveBeenCalled()
+    })
+
+    it('marks intentional stop on emptyQueue', async () => {
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-5', name: 'Guild 5' },
+        } as unknown as GuildQueue
+
+        await handlers.emptyQueue(queue)
+
+        expect(watchdogMarkIntentionalStopMock).toHaveBeenCalledWith('guild-5')
     })
 })

--- a/packages/bot/src/handlers/player/lifecycleHandlers.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.ts
@@ -1,4 +1,5 @@
 import type { GuildQueue } from 'discord-player'
+import type { Client } from 'discord.js'
 import { infoLog, debugLog } from '@lucky/shared/utils'
 import * as voiceStatus from '../../services/VoiceChannelStatusService'
 import * as musicPresence from '../../services/MusicPresenceService'
@@ -6,6 +7,20 @@ import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 import { musicWatchdogService } from '../../utils/music/watchdog'
 import { musicSessionSnapshotService } from '../../utils/music/sessionSnapshots'
 import type { QueueMetadata } from '../../types/QueueMetadata'
+
+export const setupVoiceKickDetection = (client: Client): void => {
+    client.on('voiceStateUpdate', (oldState, newState) => {
+        if (newState.member?.id !== client.user?.id) return
+        const wasInChannel = Boolean(oldState.channelId)
+        const nowDisconnected = !newState.channelId
+        if (wasInChannel && nowDisconnected && oldState.guild) {
+            musicWatchdogService.markIntentionalStop(oldState.guild.id)
+            infoLog({
+                message: `Bot was disconnected from voice in ${oldState.guild.name} — marked intentional`,
+            })
+        }
+    })
+}
 
 export const setupLifecycleHandlers = (player: {
     events: { on: (event: string, handler: Function) => void }
@@ -52,7 +67,7 @@ export const setupLifecycleHandlers = (player: {
         await voiceStatus.clearStatus(queue)
         musicPresence.clearMusicPresence(queue.guild.id)
         await musicSessionSnapshotService.saveSnapshot(queue)
-        await musicWatchdogService.checkAndRecover(queue)
+        // Queue was explicitly deleted — never attempt recovery here.
     })
 
     player.events.on('emptyChannel', async (queue: GuildQueue) => {
@@ -63,6 +78,10 @@ export const setupLifecycleHandlers = (player: {
         musicWatchdogService.clear(queue.guild.id)
     })
 
+    player.events.on('emptyQueue', async (queue: GuildQueue) => {
+        musicWatchdogService.markIntentionalStop(queue.guild.id)
+    })
+
     player.events.on('disconnect', async (queue: GuildQueue) => {
         infoLog({
             message: `Disconnected from voice channel in ${queue.guild.name}`,
@@ -71,6 +90,8 @@ export const setupLifecycleHandlers = (player: {
         await voiceStatus.clearStatus(queue)
         musicPresence.clearMusicPresence(queue.guild.id)
         await musicSessionSnapshotService.saveSnapshot(queue)
-        await musicWatchdogService.checkAndRecover(queue)
+        if (!musicWatchdogService.isIntentionalStop(queue.guild.id)) {
+            await musicWatchdogService.checkAndRecover(queue)
+        }
     })
 }

--- a/packages/bot/src/handlers/player/trackHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.spec.ts
@@ -69,6 +69,7 @@ jest.mock('../../utils/music/watchdog', () => ({
     musicWatchdogService: {
         arm: (...args: unknown[]) => watchdogArmMock(...args),
         clear: (...args: unknown[]) => watchdogClearMock(...args),
+        isIntentionalStop: () => false,
     },
 }))
 

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -213,6 +213,7 @@ const handlePlayerFinish = async (
 ): Promise<void> => {
     try {
         await scrobbleAndRecord(queue, track)
+        if (musicWatchdogService.isIntentionalStop(queue.guild.id)) return
         await replenishIfAutoplay(queue)
         await musicSessionSnapshotService.saveSnapshot(queue)
 
@@ -235,6 +236,7 @@ const handlePlayerSkip = async (
     try {
         debugLog({ message: 'Track skipped, checking queue...' })
         await scrobbleAndRecord(queue, track)
+        if (musicWatchdogService.isIntentionalStop(queue.guild.id)) return
         await replenishIfAutoplay(queue)
         await musicSessionSnapshotService.saveSnapshot(queue)
 

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -1362,6 +1362,45 @@ describe('queueManipulation.queueOperations', () => {
     })
 })
 
+describe('queueManipulation — title-only deduplication', () => {
+    it('treats same title with different authors as duplicate candidate', async () => {
+        const currentTrack = {
+            title: 'Bohemian Rhapsody',
+            author: 'Queen - Topic',
+            url: 'https://example.com/bq-topic',
+        } as Track
+
+        const candidateTrack = {
+            title: 'Bohemian Rhapsody',
+            author: 'Queen',
+            url: 'https://example.com/bq-queen',
+        } as Track
+
+        const queue = createQueueMock({
+            currentTrack,
+            tracks: {
+                size: 0,
+                toArray: jest.fn().mockReturnValue([]),
+            },
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [candidateTrack],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as any, {
+            targetQueueSize: 1,
+            guildId: 'guild-1',
+        })
+
+        // The candidate should be deduplicated by title, so no track is added
+        expect((queue as any).addTrack).not.toHaveBeenCalledWith(
+            expect.objectContaining({ title: 'Bohemian Rhapsody' }),
+        )
+    })
+})
+
 describe('queueManipulation.moveUserTrackToPriority', () => {
     it('moves user track from after autoplay tracks to before first autoplay track', () => {
         const userTrack = {

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -1399,6 +1399,45 @@ describe('queueManipulation — title-only deduplication', () => {
             expect.objectContaining({ title: 'Bohemian Rhapsody' }),
         )
     })
+
+    it('treats version suffix variants of same title as duplicate candidate', async () => {
+        const currentTrack = {
+            title: 'Bohemian Rhapsody',
+            author: 'Queen',
+            url: 'https://example.com/bq-original',
+        } as Track
+
+        const candidateTrack = {
+            title: 'Bohemian Rhapsody - Live',
+            author: 'Queen',
+            url: 'https://example.com/bq-live',
+        } as Track
+
+        const queue = createQueueMock({
+            currentTrack,
+            tracks: {
+                size: 0,
+                toArray: jest.fn().mockReturnValue([]),
+            },
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [candidateTrack],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as any, {
+            targetQueueSize: 1,
+            guildId: 'guild-1',
+        })
+
+        // The candidate with version suffix should be deduplicated by title-only, so no track is added
+        expect((queue as any).addTrack).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: expect.stringMatching(/Bohemian Rhapsody/),
+            }),
+        )
+    })
 })
 
 describe('queueManipulation.moveUserTrackToPriority', () => {

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -329,18 +329,18 @@ function buildExcludedKeys(
     historyTracks: Track[],
     persistentHistory: { title: string; author: string }[] = [],
 ): Set<string> {
-    return new Set<string>([
-        normalizeTrackKey(currentTrack.title, currentTrack.author),
-        ...historyTracks.map((track) =>
-            normalizeTrackKey(track.title, track.author),
-        ),
-        ...queue.tracks
-            .toArray()
-            .map((track) => normalizeTrackKey(track.title, track.author)),
-        ...persistentHistory.map((entry) =>
-            normalizeTrackKey(entry.title, entry.author),
-        ),
-    ])
+    const allTracks: { title?: string; author?: string }[] = [
+        currentTrack,
+        ...historyTracks,
+        ...queue.tracks.toArray(),
+        ...persistentHistory,
+    ]
+    const keys: string[] = []
+    for (const t of allTracks) {
+        keys.push(normalizeTrackKey(t.title, t.author))
+        keys.push(normalizeTitleOnly(t.title))
+    }
+    return new Set(keys)
 }
 
 function buildRecentArtists(
@@ -764,6 +764,10 @@ function normalizeTrackKey(title?: string, author?: string): string {
     return `${normalizeText(cleanedTitle)}::${normalizeText(cleanedAuthor)}`
 }
 
+function normalizeTitleOnly(title?: string): string {
+    return normalizeText(title ? cleanTitle(title) : '')
+}
+
 function normalizeText(value?: string): string {
     return (value ?? '')
         .toLowerCase()
@@ -781,9 +785,9 @@ function isDuplicateCandidate(
     excludedKeys: Set<string>,
 ): boolean {
     if (track.url && excludedUrls.has(track.url)) return true
-
-    const key = normalizeTrackKey(track.title, track.author)
-    return excludedKeys.has(key)
+    if (excludedKeys.has(normalizeTrackKey(track.title, track.author)))
+        return true
+    return excludedKeys.has(normalizeTitleOnly(track.title))
 }
 
 function calculateRecommendationScore(

--- a/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
@@ -180,3 +180,59 @@ describe('cleanTitle — version variant noise patterns', () => {
         expect(cleanTitle('Track (Bonus Track)')).toBe('Track')
     })
 })
+
+describe('cleanTitle — hyphenated version suffixes', () => {
+    it('strips " – 2011 Remaster" en-dash suffix', () => {
+        expect(cleanTitle('Bohemian Rhapsody – 2011 Remaster')).toBe(
+            'Bohemian Rhapsody',
+        )
+    })
+
+    it('strips " - Live" hyphen suffix', () => {
+        expect(cleanTitle('Song Title - Live')).toBe('Song Title')
+    })
+
+    it('leaves non-keyword suffix unchanged', () => {
+        expect(cleanTitle('Song Title - Some Other Suffix')).toBe(
+            'Song Title - Some Other Suffix',
+        )
+    })
+
+    it('handles already-parenthetical versions', () => {
+        expect(cleanTitle('Song Title (Live)')).toBe('Song Title')
+    })
+
+    it('strips " — 2020 Remastered" em-dash suffix', () => {
+        expect(cleanTitle('Classic Song — 2020 Remastered')).toBe(
+            'Classic Song',
+        )
+    })
+
+    it('does not strip suffix when no separator found', () => {
+        expect(cleanTitle('Song Title Remaster')).toBe('Song Title Remaster')
+    })
+
+    it('strips " - Acoustic" suffix', () => {
+        expect(cleanTitle('Track - Acoustic')).toBe('Track')
+    })
+
+    it('strips " - Extended" suffix', () => {
+        expect(cleanTitle('Track - Extended')).toBe('Track')
+    })
+
+    it('strips " - Radio Edit" suffix', () => {
+        expect(cleanTitle('Track - Radio Edit')).toBe('Track')
+    })
+
+    it('strips " - Demo" suffix', () => {
+        expect(cleanTitle('Track - Demo')).toBe('Track')
+    })
+
+    it('strips " - Album Version" suffix', () => {
+        expect(cleanTitle('Track - Album Version')).toBe('Track')
+    })
+
+    it('strips " - Single Version" suffix', () => {
+        expect(cleanTitle('Track - Single Version')).toBe('Track')
+    })
+})

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -81,14 +81,10 @@ const NOISE_PATTERNS: readonly RegExp[] = [
 
     // YouTube auto-generated "Topic" channel suffix
     /\s{0,3}-\s{0,3}topic\b/gi,
-
-    // Hyphenated version suffixes not wrapped in brackets — common on YouTube/Spotify:
-    //   "Song – 2011 Remaster", "Song - Remastered", "Song - Official Audio", etc.
-    // Anchored to $ so no backtracking after the keyword boundary.
-    /\s+[-–]\s+(?:\d{4}\s+)?remaster(?:ed)?\s*$/gi,
-    /\s+[-–]\s+official\s+(?:audio|video|music\s+video)\s*$/gi,
-    /\s+[-–]\s+(?:live|acoustic|demo|extended|radio\s+edit|album\s+version|single\s+version)\s*$/gi,
 ]
+
+const HYPHENATED_VERSION_SUFFIX =
+    /^(?:\d{4} +)?remaster(?:ed)?$|^official (?:audio|video|music video)$|^(?:live|acoustic|demo|extended|radio edit|album version|single version)$/i
 
 /**
  * Channels whose uploads are almost always mislabeled or compilation garbage.
@@ -113,6 +109,19 @@ export function cleanTitle(title: string): string {
     for (const pattern of NOISE_PATTERNS) {
         cleaned = cleaned.replaceAll(pattern, ' ')
     }
+    // Strip hyphenated version suffixes: "Song – 2011 Remaster", "Song - Live", etc.
+    // indexOf avoids regex quantifier nesting (S5852).
+    for (const sep of [' – ', ' - ', ' — ']) {
+        const idx = cleaned.indexOf(sep)
+        if (idx > 0) {
+            const suffix = cleaned.slice(idx + sep.length).trim()
+            if (HYPHENATED_VERSION_SUFFIX.test(suffix)) {
+                cleaned = cleaned.slice(0, idx)
+                break
+            }
+        }
+    }
+
     // Drop empty parenthesis/bracket pairs left behind by the strips above.
     cleaned = cleaned
         .replaceAll(/\(\s{0,3}\)/g, ' ')

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -84,11 +84,10 @@ const NOISE_PATTERNS: readonly RegExp[] = [
 
     // Hyphenated version suffixes not wrapped in brackets — common on YouTube/Spotify:
     //   "Song – 2011 Remaster", "Song - Remastered", "Song - Official Audio", etc.
-    // Strips everything after " - " or " – " when the remainder is a known version tag.
-    /\s+[-–]\s+\d{4}\s+remaster(?:ed)?\b.*/gi,
-    /\s+[-–]\s+remaster(?:ed)?(?:\s+\d{4})?\b.*/gi,
-    /\s+[-–]\s+official\s+(?:audio|video|music\s+video)\b.*/gi,
-    /\s+[-–]\s+(?:live|acoustic|demo|extended|radio\s+edit|album\s+version|single\s+version)\b.*/gi,
+    // Anchored to $ so no backtracking after the keyword boundary.
+    /\s+[-–]\s+(?:\d{4}\s+)?remaster(?:ed)?\s*$/gi,
+    /\s+[-–]\s+official\s+(?:audio|video|music\s+video)\s*$/gi,
+    /\s+[-–]\s+(?:live|acoustic|demo|extended|radio\s+edit|album\s+version|single\s+version)\s*$/gi,
 ]
 
 /**

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -81,6 +81,14 @@ const NOISE_PATTERNS: readonly RegExp[] = [
 
     // YouTube auto-generated "Topic" channel suffix
     /\s{0,3}-\s{0,3}topic\b/gi,
+
+    // Hyphenated version suffixes not wrapped in brackets — common on YouTube/Spotify:
+    //   "Song – 2011 Remaster", "Song - Remastered", "Song - Official Audio", etc.
+    // Strips everything after " - " or " – " when the remainder is a known version tag.
+    /\s+[-–]\s+\d{4}\s+remaster(?:ed)?\b.*/gi,
+    /\s+[-–]\s+remaster(?:ed)?(?:\s+\d{4})?\b.*/gi,
+    /\s+[-–]\s+official\s+(?:audio|video|music\s+video)\b.*/gi,
+    /\s+[-–]\s+(?:live|acoustic|demo|extended|radio\s+edit|album\s+version|single\s+version)\b.*/gi,
 ]
 
 /**

--- a/packages/bot/src/utils/music/watchdog.ts
+++ b/packages/bot/src/utils/music/watchdog.ts
@@ -105,7 +105,16 @@ export class MusicWatchdogService {
     markIntentionalStop(guildId: string): void {
         this.intentionalStops.add(guildId)
         this.clear(guildId)
-        setTimeout(() => this.intentionalStops.delete(guildId), 5_000)
+        // Window must outlive the watchdog timeout so the flag is still set
+        // when any already-scheduled checkAndRecover fires.
+        setTimeout(
+            () => this.intentionalStops.delete(guildId),
+            this.timeoutMs + 10_000,
+        )
+    }
+
+    isIntentionalStop(guildId: string): boolean {
+        return this.intentionalStops.has(guildId)
     }
 
     clear(guildId: string): void {

--- a/packages/bot/tests/utils/music/watchdog.test.ts
+++ b/packages/bot/tests/utils/music/watchdog.test.ts
@@ -88,12 +88,15 @@ describe('MusicWatchdogService', () => {
             expect(service['timers'].has('guild-1')).toBe(false)
         })
 
-        it('removes the intentional stop flag after 5 seconds', async () => {
-            const queue = makeQueue()
+        it('removes the intentional stop flag after timeoutMs + 10s', async () => {
             service.markIntentionalStop('guild-1')
 
-            jest.advanceTimersByTime(5_000)
+            // Flag must persist through the watchdog timeout window
+            jest.advanceTimersByTime(100 + 9_999)
+            expect(service['intentionalStops'].has('guild-1')).toBe(true)
 
+            // Clears after timeoutMs (100) + 10_000
+            jest.advanceTimersByTime(1)
             expect(service['intentionalStops'].has('guild-1')).toBe(false)
         })
 

--- a/packages/bot/tests/utils/music/watchdog.test.ts
+++ b/packages/bot/tests/utils/music/watchdog.test.ts
@@ -124,4 +124,21 @@ describe('MusicWatchdogService', () => {
             expect(queue.node.play).toHaveBeenCalled()
         })
     })
+
+    describe('isIntentionalStop', () => {
+        it('returns true after markIntentionalStop is called', () => {
+            service.markIntentionalStop('guild-1')
+            expect(service['intentionalStops'].has('guild-1')).toBe(true)
+        })
+
+        it('returns false before markIntentionalStop is called', () => {
+            expect(service['intentionalStops'].has('guild-new')).toBe(false)
+        })
+
+        it('returns false for a different guild after markIntentionalStop', () => {
+            service.markIntentionalStop('guild-1')
+            expect(service['intentionalStops'].has('guild-1')).toBe(true)
+            expect(service['intentionalStops'].has('guild-2')).toBe(false)
+        })
+    })
 })


### PR DESCRIPTION
## Changes

**Provider priority**: Spotify → YouTube → SoundCloud (was AUTO_SEARCH which resolved via SoundCloud)

**Duplicate play message**: Removed `nowPlaying` from the interaction reply — `sendNowPlayingEmbed` (playerStart) is now the single authoritative Now Playing display. Eliminates the race where playerStart fired before `fetchReply()` completed.

**Fallback chain**: Spotify → YouTube → SoundCloud (was AUTO which picked SoundCloud for YouTube-available tracks)

1879 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * /play now sends embeds only on initial reply (music control buttons removed).
  * Bot detects voice kicks and treats them as intentional stops, preventing automatic recovery and autoplay in those cases.
  * Intentional-stop state now persists longer before clearing.

* **Improvements**
  * Search order adjusted to prefer Spotify with SoundCloud as a fallback when needed.
  * Queue replenishment better avoids duplicates using title-only matching.
  * Title cleaning now strips common hyphenated/version suffixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->