### PR TITLE
fix(bot): deduplicate same-song versions in autoplay

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -2163,4 +2163,98 @@ describe('queueManipulation.addSelectedTracks async writes', () => {
             expect(track).toHaveProperty('metadata')
         }
     })
+
+    it('deduplicates same song different URL versions in candidates', async () => {
+        const currentTrack = {
+            url: 'https://example.com/current',
+            title: 'Current Song',
+            author: 'Artist',
+            id: 'track-current',
+            requestedBy: { id: 'user-1' },
+        }
+        const searchMock = jest.fn()
+        searchMock.mockResolvedValue({
+            tracks: [
+                {
+                    title: 'Same Song (Official)',
+                    author: 'Same Artist',
+                    url: 'https://youtube.com/watch?v=aaa',
+                    id: 'yt-1',
+                    source: 'youtube',
+                    durationMS: 200000,
+                },
+                {
+                    title: 'Same Song (Remastered)',
+                    author: 'Same Artist',
+                    url: 'https://youtube.com/watch?v=bbb',
+                    id: 'yt-2',
+                    source: 'youtube',
+                    durationMS: 200000,
+                },
+            ],
+        })
+
+        const addedTracks: unknown[] = []
+        const queue = createQueueMock({
+            currentTrack,
+            metadata: { requestedBy: { id: 'user-1' } },
+            player: { search: searchMock },
+            addTrack: jest.fn((t: unknown) => addedTracks.push(t)),
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const same_song_added = addedTracks.filter((t: any) =>
+            t.title?.includes('Same Song'),
+        ).length
+        expect(same_song_added).toBeLessThanOrEqual(1)
+    })
+
+    it('does not add both (Official) and (2011 Remaster) versions of same song', async () => {
+        const currentTrack = {
+            url: 'https://example.com/current',
+            title: 'Bohemian Rhapsody',
+            author: 'Queen',
+            id: 'track-current',
+            requestedBy: { id: 'user-1' },
+        }
+        const searchMock = jest.fn()
+        searchMock.mockResolvedValue({
+            tracks: [
+                {
+                    title: 'Bohemian Rhapsody (Official Video)',
+                    author: 'Queen',
+                    url: 'https://youtube.com/watch?v=official',
+                    id: 'yt-official',
+                    source: 'youtube',
+                    durationMS: 354000,
+                },
+                {
+                    title: 'Bohemian Rhapsody (2011 Remaster)',
+                    author: 'Queen',
+                    url: 'https://youtube.com/watch?v=remaster',
+                    id: 'yt-remaster',
+                    source: 'youtube',
+                    durationMS: 354000,
+                },
+            ],
+        })
+
+        const addedTracks: unknown[] = []
+        const queue = createQueueMock({
+            currentTrack,
+            metadata: { requestedBy: { id: 'user-1' } },
+            player: { search: searchMock },
+            addTrack: jest.fn((t: unknown) => addedTracks.push(t)),
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const bohemian_added = addedTracks.filter(
+            (t: any) =>
+                t.author === 'Queen' &&
+                t.title?.toLowerCase().includes('bohemian'),
+        ).length
+        expect(bohemian_added).toBeLessThanOrEqual(1)
+    })
 })

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -611,7 +611,11 @@ function upsertScoredCandidate(
     candidate: Track,
     recommendation: { score: number; reason: string },
 ): void {
-    const candidateKey = getTrackKey(candidate)
+    const normalizedKey = normalizeTrackKey(candidate.title, candidate.author)
+    const candidateKey =
+        normalizedKey.replace(/:/g, '').length > 4
+            ? normalizedKey
+            : getTrackKey(candidate)
     const existing = candidates.get(candidateKey)
 
     if (!existing || recommendation.score > existing.score) {
@@ -745,17 +749,21 @@ function selectDiverseCandidates(
     const selected: ScoredTrack[] = []
     const artistCount = new Map<string, number>()
     const sourceCount = new Map<string, number>()
+    const selectedTitleKeys = new Set<string>()
 
     for (const candidate of sortedCandidates) {
         const artistKey = candidate.track.author.toLowerCase()
         const sourceKey = (candidate.track.source ?? 'unknown').toLowerCase()
+        const titleKey = normalizeTitleOnly(candidate.track.title)
 
         if ((artistCount.get(artistKey) ?? 0) >= maxPerArtist) continue
         if ((sourceCount.get(sourceKey) ?? 0) >= maxPerSource) continue
+        if (titleKey && selectedTitleKeys.has(titleKey)) continue
 
         selected.push(candidate)
         artistCount.set(artistKey, (artistCount.get(artistKey) ?? 0) + 1)
         sourceCount.set(sourceKey, (sourceCount.get(sourceKey) ?? 0) + 1)
+        if (titleKey) selectedTitleKeys.add(titleKey)
         if (selected.length >= missingTracks) {
             break
         }

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -613,9 +613,7 @@ function upsertScoredCandidate(
 ): void {
     const normalizedKey = normalizeTrackKey(candidate.title, candidate.author)
     const candidateKey =
-        normalizedKey.replaceAll(':', '').length > 4
-            ? normalizedKey
-            : getTrackKey(candidate)
+        normalizedKey !== '::' ? normalizedKey : getTrackKey(candidate)
     const existing = candidates.get(candidateKey)
 
     if (!existing || recommendation.score > existing.score) {

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -613,7 +613,7 @@ function upsertScoredCandidate(
 ): void {
     const normalizedKey = normalizeTrackKey(candidate.title, candidate.author)
     const candidateKey =
-        normalizedKey.replace(/:/g, '').length > 4
+        normalizedKey.replaceAll(':', '').length > 4
             ? normalizedKey
             : getTrackKey(candidate)
     const existing = candidates.get(candidateKey)

--- a/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
@@ -235,4 +235,30 @@ describe('cleanTitle — hyphenated version suffixes', () => {
     it('strips " - Single Version" suffix', () => {
         expect(cleanTitle('Track - Single Version')).toBe('Track')
     })
+
+    it('strips year-suffix remaster: "Song - Remastered 2011" → "Song"', () => {
+        expect(cleanTitle('Bohemian Rhapsody - Remastered 2011')).toBe(
+            'Bohemian Rhapsody',
+        )
+    })
+
+    it('strips year-only: "Song - 2024" → "Song"', () => {
+        expect(cleanTitle('Track - 2024')).toBe('Track')
+    })
+
+    it('strips original mix: "Song - Original Mix" → "Song"', () => {
+        expect(cleanTitle('Electronic Track - Original Mix')).toBe(
+            'Electronic Track',
+        )
+    })
+
+    it('strips original version: "Song - Original Version" → "Song"', () => {
+        expect(cleanTitle('Classic Song - Original Version')).toBe(
+            'Classic Song',
+        )
+    })
+
+    it('preserves normal title: "Song Name" → "Song Name"', () => {
+        expect(cleanTitle('Song Name')).toBe('Song Name')
+    })
 })

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -83,8 +83,18 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     /\s{0,3}-\s{0,3}topic\b/gi,
 ]
 
-const HYPHENATED_VERSION_SUFFIX =
-    /^(?:\d{4} +)?remaster(?:ed)?(?:\s+\d{4})?$|^official (?:audio|video|music video)$|^(?:live|acoustic|demo|extended|radio edit|album version|single version|original mix|original version|\d{4})$/i
+const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
+    /^(?:\d{4} +)?remaster(?:ed)?(?:\s+\d{4})?$/i,
+    /^official (?:audio|video|music video)$/i,
+    /^(?:live|acoustic|demo|extended)$/i,
+    /^(?:radio edit|album version|single version)$/i,
+    /^(?:original mix|original version)$/i,
+    /^\d{4}$/,
+]
+
+function isVersionSuffix(suffix: string): boolean {
+    return HYPHENATED_VERSION_SUFFIXES.some((re) => re.test(suffix))
+}
 
 /**
  * Channels whose uploads are almost always mislabeled or compilation garbage.
@@ -115,7 +125,7 @@ export function cleanTitle(title: string): string {
         const idx = cleaned.indexOf(sep)
         if (idx > 0) {
             const suffix = cleaned.slice(idx + sep.length).trim()
-            if (HYPHENATED_VERSION_SUFFIX.test(suffix)) {
+            if (isVersionSuffix(suffix)) {
                 cleaned = cleaned.slice(0, idx)
                 break
             }

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -89,7 +89,7 @@ const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
     /^(?:live|acoustic|demo|extended)$/i,
     /^(?:radio edit|album version|single version)$/i,
     /^(?:original mix|original version)$/i,
-    /^\d{4}$/,
+    /^(?:19|20)\d{2}$/,
 ]
 
 function isVersionSuffix(suffix: string): boolean {

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -84,7 +84,7 @@ const NOISE_PATTERNS: readonly RegExp[] = [
 ]
 
 const HYPHENATED_VERSION_SUFFIX =
-    /^(?:\d{4} +)?remaster(?:ed)?$|^official (?:audio|video|music video)$|^(?:live|acoustic|demo|extended|radio edit|album version|single version)$/i
+    /^(?:\d{4} +)?remaster(?:ed)?(?:\s+\d{4})?$|^official (?:audio|video|music video)$|^(?:live|acoustic|demo|extended|radio edit|album version|single version|original mix|original version|\d{4})$/i
 
 /**
  * Channels whose uploads are almost always mislabeled or compilation garbage.


### PR DESCRIPTION
## Summary
- Keys autoplay candidates by normalized title+author instead of URL — prevents duplicate versions (Official, Remastered, Live) from both entering the candidate pool
- Adds title-key dedup in selectDiverseCandidates as belt-and-suspenders
- Fixes HYPHENATED_VERSION_SUFFIX regex to handle year-suffix and Original Mix patterns

## Root cause
`upsertScoredCandidate` used `track.url` as map key. Two YouTube videos of the same song had different URLs → both entered candidates → both could be selected in the same replenish.

## Test plan
- [x] `cleanTitle("Song - Remastered 2011")` → `"Song"`
- [x] `cleanTitle("Song - 2024")` → `"Song"`
- [x] `cleanTitle("Song - Original Mix")` → `"Song"`
- [x] Two versions of same song in search results → only 1 added to queue
- [x] All existing 1958 tests pass

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-song detection when adding tracks to the queue by de-duplicating by normalized title/author and preventing multiple title variants from being added.
  * Enhanced search query cleaning to strip more hyphenated suffixes (remasters with years, original mixes/versions, standalone years, and other common tags).

* **Tests**
  * Added tests validating deduplication of same-song variants during queue addition.
  * Added tests covering the expanded suffix-cleaning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->