### PR TITLE
chore(release): v2.6.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.84] - 2026-04-11
+
+### Fixed
+
+- Provider priority: Spotify → YouTube → SoundCloud; no more SoundCloud-first resolution
+- Duplicate Now Playing message eliminated — interaction reply is addedToQueue only
+- Autoplay dedup: hyphenated version suffixes stripped (– Remaster, - Live, - Official Audio)
+- /stop no longer triggers watchdog reconnect (intentional-stop window extended)
+- Manual voice kick detected via voiceStateUpdate, marked intentional
+- /skip last song no longer triggers reconnect via emptyQueue event
+- Queue embed empty field guard prevents Discord API rejection
+
 ## [2.6.82] - 2026-04-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.82",
+  "version": "2.6.84",
   "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/backend",
-  "version": "2.6.82",
+  "version": "2.6.84",
   "description": "Express API server for Lucky",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/bot",
-  "version": "2.6.82",
+  "version": "2.6.84",
   "description": "Discord bot application",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucky-webapp",
   "private": true,
-  "version": "2.6.82",
+  "version": "2.6.84",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/shared",
-  "version": "2.6.82",
+  "version": "2.6.84",
   "description": "Shared code for Lucky modular monolith",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
spotify-first provider, dedup fixes, /stop reconnect fix, voice kick detection, queue embed fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Adjusted music provider source priority for better availability
* Eliminated duplicate playback notifications
* Enhanced autoplay deduplication to prevent duplicate track variants
* Improved bot stability when using `/stop` command
* Fixed voice state detection for manual disconnections
* Resolved skip behavior on final queue item
* Fixed queue display formatting issues

**Version:** 2.6.84

<!-- end of auto-generated comment: release notes by coderabbit.ai -->