### PR TITLE
chore(release): v2.6.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.87] - 2026-04-11
+
+### Fixed
+
+- Autoplay repeats: per-guild mutex serializes concurrent replenish calls so race conditions no longer allow the same track to be selected twice
+- Autoplay repeats: tracks added to queue are immediately written to Redis history so the next replenish call excludes them
+- Autoplay: history lookback increased from 20 to 50 entries (~3h session coverage)
+
 ## [2.6.86] - 2026-04-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.86",
+  "version": "2.6.87",
   "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/backend",
-  "version": "2.6.86",
+  "version": "2.6.87",
   "description": "Express API server for Lucky",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/bot",
-  "version": "2.6.86",
+  "version": "2.6.87",
   "description": "Discord bot application",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucky-webapp",
   "private": true,
-  "version": "2.6.86",
+  "version": "2.6.87",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucky/shared",
-  "version": "2.6.86",
+  "version": "2.6.87",
   "description": "Shared code for Lucky modular monolith",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
autoplay mutex, redis write on add, 50-entry history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 2.6.87

* **Bug Fixes**
  * Fixed autoplay from selecting the same track multiple times
  * Improved exclusion of recently queued tracks from autoplay selection
  * Extended autoplay history window to increase available track variety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->