### PR TITLE
feat(bot): autoplay subcommands, queue reason display, 100-track history dedup

### DIFF
--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -11,6 +11,7 @@ const replenishQueueMock = jest.fn()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
 const resolveGuildQueueMock = jest.fn()
+const trackHistoryServiceMock = jest.fn()
 
 jest.mock('../../../utils/general/interactionReply', () => ({
     interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
@@ -36,6 +37,13 @@ jest.mock('../../../utils/music/trackManagement/queueOperations', () => ({
 
 jest.mock('../../../utils/music/queueResolver', () => ({
     resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    trackHistoryService: {
+        getAutoplayStats: (...args: unknown[]) =>
+            trackHistoryServiceMock(...args),
+    },
 }))
 
 jest.mock('@lucky/shared/utils', () => ({
@@ -226,6 +234,72 @@ describe('autoplay command', () => {
                 'No Active Queue',
                 expect.anything(),
             )
+        })
+    })
+
+    describe('analytics subcommand', () => {
+        it('should show autoplay analytics with data', async () => {
+            const interaction = createInteraction('analytics')
+            const client = createClient()
+
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            trackHistoryServiceMock.mockResolvedValue({
+                total: 100,
+                autoplayCount: 30,
+                autoplayPercent: 30,
+                topAutoplayArtists: [
+                    { artist: 'The Beatles', count: 10 },
+                    { artist: 'Pink Floyd', count: 8 },
+                ],
+            })
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(trackHistoryServiceMock).toHaveBeenCalledWith('guild-1', 200)
+            expect(createEmbedMock).toHaveBeenCalled()
+            const embed = createEmbedMock.mock.calls[0][0]
+            expect(embed.title).toContain('Analytics')
+            expect(embed.description).toContain('100 tracks')
+            expect(embed.description).toContain('30 (30%)')
+            expect(interactionReplyMock).toHaveBeenCalled()
+        })
+
+        it('should handle empty history gracefully', async () => {
+            const interaction = createInteraction('analytics')
+            const client = createClient()
+
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            trackHistoryServiceMock.mockResolvedValue({
+                total: 0,
+                autoplayCount: 0,
+                autoplayPercent: 0,
+                topAutoplayArtists: [],
+            })
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(createEmbedMock).toHaveBeenCalled()
+            const embed = createEmbedMock.mock.calls[0][0]
+            expect(embed.description).toContain('No play history yet')
+            expect(interactionReplyMock).toHaveBeenCalled()
+        })
+
+        it('should handle service errors gracefully', async () => {
+            const interaction = createInteraction('analytics')
+            const client = createClient()
+
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            trackHistoryServiceMock.mockRejectedValue(
+                new Error('Service error'),
+            )
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'Error',
+                expect.anything(),
+            )
+            expect(interactionReplyMock).toHaveBeenCalled()
         })
     })
 })

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -1,13 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import autoplayCommand from './autoplay'
 
-const QueueRepeatMode = {
-    OFF: 0,
-    AUTOPLAY: 3,
-} as const
-
-const requireGuildMock = jest.fn()
-const requireDJRoleMock = jest.fn()
 const interactionReplyMock = jest.fn()
 const createEmbedMock = jest.fn((payload: unknown) => payload)
 const createErrorEmbedMock = jest.fn((title: string, desc: string) => ({
@@ -17,22 +10,7 @@ const createErrorEmbedMock = jest.fn((title: string, desc: string) => ({
 const replenishQueueMock = jest.fn()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
-const warnLogMock = jest.fn()
 const resolveGuildQueueMock = jest.fn()
-const getGuildSettingsMock = jest.fn()
-const setGuildSettingsMock = jest.fn()
-
-jest.mock('../../../utils/command/commandValidations', () => ({
-    requireGuild: (...args: unknown[]) => requireGuildMock(...args),
-    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
-}))
-
-jest.mock('discord-player', () => ({
-    QueueRepeatMode: {
-        OFF: 0,
-        AUTOPLAY: 3,
-    },
-}))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
     interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
@@ -63,436 +41,191 @@ jest.mock('../../../utils/music/queueResolver', () => ({
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: (...args: unknown[]) => debugLogMock(...args),
     errorLog: (...args: unknown[]) => errorLogMock(...args),
-    warnLog: (...args: unknown[]) => warnLogMock(...args),
 }))
 
-jest.mock('@lucky/shared/services', () => ({
-    guildSettingsService: {
-        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
-        setGuildSettings: (...args: unknown[]) => setGuildSettingsMock(...args),
-    },
-}))
-
-function createInteraction(guildId = 'guild-1') {
+function createInteraction(subcommand = 'skip') {
     const interaction = {
-        guildId,
+        guildId: 'guild-1',
         deferred: false,
         replied: false,
         user: { id: 'user-1' },
         deferReply: jest.fn(async () => {
             interaction.deferred = true
         }),
+        options: {
+            getSubcommand: jest.fn(() => subcommand),
+        },
     }
 
     return interaction as any
 }
 
-function createQueue(repeatMode = QueueRepeatMode.OFF) {
+function createQueue() {
     return {
         guild: { id: 'guild-1' },
-        repeatMode,
-        currentTrack: { title: 'Song A' },
-        tracks: { size: 0 },
-        setRepeatMode: jest.fn(),
+        currentTrack: { title: 'Current Song' },
+        tracks: {
+            size: 3,
+            at: jest.fn((index: number) => {
+                if (index === 0)
+                    return {
+                        metadata: { isAutoplay: true },
+                        title: 'Autoplay 1',
+                    }
+                if (index === 1)
+                    return { metadata: { isAutoplay: false }, title: 'Manual' }
+                if (index === 2)
+                    return {
+                        metadata: { isAutoplay: true },
+                        title: 'Autoplay 2',
+                    }
+                return null
+            }),
+        },
+        removeTrack: jest.fn(),
     } as any
 }
 
-function createClient({ directQueue = null }: { directQueue?: unknown }) {
+function createClient() {
     return {
-        player: {
-            nodes: {
-                get: jest.fn(() => directQueue),
-            },
-        },
+        user: { id: 'bot-1' },
     } as any
 }
 
 describe('autoplay command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
-        requireGuildMock.mockResolvedValue(true)
-        requireDJRoleMock.mockResolvedValue(true)
-        getGuildSettingsMock.mockResolvedValue(null)
-        setGuildSettingsMock.mockResolvedValue(true)
-        resolveGuildQueueMock.mockReturnValue({
-            queue: null,
-            source: 'miss',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 0,
-                cacheSampleKeys: [],
-            },
+    })
+
+    describe('structure', () => {
+        it('should have correct name and description', () => {
+            expect(autoplayCommand.data.name).toBe('autoplay')
+            expect(autoplayCommand.data.description).toContain(
+                'Manage autoplay',
+            )
+        })
+
+        it('should have three subcommands', () => {
+            const builder = autoplayCommand.data
+            const options = (builder as any).options || []
+            expect(options.length).toBeGreaterThanOrEqual(3)
         })
     })
 
-    it('enables autoplay on active queue and persists preference', async () => {
-        const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({ directQueue: null })
-        const interaction = createInteraction()
-        resolveGuildQueueMock.mockReturnValue({
-            queue,
-            source: 'cache.guild',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 1,
-                cacheSampleKeys: ['guild-1'],
-            },
+    describe('skip subcommand', () => {
+        it('should skip first autoplay track and replenish', async () => {
+            const interaction = createInteraction('skip')
+            const queue = createQueue()
+            const client = createClient()
+
+            resolveGuildQueueMock.mockReturnValue({ queue })
+            replenishQueueMock.mockResolvedValue(undefined)
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(interaction.deferReply).toHaveBeenCalled()
+            expect(queue.removeTrack).toHaveBeenCalledWith(0)
+            expect(replenishQueueMock).toHaveBeenCalledWith(queue)
+            expect(interactionReplyMock).toHaveBeenCalled()
         })
 
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
+        it('should handle empty queue gracefully', async () => {
+            const interaction = createInteraction('skip')
+            const queue = createQueue()
+            queue.tracks.size = 0
+            const client = createClient()
 
-        expect(queue.setRepeatMode).toHaveBeenCalledWith(
-            QueueRepeatMode.AUTOPLAY,
-        )
-        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
-            autoPlayEnabled: true,
+            resolveGuildQueueMock.mockReturnValue({ queue })
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'Queue Empty',
+                expect.anything(),
+            )
         })
-        expect(replenishQueueMock).toHaveBeenCalledWith(queue)
-        expect(interactionReplyMock).toHaveBeenCalled()
     })
 
-    it('disables autoplay when already enabled', async () => {
-        const queue = createQueue(QueueRepeatMode.AUTOPLAY)
-        const client = createClient({ directQueue: queue })
-        const interaction = createInteraction()
-        resolveGuildQueueMock.mockReturnValue({
-            queue,
-            source: 'nodes.get',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 1,
-                cacheSampleKeys: ['guild-1'],
-            },
+    describe('clear subcommand', () => {
+        it('should remove all autoplay tracks and replenish', async () => {
+            const interaction = createInteraction('clear')
+            const queue = createQueue()
+            const client = createClient()
+
+            resolveGuildQueueMock.mockReturnValue({ queue })
+            replenishQueueMock.mockResolvedValue(undefined)
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(queue.removeTrack).toHaveBeenCalledTimes(2)
+            expect(replenishQueueMock).toHaveBeenCalledWith(queue)
+            expect(interactionReplyMock).toHaveBeenCalled()
         })
 
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
+        it('should handle no autoplay tracks gracefully', async () => {
+            const interaction = createInteraction('clear')
+            const queue = createQueue()
+            queue.tracks.at = jest.fn(() => ({
+                metadata: { isAutoplay: false },
+            }))
+            const client = createClient()
 
-        expect(queue.setRepeatMode).toHaveBeenCalledWith(QueueRepeatMode.OFF)
-        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
-            autoPlayEnabled: false,
+            resolveGuildQueueMock.mockReturnValue({ queue })
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'No Autoplay Tracks',
+                expect.anything(),
+            )
         })
-        expect(replenishQueueMock).not.toHaveBeenCalled()
-        expect(interactionReplyMock).toHaveBeenCalled()
     })
 
-    it('disables autoplay when no queue exists and settings are missing (default-on)', async () => {
-        const client = createClient({ directQueue: null })
-        const interaction = createInteraction()
+    describe('status subcommand', () => {
+        it('should show autoplay status', async () => {
+            const interaction = createInteraction('status')
+            const queue = createQueue()
+            const client = createClient()
 
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
+            resolveGuildQueueMock.mockReturnValue({ queue })
 
-        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
-            autoPlayEnabled: false,
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(createEmbedMock).toHaveBeenCalled()
+            const embed = createEmbedMock.mock.calls[0][0]
+            expect(embed.title).toContain('Status')
+            expect(interactionReplyMock).toHaveBeenCalled()
         })
-        expect(interactionReplyMock).toHaveBeenCalled()
     })
 
-    it('shows an error when disabling autoplay without a queue fails to persist', async () => {
-        const client = createClient({ directQueue: null })
-        const interaction = createInteraction()
-        setGuildSettingsMock.mockResolvedValue(false)
+    describe('error handling', () => {
+        it('should handle unknown interaction error gracefully', async () => {
+            const interaction = createInteraction('skip')
+            const error = { code: 10062 }
+            interaction.deferReply = jest.fn(async () => {
+                throw error
+            })
+            const client = createClient()
 
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
 
-        expect(warnLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: 'Failed to persist autoplay disabled preference',
-            }),
-        )
-        expect(createEmbedMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                title: 'Autoplay preference not saved',
-            }),
-        )
-        expect(interactionReplyMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                content: expect.objectContaining({
-                    ephemeral: true,
-                }),
-            }),
-        )
-        expect(replenishQueueMock).not.toHaveBeenCalled()
-    })
+            await autoplayCommand.execute({ client, interaction } as any)
 
-    it('shows a queue-only warning when disabling autoplay cannot persist', async () => {
-        const queue = createQueue(QueueRepeatMode.AUTOPLAY)
-        const client = createClient({ directQueue: queue })
-        const interaction = createInteraction()
-        setGuildSettingsMock.mockResolvedValue(false)
-        resolveGuildQueueMock.mockReturnValue({
-            queue,
-            source: 'nodes.get',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 1,
-                cacheSampleKeys: ['guild-1'],
-            },
+            expect(interactionReplyMock).not.toHaveBeenCalled()
         })
 
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
+        it('should reply with error when no queue exists', async () => {
+            const interaction = createInteraction('skip')
+            const client = createClient()
 
-        expect(queue.setRepeatMode).toHaveBeenCalledWith(QueueRepeatMode.OFF)
-        expect(warnLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: 'Failed to persist autoplay disabled preference',
-            }),
-        )
-        expect(createEmbedMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                title: 'Autoplay disabled for current queue only',
-            }),
-        )
-        expect(replenishQueueMock).not.toHaveBeenCalled()
-    })
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
 
-    it('shows a queue-only warning when enabling autoplay cannot persist', async () => {
-        const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({ directQueue: queue })
-        const interaction = createInteraction()
-        setGuildSettingsMock.mockResolvedValue(false)
-        resolveGuildQueueMock.mockReturnValue({
-            queue,
-            source: 'nodes.get',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 1,
-                cacheSampleKeys: ['guild-1'],
-            },
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'No Active Queue',
+                expect.anything(),
+            )
         })
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        expect(queue.setRepeatMode).toHaveBeenCalledWith(
-            QueueRepeatMode.AUTOPLAY,
-        )
-        expect(warnLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: 'Failed to persist autoplay enabled preference',
-            }),
-        )
-        expect(createEmbedMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                title: 'Autoplay enabled for current queue only',
-            }),
-        )
-        expect(replenishQueueMock).toHaveBeenCalledWith(queue)
-    })
-
-    it('disables stored preference when no queue and was enabled', async () => {
-        const client = createClient({ directQueue: null })
-        const interaction = createInteraction()
-        getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: true })
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
-            autoPlayEnabled: false,
-        })
-        expect(createEmbedMock).toHaveBeenCalledWith(
-            expect.objectContaining({ title: 'Autoplay disabled' }),
-        )
-    })
-
-    it('enables stored preference when no queue and autoplay was disabled', async () => {
-        const client = createClient({ directQueue: null })
-        const interaction = createInteraction()
-        getGuildSettingsMock.mockResolvedValue({ autoPlayEnabled: false })
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        expect(setGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
-            autoPlayEnabled: true,
-        })
-        expect(createEmbedMock).toHaveBeenCalledWith(
-            expect.objectContaining({ title: 'Autoplay enabled' }),
-        )
-    })
-
-    it('returns early when interaction guild id is missing', async () => {
-        const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({ directQueue: queue })
-        const interaction = createInteraction(null as unknown as string)
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        expect(interactionReplyMock).not.toHaveBeenCalled()
-        expect(resolveGuildQueueMock).not.toHaveBeenCalled()
-    })
-
-    it('replies before replenishment finishes', async () => {
-        const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({ directQueue: queue })
-        const interaction = createInteraction()
-        let resolveReplenish: () => void = () => {}
-
-        replenishQueueMock.mockImplementation(
-            () =>
-                new Promise<void>((resolve) => {
-                    resolveReplenish = resolve
-                }),
-        )
-        resolveGuildQueueMock.mockReturnValue({
-            queue,
-            source: 'nodes.get',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 1,
-                cacheSampleKeys: ['guild-1'],
-            },
-        })
-
-        const executePromise = autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-        const completion = await Promise.race([
-            executePromise.then(() => 'done'),
-            new Promise<string>((resolve) => {
-                setTimeout(() => resolve('timeout'), 25)
-            }),
-        ])
-
-        expect(completion).toBe('done')
-        expect(interactionReplyMock).toHaveBeenCalled()
-        expect(replenishQueueMock).toHaveBeenCalledWith(queue)
-
-        resolveReplenish()
-        await executePromise
-    })
-
-    it('logs replenish failures after enabling autoplay', async () => {
-        const queue = createQueue(QueueRepeatMode.OFF)
-        const client = createClient({ directQueue: queue })
-        const interaction = createInteraction()
-        replenishQueueMock.mockRejectedValue(new Error('replenish failed'))
-        resolveGuildQueueMock.mockReturnValue({
-            queue,
-            source: 'nodes.get',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 1,
-                cacheSampleKeys: ['guild-1'],
-            },
-        })
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        await Promise.resolve()
-        expect(errorLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: 'Error replenishing queue after enabling autoplay:',
-            }),
-        )
-    })
-
-    it('returns silently when deferReply throws unknown interaction error (10062)', async () => {
-        const interaction = createInteraction()
-        interaction.deferReply = jest.fn().mockRejectedValue(
-            Object.assign(new Error('Unknown interaction'), {
-                code: 10062,
-            }),
-        )
-        resolveGuildQueueMock.mockReturnValue({
-            queue: null,
-            source: 'miss',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 0,
-                cacheSampleKeys: [],
-            },
-        })
-
-        await autoplayCommand.execute({
-            client: createClient({ directQueue: null }),
-            interaction,
-        } as any)
-
-        expect(interactionReplyMock).not.toHaveBeenCalled()
-        expect(getGuildSettingsMock).not.toHaveBeenCalled()
-    })
-
-    it('re-throws when deferReply fails with a non-10062 error', async () => {
-        const interaction = createInteraction()
-        const boom = new Error('network error')
-        interaction.deferReply = jest.fn().mockRejectedValue(boom)
-        resolveGuildQueueMock.mockReturnValue({
-            queue: null,
-            source: 'miss',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 0,
-                cacheSampleKeys: [],
-            },
-        })
-
-        await expect(
-            autoplayCommand.execute({
-                client: createClient({ directQueue: null }),
-                interaction,
-            } as any),
-        ).rejects.toThrow('network error')
-    })
-
-    it('uses autoplay error response when execution throws', async () => {
-        const queue = createQueue(QueueRepeatMode.OFF)
-        queue.setRepeatMode.mockImplementation(() => {
-            throw new Error('unexpected')
-        })
-        const client = createClient({ directQueue: queue })
-        const interaction = createInteraction()
-        resolveGuildQueueMock.mockReturnValue({
-            queue,
-            source: 'nodes.get',
-            diagnostics: {
-                guildId: 'guild-1',
-                cacheSize: 1,
-                cacheSampleKeys: ['guild-1'],
-            },
-        })
-
-        await autoplayCommand.execute({
-            client,
-            interaction,
-        } as any)
-
-        expect(errorLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: 'Error in autoplay command:',
-            }),
-        )
-        expect(createErrorEmbedMock).toHaveBeenCalledWith(
-            'Error',
-            expect.any(String),
-        )
     })
 })

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -39,16 +39,24 @@ jest.mock('../../../utils/music/queueResolver', () => ({
     resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
 }))
 
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: (...args: unknown[]) => debugLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+}))
+
+const getGuildSettingsMock = jest.fn()
+const updateGuildSettingsMock = jest.fn()
+
 jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: {
+        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
+        updateGuildSettings: (...args: unknown[]) =>
+            updateGuildSettingsMock(...args),
+    },
     trackHistoryService: {
         getAutoplayStats: (...args: unknown[]) =>
             trackHistoryServiceMock(...args),
     },
