### PR TITLE
fix(bot): serialize autoplay replenish per guild, write redis on add

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -42,13 +42,17 @@ type Track = any
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
     errorLog: jest.fn(),
+    warnLog: jest.fn(),
 }))
 
 const getTrackHistoryMock = jest.fn()
+const addTrackToHistoryMock = jest.fn().mockResolvedValue(true)
 
 jest.mock('@lucky/shared/services', () => ({
     trackHistoryService: {
         getTrackHistory: (...args: unknown[]) => getTrackHistoryMock(...args),
+        addTrackToHistory: (...args: unknown[]) =>
+            addTrackToHistoryMock(...args),
     },
 }))
 

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -6,7 +6,7 @@ import {
 } from 'discord-player'
 import { randomInt } from 'node:crypto'
 import type { User } from 'discord.js'
-import { debugLog, errorLog } from '@lucky/shared/utils'
+import { debugLog, errorLog, warnLog } from '@lucky/shared/utils'
 import { recommendationFeedbackService } from '../../services/musicRecommendation/feedbackService'
 import { trackHistoryService } from '@lucky/shared/services'
 import { getLastFmSeedTracks } from './autoplay/lastFmSeeds'
@@ -187,7 +187,26 @@ export async function moveTrackInQueue(
     }
 }
 
-export async function replenishQueue(
+// Per-guild mutex: serializes concurrent replenishQueue calls so two events
+// firing within milliseconds (playerStart + playerFinish) cannot both read
+// the same exclusion sets and independently select the same track.
+const replenishLocks = new Map<string, Promise<void>>()
+
+export function replenishQueue(
+    queue: GuildQueue,
+    finishedTrack?: Track,
+): Promise<void> {
+    const guildId = queue.guild.id
+    const prev = replenishLocks.get(guildId) ?? Promise.resolve()
+    const next = prev.then(() => _replenishQueue(queue, finishedTrack))
+    replenishLocks.set(
+        guildId,
+        next.catch(() => {}),
+    )
+    return next
+}
+
+async function _replenishQueue(
     queue: GuildQueue,
     finishedTrack?: Track,
 ): Promise<void> {
@@ -219,8 +238,15 @@ export async function replenishQueue(
                     queue.guild.id,
                     requestedBy?.id,
                 ),
-                trackHistoryService.getTrackHistory(queue.guild.id, 20),
+                trackHistoryService.getTrackHistory(queue.guild.id, 50),
             ])
+        if (persistentHistory.length === 0) {
+            warnLog({
+                message:
+                    'Autoplay: persistent history empty — Redis may be unavailable',
+                data: { guildId: queue.guild.id },
+            })
+        }
         const excludedUrls = buildExcludedUrls(
             queue,
             currentTrack,
@@ -233,6 +259,16 @@ export async function replenishQueue(
             historyTracks,
             persistentHistory,
         )
+        debugLog({
+            message: 'Autoplay: exclusion sets built',
+            data: {
+                guildId: queue.guild.id,
+                excludedUrlCount: excludedUrls.size,
+                excludedKeyCount: excludedKeys.size,
+                historyTracks: historyTracks.length,
+                persistentHistory: persistentHistory.length,
+            },
+        })
         const recentArtists = buildRecentArtists(currentTrack, historyTracks)
         const candidates = await collectRecommendationCandidates(
             queue,
@@ -670,9 +706,26 @@ function addSelectedTracks(
     for (const candidate of selected) {
         markAsAutoplayTrack(candidate.track, candidate.reason, requestedById)
         queue.addTrack(candidate.track)
+        // Update local exclusion sets for this replenish call
         excludedUrls.add(candidate.track.url)
+        const vid = extractYouTubeVideoId(candidate.track.url)
+        if (vid) excludedUrls.add(vid)
         excludedKeys.add(
             normalizeTrackKey(candidate.track.title, candidate.track.author),
+        )
+        excludedKeys.add(normalizeTitleOnly(candidate.track.title))
+        // Write to Redis immediately so the NEXT replenish call (from the
+        // subsequent event) also excludes this track — not just the local set.
+        void trackHistoryService.addTrackToHistory(
+            {
+                id: candidate.track.id || candidate.track.url,
+                url: candidate.track.url,
+                title: candidate.track.title,
+                author: candidate.track.author,
+                duration: candidate.track.duration ?? '',
+                metadata: { isAutoplay: true },
+            },
+            queue.guild.id,
         )
     }
 }


### PR DESCRIPTION
## Root Causes Fixed

Full analysis is in `.claude/plans/autoplay-dedup-fix-2026-04-11.md`.

### 1. Race condition (CRITICAL) — per-guild mutex
`replenishQueue` was called concurrently from `playerStart`, `playerFinish`, and `playerSkip`. Each call built its own local `excludedUrls`/`excludedKeys` sets at call time. If two calls overlapped by even a few milliseconds, both would see the same exclusion sets and independently select the same track.

**Fix**: Module-level `replenishLocks: Map<string, Promise<void>>`. Each `replenishQueue` call for a guild chains onto the previous call's promise, ensuring serialization.

### 2. Just-added tracks not in Redis for concurrent calls
Previously, autoplay tracks were only written to Redis history when they *finished playing*. The concurrent call from the next event would not find them in Redis exclusions.

**Fix**: `addSelectedTracks` now immediately writes each added track to Redis history (fire-and-forget `void`). The next replenish call (milliseconds later) finds them in Redis.

### 3. History lookback too short
Changed `getTrackHistory(guild.id, 20)` → `getTrackHistory(guild.id, 50)`. Covers ~3h sessions.

### Observability
- `warnLog` when Redis history is empty (potential Redis issue)
- `debugLog` with exclusion set sizes after build (visible in debug mode)

1905 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the historical track pool for autoplay selection from 20 to 50 entries, enhancing song variety and reducing repeat plays
  * Improved queue synchronization to prevent processing conflicts during concurrent operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->