### PR TITLE
feat(bot): autoplay artist prefer/block preferences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.82",
+    "version": "2.6.87",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.82",
+            "version": "2.6.87",
             "license": "ISC",
             "workspaces": [
                 "packages/*"
@@ -20844,6 +20844,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
             "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -24259,7 +24260,7 @@
         },
         "packages/backend": {
             "name": "@lucky/backend",
-            "version": "2.6.82",
+            "version": "2.6.87",
             "dependencies": {
                 "@lucky/shared": "file:../shared",
                 "connect-redis": "^9.0.0",
@@ -24320,7 +24321,7 @@
         },
         "packages/bot": {
             "name": "@lucky/bot",
-            "version": "2.6.82",
+            "version": "2.6.87",
             "dependencies": {
                 "@discord-player/extractor": "^7.2.0",
                 "@discordjs/builders": "^1.14.1",
@@ -24416,7 +24417,7 @@
         },
         "packages/frontend": {
             "name": "lucky-webapp",
-            "version": "2.6.82",
+            "version": "2.6.87",
             "dependencies": {
                 "@hookform/resolvers": "^5.0.0",
                 "@radix-ui/react-avatar": "^1.1.11",
@@ -24437,8 +24438,8 @@
                 "clsx": "^2.1.1",
                 "framer-motion": "^12.38.0",
                 "lucide-react": "^1.7.0",
-                "react": "^19.2.5",
-                "react-dom": "19.2.5",
+                "react": "^19.0.0",
+                "react-dom": "^19.0.0",
                 "react-hook-form": "^7.72.1",
                 "react-router-dom": "^7.14.0",
                 "sonner": "^2.0.7",
@@ -25248,18 +25249,6 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
-        "packages/frontend/node_modules/react-dom": {
-            "version": "19.2.5",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-            "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-            "license": "MIT",
-            "dependencies": {
-                "scheduler": "^0.27.0"
-            },
-            "peerDependencies": {
-                "react": "^19.2.5"
-            }
-        },
         "packages/frontend/node_modules/rolldown": {
             "version": "1.0.0-rc.15",
             "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -25511,7 +25500,7 @@
         },
         "packages/shared": {
             "name": "@lucky/shared",
-            "version": "2.6.82",
+            "version": "2.6.87",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.3",
                 "@npmcli/agent": "^4.0.0",

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -702,6 +702,48 @@ describe('autoplay command', () => {
                 expect.any(String),
             )
         })
+
+        it('artist block — shows error when no artist name', async () => {
+            const interaction = createArtistInteraction('block', undefined)
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'Missing Input',
+                expect.any(String),
+            )
+        })
+
+        it('artist remove — shows error when no artist name', async () => {
+            const interaction = createArtistInteraction('remove', undefined)
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'Missing Input',
+                expect.any(String),
+            )
+        })
+
+        it('artist prefer — handles service error gracefully', async () => {
+            setArtistFeedbackMock.mockRejectedValue(new Error('Redis down'))
+            const interaction = createArtistInteraction('prefer', 'The Beatles')
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'Error',
+                expect.any(String),
+            )
+        })
+
+        it('artist unknown subcommand — shows error', async () => {
+            const interaction = createArtistInteraction('unknown')
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(interactionReplyMock).toHaveBeenCalled()
+        })
     })
 
     describe('execute function edge cases', () => {

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -623,7 +623,7 @@ describe('autoplay command', () => {
 
             expect(createErrorEmbedMock).toHaveBeenCalledWith(
                 'Unknown Subcommand',
-                'Please use skip, clear, status, analytics, mode, or genre.',
+                'Please use skip, clear, status, analytics, or mode.',
             )
             expect(interactionReplyMock).toHaveBeenCalled()
         })

--- a/packages/bot/src/functions/music/commands/autoplay.spec.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.spec.ts
@@ -12,6 +12,9 @@ const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
 const resolveGuildQueueMock = jest.fn()
 const trackHistoryServiceMock = jest.fn()
+const setArtistFeedbackMock = jest.fn()
+const removeArtistFeedbackMock = jest.fn()
+const getArtistFeedbackSummaryMock = jest.fn()
 
 jest.mock('../../../utils/general/interactionReply', () => ({
     interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
@@ -56,6 +59,17 @@ jest.mock('@lucky/shared/services', () => ({
     trackHistoryService: {
         getAutoplayStats: (...args: unknown[]) =>
             trackHistoryServiceMock(...args),
+    },
+}))
+
+jest.mock('../../../services/musicRecommendation/feedbackService', () => ({
+    recommendationFeedbackService: {
+        setArtistFeedback: (...args: unknown[]) =>
+            setArtistFeedbackMock(...args),
+        removeArtistFeedback: (...args: unknown[]) =>
+            removeArtistFeedbackMock(...args),
+        getArtistFeedbackSummary: (...args: unknown[]) =>
+            getArtistFeedbackSummaryMock(...args),
     },
 }))
 
@@ -590,6 +604,101 @@ describe('autoplay command', () => {
 
             expect(createErrorEmbedMock).toHaveBeenCalledWith(
                 'Error',
+                expect.any(String),
+            )
+        })
+    })
+
+    describe('artist subcommand group', () => {
+        beforeEach(() => {
+            setArtistFeedbackMock.mockResolvedValue(undefined)
+            removeArtistFeedbackMock.mockResolvedValue(undefined)
+            getArtistFeedbackSummaryMock.mockResolvedValue({
+                preferred: [],
+                blocked: [],
+            })
+        })
+
+        function createArtistInteraction(subcommand: string, artist?: string) {
+            const interaction = {
+                guildId: 'guild-1',
+                deferred: false,
+                replied: false,
+                user: { id: 'user-1' },
+                deferReply: jest.fn(async () => {
+                    interaction.deferred = true
+                }),
+                options: {
+                    getSubcommand: jest.fn(() => subcommand),
+                    getSubcommandGroup: jest.fn(() => 'artist'),
+                    getString: jest.fn(() => artist ?? null),
+                },
+            }
+            return interaction as any
+        }
+
+        it('artist prefer — marks artist as preferred', async () => {
+            const interaction = createArtistInteraction('prefer', 'The Beatles')
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(setArtistFeedbackMock).toHaveBeenCalledWith(
+                'guild-1',
+                'user-1',
+                'The Beatles',
+                'prefer',
+            )
+            expect(createEmbedMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    title: expect.stringContaining('Preferred'),
+                }),
+            )
+        })
+
+        it('artist block — blocks artist from autoplay', async () => {
+            const interaction = createArtistInteraction('block', 'Artist X')
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(setArtistFeedbackMock).toHaveBeenCalledWith(
+                'guild-1',
+                'user-1',
+                'Artist X',
+                'block',
+            )
+        })
+
+        it('artist remove — removes preference', async () => {
+            const interaction = createArtistInteraction('remove', 'The Beatles')
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(removeArtistFeedbackMock).toHaveBeenCalledWith(
+                'guild-1',
+                'user-1',
+                'The Beatles',
+            )
+        })
+
+        it('artist list — shows preferences', async () => {
+            const interaction = createArtistInteraction('list')
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(createEmbedMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    title: expect.stringContaining('Preferences'),
+                }),
+            )
+        })
+
+        it('artist prefer — shows error when no artist name', async () => {
+            const interaction = createArtistInteraction('prefer', undefined)
+            const client = createClient()
+            resolveGuildQueueMock.mockReturnValue({ queue: null })
+            await autoplayCommand.execute({ client, interaction } as any)
+            expect(createErrorEmbedMock).toHaveBeenCalledWith(
+                'Missing Input',
                 expect.any(String),
             )
         })

--- a/packages/bot/src/functions/music/commands/autoplay.ts
+++ b/packages/bot/src/functions/music/commands/autoplay.ts
@@ -2,6 +2,7 @@ import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import { guildSettingsService } from '@lucky/shared/services'
+import { recommendationFeedbackService } from '../../../services/musicRecommendation/feedbackService'
 import {
     createEmbed,
     createErrorEmbed,
@@ -590,6 +591,230 @@ async function handleAutoplayGenre(
     }
 }
 
+async function handleAutoplayArtist(
+    interaction: ChatInputCommandInteraction,
+): Promise<void> {
+    const userId = interaction.user.id
+    const guildId = interaction.guildId
+    if (!guildId) {
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'Guild Not Found',
+                        'Unable to retrieve guild information.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+        return
+    }
+
+    const subcommandName = interaction.options.getSubcommand()
+    const artistName = interaction.options.getString('artist')
+
+    try {
+        switch (subcommandName) {
+            case 'prefer': {
+                if (!artistName) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [
+                                createErrorEmbed(
+                                    'Missing Input',
+                                    'Please provide an artist name.',
+                                ),
+                            ],
+                            ephemeral: true,
+                        },
+                    })
+                    return
+                }
+
+                await recommendationFeedbackService.setArtistFeedback(
+                    guildId,
+                    userId,
+                    artistName,
+                    'prefer',
+                )
+
+                const preferEmbed = createEmbed({
+                    title: '⭐ Artist Preferred',
+                    description: `**${artistName}** will be prioritized in autoplay recommendations.`,
+                    color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+                    emoji: EMOJIS.AUTOPLAY,
+                    timestamp: true,
+                })
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [preferEmbed],
+                        ephemeral: true,
+                    },
+                })
+                break
+            }
+
+            case 'block': {
+                if (!artistName) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [
+                                createErrorEmbed(
+                                    'Missing Input',
+                                    'Please provide an artist name.',
+                                ),
+                            ],
+                            ephemeral: true,
+                        },
+                    })
+                    return
+                }
+
+                await recommendationFeedbackService.setArtistFeedback(
+                    guildId,
+                    userId,
+                    artistName,
+                    'block',
+                )
+
+                const blockEmbed = createEmbed({
+                    title: '🚫 Artist Blocked',
+                    description: `**${artistName}** will not appear in autoplay recommendations.`,
+                    color: EMBED_COLORS.ERROR as ColorResolvable,
+                    emoji: EMOJIS.AUTOPLAY,
+                    timestamp: true,
+                })
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [blockEmbed],
+                        ephemeral: true,
+                    },
+                })
+                break
+            }
+
+            case 'remove': {
+                if (!artistName) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [
+                                createErrorEmbed(
+                                    'Missing Input',
+                                    'Please provide an artist name.',
+                                ),
+                            ],
+                            ephemeral: true,
+                        },
+                    })
+                    return
+                }
+
+                await recommendationFeedbackService.removeArtistFeedback(
+                    guildId,
+                    userId,
+                    artistName,
+                )
+
+                const removeEmbed = createEmbed({
+                    title: '✓ Preference Removed',
+                    description: `**${artistName}** preference has been removed.`,
+                    color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+                    emoji: EMOJIS.AUTOPLAY,
+                    timestamp: true,
+                })
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [removeEmbed],
+                        ephemeral: true,
+                    },
+                })
+                break
+            }
+
+            case 'list': {
+                const summary =
+                    await recommendationFeedbackService.getArtistFeedbackSummary(
+                        userId,
+                    )
+
+                const preferredText =
+                    summary.preferred.length > 0
+                        ? summary.preferred
+                              .map((a: string) => `⭐ ${a}`)
+                              .join('\n')
+                        : 'No preferred artists.'
+
+                const blockedText =
+                    summary.blocked.length > 0
+                        ? summary.blocked
+                              .map((a: string) => `🚫 ${a}`)
+                              .join('\n')
+                        : 'No blocked artists.'
+
+                const listEmbed = createEmbed({
+                    title: '🎯 Your Artist Preferences',
+                    description: `**Preferred:** (${summary.preferred.length})\n${preferredText}\n\n**Blocked:** (${summary.blocked.length})\n${blockedText}`,
+                    color: EMBED_COLORS.AUTOPLAY as ColorResolvable,
+                    emoji: EMOJIS.AUTOPLAY,
+                    timestamp: true,
+                })
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [listEmbed],
+                        ephemeral: true,
+                    },
+                })
+                break
+            }
+
+            default:
+                await interactionReply({
+                    interaction,
+                    content: {
+                        embeds: [
+                            createErrorEmbed(
+                                'Unknown Subcommand',
+                                'This subcommand is not recognized.',
+                            ),
+                        ],
+                        ephemeral: true,
+                    },
+                })
+        }
+    } catch (error) {
+        errorLog({
+            message: 'Failed to handle artist preference',
+            error,
+            data: { guildId, userId, subcommandName },
+        })
+        await interactionReply({
+            interaction,
+            content: {
+                embeds: [
+                    createErrorEmbed(
+                        'Error',
+                        'Failed to update artist preferences.',
+                    ),
+                ],
+                ephemeral: true,
+            },
+        })
+    }
+}
+
 export default new Command({
     data: new SlashCommandBuilder()
         .setName('autoplay')
@@ -681,6 +906,51 @@ export default new Command({
                 .addSubcommand((sub) =>
                     sub.setName('clear').setDescription('Remove all genres'),
                 ),
+        )
+        .addSubcommandGroup((group) =>
+            group
+                .setName('artist')
+                .setDescription('Manage artist preferences for autoplay')
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('prefer')
+                        .setDescription('Mark an artist as preferred')
+                        .addStringOption((opt) =>
+                            opt
+                                .setName('artist')
+                                .setDescription('Artist name')
+                                .setRequired(true),
+                        ),
+                )
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('block')
+                        .setDescription('Block an artist from appearing')
+                        .addStringOption((opt) =>
+                            opt
+                                .setName('artist')
+                                .setDescription('Artist name')
+                                .setRequired(true),
+                        ),
+                )
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('list')
+                        .setDescription(
+                            'Show your preferred and blocked artists',
+                        ),
+                )
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('remove')
+                        .setDescription('Remove artist preference')
+                        .addStringOption((opt) =>
+                            opt
+                                .setName('artist')
+                                .setDescription('Artist name')
+                                .setRequired(true),
+                        ),
+                ),
         ),
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
@@ -708,6 +978,11 @@ export default new Command({
 
             if (subcommandGroup === 'genre') {
                 await handleAutoplayGenre(interaction, subcommand)
+                return
+            }
+
+            if (subcommandGroup === 'artist') {
+                await handleAutoplayArtist(interaction)
                 return
             }
 
@@ -742,6 +1017,9 @@ export default new Command({
                 case 'mode':
                     await handleAutoplayMode(interaction)
                     break
+                case 'artist':
+                    await handleAutoplayArtist(interaction)
+                    break
                 default:
                     await interactionReply({
                         interaction,
@@ -749,7 +1027,7 @@ export default new Command({
                             embeds: [
                                 createErrorEmbed(
                                     'Unknown Subcommand',
-                                    'Please use skip, clear, status, analytics, mode, or genre.',
+                                    'Please use skip, clear, status, analytics, or mode.',
                                 ),
                             ],
                             ephemeral: true,

--- a/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
@@ -121,9 +121,21 @@ describe('RecommendationFeedbackService', () => {
 
         getMock.mockResolvedValue(
             JSON.stringify({
-                [keyA]: { feedback: 'like', updatedAt: now, expiresAt: now + 1_000_000 },
-                [keyB]: { feedback: 'dislike', updatedAt: now, expiresAt: now + 1_000_000 },
-                [keyC]: { feedback: 'like', updatedAt: now, expiresAt: now + 1_000_000 },
+                [keyA]: {
+                    feedback: 'like',
+                    updatedAt: now,
+                    expiresAt: now + 1_000_000,
+                },
+                [keyB]: {
+                    feedback: 'dislike',
+                    updatedAt: now,
+                    expiresAt: now + 1_000_000,
+                },
+                [keyC]: {
+                    feedback: 'like',
+                    updatedAt: now,
+                    expiresAt: now + 1_000_000,
+                },
             }),
         )
 
@@ -181,6 +193,158 @@ describe('RecommendationFeedbackService', () => {
 
         const result = await service.getLikedTrackKeys('guild-1', undefined)
         expect(result.size).toBe(0)
+        expect(getMock).not.toHaveBeenCalled()
+    })
+
+    it('setArtistFeedback stores prefer feedback', async () => {
+        const service = new RecommendationFeedbackService(30)
+        getMock.mockResolvedValue(null)
+        setexMock.mockResolvedValue(true)
+
+        await service.setArtistFeedback(
+            'guild-1',
+            'user-1',
+            'Taylor Swift',
+            'prefer',
+        )
+
+        expect(setexMock).toHaveBeenCalledWith(
+            'music:artist_feedback:user-1',
+            30 * 24 * 60 * 60,
+            expect.any(String),
+        )
+        expect(getMock).toHaveBeenCalledWith('music:artist_feedback:user-1')
+    })
+
+    it('setArtistFeedback stores block feedback', async () => {
+        const service = new RecommendationFeedbackService(30)
+        getMock.mockResolvedValue(null)
+        setexMock.mockResolvedValue(true)
+
+        await service.setArtistFeedback(
+            'guild-1',
+            'user-1',
+            'Unknown Artist',
+            'block',
+        )
+
+        expect(setexMock).toHaveBeenCalled()
+        const callArgs = setexMock.mock.calls[0]
+        const storedData = JSON.parse(callArgs[2] as string)
+        expect(Object.values(storedData)[0]).toBe('block')
+    })
+
+    it('getPreferredArtistKeys returns preferred artists', async () => {
+        const service = new RecommendationFeedbackService(30)
+        const artistKey1 = 'taylorswift'
+        const artistKey2 = 'arianagrande'
+
+        getMock.mockResolvedValue(
+            JSON.stringify({
+                [artistKey1]: 'prefer',
+                [artistKey2]: 'prefer',
+                badartist: 'block',
+            }),
+        )
+
+        const preferred = await service.getPreferredArtistKeys(
+            'guild-1',
+            'user-1',
+        )
+
+        expect(preferred.has(artistKey1)).toBe(true)
+        expect(preferred.has(artistKey2)).toBe(true)
+        expect(preferred.has('badartist')).toBe(false)
+        expect(preferred.size).toBe(2)
+    })
+
+    it('getBlockedArtistKeys returns blocked artists', async () => {
+        const service = new RecommendationFeedbackService(30)
+        const artistKey1 = 'badartist1'
+        const artistKey2 = 'badartist2'
+
+        getMock.mockResolvedValue(
+            JSON.stringify({
+                [artistKey1]: 'block',
+                [artistKey2]: 'block',
+                goodartist: 'prefer',
+            }),
+        )
+
+        const blocked = await service.getBlockedArtistKeys('guild-1', 'user-1')
+
+        expect(blocked.has(artistKey1)).toBe(true)
+        expect(blocked.has(artistKey2)).toBe(true)
+        expect(blocked.has('goodartist')).toBe(false)
+        expect(blocked.size).toBe(2)
+    })
+
+    it('getPreferredArtistKeys returns empty set for undefined userId', async () => {
+        const service = new RecommendationFeedbackService(30)
+
+        const result = await service.getPreferredArtistKeys(
+            'guild-1',
+            undefined,
+        )
+
+        expect(result.size).toBe(0)
+        expect(getMock).not.toHaveBeenCalled()
+    })
+
+    it('getBlockedArtistKeys returns empty set for undefined userId', async () => {
+        const service = new RecommendationFeedbackService(30)
+
+        const result = await service.getBlockedArtistKeys('guild-1', undefined)
+
+        expect(result.size).toBe(0)
+        expect(getMock).not.toHaveBeenCalled()
+    })
+
+    it('removeArtistFeedback deletes artist preference', async () => {
+        const service = new RecommendationFeedbackService(30)
+        getMock.mockResolvedValue(
+            JSON.stringify({
+                taylorswift: 'prefer',
+                arianagrande: 'prefer',
+            }),
+        )
+        setexMock.mockResolvedValue(true)
+
+        await service.removeArtistFeedback('guild-1', 'user-1', 'Taylor Swift')
+
+        expect(setexMock).toHaveBeenCalled()
+        const callArgs = setexMock.mock.calls[0]
+        const storedData = JSON.parse(callArgs[2] as string)
+        expect(storedData).not.toHaveProperty('taylorswift')
+        expect(storedData).toHaveProperty('arianagrande')
+    })
+
+    it('getArtistFeedbackSummary returns preferred and blocked lists', async () => {
+        const service = new RecommendationFeedbackService(30)
+        getMock.mockResolvedValue(
+            JSON.stringify({
+                artistone: 'prefer',
+                artisttwo: 'prefer',
+                badartist: 'block',
+            }),
+        )
+
+        const summary = await service.getArtistFeedbackSummary('user-1')
+
+        expect(summary.preferred).toContain('artistone')
+        expect(summary.preferred).toContain('artisttwo')
+        expect(summary.blocked).toContain('badartist')
+        expect(summary.preferred.length).toBe(2)
+        expect(summary.blocked.length).toBe(1)
+    })
+
+    it('getArtistFeedbackSummary returns empty lists for undefined userId', async () => {
+        const service = new RecommendationFeedbackService(30)
+
+        const summary = await service.getArtistFeedbackSummary(undefined)
+
+        expect(summary.preferred).toEqual([])
+        expect(summary.blocked).toEqual([])
         expect(getMock).not.toHaveBeenCalled()
     })
 })

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -177,7 +177,9 @@ export class RecommendationFeedbackService {
         return `music:artist_feedback:${userId}`
     }
 
-    private async getArtistFeedbackMap(userId: string): Promise<Record<string, ArtistFeedback>> {
+    private async getArtistFeedbackMap(
+        userId: string,
+    ): Promise<Record<string, ArtistFeedback>> {
         const key = this.getArtistFeedbackRedisKey(userId)
         try {
             const value = await redisClient.get(key)

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -1,7 +1,9 @@
 import { redisClient } from '@lucky/shared/services'
 import { errorLog } from '@lucky/shared/utils'
+import { cleanAuthor } from '../../utils/music/searchQueryCleaner'
 
 export type RecommendationFeedback = 'like' | 'dislike'
+export type ArtistFeedback = 'prefer' | 'block'
 
 type FeedbackEntry = {
     feedback: RecommendationFeedback
@@ -169,6 +171,132 @@ export class RecommendationFeedbackService {
         }
 
         return { liked, disliked }
+    }
+
+    private getArtistFeedbackRedisKey(userId: string): string {
+        return `music:artist_feedback:${userId}`
+    }
+
+    private async getArtistFeedbackMap(userId: string): Promise<Record<string, ArtistFeedback>> {
+        const key = this.getArtistFeedbackRedisKey(userId)
+        try {
+            const value = await redisClient.get(key)
+            if (!value) return {}
+            const parsed = JSON.parse(value) as Record<string, ArtistFeedback>
+            return parsed && typeof parsed === 'object' ? parsed : {}
+        } catch (error) {
+            errorLog({
+                message: 'Failed to load artist feedback map',
+                error,
+            })
+            return {}
+        }
+    }
+
+    private async saveArtistFeedbackMap(
+        userId: string,
+        map: Record<string, ArtistFeedback>,
+    ): Promise<void> {
+        const key = this.getArtistFeedbackRedisKey(userId)
+        const ttlSeconds = this.ttlDays * 24 * 60 * 60
+
+        await redisClient.setex(key, ttlSeconds, JSON.stringify(map))
+    }
+
+    private normalizeArtistKey(artistName: string): string {
+        const cleaned = cleanAuthor(artistName)
+        return cleaned
+            .toLowerCase()
+            .replaceAll(/[^a-z0-9]+/g, '')
+            .trim()
+    }
+
+    async setArtistFeedback(
+        guildId: string,
+        userId: string,
+        artistName: string,
+        feedback: ArtistFeedback,
+    ): Promise<void> {
+        try {
+            const artistKey = this.normalizeArtistKey(artistName)
+            if (!artistKey) return
+
+            const map = await this.getArtistFeedbackMap(userId)
+            map[artistKey] = feedback
+            await this.saveArtistFeedbackMap(userId, map)
+        } catch (error) {
+            errorLog({
+                message: 'Failed to store artist feedback',
+                error,
+                data: { guildId },
+            })
+        }
+    }
+
+    async removeArtistFeedback(
+        guildId: string,
+        userId: string,
+        artistName: string,
+    ): Promise<void> {
+        try {
+            const artistKey = this.normalizeArtistKey(artistName)
+            if (!artistKey) return
+
+            const map = await this.getArtistFeedbackMap(userId)
+            delete map[artistKey]
+            await this.saveArtistFeedbackMap(userId, map)
+        } catch (error) {
+            errorLog({
+                message: 'Failed to remove artist feedback',
+                error,
+                data: { guildId },
+            })
+        }
+    }
+
+    async getPreferredArtistKeys(
+        guildId: string,
+        userId: string | undefined,
+    ): Promise<Set<string>> {
+        if (!userId) return new Set<string>()
+
+        const map = await this.getArtistFeedbackMap(userId)
+        return new Set(
+            Object.entries(map)
+                .filter(([, feedback]) => feedback === 'prefer')
+                .map(([artistKey]) => artistKey),
+        )
+    }
+
+    async getBlockedArtistKeys(
+        guildId: string,
+        userId: string | undefined,
+    ): Promise<Set<string>> {
+        if (!userId) return new Set<string>()
+
+        const map = await this.getArtistFeedbackMap(userId)
+        return new Set(
+            Object.entries(map)
+                .filter(([, feedback]) => feedback === 'block')
+                .map(([artistKey]) => artistKey),
+        )
+    }
+
+    async getArtistFeedbackSummary(
+        userId: string | undefined,
+    ): Promise<{ preferred: string[]; blocked: string[] }> {
+        if (!userId) return { preferred: [], blocked: [] }
+
+        const map = await this.getArtistFeedbackMap(userId)
+        const preferred: string[] = []
+        const blocked: string[] = []
+
+        for (const [artistKey, feedback] of Object.entries(map)) {
+            if (feedback === 'prefer') preferred.push(artistKey)
+            else if (feedback === 'block') blocked.push(artistKey)
+        }
+
+        return { preferred, blocked }
     }
 }
 

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -77,12 +77,18 @@ jest.mock('../../lastfm', () => ({
 
 const dislikedTrackKeysMock = jest.fn()
 const likedTrackKeysMock = jest.fn()
+const getPreferredArtistKeysMock = jest.fn()
+const getBlockedArtistKeysMock = jest.fn()
 
 jest.mock('../../services/musicRecommendation/feedbackService', () => ({
     recommendationFeedbackService: {
         getDislikedTrackKeys: (...args: unknown[]) =>
             dislikedTrackKeysMock(...args),
         getLikedTrackKeys: (...args: unknown[]) => likedTrackKeysMock(...args),
+        getPreferredArtistKeys: (...args: unknown[]) =>
+            getPreferredArtistKeysMock(...args),
+        getBlockedArtistKeys: (...args: unknown[]) =>
+            getBlockedArtistKeysMock(...args),
     },
 }))
 
@@ -127,6 +133,8 @@ describe('queueManipulation.replenishQueue', () => {
     beforeEach(() => {
         dislikedTrackKeysMock.mockResolvedValue(new Set())
         likedTrackKeysMock.mockResolvedValue(new Set())
+        getPreferredArtistKeysMock.mockResolvedValue(new Set())
+        getBlockedArtistKeysMock.mockResolvedValue(new Set())
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -1900,6 +1900,8 @@ describe('queueManipulation.replenishQueue query variation', () => {
     beforeEach(() => {
         dislikedTrackKeysMock.mockResolvedValue(new Set())
         likedTrackKeysMock.mockResolvedValue(new Set())
+        getPreferredArtistKeysMock.mockResolvedValue(new Set())
+        getBlockedArtistKeysMock.mockResolvedValue(new Set())
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
@@ -1989,6 +1991,8 @@ describe('queueManipulation.collectBroadFallbackCandidates diversification', () 
     beforeEach(() => {
         dislikedTrackKeysMock.mockResolvedValue(new Set())
         likedTrackKeysMock.mockResolvedValue(new Set())
+        getPreferredArtistKeysMock.mockResolvedValue(new Set())
+        getBlockedArtistKeysMock.mockResolvedValue(new Set())
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
@@ -2029,6 +2033,8 @@ describe('queueManipulation.selectDiverseCandidates score jitter', () => {
     beforeEach(() => {
         dislikedTrackKeysMock.mockResolvedValue(new Set())
         likedTrackKeysMock.mockResolvedValue(new Set())
+        getPreferredArtistKeysMock.mockResolvedValue(new Set())
+        getBlockedArtistKeysMock.mockResolvedValue(new Set())
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
@@ -2087,6 +2093,8 @@ describe('queueManipulation.addSelectedTracks async writes', () => {
     beforeEach(() => {
         dislikedTrackKeysMock.mockResolvedValue(new Set())
         likedTrackKeysMock.mockResolvedValue(new Set())
+        getPreferredArtistKeysMock.mockResolvedValue(new Set())
+        getBlockedArtistKeysMock.mockResolvedValue(new Set())
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -340,6 +340,8 @@ async function _replenishQueue(
                     currentTrack,
                     excludedUrls,
                     excludedKeys,
+                    preferredArtistKeys,
+                    blockedArtistKeys,
                     autoplayMode,
                 },
             )
@@ -700,9 +702,9 @@ async function collectLastFmCandidates(
                 currentTrack,
                 recentArtists,
                 likedTrackKeys,
-            preferredArtistKeys,
-            blockedArtistKeys,
-            autoplayMode,
+                preferredArtistKeys,
+                blockedArtistKeys,
+                autoplayMode,
             )
             if (rec.score === -Infinity) continue
             upsertScoredCandidate(candidates, track, {
@@ -790,6 +792,8 @@ interface CandidateContext {
     currentTrack: Track
     excludedUrls: Set<string>
     excludedKeys: Set<string>
+    preferredArtistKeys: Set<string>
+    blockedArtistKeys: Set<string>
     autoplayMode: 'similar' | 'discover' | 'popular'
 }
 
@@ -807,6 +811,8 @@ function addGenreTrackCandidate(
         ctx.currentTrack,
         ctx.recentArtists,
         ctx.likedTrackKeys,
+        ctx.preferredArtistKeys,
+        ctx.blockedArtistKeys,
         ctx.autoplayMode,
     )
     upsertScoredCandidate(ctx.candidates, track, {

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -239,6 +239,8 @@ async function _replenishQueue(
         const [
             dislikedTrackKeys,
             likedTrackKeys,
+            preferredArtistKeys,
+            blockedArtistKeys,
             persistentHistory,
             guildSettings,
         ] = await Promise.all([
@@ -247,6 +249,14 @@ async function _replenishQueue(
                 requestedBy?.id,
             ),
             recommendationFeedbackService.getLikedTrackKeys(
+                queue.guild.id,
+                requestedBy?.id,
+            ),
+            recommendationFeedbackService.getPreferredArtistKeys(
+                queue.guild.id,
+                requestedBy?.id,
+            ),
+            recommendationFeedbackService.getBlockedArtistKeys(
                 queue.guild.id,
                 requestedBy?.id,
             ),
@@ -294,6 +304,8 @@ async function _replenishQueue(
             excludedKeys,
             dislikedTrackKeys,
             likedTrackKeys,
+            preferredArtistKeys,
+            blockedArtistKeys,
             currentTrack,
             recentArtists,
             replenishCount,
@@ -307,6 +319,8 @@ async function _replenishQueue(
                 excludedKeys,
                 dislikedTrackKeys,
                 likedTrackKeys,
+                preferredArtistKeys,
+                blockedArtistKeys,
                 currentTrack,
                 recentArtists,
                 candidates,
@@ -339,6 +353,8 @@ async function _replenishQueue(
                 excludedKeys,
                 dislikedTrackKeys,
                 likedTrackKeys,
+                preferredArtistKeys,
+                blockedArtistKeys,
                 recentArtists,
                 candidates,
                 autoplayMode,
@@ -466,6 +482,8 @@ async function collectRecommendationCandidates(
     excludedKeys: Set<string>,
     dislikedTrackKeys: Set<string>,
     likedTrackKeys: Set<string>,
+    preferredArtistKeys: Set<string>,
+    blockedArtistKeys: Set<string>,
     currentTrack: Track,
     recentArtists: Set<string>,
     replenishCount = 0,
@@ -493,17 +511,18 @@ async function collectRecommendationCandidates(
             if (dislikedTrackKeys.has(normalizedKey)) {
                 continue
             }
-            upsertScoredCandidate(
-                candidates,
+            const rec = calculateRecommendationScore(
                 candidate,
-                calculateRecommendationScore(
-                    candidate,
-                    currentTrack,
-                    recentArtists,
-                    likedTrackKeys,
-                    autoplayMode,
-                ),
+                currentTrack,
+                recentArtists,
+                likedTrackKeys,
+                preferredArtistKeys,
+                blockedArtistKeys,
+                autoplayMode,
             )
+            if (rec.score !== -Infinity) {
+                upsertScoredCandidate(candidates, candidate, rec)
+            }
         }
     }
 
@@ -564,6 +583,8 @@ async function collectBroadFallbackCandidates(
     excludedKeys: Set<string>,
     dislikedTrackKeys: Set<string>,
     likedTrackKeys: Set<string>,
+    preferredArtistKeys: Set<string>,
+    blockedArtistKeys: Set<string>,
     recentArtists: Set<string>,
     candidates: Map<string, ScoredTrack>,
     autoplayMode: 'similar' | 'discover' | 'popular' = 'similar',
@@ -598,8 +619,11 @@ async function collectBroadFallbackCandidates(
                     currentTrack,
                     recentArtists,
                     likedTrackKeys,
+                    preferredArtistKeys,
+                    blockedArtistKeys,
                     autoplayMode,
                 )
+                if (rec.score === -Infinity) continue
                 upsertScoredCandidate(candidates, track, {
                     score: rec.score - 0.1,
                     reason: rec.reason
@@ -649,6 +673,8 @@ async function collectLastFmCandidates(
     excludedKeys: Set<string>,
     dislikedTrackKeys: Set<string>,
     likedTrackKeys: Set<string>,
+    preferredArtistKeys: Set<string>,
+    blockedArtistKeys: Set<string>,
     currentTrack: Track,
     recentArtists: Set<string>,
     candidates: Map<string, ScoredTrack>,
@@ -674,8 +700,11 @@ async function collectLastFmCandidates(
                 currentTrack,
                 recentArtists,
                 likedTrackKeys,
-                autoplayMode,
+            preferredArtistKeys,
+            blockedArtistKeys,
+            autoplayMode,
             )
+            if (rec.score === -Infinity) continue
             upsertScoredCandidate(candidates, track, {
                 score: rec.score + LASTFM_SCORE_BOOST,
                 reason: rec.reason
@@ -702,6 +731,8 @@ async function collectLastFmCandidates(
                     currentTrack,
                     recentArtists,
                     likedTrackKeys,
+                    preferredArtistKeys,
+                    blockedArtistKeys,
                     autoplayMode,
                 )
                 upsertScoredCandidate(candidates, track, {
@@ -1035,12 +1066,25 @@ function calculateRecommendationScore(
     currentTrack: Track,
     recentArtists: Set<string>,
     likedTrackKeys: Set<string> = new Set(),
+    preferredArtistKeys: Set<string> = new Set(),
+    blockedArtistKeys: Set<string> = new Set(),
     autoplayMode: 'similar' | 'discover' | 'popular' = 'similar',
 ): { score: number; reason: string } {
-    let score = 1
-    const reasons: string[] = []
     const currentArtist = currentTrack.author.toLowerCase()
     const candidateArtist = candidate.author.toLowerCase()
+    const candidateArtistKey = normalizeText(cleanAuthor(candidate.author))
+
+    if (blockedArtistKeys.has(candidateArtistKey)) {
+        return { score: -Infinity, reason: 'blocked artist' }
+    }
+
+    let score = 1
+    const reasons: string[] = []
+
+    if (preferredArtistKeys.has(candidateArtistKey)) {
+        score += 0.3
+        reasons.push('preferred artist')
+    }
 
     const candidateKey = normalizeTrackKey(candidate.title, candidate.author)
     if (likedTrackKeys.has(candidateKey)) {


### PR DESCRIPTION
## Summary

- Extends `feedbackService` with artist-level feedback: `setArtistFeedback`, `removeArtistFeedback`, `getPreferredArtistKeys`, `getBlockedArtistKeys`, `getArtistFeedbackSummary`
- Artist keys normalized via `cleanAuthor()` + lowercase for consistent matching
- Wires artist preferences into `calculateRecommendationScore`: blocked artists excluded, preferred get `+0.3` boost
- Adds `/autoplay artist` subcommand group: `prefer`, `block`, `remove`, `list`
- All data stored in Redis with 30d TTL

Replaces #571 (rebased onto main after v2.6.91 merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an /autoplay "artist" group so users can prefer, block, list, and remove artists to influence recommendations.
  * Recommendations now respect per-user artist preferences and blocks, improving suggestion relevance.

* **Bug Fixes**
  * Clarified "Unknown Subcommand" help text to remove an obsolete hint.

* **Tests**
  * Expanded test coverage for artist-level feedback and recommendation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->