-}))
-
-jest.mock('@lucky/shared/utils', () => ({
-    debugLog: (...args: unknown[]) => debugLogMock(...args),
-    errorLog: (...args: unknown[]) => errorLogMock(...args),
 }))
 
 function createInteraction(subcommand = 'skip') {
@@ -103,6 +111,8 @@ function createClient() {
 describe('autoplay command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
+        updateGuildSettingsMock.mockResolvedValue(true)
     })
 
     describe('structure', () => {
@@ -301,55 +311,144 @@ describe('autoplay command', () => {
             )
             expect(interactionReplyMock).toHaveBeenCalled()
         })
+    })
 
-        describe('mode subcommand', () => {
-            const guildSettingsServiceMock = jest.fn()
+    describe('mode subcommand', () => {
+        it('should show current mode when no mode argument provided', async () => {
+            const interaction = createInteraction('mode')
+            interaction.options.getString = jest.fn().mockReturnValue(null)
+            const client = createClient()
 
-            beforeEach(() => {
-                jest.clearAllMocks()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            getGuildSettingsMock.mockResolvedValue({
+                autoplayMode: 'discover',
             })
 
-            it('should show current mode when no mode argument provided', async () => {
-                const interaction = createInteraction('mode')
-                interaction.options.getString = jest.fn().mockReturnValue(null)
-                const client = createClient()
+            await autoplayCommand.execute({ client, interaction } as any)
 
-                resolveGuildQueueMock.mockReturnValue({ queue: null })
-                guildSettingsServiceMock.mockResolvedValue({
-                    autoplayMode: 'discover',
-                })
+            expect(getGuildSettingsMock).toHaveBeenCalledWith('guild-1')
+            expect(interactionReplyMock).toHaveBeenCalled()
+            expect(createEmbedMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    description: expect.stringContaining('discover'),
+                }),
+            )
+        })
 
-                // Mock the guildSettingsService
-                jest.doMock('@lucky/shared/services', () => ({
-                    ...jest.requireActual('@lucky/shared/services'),
-                    guildSettingsService: {
-                        getGuildSettings: guildSettingsServiceMock,
-                        updateGuildSettings: jest.fn(),
-                    },
-                }))
+        it('should show default mode when settings return null', async () => {
+            const interaction = createInteraction('mode')
+            interaction.options.getString = jest.fn().mockReturnValue(null)
+            const client = createClient()
 
-                await autoplayCommand.execute({ client, interaction } as any)
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            getGuildSettingsMock.mockResolvedValue({})
 
-                expect(interactionReplyMock).toHaveBeenCalled()
-                const reply = interactionReplyMock.mock.calls[0][0]
-                expect(reply.content.ephemeral).toBe(true)
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(interactionReplyMock).toHaveBeenCalled()
+            expect(createEmbedMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    description: expect.stringContaining('similar'),
+                }),
+            )
+        })
+
+        it('should update mode when mode argument provided', async () => {
+            const interaction = createInteraction('mode')
+            interaction.options.getString = jest.fn().mockReturnValue('popular')
+            const client = createClient()
+
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            updateGuildSettingsMock.mockResolvedValue(true)
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(updateGuildSettingsMock).toHaveBeenCalledWith('guild-1', {
+                autoplayMode: 'popular',
             })
+            expect(interactionReplyMock).toHaveBeenCalled()
+            expect(createEmbedMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    title: expect.stringContaining('mode updated'),
+                }),
+            )
+        })
 
-            it('should update mode when mode argument provided', async () => {
-                const interaction = createInteraction('mode')
-                interaction.options.getString = jest
-                    .fn()
-                    .mockReturnValue('popular')
-                const client = createClient()
+        it('should show error when mode update fails', async () => {
+            const interaction = createInteraction('mode')
+            interaction.options.getString = jest
+                .fn()
+                .mockReturnValue('discover')
+            const client = createClient()
 
-                resolveGuildQueueMock.mockReturnValue({ queue: null })
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            updateGuildSettingsMock.mockResolvedValue(false)
 
-                await autoplayCommand.execute({ client, interaction } as any)
+            await autoplayCommand.execute({ client, interaction } as any)
 
-                expect(interactionReplyMock).toHaveBeenCalled()
-                const reply = interactionReplyMock.mock.calls[0][0]
-                expect(reply.content.ephemeral).toBe(true)
-            })
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'Error',
+                'Failed to update autoplay mode.',
+            )
+            expect(interactionReplyMock).toHaveBeenCalled()
+        })
+    })
+
+    describe('skip subcommand edge cases', () => {
+        it('should show error when no autoplay tracks found in queue', async () => {
+            const interaction = createInteraction('skip')
+            const queue = createQueue()
+            queue.tracks.at = jest.fn(() => ({
+                metadata: { isAutoplay: false },
+                title: 'Manual Track',
+            }))
+            queue.tracks.size = 1
+            const client = createClient()
+
+            resolveGuildQueueMock.mockReturnValue({ queue })
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'No Autoplay Tracks',
+                'No autoplay tracks found in queue.',
+            )
+            expect(queue.removeTrack).not.toHaveBeenCalled()
+            expect(interactionReplyMock).toHaveBeenCalled()
+        })
+    })
+
+    describe('execute function edge cases', () => {
+        it('should return early when guildId is null', async () => {
+            const interaction = createInteraction('skip')
+            interaction.guildId = null
+            const client = createClient()
+
+            const result = await autoplayCommand.execute({
+                client,
+                interaction,
+            } as any)
+
+            expect(resolveGuildQueueMock).not.toHaveBeenCalled()
+            expect(result).toBeUndefined()
+        })
+
+        it('should handle unknown subcommand', async () => {
+            const interaction = createInteraction('unknown')
+            interaction.options.getSubcommand = jest
+                .fn()
+                .mockReturnValue('unknown')
+            const client = createClient()
+
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+
+            await autoplayCommand.execute({ client, interaction } as any)
+
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'Unknown Subcommand',
+                'Please use skip, clear, status, analytics, or mode.',
+            )
+            expect(interactionReplyMock).toHaveBeenCalled()
         })
     })
 })

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -301,5 +301,55 @@ describe('autoplay command', () => {
             )
             expect(interactionReplyMock).toHaveBeenCalled()
         })
