### PR TITLE
ci: restore self-contained sonarcloud coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,28 +44,17 @@ jobs:
             - name: Build project
               run: npm run build
 
-            - name: Run backend tests with coverage
-              run: npm run test:ci -- --coverage
+            - name: Run backend tests
+              run: npm run test:ci
 
-            - name: Run bot tests with coverage
-              run: npm run test --workspace=packages/bot -- --ci --coverage
+            - name: Run bot tests
+              run: npm run test --workspace=packages/bot -- --ci
 
             - name: Run music incident regression suite
               run: npm run test:music:incident
 
-            - name: Run frontend tests with coverage
-              run: npm run test --workspace=packages/frontend -- --coverage --coverage.reporter=lcov --coverage.reporter=text
-
-            - name: Upload coverage artifacts
-              uses: actions/upload-artifact@v4
-              if: always()
-              with:
-                  name: coverage-reports
-                  path: |
-                      packages/backend/coverage/lcov.info
-                      packages/bot/coverage/lcov.info
-                      packages/frontend/coverage/lcov.info
-                  retention-days: 1
+            - name: Run frontend tests
+              run: npm run test --workspace=packages/frontend
 
     security:
         name: Security

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -34,11 +34,16 @@ jobs:
               run: npx prisma generate && npm run build:shared
               continue-on-error: true
 
-            - name: Download coverage artifacts
-              uses: actions/download-artifact@v4
-              with:
-                  name: coverage-reports
-                  path: .
+            - name: Run backend tests with coverage
+              run: npm run test --workspace=packages/backend -- --ci --coverage
+              continue-on-error: true
+
+            - name: Run bot tests with coverage
+              run: npm run test --workspace=packages/bot -- --ci --coverage
+              continue-on-error: true
+
+            - name: Run frontend tests with coverage (lcov)
+              run: npm run test --workspace=packages/frontend -- --coverage --coverage.reporter=lcov --coverage.reporter=text
               continue-on-error: true
 
             - name: Validate Sonar token policy


### PR DESCRIPTION
Reverted ci.yml/sonarcloud.yml to self-contained approach. Artifact sharing between concurrent workflows fails because sonarcloud runs in parallel with ci.yml, not after it.