### PR TITLE
fix(bot): eliminate same-song repetition in autoplay

### DIFF
--- a/packages/bot/src/utils/music/autoplay/lastFmSeeds.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeds.ts
@@ -5,6 +5,7 @@ import {
     getSimilarTracks,
 } from '../../../lastfm'
 import { debugLog, errorLog } from '@lucky/shared/utils'
+import { cleanTitle } from '../searchQueryCleaner'
 
 const CACHE_TTL_MS = 15 * 60 * 1000
 const TOP_TRACKS_LIMIT = 50
@@ -28,7 +29,8 @@ function deduplicateTracks(
 ): { artist: string; title: string }[] {
     const seen = new Set<string>()
     return tracks.filter((t) => {
-        const key = `${t.artist.toLowerCase()}|${t.title.toLowerCase()}`
+        const normalizedTitle = cleanTitle(t.title).toLowerCase().trim()
+        const key = `${t.artist.toLowerCase()}|${normalizedTitle}`
         if (seen.has(key)) return false
         seen.add(key)
         return true

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -725,7 +725,7 @@ async function collectLastFmCandidates(
 
     // Search for each seed via track search
     for (const seed of seedSlice) {
-        const query = `${seed.title} ${seed.artist}`.trim()
+        const query = cleanSearchQuery(seed.title, seed.artist)
         const tracks = await searchLastFmQuery(queue, query, requestedBy)
         for (const track of tracks) {
             if (!shouldIncludeCandidate(track, excludedUrls, excludedKeys))
@@ -751,9 +751,9 @@ async function collectLastFmCandidates(
         }
 
         // Also search for similar tracks via Last.fm API
-        const similar = await getSimilarTracks(seed.artist, seed.title)
+        const similar = await getSimilarTracks(seed.artist, cleanTitle(seed.title))
         for (const s of similar.slice(0, MAX_SIMILAR_LOOKUPS)) {
-            const query = `${s.title} ${s.artist}`.trim()
+            const query = cleanSearchQuery(s.title, s.artist)
             const tracks = await searchLastFmQuery(queue, query, requestedBy)
             for (const track of tracks) {
                 if (!shouldIncludeCandidate(track, excludedUrls, excludedKeys))
@@ -869,7 +869,7 @@ async function collectGenreCandidates(
             if (ctx.candidates.size >= AUTOPLAY_BUFFER_SIZE) break
             const results = await searchLastFmQuery(
                 queue,
-                `${seed.title} ${seed.artist}`.trim(),
+                cleanSearchQuery(seed.title, seed.artist),
                 requestedBy,
             )
             for (const track of results) addGenreTrackCandidate(track, tag, ctx)

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -84,11 +84,13 @@ const NOISE_PATTERNS: readonly RegExp[] = [
 ]
 
 const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
-    /^(?:\d{4} +)?remaster(?:ed)?(?:\s+\d{4})?$/i,
-    /^official (?:audio|video|music video)$/i,
-    /^(?:live|acoustic|demo|extended)$/i,
-    /^(?:radio edit|album version|single version)$/i,
-    /^(?:original mix|original version)$/i,
+    /^(?:\d{4}\s+)?remaster(?:ed)?(?:\s+(?:version|\d{4}))?(?:\s+\d{4})?$/i,
+    /^official\s+(?:audio|video|music\s+video)$/i,
+    /^(?:live|acoustic|demo|extended|instrumental|karaoke)(?:\s+(?:version|edit|session|mix))?$/i,
+    /^(?:radio\s+edit|album\s+version|single\s+version|bonus\s+track)$/i,
+    /^(?:original\s+(?:mix|version)|original)$/i,
+    /^(?:deluxe|deluxe\s+(?:version|edition))$/i,
+    /^(?:explicit|clean|explicit\s+version|clean\s+version)$/i,
     /^(?:19|20)\d{2}$/,
 ]
 


### PR DESCRIPTION
## Problem

Autoplay was repeatedly queuing different versions of the same song (e.g. "Song - Remastered", "Song - Live Version", "Song - Deluxe Edition") because:

1. **`HYPHENATED_VERSION_SUFFIXES` was incomplete** — patterns like `"Live Version"`, `"Remastered Version"`, `"Deluxe Edition"` didn't match, so `cleanTitle()` left the suffix in place and two versions normalized to different keys
2. **Last.fm seed deduplication used raw titles** — if Last.fm stored both `"Song"` and `"Song - Remastered"` as top tracks, both passed dedup and generated separate searches
3. **Seed search queries were built with raw titles** — `"Song - Remastered Artist"` as a search query produces different YouTube results than `"Song Artist"`, allowing version variants to slip through the candidates map

## Changes

- `searchQueryCleaner.ts`: Expand `HYPHENATED_VERSION_SUFFIXES` to handle `"Live Version"`, `"Remastered Version"`, `"Deluxe Edition"`, `"Explicit Version"`, `"Instrumental Version"`, etc.
- `lastFmSeeds.ts`: Use `cleanTitle()` when building the dedup key so `"Song - Remastered"` and `"Song"` collapse to one seed entry
- `queueManipulation.ts`: Use `cleanSearchQuery()` for all seed-based Last.fm searches (direct search + getSimilarTracks) to strip version noise before querying

## Result

Different versions of the same song now normalize to the same key at every stage of the pipeline — seed dedup, search query, candidates map, and history exclusion — so they can't both make it into the queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced track deduplication logic to better identify and remove duplicate music entries that differ only by formatting, whitespace, or minor title variations.
  * Improved search query processing and title normalization for more accurate music recommendations and better matching of similar tracks across music databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->