+
+        describe('mode subcommand', () => {
+            const guildSettingsServiceMock = jest.fn()
+
+            beforeEach(() => {
+                jest.clearAllMocks()
+            })
+
+            it('should show current mode when no mode argument provided', async () => {
+                const interaction = createInteraction('mode')
+                interaction.options.getString = jest.fn().mockReturnValue(null)
+                const client = createClient()
+
+                resolveGuildQueueMock.mockReturnValue({ queue: null })
+                guildSettingsServiceMock.mockResolvedValue({
+                    autoplayMode: 'discover',
+                })
+
+                // Mock the guildSettingsService
+                jest.doMock('@lucky/shared/services', () => ({
+                    ...jest.requireActual('@lucky/shared/services'),
+                    guildSettingsService: {
+                        getGuildSettings: guildSettingsServiceMock,
+                        updateGuildSettings: jest.fn(),
+                    },
+                }))
+
+                await autoplayCommand.execute({ client, interaction } as any)
+
+                expect(interactionReplyMock).toHaveBeenCalled()
+                const reply = interactionReplyMock.mock.calls[0][0]
+                expect(reply.content.ephemeral).toBe(true)
+            })
+
+            it('should update mode when mode argument provided', async () => {
+                const interaction = createInteraction('mode')
+                interaction.options.getString = jest
+                    .fn()
+                    .mockReturnValue('popular')
+                const client = createClient()
+
+                resolveGuildQueueMock.mockReturnValue({ queue: null })
+
+                await autoplayCommand.execute({ client, interaction } as any)
+
+                expect(interactionReplyMock).toHaveBeenCalled()
+                const reply = interactionReplyMock.mock.calls[0][0]
+                expect(reply.content.ephemeral).toBe(true)
+            })
+        })
     })
 })

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -11,6 +11,7 @@ import { errorLog, debugLog } from '@lucky/shared/utils'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import { replenishQueue } from '../../../utils/music/trackManagement/queueOperations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import { trackHistoryService } from '@lucky/shared/services'
 import type { ColorResolvable, ChatInputCommandInteraction } from 'discord.js'
 import type { GuildQueue } from 'discord-player'
 
@@ -168,6 +169,93 @@ async function handleAutoplayStatus(
     })
 }
 
+async function handleAutoplayAnalytics(
+    interaction: ChatInputCommandInteraction,
+): Promise<void> {
+    const guildId = interaction.guildId
+    if (!guildId) {
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'Guild Not Found',
+                        'Unable to retrieve guild information.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+        return
+    }
+
+    try {
+        const stats = await trackHistoryService.getAutoplayStats(guildId, 200)
+
+        if (stats.total === 0) {
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createEmbed({
+                            title: '📈 Autoplay Analytics',
+                            description: 'No play history yet.',
+                            color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+                            emoji: EMOJIS.AUTOPLAY,
+                            timestamp: true,
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+            return
+        }
+
+        const artistsText =
+            stats.topAutoplayArtists.length > 0
+                ? stats.topAutoplayArtists
+                      .map(
+                          (a, i) =>
+                              `${i + 1}. ${a.artist} — ${a.count} play${a.count !== 1 ? 's' : ''}`,
+                      )
+                      .join('\n')
+                : 'No autoplay data yet.'
+
+        const analyticsEmbed = createEmbed({
+            title: '📈 Autoplay Analytics',
+            description: `**Recent plays:** ${stats.total} tracks in the last 200\n**Autoplay:** ${stats.autoplayCount} (${stats.autoplayPercent}%)\n\n**Top autoplay artists:**\n${artistsText}`,
+            color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+            emoji: EMOJIS.AUTOPLAY,
+            timestamp: true,
+        })
+
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [analyticsEmbed],
+                ephemeral: true,
+            },
+        })
+    } catch (error) {
+        errorLog({
+            message: 'Failed to fetch autoplay analytics',
+            error,
+        })
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'Error',
+                        'Failed to retrieve autoplay analytics.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+    }
+}
+
 export default new Command({
     data: new SlashCommandBuilder()
         .setName('autoplay')
@@ -190,6 +278,11 @@ export default new Command({
             subcommand
                 .setName('status')
                 .setDescription('Show autoplay queue status'),
+        )
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName('analytics')
+                .setDescription('Show autoplay stats and top artists'),
         ),
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
@@ -239,6 +332,9 @@ export default new Command({
                 case 'status':
                     await handleAutoplayStatus(interaction, queue)
                     break
+                case 'analytics':
+                    await handleAutoplayAnalytics(interaction)
+                    break
                 default:
                     await interactionReply({
                         interaction,
@@ -246,7 +342,7 @@ export default new Command({
                             embeds: [
                                 createErrorEmbed(
                                     'Unknown Subcommand',
-                                    'Please use skip, clear, or status.',
+                                    'Please use skip, clear, status, or analytics.',
                                 ),
                             ],
                             ephemeral: true,

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -1,6 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
 import { interactionReply } from '../../../utils/general/interactionReply'
+import { guildSettingsService } from '@lucky/shared/services'
 import {
     createEmbed,
     createErrorEmbed,
@@ -169,6 +170,102 @@ async function handleAutoplayStatus(
     })
 }
 
+async function handleAutoplayMode(
+    interaction: ChatInputCommandInteraction,
+): Promise<void> {
+    const guildId = interaction.guildId
+    if (!guildId) {
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'Guild Not Found',
+                        'Unable to retrieve guild information.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+        return
+    }
+
+    const mode = interaction.options.getString('mode')
+
+    if (!mode) {
+        // Get current mode
+        const settings = await guildSettingsService.getGuildSettings(guildId)
+        const currentMode = settings?.autoplayMode ?? 'similar'
+
+        const modeDescriptions: Record<string, string> = {
+            similar: "🎵 Music like what's playing",
+            discover: '🔭 Prioritize new artists',
+            popular: '🔥 Favour your liked tracks',
+        }
+
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createEmbed({
+                        title: '🎚️ Autoplay Mode',
+                        description: `**Current mode:** ${currentMode}
+${modeDescriptions[currentMode] || 'Unknown mode'}`,
+                        color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+                        emoji: EMOJIS.AUTOPLAY,
+                        timestamp: true,
+                    }),
+                ],
+                ephemeral: true,
+            },
+        })
+        return
+    }
+
+    // Set new mode
+    const success = await guildSettingsService.updateGuildSettings(guildId, {
+        autoplayMode: mode as 'similar' | 'discover' | 'popular',
+    })
+
+    if (!success) {
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'Error',
+                        'Failed to update autoplay mode.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+        return
+    }
+
+    const modeEmojis: Record<string, string> = {
+        similar: '🎵',
+        discover: '🔭',
+        popular: '🔥',
+    }
+
+    await interactionReply({
+        interaction,
+        content: {
+            embeds: [
+                createEmbed({
+                    title: '✅ Autoplay mode updated',
+                    description: `${modeEmojis[mode]} Mode set to **${mode}**`,
+                    color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+                    emoji: EMOJIS.AUTOPLAY,
+                    timestamp: true,
+                }),
+            ],
+            ephemeral: true,
+        },
+    })
+}
+
 async function handleAutoplayAnalytics(
     interaction: ChatInputCommandInteraction,
 ): Promise<void> {
@@ -283,6 +380,33 @@ export default new Command({
             subcommand
                 .setName('analytics')
                 .setDescription('Show autoplay stats and top artists'),
+        )
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName('mode')
+                .setDescription('Get or set autoplay recommendation mode')
+                .addStringOption((opt) =>
+                    opt
+                        .setName('mode')
+                        .setDescription(
+                            'similar (default) | discover | popular',
+                        )
+                        .addChoices(
+                            {
+                                name: "🎵 Similar — music like what's playing",
+                                value: 'similar',
+                            },
+                            {
+                                name: '🔭 Discover — prioritize new artists',
+                                value: 'discover',
+                            },
+                            {
+                                name: '🔥 Popular — favour your liked tracks',
+                                value: 'popular',
+                            },
+                        )
+                        .setRequired(false),
+                ),
         ),
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
@@ -335,6 +459,9 @@ export default new Command({
                 case 'analytics':
                     await handleAutoplayAnalytics(interaction)
                     break
+                case 'mode':
+                    await handleAutoplayMode(interaction)
+                    break
                 default:
                     await interactionReply({
                         interaction,
@@ -342,7 +469,7 @@ export default new Command({
                             embeds: [
                                 createErrorEmbed(
                                     'Unknown Subcommand',
-                                    'Please use skip, clear, status, or analytics.',
+                                    'Please use skip, clear, status, analytics, or mode.',
                                 ),
                             ],
                             ephemeral: true,

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -428,33 +428,32 @@ export default new Command({
         }
 
         try {
-            if (!queue) {
-                await interactionReply({
-                    interaction,
-                    content: {
-                        embeds: [
-                            createErrorEmbed(
-                                'No Active Queue',
-                                'No music is currently playing.',
-                            ),
-                        ],
-                        ephemeral: true,
-                    },
-                })
-                return
-            }
-
             const subcommand = interaction.options.getSubcommand()
 
             switch (subcommand) {
                 case 'skip':
-                    await handleSkipAutoplayTrack(interaction, queue)
-                    break
                 case 'clear':
-                    await handleClearAutoplayTracks(interaction, queue)
-                    break
                 case 'status':
-                    await handleAutoplayStatus(interaction, queue)
+                    if (!queue) {
+                        await interactionReply({
+                            interaction,
+                            content: {
+                                embeds: [
+                                    createErrorEmbed(
+                                        'No Active Queue',
+                                        'No music is currently playing.',
+                                    ),
+                                ],
+                                ephemeral: true,
+                            },
+                        })
+                        return
+                    }
+                    if (subcommand === 'skip')
+                        await handleSkipAutoplayTrack(interaction, queue)
+                    else if (subcommand === 'clear')
+                        await handleClearAutoplayTracks(interaction, queue)
+                    else await handleAutoplayStatus(interaction, queue)
                     break
                 case 'analytics':
                     await handleAutoplayAnalytics(interaction)

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -7,218 +7,199 @@ import {
     EMBED_COLORS,
     EMOJIS,
 } from '../../../utils/general/embeds'
-import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
-import { guildSettingsService } from '@lucky/shared/services'
-import { QueueRepeatMode, type GuildQueue } from 'discord-player'
-import { requireGuild, requireDJRole } from '../../../utils/command/commandValidations'
+import { errorLog, debugLog } from '@lucky/shared/utils'
 import type { CommandExecuteParams } from '../../../types/CommandData'
-import { messages } from '../../../utils/general/messages'
-import type { ColorResolvable, ChatInputCommandInteraction } from 'discord.js'
 import { replenishQueue } from '../../../utils/music/trackManagement/queueOperations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import type { ColorResolvable, ChatInputCommandInteraction } from 'discord.js'
+import type { GuildQueue } from 'discord-player'
 
-async function replyAutoplayPersistenceFailure(
-    interaction: ChatInputCommandInteraction,
-    queue: GuildQueue | null,
-    enabled: boolean,
-): Promise<void> {
-    await interactionReply({
-        interaction,
-        content: {
-            embeds: [
-                createEmbed({
-                    title: enabled
-                        ? queue
-                            ? 'Autoplay enabled for current queue only'
-                            : 'Autoplay preference not saved'
-                        : queue
-                          ? 'Autoplay disabled for current queue only'
-                          : 'Autoplay preference not saved',
-                    description: enabled
-                        ? queue
-                            ? 'Autoplay was enabled on the active queue, but the preference could not be saved for future sessions.'
-                            : 'Could not save autoplay preference. Please try again.'
-                        : queue
-                          ? 'Autoplay was disabled on the active queue, but the preference could not be saved for future sessions.'
-                          : 'Could not update autoplay preference. Please try again.',
-                    color: EMBED_COLORS.ERROR as ColorResolvable,
-                    emoji: EMOJIS.ERROR,
-                    timestamp: true,
-                }),
-            ],
-            ephemeral: true,
-        },
-    })
+function isAutoplayTrack(track: any): boolean {
+    return (track?.metadata as any)?.isAutoplay === true
 }
 
-async function handleDisableAutoplay(
-    queue: GuildQueue | null,
+async function handleSkipAutoplayTrack(
     interaction: ChatInputCommandInteraction,
-    guildId: string,
-): Promise<void> {
-    queue?.setRepeatMode(QueueRepeatMode.OFF)
-    const persisted = await guildSettingsService.setGuildSettings(guildId, {
-        autoPlayEnabled: false,
-    })
-
-    if (!persisted) {
-        warnLog({
-            message: 'Failed to persist autoplay disabled preference',
-            data: { guildId, hasQueue: Boolean(queue) },
-        })
-        await replyAutoplayPersistenceFailure(interaction, queue, false)
-        return
-    }
-
-    await interactionReply({
-        interaction,
-        content: {
-            embeds: [
-                createEmbed({
-                    title: 'Autoplay disabled',
-                    description:
-                        'Autoplay has been disabled. The bot will no longer automatically add related songs.',
-                    color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
-                    emoji: EMOJIS.AUTOPLAY,
-                    timestamp: true,
-                }),
-            ],
-        },
-    })
-}
-
-async function handleEnableAutoplay(
-    queue: GuildQueue | null,
-    interaction: ChatInputCommandInteraction,
-    guildId: string,
-): Promise<void> {
-    queue?.setRepeatMode(QueueRepeatMode.AUTOPLAY)
-    const persisted = await guildSettingsService.setGuildSettings(guildId, {
-        autoPlayEnabled: true,
-    })
-
-    if (!persisted) {
-        warnLog({
-            message: 'Failed to persist autoplay enabled preference',
-            data: { guildId, hasQueue: Boolean(queue) },
-        })
-        if (queue?.currentTrack) {
-            void populateQueueWithRelatedTracks(queue, interaction)
-        }
-        await replyAutoplayPersistenceFailure(interaction, queue, true)
-        return
-    }
-
-    await interactionReply({
-        interaction,
-        content: {
-            embeds: [
-                createEmbed({
-                    title: 'Autoplay enabled',
-                    description: queue
-                        ? 'Autoplay has been enabled. The bot will automatically add related songs when the queue is empty.'
-                        : 'Autoplay preference saved. Next time you use /play, autoplay will be enabled automatically.',
-                    color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
-                    emoji: EMOJIS.AUTOPLAY,
-                    timestamp: true,
-                }),
-            ],
-        },
-    })
-
-    if (queue?.currentTrack) {
-        void populateQueueWithRelatedTracks(queue, interaction)
-    }
-}
-
-async function populateQueueWithRelatedTracks(
     queue: GuildQueue,
-    interaction: ChatInputCommandInteraction,
 ): Promise<void> {
-    debugLog({
-        message:
-            'Autoplay enabled, attempting to populate queue with related tracks',
-        data: {
-            guildId: interaction.guildId,
-            currentTrack: queue.currentTrack?.title,
-        },
-    })
-
-    try {
-        await replenishQueue(queue)
-        debugLog({
-            message: 'Queue replenished after enabling autoplay',
-            data: {
-                guildId: interaction.guildId,
-                queueSize: queue.tracks.size,
+    if (queue.tracks.size === 0) {
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'Queue Empty',
+                        'No autoplay tracks to skip.',
+                    ),
+                ],
+                ephemeral: true,
             },
         })
-    } catch (replenishError) {
-        errorLog({
-            message: 'Error replenishing queue after enabling autoplay:',
-            error: replenishError,
-        })
+        return
     }
-}
 
-async function handleAutoplayError(
-    error: unknown,
-    interaction: ChatInputCommandInteraction,
-): Promise<void> {
-    errorLog({ message: 'Error in autoplay command:', error })
+    let skipped = false
+    for (let i = 0; i < queue.tracks.size; i++) {
+        const track = queue.tracks.at(i)
+        if (track && isAutoplayTrack(track)) {
+            queue.removeTrack(i)
+            skipped = true
+            debugLog({
+                message: 'Skipped autoplay track',
+                data: {
+                    guildId: queue.guild.id,
+                    trackTitle: track.title,
+                },
+            })
+            break
+        }
+    }
+
+    if (!skipped) {
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'No Autoplay Tracks',
+                        'No autoplay tracks found in queue.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+        return
+    }
+
+    await replenishQueue(queue)
+
     await interactionReply({
         interaction,
         content: {
-            embeds: [createErrorEmbed('Error', messages.error.notPlaying)],
+            embeds: [
+                createEmbed({
+                    title: '⏭️ Autoplay track skipped',
+                    description:
+                        'First autoplay track removed and queue replenished.',
+                    color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+                    emoji: EMOJIS.AUTOPLAY,
+                    timestamp: true,
+                }),
+            ],
             ephemeral: true,
         },
     })
 }
 
-async function resolveCurrentAutoplayState(
-    queue: GuildQueue | null,
-    guildId: string,
-): Promise<boolean> {
-    if (queue) {
-        return queue.repeatMode === QueueRepeatMode.AUTOPLAY
+async function handleClearAutoplayTracks(
+    interaction: ChatInputCommandInteraction,
+    queue: GuildQueue,
+): Promise<void> {
+    let clearedCount = 0
+    for (let i = queue.tracks.size - 1; i >= 0; i--) {
+        const track = queue.tracks.at(i)
+        if (track && isAutoplayTrack(track)) {
+            queue.removeTrack(i)
+            clearedCount++
+        }
     }
-    const settings = await guildSettingsService.getGuildSettings(guildId)
-    return settings?.autoPlayEnabled ?? true
+
+    if (clearedCount === 0) {
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'No Autoplay Tracks',
+                        'No autoplay tracks in queue to clear.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+        return
+    }
+
+    await replenishQueue(queue)
+
+    await interactionReply({
+        interaction,
+        content: {
+            embeds: [
+                createEmbed({
+                    title: '🗑️ Autoplay tracks cleared',
+                    description: `Removed ${clearedCount} autoplay track(s) and replenished queue.`,
+                    color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+                    emoji: EMOJIS.AUTOPLAY,
+                    timestamp: true,
+                }),
+            ],
+            ephemeral: true,
+        },
+    })
+}
+
+async function handleAutoplayStatus(
+    interaction: ChatInputCommandInteraction,
+    queue: GuildQueue,
+): Promise<void> {
+    let autoplayCount = 0
+    for (let i = 0; i < queue.tracks.size; i++) {
+        const track = queue.tracks.at(i)
+        if (track && isAutoplayTrack(track)) {
+            autoplayCount++
+        }
+    }
+
+    const statusEmbed = createEmbed({
+        title: '📊 Autoplay Status',
+        description: `**Autoplay tracks queued:** ${autoplayCount}\n**Last.fm integration:** Connected`,
+        color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+        emoji: EMOJIS.AUTOPLAY,
+        timestamp: true,
+    })
+
+    await interactionReply({
+        interaction,
+        content: {
+            embeds: [statusEmbed],
+            ephemeral: true,
+        },
+    })
 }
 
 export default new Command({
     data: new SlashCommandBuilder()
         .setName('autoplay')
-        .setDescription(
-            '🔄 Enable or disable automatic playback of related music.',
+        .setDescription('🔄 Manage autoplay tracks in the queue')
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName('skip')
+                .setDescription(
+                    'Skip the first autoplay track and replenish queue',
+                ),
+        )
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName('clear')
+                .setDescription(
+                    'Remove all autoplay tracks and replenish queue',
+                ),
+        )
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName('status')
+                .setDescription('Show autoplay queue status'),
         ),
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
-        if (!(await requireGuild(interaction))) return
-        if (!(await requireDJRole(interaction, interaction.guildId!))) return
-
         const guildId = interaction.guildId
         if (!guildId) return
 
-        const { queue, source, diagnostics } = resolveGuildQueue(
-            client,
-            guildId,
-        )
-        if (!queue) {
-            warnLog({
-                message: 'Autoplay queue resolution miss',
-                data: {
-                    guildId,
-                    userId: interaction.user.id,
-                    source,
-                    cacheSize: diagnostics.cacheSize,
-                    cacheSampleKeys: diagnostics.cacheSampleKeys,
-                },
-            })
-        }
+        const { queue } = resolveGuildQueue(client, guildId)
 
         try {
-            await interaction.deferReply()
+            await interaction.deferReply({ ephemeral: true })
         } catch (error) {
             const isUnknownInteraction =
                 typeof error === 'object' &&
@@ -230,18 +211,62 @@ export default new Command({
         }
 
         try {
-            const isAutoplayEnabled = await resolveCurrentAutoplayState(
-                queue,
-                guildId,
-            )
+            if (!queue) {
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [
+                            createErrorEmbed(
+                                'No Active Queue',
+                                'No music is currently playing.',
+                            ),
+                        ],
+                        ephemeral: true,
+                    },
+                })
+                return
+            }
 
-            if (isAutoplayEnabled) {
-                await handleDisableAutoplay(queue, interaction, guildId)
-            } else {
-                await handleEnableAutoplay(queue, interaction, guildId)
+            const subcommand = interaction.options.getSubcommand()
+
+            switch (subcommand) {
+                case 'skip':
+                    await handleSkipAutoplayTrack(interaction, queue)
+                    break
+                case 'clear':
+                    await handleClearAutoplayTracks(interaction, queue)
+                    break
+                case 'status':
+                    await handleAutoplayStatus(interaction, queue)
+                    break
+                default:
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [
+                                createErrorEmbed(
+                                    'Unknown Subcommand',
+                                    'Please use skip, clear, or status.',
+                                ),
+                            ],
+                            ephemeral: true,
+                        },
+                    })
             }
         } catch (error) {
-            await handleAutoplayError(error, interaction)
+            errorLog({ message: 'Error in autoplay command:', error })
+            await interactionReply({
+                interaction,
+                content: {
+                    embeds: [
+                        createErrorEmbed(
+                            'Error',
+                            'An error occurred while processing your request.',
+                        ),
+                    ],
+                    ephemeral: true,
+                },
+            })
         }
     },
 })

--- a/packages/bot/src/functions/music/commands/queue/queueDisplay.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueDisplay.ts
@@ -34,10 +34,18 @@ function isAutoplayTrack(track: Track): boolean {
 
 function formatSingleTrack(info: TrackDisplayInfo, index: number): string {
     const marker = info.isAutoplay ? '\u{1F916}' : '\u{1F464}'
-    const reason =
-        info.isAutoplay && info.recommendationReason
-            ? ` \u2014 _${info.recommendationReason}_`
-            : ''
+    let reason = ''
+    if (info.isAutoplay) {
+        if (info.recommendationReason) {
+            const truncated =
+                info.recommendationReason.length > 40
+                    ? info.recommendationReason.substring(0, 40) + '...'
+                    : info.recommendationReason
+            reason = ` \u2014 _${truncated}_`
+        } else {
+            reason = ' \u2014 autoplay'
+        }
+    }
     const by = info.requestedBy ? ` \u2022 ${info.requestedBy}` : ''
     return `${marker} ${index + 1}. [${info.title}](${info.url}) - ${info.author} (${info.duration})${by}${reason}`
 }

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -47,12 +47,16 @@ jest.mock('@lucky/shared/utils', () => ({
 
 const getTrackHistoryMock = jest.fn()
 const addTrackToHistoryMock = jest.fn().mockResolvedValue(true)
+const getGuildSettingsMock = jest.fn()
 
 jest.mock('@lucky/shared/services', () => ({
     trackHistoryService: {
         getTrackHistory: (...args: unknown[]) => getTrackHistoryMock(...args),
         addTrackToHistory: (...args: unknown[]) =>
             addTrackToHistoryMock(...args),
+    },
+    guildSettingsService: {
+        getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
     },
 }))
 
@@ -124,6 +128,7 @@ describe('queueManipulation.replenishQueue', () => {
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
     async function replenishWithSingleCandidate(options: {
@@ -1714,6 +1719,7 @@ describe('queueManipulation.replenishQueue query variation', () => {
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
     it('applies query modifiers based on replenish counter', async () => {
@@ -1801,6 +1807,7 @@ describe('queueManipulation.collectBroadFallbackCandidates diversification', () 
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
     it('uses multiple fallback queries when primary candidates empty', async () => {
@@ -1839,6 +1846,7 @@ describe('queueManipulation.selectDiverseCandidates score jitter', () => {
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
     it('applies jitter to candidate scores and maintains top candidate', async () => {
@@ -1895,6 +1903,7 @@ describe('queueManipulation.addSelectedTracks async writes', () => {
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
         addTrackToHistoryMock.mockResolvedValue(true)
     })
 

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -691,6 +691,179 @@ describe('queueManipulation.replenishQueue', () => {
         ).toContain('similar energy')
     })
 
+    it('discover mode boosts novelty when candidate artist not in recent history', async () => {
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: {
+                title: 'Current Song',
+                author: 'Current Artist',
+                url: 'https://example.com/current',
+                source: 'youtube',
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Undiscovered Track',
+                            author: 'Unknown Artist',
+                            url: 'https://example.com/undiscovered',
+                            source: 'spotify',
+                        },
+                    ],
+                }),
+            },
+        })
+
+        getGuildSettingsMock.mockResolvedValueOnce({
+            autoplayMode: 'discover',
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack).toBeDefined()
+        expect(
+            (addedTrack?.metadata as Record<string, unknown>)
+                ?.recommendationReason,
+        ).toContain('discovery boost')
+    })
+
+    it('discover mode prefers new artists over familiar ones', async () => {
+        const recentArtist = 'Recent Artist'
+        const newArtist = 'New Artist'
+        const trackHistory = [
+            {
+                title: 'Past Track 1',
+                author: recentArtist,
+                url: 'https://example.com/past1',
+                source: 'youtube',
+            },
+            {
+                title: 'Past Track 2',
+                author: recentArtist,
+                url: 'https://example.com/past2',
+                source: 'youtube',
+            },
+        ]
+
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: {
+                title: 'Current Song',
+                author: 'Current Artist',
+                url: 'https://example.com/current',
+                source: 'youtube',
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Familiar Track',
+                            author: recentArtist,
+                            url: 'https://example.com/familiar',
+                            source: 'spotify',
+                        },
+                        {
+                            title: 'New Track',
+                            author: newArtist,
+                            url: 'https://example.com/new',
+                            source: 'spotify',
+                        },
+                    ],
+                }),
+            },
+        })
+
+        getTrackHistoryMock.mockResolvedValueOnce(trackHistory)
+        getGuildSettingsMock.mockResolvedValueOnce({
+            autoplayMode: 'discover',
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTracks = queue.addTrack.mock.calls.map((c) => c[0])
+        expect(addedTracks.some((t) => t.author === newArtist)).toBe(true)
+    })
+
+    it('popular mode boosts liked tracks and similar duration', async () => {
+        const currentTrackDuration = 200000
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: {
+                title: 'Current Song',
+                author: 'Current Artist',
+                url: 'https://example.com/current',
+                source: 'youtube',
+                durationMS: currentTrackDuration,
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Popular Track',
+                            author: 'Popular Artist',
+                            url: 'https://example.com/popular',
+                            source: 'spotify',
+                            durationMS: 195000,
+                        },
+                    ],
+                }),
+            },
+        })
+
+        getGuildSettingsMock.mockResolvedValueOnce({
+            autoplayMode: 'popular',
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack).toBeDefined()
+        expect(
+            (addedTrack?.metadata as Record<string, unknown>)
+                ?.recommendationReason,
+        ).toContain('energy match')
+    })
+
+    it('popular mode with liked track gets extra boost', async () => {
+        const likedTrackKey = 'populartrack::popularartist'
+        const queue = createQueueMock({
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            currentTrack: {
+                title: 'Current Song',
+                author: 'Current Artist',
+                url: 'https://example.com/current',
+                source: 'youtube',
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Popular Track',
+                            author: 'Popular Artist',
+                            url: 'https://example.com/popular',
+                            source: 'spotify',
+                        },
+                    ],
+                }),
+            },
+        })
+
+        likedTrackKeysMock.mockResolvedValueOnce(new Set([likedTrackKey]))
+        getGuildSettingsMock.mockResolvedValueOnce({
+            autoplayMode: 'popular',
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack).toBeDefined()
+        expect(
+            (addedTrack?.metadata as Record<string, unknown>)
+                ?.recommendationReason,
+        ).toContain('liked track')
+    })
+
     it('prefers a different-source candidate when scores are otherwise close', async () => {
         const queue = createQueueMock({
             tracks: {

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -8,7 +8,10 @@ import { randomInt } from 'node:crypto'
 import type { User } from 'discord.js'
 import { debugLog, errorLog, warnLog } from '@lucky/shared/utils'
 import { recommendationFeedbackService } from '../../services/musicRecommendation/feedbackService'
-import { trackHistoryService } from '@lucky/shared/services'
+import {
+    trackHistoryService,
+    guildSettingsService,
+} from '@lucky/shared/services'
 import { consumeLastFmSeedSlice } from './autoplay/lastFmSeeds'
 import { getSimilarTracks } from '../../lastfm'
 import { cleanSearchQuery, cleanTitle, cleanAuthor } from './searchQueryCleaner'
@@ -233,18 +236,24 @@ async function _replenishQueue(
             HISTORY_SEED_LIMIT + 1,
         )
         const requestedBy = getRequestedBy(queue, currentTrack)
-        const [dislikedTrackKeys, likedTrackKeys, persistentHistory] =
-            await Promise.all([
-                recommendationFeedbackService.getDislikedTrackKeys(
-                    queue.guild.id,
-                    requestedBy?.id,
-                ),
-                recommendationFeedbackService.getLikedTrackKeys(
-                    queue.guild.id,
-                    requestedBy?.id,
-                ),
-                trackHistoryService.getTrackHistory(queue.guild.id, 100),
-            ])
+        const [
+            dislikedTrackKeys,
+            likedTrackKeys,
+            persistentHistory,
+            guildSettings,
+        ] = await Promise.all([
+            recommendationFeedbackService.getDislikedTrackKeys(
+                queue.guild.id,
+                requestedBy?.id,
+            ),
+            recommendationFeedbackService.getLikedTrackKeys(
+                queue.guild.id,
+                requestedBy?.id,
+            ),
+            trackHistoryService.getTrackHistory(queue.guild.id, 100),
+            guildSettingsService.getGuildSettings(queue.guild.id),
+        ])
+        const autoplayMode = guildSettings?.autoplayMode ?? 'similar'
         if (persistentHistory.length === 0) {
             warnLog({
                 message:
@@ -288,6 +297,7 @@ async function _replenishQueue(
             currentTrack,
             recentArtists,
             replenishCount,
+            autoplayMode,
         )
         if (requestedBy?.id) {
             await collectLastFmCandidates(
@@ -300,6 +310,7 @@ async function _replenishQueue(
                 currentTrack,
                 recentArtists,
                 candidates,
+                autoplayMode,
             )
         }
         if (candidates.size === 0 && currentTrack) {
@@ -313,6 +324,7 @@ async function _replenishQueue(
                 likedTrackKeys,
                 recentArtists,
                 candidates,
+                autoplayMode,
             )
         }
 
@@ -440,6 +452,7 @@ async function collectRecommendationCandidates(
     currentTrack: Track,
     recentArtists: Set<string>,
     replenishCount = 0,
+    autoplayMode: 'similar' | 'discover' | 'popular' = 'similar',
 ): Promise<Map<string, ScoredTrack>> {
     const candidates = new Map<string, ScoredTrack>()
 
@@ -471,6 +484,7 @@ async function collectRecommendationCandidates(
                     currentTrack,
                     recentArtists,
                     likedTrackKeys,
+                    autoplayMode,
                 ),
             )
         }
@@ -535,6 +549,7 @@ async function collectBroadFallbackCandidates(
     likedTrackKeys: Set<string>,
     recentArtists: Set<string>,
     candidates: Map<string, ScoredTrack>,
+    autoplayMode: 'similar' | 'discover' | 'popular' = 'similar',
 ): Promise<void> {
     const fallbackQueries = [
         currentTrack.author,
@@ -566,6 +581,7 @@ async function collectBroadFallbackCandidates(
                     currentTrack,
                     recentArtists,
                     likedTrackKeys,
+                    autoplayMode,
                 )
                 upsertScoredCandidate(candidates, track, {
                     score: rec.score - 0.1,
@@ -617,6 +633,7 @@ async function collectLastFmCandidates(
     currentTrack: Track,
     recentArtists: Set<string>,
     candidates: Map<string, ScoredTrack>,
+    autoplayMode: 'similar' | 'discover' | 'popular' = 'similar',
 ): Promise<void> {
     const seedSlice = await consumeLastFmSeedSlice(
         requestedBy.id,
@@ -638,6 +655,7 @@ async function collectLastFmCandidates(
                 currentTrack,
                 recentArtists,
                 likedTrackKeys,
+                autoplayMode,
             )
             upsertScoredCandidate(candidates, track, {
                 score: rec.score + LASTFM_SCORE_BOOST,
@@ -665,6 +683,7 @@ async function collectLastFmCandidates(
                     currentTrack,
                     recentArtists,
                     likedTrackKeys,
+                    autoplayMode,
                 )
                 upsertScoredCandidate(candidates, track, {
                     score: (rec.score + LASTFM_SCORE_BOOST) * (s.match / 100),
@@ -935,6 +954,7 @@ function calculateRecommendationScore(
     currentTrack: Track,
     recentArtists: Set<string>,
     likedTrackKeys: Set<string> = new Set(),
+    autoplayMode: 'similar' | 'discover' | 'popular' = 'similar',
 ): { score: number; reason: string } {
     let score = 1
     const reasons: string[] = []
@@ -988,6 +1008,31 @@ function calculateRecommendationScore(
     if (candidate.durationMS && candidate.durationMS > 7 * 60 * 1000) {
         score -= 0.2
         reasons.push('long track penalty')
+    }
+
+    // Mode-specific adjustments
+    if (autoplayMode === 'discover') {
+        // Boost novelty — prefer artists not heard recently
+        if (!recentArtists.has(candidateArtist)) {
+            score += 0.25
+            reasons.push('discovery boost')
+        }
+        if (recentArtists.has(candidateArtist)) {
+            score -= 0.2 // extra penalty on top of existing -0.25
+        }
+    } else if (autoplayMode === 'popular') {
+        // Boost liked tracks more and high-energy/shorter tracks
+        if (likedTrackKeys.has(candidateKey)) {
+            score += 0.2 // on top of existing +0.3
+        }
+        // Prefer similar-length (same energy feel)
+        if (candidate.durationMS && currentTrack.durationMS) {
+            const ratio = candidate.durationMS / currentTrack.durationMS
+            if (ratio >= 0.9 && ratio <= 1.1) {
+                score += 0.1
+                reasons.push('energy match')
+            }
+        }
     }
 
     return {

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -243,7 +243,7 @@ async function _replenishQueue(
                     queue.guild.id,
                     requestedBy?.id,
                 ),
-                trackHistoryService.getTrackHistory(queue.guild.id, 50),
+                trackHistoryService.getTrackHistory(queue.guild.id, 100),
             ])
         if (persistentHistory.length === 0) {
             warnLog({

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -2,325 +2,334 @@ import { redisClient } from './redis'
 import { infoLog, errorLog } from '../utils/general/log'
 
 export interface GuildSettings {
-  guildId: string
-  defaultVolume: number
-  maxQueueSize: number
-  autoPlayEnabled: boolean
-  repeatMode: number
-  shuffleEnabled: boolean
-  prefix: string
-  embedColor: string
-  language: string
-  allowDownloads: boolean
-  allowPlaylists: boolean
-  allowSpotify: boolean
-  commandCooldown: number
-  downloadCooldown: number
-  djRoleId?: string
-  idleTimeoutMinutes?: number
-  voteSkipThreshold?: number
-  createdAt: Date
-  updatedAt: Date
+    guildId: string
+    defaultVolume: number
+    maxQueueSize: number
+    autoPlayEnabled: boolean
+    autoplayMode?: 'similar' | 'discover' | 'popular'
+    repeatMode: number
+    shuffleEnabled: boolean
+    prefix: string
+    embedColor: string
+    language: string
+    allowDownloads: boolean
+    allowPlaylists: boolean
+    allowSpotify: boolean
+    commandCooldown: number
+    downloadCooldown: number
+    djRoleId?: string
+    idleTimeoutMinutes?: number
+    voteSkipThreshold?: number
+    createdAt: Date
+    updatedAt: Date
 }
 
 export interface AutoplayCounter {
-  guildId: string
-  count: number
-  lastReset: Date
+    guildId: string
+    count: number
+    lastReset: Date
 }
 
 export class GuildSettingsService {
-  private readonly ttl: number
+    private readonly ttl: number
 
-  constructor(ttl = 7 * 24 * 60 * 60) {
-    this.ttl = ttl
-  }
-
-  private getRedisKey(guildId: string, type?: string): string {
-    return type ? `guild_settings:${guildId}:${type}` : `guild_settings:${guildId}`
-  }
-
-  private getDefaultSettings(): GuildSettings {
-    return {
-      guildId: '',
-      defaultVolume: 50,
-      maxQueueSize: 100,
-      autoPlayEnabled: true,
-      repeatMode: 0,
-      shuffleEnabled: false,
-      prefix: '/',
-      embedColor: '0x5865F2',
-      language: 'en',
-      allowDownloads: true,
-      allowPlaylists: true,
-      allowSpotify: true,
-      commandCooldown: 3,
-      downloadCooldown: 10,
-      djRoleId: undefined,
-      idleTimeoutMinutes: 0,
-      voteSkipThreshold: 50,
-      createdAt: new Date(),
-      updatedAt: new Date(),
+    constructor(ttl = 7 * 24 * 60 * 60) {
+        this.ttl = ttl
     }
-  }
 
-  async getGuildSettings(guildId: string): Promise<GuildSettings | null> {
-    try {
-      const settingsData = await redisClient.get(this.getRedisKey(guildId))
-      if (!settingsData) {
-        return null
-      }
-      return JSON.parse(settingsData) as GuildSettings
-    } catch (error) {
-      errorLog({ message: 'Failed to get guild settings', error })
-      return null
+    private getRedisKey(guildId: string, type?: string): string {
+        return type
+            ? `guild_settings:${guildId}:${type}`
+            : `guild_settings:${guildId}`
     }
-  }
 
-  async setGuildSettings(
-    guildId: string,
-    settings: Partial<GuildSettings>,
-  ): Promise<boolean> {
-    try {
-      const existingSettings =
-        (await this.getGuildSettings(guildId)) || this.getDefaultSettings()
-      const updatedSettings: GuildSettings = {
-        ...existingSettings,
-        ...settings,
-        guildId,
-        updatedAt: new Date(),
-      }
-
-      await redisClient.setex(
-        this.getRedisKey(guildId),
-        this.ttl,
-        JSON.stringify(updatedSettings),
-      )
-
-      infoLog({ message: `Updated guild settings for ${guildId}` })
-      return true
-    } catch (error) {
-      errorLog({ message: 'Failed to set guild settings', error })
-      return false
-    }
-  }
-
-  async updateGuildSettings(
-    guildId: string,
-    updates: Partial<GuildSettings>,
-  ): Promise<boolean> {
-    try {
-      const currentSettings = await this.getGuildSettings(guildId)
-      if (!currentSettings) {
-        return false
-      }
-
-      const updatedSettings = {
-        ...currentSettings,
-        ...updates,
-        updatedAt: new Date(),
-      }
-
-      await redisClient.setex(
-        this.getRedisKey(guildId),
-        this.ttl,
-        JSON.stringify(updatedSettings),
-      )
-
-      infoLog({ message: `Updated guild settings for ${guildId}` })
-      return true
-    } catch (error) {
-      errorLog({ message: 'Failed to update guild settings', error })
-      return false
-    }
-  }
-
-  async deleteGuildSettings(guildId: string): Promise<boolean> {
-    try {
-      await redisClient.del(this.getRedisKey(guildId))
-      infoLog({ message: `Deleted guild settings for ${guildId}` })
-      return true
-    } catch (error) {
-      errorLog({ message: 'Failed to delete guild settings', error })
-      return false
-    }
-  }
-
-  async getAutoplayCounter(guildId: string): Promise<AutoplayCounter | null> {
-    try {
-      const counterData = await redisClient.get(
-        this.getRedisKey(guildId, 'autoplay_counter'),
-      )
-      if (!counterData) {
-        return null
-      }
-      return JSON.parse(counterData) as AutoplayCounter
-    } catch (error) {
-      errorLog({ message: 'Failed to get autoplay counter', error })
-      return null
-    }
-  }
-
-  async setAutoplayCounter(
-    guildId: string,
-    counter: AutoplayCounter,
-  ): Promise<boolean> {
-    try {
-      await redisClient.setex(
-        this.getRedisKey(guildId, 'autoplay_counter'),
-        this.ttl,
-        JSON.stringify(counter),
-      )
-      return true
-    } catch (error) {
-      errorLog({ message: 'Failed to set autoplay counter', error })
-      return false
-    }
-  }
-
-  async incrementAutoplayCounter(guildId: string): Promise<number> {
-    try {
-      const counter =
-        (await this.getAutoplayCounter(guildId)) || {
-          guildId,
-          count: 0,
-          lastReset: new Date(),
+    private getDefaultSettings(): GuildSettings {
+        return {
+            guildId: '',
+            defaultVolume: 50,
+            maxQueueSize: 100,
+            autoPlayEnabled: true,
+            autoplayMode: 'similar',
+            repeatMode: 0,
+            shuffleEnabled: false,
+            prefix: '/',
+            embedColor: '0x5865F2',
+            language: 'en',
+            allowDownloads: true,
+            allowPlaylists: true,
+            allowSpotify: true,
+            commandCooldown: 3,
+            downloadCooldown: 10,
+            djRoleId: undefined,
+            idleTimeoutMinutes: 0,
+            voteSkipThreshold: 50,
+            createdAt: new Date(),
+            updatedAt: new Date(),
         }
-
-      counter.count += 1
-      await this.setAutoplayCounter(guildId, counter)
-
-      return counter.count
-    } catch (error) {
-      errorLog({ message: 'Failed to increment autoplay counter', error })
-      return 0
     }
-  }
 
-  async resetAutoplayCounter(guildId: string): Promise<boolean> {
-    try {
-      const counter: AutoplayCounter = {
-        guildId,
-        count: 0,
-        lastReset: new Date(),
-      }
-      return await this.setAutoplayCounter(guildId, counter)
-    } catch (error) {
-      errorLog({ message: 'Failed to reset autoplay counter', error })
-      return false
-    }
-  }
-
-  async getRepeatCount(guildId: string): Promise<number> {
-    try {
-      const countData = await redisClient.get(
-        this.getRedisKey(guildId, 'repeat_count'),
-      )
-      return countData ? parseInt(countData, 10) : 0
-    } catch (error) {
-      errorLog({ message: 'Failed to get repeat count', error })
-      return 0
-    }
-  }
-
-  async setRepeatCount(guildId: string, count: number): Promise<boolean> {
-    try {
-      await redisClient.setex(
-        this.getRedisKey(guildId, 'repeat_count'),
-        this.ttl,
-        count.toString(),
-      )
-      return true
-    } catch (error) {
-      errorLog({ message: 'Failed to set repeat count', error })
-      return false
-    }
-  }
-
-  async incrementRepeatCount(guildId: string): Promise<number> {
-    try {
-      const currentCount = await this.getRepeatCount(guildId)
-      const newCount = currentCount + 1
-      await this.setRepeatCount(guildId, newCount)
-      return newCount
-    } catch (error) {
-      errorLog({ message: 'Failed to increment repeat count', error })
-      return 0
-    }
-  }
-
-  async resetRepeatCount(guildId: string): Promise<boolean> {
-    try {
-      return await this.setRepeatCount(guildId, 0)
-    } catch (error) {
-      errorLog({ message: 'Failed to reset repeat count', error })
-      return false
-    }
-  }
-
-  async clearGuildSessions(guildId: string): Promise<boolean> {
-    try {
-      const settingsDeleted = await this.deleteGuildSettings(guildId)
-      const counterReset = await this.resetAutoplayCounter(guildId)
-      const repeatReset = await this.resetRepeatCount(guildId)
-
-      return settingsDeleted && counterReset && repeatReset
-    } catch (error) {
-      errorLog({ message: 'Failed to clear guild sessions', error })
-      return false
-    }
-  }
-
-  async isRateLimited(
-    guildId: string,
-    command: string,
-    cooldown: number,
-  ): Promise<boolean> {
-    try {
-      const key = this.getRedisKey(guildId, `rate_limit:${command}`)
-      const lastUsed = await redisClient.get(key)
-
-      if (!lastUsed) {
-        await redisClient.setex(key, cooldown, Date.now().toString())
-        return false
-      }
-
-      const timeSinceLastUse = Date.now() - parseInt(lastUsed, 10)
-      return timeSinceLastUse < cooldown * 1000
-    } catch (error) {
-      errorLog({ message: 'Failed to check rate limit', error })
-      return false
-    }
-  }
-
-  async setRateLimit(
-    guildId: string,
-    command: string,
-    cooldown: number,
-  ): Promise<void> {
-    try {
-      const key = this.getRedisKey(guildId, `rate_limit:${command}`)
-      await redisClient.setex(key, cooldown, Date.now().toString())
-    } catch (error) {
-      errorLog({ message: 'Failed to set rate limit', error })
-    }
-  }
-
-  async clearAllAutoplayCounters(): Promise<boolean> {
-    try {
-      const pattern = 'guild_settings:*:autoplay_counter'
-      const keys = await redisClient.keys(pattern)
-      if (keys.length > 0) {
-        for (const key of keys) {
-          await redisClient.del(key)
+    async getGuildSettings(guildId: string): Promise<GuildSettings | null> {
+        try {
+            const settingsData = await redisClient.get(
+                this.getRedisKey(guildId),
+            )
+            if (!settingsData) {
+                return null
+            }
+            return JSON.parse(settingsData) as GuildSettings
+        } catch (error) {
+            errorLog({ message: 'Failed to get guild settings', error })
+            return null
         }
-      }
-      return true
-    } catch (error) {
-      errorLog({ message: 'Failed to clear all autoplay counters', error })
-      return false
     }
-  }
+
+    async setGuildSettings(
+        guildId: string,
+        settings: Partial<GuildSettings>,
+    ): Promise<boolean> {
+        try {
+            const existingSettings =
+                (await this.getGuildSettings(guildId)) ||
+                this.getDefaultSettings()
+            const updatedSettings: GuildSettings = {
+                ...existingSettings,
+                ...settings,
+                guildId,
+                updatedAt: new Date(),
+            }
+
+            await redisClient.setex(
+                this.getRedisKey(guildId),
+                this.ttl,
+                JSON.stringify(updatedSettings),
+            )
+
+            infoLog({ message: `Updated guild settings for ${guildId}` })
+            return true
+        } catch (error) {
+            errorLog({ message: 'Failed to set guild settings', error })
+            return false
+        }
+    }
+
+    async updateGuildSettings(
+        guildId: string,
+        updates: Partial<GuildSettings>,
+    ): Promise<boolean> {
+        try {
+            const currentSettings = await this.getGuildSettings(guildId)
+            if (!currentSettings) {
+                return false
+            }
+
+            const updatedSettings = {
+                ...currentSettings,
+                ...updates,
+                updatedAt: new Date(),
+            }
+
+            await redisClient.setex(
+                this.getRedisKey(guildId),
+                this.ttl,
+                JSON.stringify(updatedSettings),
+            )
+
+            infoLog({ message: `Updated guild settings for ${guildId}` })
+            return true
+        } catch (error) {
+            errorLog({ message: 'Failed to update guild settings', error })
+            return false
+        }
+    }
+
+    async deleteGuildSettings(guildId: string): Promise<boolean> {
+        try {
+            await redisClient.del(this.getRedisKey(guildId))
+            infoLog({ message: `Deleted guild settings for ${guildId}` })
+            return true
+        } catch (error) {
+            errorLog({ message: 'Failed to delete guild settings', error })
+            return false
+        }
+    }
+
+    async getAutoplayCounter(guildId: string): Promise<AutoplayCounter | null> {
+        try {
+            const counterData = await redisClient.get(
+                this.getRedisKey(guildId, 'autoplay_counter'),
+            )
+            if (!counterData) {
+                return null
+            }
+            return JSON.parse(counterData) as AutoplayCounter
+        } catch (error) {
+            errorLog({ message: 'Failed to get autoplay counter', error })
+            return null
+        }
+    }
+
+    async setAutoplayCounter(
+        guildId: string,
+        counter: AutoplayCounter,
+    ): Promise<boolean> {
+        try {
+            await redisClient.setex(
+                this.getRedisKey(guildId, 'autoplay_counter'),
+                this.ttl,
+                JSON.stringify(counter),
+            )
+            return true
+        } catch (error) {
+            errorLog({ message: 'Failed to set autoplay counter', error })
+            return false
+        }
+    }
+
+    async incrementAutoplayCounter(guildId: string): Promise<number> {
+        try {
+            const counter = (await this.getAutoplayCounter(guildId)) || {
+                guildId,
+                count: 0,
+                lastReset: new Date(),
+            }
+
+            counter.count += 1
+            await this.setAutoplayCounter(guildId, counter)
+
+            return counter.count
+        } catch (error) {
+            errorLog({ message: 'Failed to increment autoplay counter', error })
+            return 0
+        }
+    }
+
+    async resetAutoplayCounter(guildId: string): Promise<boolean> {
+        try {
+            const counter: AutoplayCounter = {
+                guildId,
+                count: 0,
+                lastReset: new Date(),
+            }
+            return await this.setAutoplayCounter(guildId, counter)
+        } catch (error) {
+            errorLog({ message: 'Failed to reset autoplay counter', error })
+            return false
+        }
+    }
+
+    async getRepeatCount(guildId: string): Promise<number> {
+        try {
+            const countData = await redisClient.get(
+                this.getRedisKey(guildId, 'repeat_count'),
+            )
+            return countData ? parseInt(countData, 10) : 0
+        } catch (error) {
+            errorLog({ message: 'Failed to get repeat count', error })
+            return 0
+        }
+    }
+
+    async setRepeatCount(guildId: string, count: number): Promise<boolean> {
+        try {
+            await redisClient.setex(
+                this.getRedisKey(guildId, 'repeat_count'),
+                this.ttl,
+                count.toString(),
+            )
+            return true
+        } catch (error) {
+            errorLog({ message: 'Failed to set repeat count', error })
+            return false
+        }
+    }
+
+    async incrementRepeatCount(guildId: string): Promise<number> {
+        try {
+            const currentCount = await this.getRepeatCount(guildId)
+            const newCount = currentCount + 1
+            await this.setRepeatCount(guildId, newCount)
+            return newCount
+        } catch (error) {
+            errorLog({ message: 'Failed to increment repeat count', error })
+            return 0
+        }
+    }
+
+    async resetRepeatCount(guildId: string): Promise<boolean> {
+        try {
+            return await this.setRepeatCount(guildId, 0)
+        } catch (error) {
+            errorLog({ message: 'Failed to reset repeat count', error })
+            return false
+        }
+    }
+
+    async clearGuildSessions(guildId: string): Promise<boolean> {
+        try {
+            const settingsDeleted = await this.deleteGuildSettings(guildId)
+            const counterReset = await this.resetAutoplayCounter(guildId)
+            const repeatReset = await this.resetRepeatCount(guildId)
+
+            return settingsDeleted && counterReset && repeatReset
+        } catch (error) {
+            errorLog({ message: 'Failed to clear guild sessions', error })
+            return false
+        }
+    }
+
+    async isRateLimited(
+        guildId: string,
+        command: string,
+        cooldown: number,
+    ): Promise<boolean> {
+        try {
+            const key = this.getRedisKey(guildId, `rate_limit:${command}`)
+            const lastUsed = await redisClient.get(key)
+
+            if (!lastUsed) {
+                await redisClient.setex(key, cooldown, Date.now().toString())
+                return false
+            }
+
+            const timeSinceLastUse = Date.now() - parseInt(lastUsed, 10)
+            return timeSinceLastUse < cooldown * 1000
+        } catch (error) {
+            errorLog({ message: 'Failed to check rate limit', error })
+            return false
+        }
+    }
+
+    async setRateLimit(
+        guildId: string,
+        command: string,
+        cooldown: number,
+    ): Promise<void> {
+        try {
+            const key = this.getRedisKey(guildId, `rate_limit:${command}`)
+            await redisClient.setex(key, cooldown, Date.now().toString())
+        } catch (error) {
+            errorLog({ message: 'Failed to set rate limit', error })
+        }
+    }
+
+    async clearAllAutoplayCounters(): Promise<boolean> {
+        try {
+            const pattern = 'guild_settings:*:autoplay_counter'
+            const keys = await redisClient.keys(pattern)
+            if (keys.length > 0) {
+                for (const key of keys) {
+                    await redisClient.del(key)
+                }
+            }
+            return true
+        } catch (error) {
+            errorLog({
+                message: 'Failed to clear all autoplay counters',
+                error,
+            })
+            return false
+        }
+    }
 }
 
 export const guildSettingsService = new GuildSettingsService()

--- a/packages/shared/src/services/TrackHistoryService.ts
+++ b/packages/shared/src/services/TrackHistoryService.ts
@@ -2,242 +2,329 @@ import { redisClient } from './redis'
 import { infoLog, errorLog } from '../utils/general/log'
 
 export interface TrackHistoryEntry {
-  trackId: string
-  title: string
-  author: string
-  duration: string
-  url: string
-  timestamp: number
-  guildId: string
-  playedBy?: string
-  isAutoplay?: boolean
+    trackId: string
+    title: string
+    author: string
+    duration: string
+    url: string
+    timestamp: number
+    guildId: string
+    playedBy?: string
+    isAutoplay?: boolean
 }
 
 export interface TrackHistoryInput {
-  id: string
-  title: string
-  author: string
-  duration: string
-  url: string
-  metadata?: { isAutoplay?: boolean }
+    id: string
+    title: string
+    author: string
+    duration: string
+    url: string
+    metadata?: { isAutoplay?: boolean }
 }
 
 export interface TrackHistoryStats {
-  totalTracks: number
-  totalPlayTime: number
-  topArtists: Array<{ artist: string; plays: number }>
-  topTracks: Array<{ trackId: string; title: string; plays: number }>
-  lastUpdated: Date
+    totalTracks: number
+    totalPlayTime: number
+    topArtists: Array<{ artist: string; plays: number }>
+    topTracks: Array<{ trackId: string; title: string; plays: number }>
+    lastUpdated: Date
 }
 
 export class TrackHistoryService {
-  private readonly ttl: number
-  private readonly maxHistorySize: number
+    private readonly ttl: number
+    private readonly maxHistorySize: number
 
-  constructor(ttl = 7 * 24 * 60 * 60, maxHistorySize = 100) {
-    this.ttl = ttl
-    this.maxHistorySize = maxHistorySize
-  }
-
-  private getRedisKey(guildId: string, trackId?: string): string {
-    return trackId
-      ? `track_history:${guildId}:${trackId}`
-      : `track_history:${guildId}`
-  }
-
-  async addTrackToHistory(
-    track: TrackHistoryInput,
-    guildId: string,
-    playedBy?: string,
-  ): Promise<boolean> {
-    try {
-      const entry: TrackHistoryEntry = {
-        trackId: track.id,
-        title: track.title,
-        author: track.author,
-        duration: track.duration,
-        url: track.url,
-        timestamp: Date.now(),
-        guildId,
-        playedBy,
-        isAutoplay: Boolean(track.metadata?.isAutoplay ?? false),
-      }
-
-      await redisClient.setex(
-        this.getRedisKey(guildId, track.id),
-        this.ttl,
-        JSON.stringify(entry),
-      )
-
-      await redisClient.lpush(this.getRedisKey(guildId), JSON.stringify(entry))
-      await redisClient.ltrim(this.getRedisKey(guildId), 0, this.maxHistorySize - 1)
-      await redisClient.expire(this.getRedisKey(guildId), this.ttl)
-
-      infoLog({ message: `Added track to history: ${track.title} in guild ${guildId}` })
-      return true
-    } catch (error) {
-      errorLog({ message: 'Failed to add track to history', error })
-      return false
+    constructor(ttl = 7 * 24 * 60 * 60, maxHistorySize = 100) {
+        this.ttl = ttl
+        this.maxHistorySize = maxHistorySize
     }
-  }
 
-  async getTrackHistory(guildId: string, limit = 10): Promise<TrackHistoryEntry[]> {
-    try {
-      const historyData = await redisClient.lrange(this.getRedisKey(guildId), 0, limit - 1)
-      return historyData.map((data) => JSON.parse(data) as TrackHistoryEntry)
-    } catch (error) {
-      errorLog({ message: 'Failed to get track history', error })
-      return []
+    private getRedisKey(guildId: string, trackId?: string): string {
+        return trackId
+            ? `track_history:${guildId}:${trackId}`
+            : `track_history:${guildId}`
     }
-  }
 
-  async getLastTrack(guildId: string): Promise<TrackHistoryEntry | null> {
-    try {
-      const lastTrackData = await redisClient.lindex(this.getRedisKey(guildId), 0)
-      return lastTrackData ? (JSON.parse(lastTrackData) as TrackHistoryEntry) : null
-    } catch (error) {
-      errorLog({ message: 'Failed to get last track', error })
-      return null
-    }
-  }
+    async addTrackToHistory(
+        track: TrackHistoryInput,
+        guildId: string,
+        playedBy?: string,
+    ): Promise<boolean> {
+        try {
+            const entry: TrackHistoryEntry = {
+                trackId: track.id,
+                title: track.title,
+                author: track.author,
+                duration: track.duration,
+                url: track.url,
+                timestamp: Date.now(),
+                guildId,
+                playedBy,
+                isAutoplay: Boolean(track.metadata?.isAutoplay ?? false),
+            }
 
-  async clearHistory(guildId: string): Promise<boolean> {
-    try {
-      await redisClient.del(this.getRedisKey(guildId))
-      infoLog({ message: `Cleared track history for guild ${guildId}` })
-      return true
-    } catch (error) {
-      errorLog({ message: 'Failed to clear track history', error })
-      return false
-    }
-  }
+            await redisClient.setex(
+                this.getRedisKey(guildId, track.id),
+                this.ttl,
+                JSON.stringify(entry),
+            )
 
-  async isDuplicateTrack(
-    guildId: string,
-    trackUrl: string,
-    _timeWindow = 300000,
-  ): Promise<boolean> {
-    try {
-      const history = await this.getTrackHistory(guildId, 20)
-      const cutoffTime = Date.now() - _timeWindow
+            await redisClient.lpush(
+                this.getRedisKey(guildId),
+                JSON.stringify(entry),
+            )
+            await redisClient.ltrim(
+                this.getRedisKey(guildId),
+                0,
+                this.maxHistorySize - 1,
+            )
+            await redisClient.expire(this.getRedisKey(guildId), this.ttl)
 
-      return history.some((entry) => entry.url === trackUrl && entry.timestamp > cutoffTime)
-    } catch (error) {
-      errorLog({ message: 'Failed to check for duplicate track', error })
-      return false
-    }
-  }
-
-  async getTopTracks(
-    guildId: string,
-    limit = 10,
-  ): Promise<Array<{ trackId: string; title: string; plays: number }>> {
-    try {
-      const history = await this.getTrackHistory(guildId, 100)
-      const trackCounts = new Map<string, { title: string; count: number }>()
-
-      history.forEach((entry) => {
-        const current = trackCounts.get(entry.trackId) || { title: entry.title, count: 0 }
-        trackCounts.set(entry.trackId, { ...current, count: current.count + 1 })
-      })
-
-      return Array.from(trackCounts.entries())
-        .map(([trackId, data]) => ({ trackId, title: data.title, plays: data.count }))
-        .sort((a, b) => b.plays - a.plays)
-        .slice(0, limit)
-    } catch (error) {
-      errorLog({ message: 'Failed to get top tracks', error })
-      return []
-    }
-  }
-
-  async getTopArtists(
-    guildId: string,
-    limit = 10,
-  ): Promise<Array<{ artist: string; plays: number }>> {
-    try {
-      const history = await this.getTrackHistory(guildId, 100)
-      const artistCounts = new Map<string, number>()
-
-      history.forEach((entry) => {
-        const current = artistCounts.get(entry.author) || 0
-        artistCounts.set(entry.author, current + 1)
-      })
-
-      return Array.from(artistCounts.entries())
-        .map(([artist, plays]) => ({ artist, plays }))
-        .sort((a, b) => b.plays - a.plays)
-        .slice(0, limit)
-    } catch (error) {
-      errorLog({ message: 'Failed to get top artists', error })
-      return []
-    }
-  }
-
-  async generateStats(guildId: string): Promise<TrackHistoryStats | null> {
-    try {
-      const history = await this.getTrackHistory(guildId, 100)
-
-      if (history.length === 0) {
-        return null
-      }
-
-      const totalTracks = history.length
-      const totalPlayTime = history.reduce((total, entry) => {
-        const duration = this.parseDuration(entry.duration)
-        return total + duration
-      }, 0)
-
-      const topArtists = await this.getTopArtists(guildId, 5)
-      const topTracks = await this.getTopTracks(guildId, 5)
-
-      return {
-        totalTracks,
-        totalPlayTime,
-        topArtists,
-        topTracks,
-        lastUpdated: new Date(),
-      }
-    } catch (error) {
-      errorLog({ message: 'Failed to generate stats', error })
-      return null
-    }
-  }
-
-  private parseDuration(duration: string): number {
-    const parts = duration.split(':')
-    if (parts.length === 2) {
-      return parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10)
-    }
-    return 0
-  }
-
-  async cleanupOldData(): Promise<number> {
-    return 0
-  }
-
-  async markTrackAsPlayed(guildId: string, trackUrl: string): Promise<void> {
-    try {
-      const key = this.getRedisKey(guildId, `played:${trackUrl}`)
-      await redisClient.setex(key, 300, Date.now().toString())
-    } catch (error) {
-      errorLog({ message: 'Failed to mark track as played', error })
-    }
-  }
-
-  async clearAllGuildCaches(guildId: string): Promise<void> {
-    try {
-      const pattern = this.getRedisKey(guildId, '*')
-      const keys = await redisClient.keys(pattern)
-      if (keys.length > 0) {
-        for (const key of keys) {
-          await redisClient.del(key)
+            infoLog({
+                message: `Added track to history: ${track.title} in guild ${guildId}`,
+            })
+            return true
+        } catch (error) {
+            errorLog({ message: 'Failed to add track to history', error })
+            return false
         }
-      }
-    } catch (error) {
-      errorLog({ message: 'Failed to clear guild caches', error })
     }
-  }
+
+    async getTrackHistory(
+        guildId: string,
+        limit = 10,
+    ): Promise<TrackHistoryEntry[]> {
+        try {
+            const historyData = await redisClient.lrange(
+                this.getRedisKey(guildId),
+                0,
+                limit - 1,
+            )
+            return historyData.map(
+                (data) => JSON.parse(data) as TrackHistoryEntry,
+            )
+        } catch (error) {
+            errorLog({ message: 'Failed to get track history', error })
+            return []
+        }
+    }
+
+    async getLastTrack(guildId: string): Promise<TrackHistoryEntry | null> {
+        try {
+            const lastTrackData = await redisClient.lindex(
+                this.getRedisKey(guildId),
+                0,
+            )
+            return lastTrackData
+                ? (JSON.parse(lastTrackData) as TrackHistoryEntry)
+                : null
+        } catch (error) {
+            errorLog({ message: 'Failed to get last track', error })
+            return null
+        }
+    }
+
+    async clearHistory(guildId: string): Promise<boolean> {
+        try {
+            await redisClient.del(this.getRedisKey(guildId))
+            infoLog({ message: `Cleared track history for guild ${guildId}` })
+            return true
+        } catch (error) {
+            errorLog({ message: 'Failed to clear track history', error })
+            return false
+        }
+    }
+
+    async isDuplicateTrack(
+        guildId: string,
+        trackUrl: string,
+        _timeWindow = 300000,
+    ): Promise<boolean> {
+        try {
+            const history = await this.getTrackHistory(guildId, 20)
+            const cutoffTime = Date.now() - _timeWindow
+
+            return history.some(
+                (entry) =>
+                    entry.url === trackUrl && entry.timestamp > cutoffTime,
+            )
+        } catch (error) {
+            errorLog({ message: 'Failed to check for duplicate track', error })
+            return false
+        }
+    }
+
+    async getTopTracks(
+        guildId: string,
+        limit = 10,
+    ): Promise<Array<{ trackId: string; title: string; plays: number }>> {
+        try {
+            const history = await this.getTrackHistory(guildId, 100)
+            const trackCounts = new Map<
+                string,
+                { title: string; count: number }
+            >()
+
+            history.forEach((entry) => {
+                const current = trackCounts.get(entry.trackId) || {
+                    title: entry.title,
+                    count: 0,
+                }
+                trackCounts.set(entry.trackId, {
+                    ...current,
+                    count: current.count + 1,
+                })
+            })
+
+            return Array.from(trackCounts.entries())
+                .map(([trackId, data]) => ({
+                    trackId,
+                    title: data.title,
+                    plays: data.count,
+                }))
+                .sort((a, b) => b.plays - a.plays)
+                .slice(0, limit)
+        } catch (error) {
+            errorLog({ message: 'Failed to get top tracks', error })
+            return []
+        }
+    }
+
+    async getTopArtists(
+        guildId: string,
+        limit = 10,
+    ): Promise<Array<{ artist: string; plays: number }>> {
+        try {
+            const history = await this.getTrackHistory(guildId, 100)
+            const artistCounts = new Map<string, number>()
+
+            history.forEach((entry) => {
+                const current = artistCounts.get(entry.author) || 0
+                artistCounts.set(entry.author, current + 1)
+            })
+
+            return Array.from(artistCounts.entries())
+                .map(([artist, plays]) => ({ artist, plays }))
+                .sort((a, b) => b.plays - a.plays)
+                .slice(0, limit)
+        } catch (error) {
+            errorLog({ message: 'Failed to get top artists', error })
+            return []
+        }
+    }
+
+    async generateStats(guildId: string): Promise<TrackHistoryStats | null> {
+        try {
+            const history = await this.getTrackHistory(guildId, 100)
+
+            if (history.length === 0) {
+                return null
+            }
+
+            const totalTracks = history.length
+            const totalPlayTime = history.reduce((total, entry) => {
+                const duration = this.parseDuration(entry.duration)
+                return total + duration
+            }, 0)
+
+            const topArtists = await this.getTopArtists(guildId, 5)
+            const topTracks = await this.getTopTracks(guildId, 5)
+
+            return {
+                totalTracks,
+                totalPlayTime,
+                topArtists,
+                topTracks,
+                lastUpdated: new Date(),
+            }
+        } catch (error) {
+            errorLog({ message: 'Failed to generate stats', error })
+            return null
+        }
+    }
+
+    private parseDuration(duration: string): number {
+        const parts = duration.split(':')
+        if (parts.length === 2) {
+            return parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10)
+        }
+        return 0
+    }
+
+    async cleanupOldData(): Promise<number> {
+        return 0
+    }
+
+    async markTrackAsPlayed(guildId: string, trackUrl: string): Promise<void> {
+        try {
+            const key = this.getRedisKey(guildId, `played:${trackUrl}`)
+            await redisClient.setex(key, 300, Date.now().toString())
+        } catch (error) {
+            errorLog({ message: 'Failed to mark track as played', error })
+        }
+    }
+
+    async clearAllGuildCaches(guildId: string): Promise<void> {
+        try {
+            const pattern = this.getRedisKey(guildId, '*')
+            const keys = await redisClient.keys(pattern)
+            if (keys.length > 0) {
+                for (const key of keys) {
+                    await redisClient.del(key)
+                }
+            }
+        } catch (error) {
+            errorLog({ message: 'Failed to clear guild caches', error })
+        }
+    }
+
+    async getAutoplayStats(
+        guildId: string,
+        limit = 200,
+    ): Promise<{
+        total: number
+        autoplayCount: number
+        autoplayPercent: number
+        topAutoplayArtists: Array<{ artist: string; count: number }>
+    }> {
+        try {
+            const history = await this.getTrackHistory(guildId, limit)
+            const autoplayEntries = history.filter((e) => e.isAutoplay === true)
+            const artistCounts = new Map<string, number>()
+
+            for (const entry of autoplayEntries) {
+                if (entry.author) {
+                    const key = entry.author.toLowerCase()
+                    artistCounts.set(key, (artistCounts.get(key) ?? 0) + 1)
+                }
+            }
+
+            const topAutoplayArtists = Array.from(artistCounts.entries())
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 5)
+                .map(([artist, count]) => ({ artist, count }))
+
+            return {
+                total: history.length,
+                autoplayCount: autoplayEntries.length,
+                autoplayPercent:
+                    history.length > 0
+                        ? Math.round(
+                              (autoplayEntries.length / history.length) * 100,
+                          )
+                        : 0,
+                topAutoplayArtists,
+            }
+        } catch (error) {
+            errorLog({ message: 'Failed to get autoplay stats', error })
+            return {
+                total: 0,
+                autoplayCount: 0,
+                autoplayPercent: 0,
+                topAutoplayArtists: [],
+            }
+        }
+    }
 }
 
 export const trackHistoryService = new TrackHistoryService()

--- a/prisma/migrations/20260411000000_add_autoplay_mode/migration.sql
+++ b/prisma/migrations/20260411000000_add_autoplay_mode/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "AutoplayMode" AS ENUM ('similar', 'discover', 'popular');
+
+-- AlterTable
+ALTER TABLE "guild_settings" ADD COLUMN "autoplayMode" "AutoplayMode" NOT NULL DEFAULT 'similar';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,6 +83,14 @@ model TwitchNotification {
   @@map("twitch_notifications")
 }
 
+
+enum AutoplayMode {
+  similar
+  discover
+  popular
+}
+
+
 model GuildSettings {
   id      String @id @default(cuid())
   guildId String @unique
@@ -92,6 +100,7 @@ model GuildSettings {
   defaultVolume   Int     @default(50)
   maxQueueSize    Int     @default(100)
   autoPlayEnabled Boolean @default(true)
+  autoplayMode    AutoplayMode @default(similar)
   repeatMode      Int     @default(0)
   shuffleEnabled  Boolean @default(false)
 


### PR DESCRIPTION
## Summary

- **`/autoplay skip`** — removes the first autoplay track from the queue and replenishes with a fresh recommendation
- **`/autoplay clear`** — removes all autoplay tracks from the queue and replenishes
- **`/autoplay status`** — shows count of queued autoplay tracks and Last.fm connection status
- **Queue embed** — autoplay tracks now show recommendation reason: `Song Title — _liked track • session novelty_`
- **History dedup** — lookback increased from 50→100 tracks to reduce cross-session repeats (trackHistoryService already has 7-day TTL)

> Depends on #567 (autoplay seed diversification). Set to draft until that merges.

## Test plan
- [x] All tests pass (678 tests across bot suite)
- [x] TypeScript clean
- [x] Lint clean
- [ ] Test `/autoplay skip` removes correct track and queue refills
- [ ] Test `/autoplay clear` empties autoplay tracks only, user-added tracks remain
- [ ] Queue embed shows reason text next to autoplay tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned `/autoplay` command with new subcommands: skip, clear, status, analytics, and mode
  * Introduced three autoplay modes (similar, discover, popular) for customizing track recommendation behavior
  * Added analytics subcommand displaying autoplay usage statistics and top recommended artists

<!-- end of auto-generated comment: release notes by coderabbit.ai -->