### PR TITLE
fix(bot): full session history for autoplay exclusion + broader version suffix detection

### DIFF
--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -237,7 +237,16 @@ const handlePlayerSkip = async (
     track?: Track,
 ): Promise<void> => {
     try {
-        debugLog({ message: 'Track skipped, checking queue...' })
+        infoLog({
+            message: 'Track skipped',
+            data: {
+                guildId: queue.guild.id,
+                skippedTrack: track?.title ?? 'unknown',
+                skippedUrl: track?.url ?? '',
+                queueSizeAfter: queue.tracks.size,
+                currentTrack: queue.currentTrack?.title ?? 'none',
+            },
+        })
         await scrobbleAndRecord(queue, track)
         if (musicWatchdogService.isIntentionalStop(queue.guild.id)) return
         await replenishIfAutoplay(queue, track)

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -317,7 +317,13 @@ async function _replenishQueue(
             replenishCount,
             autoplayMode,
         )
+        debugLog({
+            message: 'Autoplay: recommendation candidates',
+            data: { guildId, count: candidates.size, source: 'recommendation' },
+        })
+
         if (requestedBy?.id) {
+            const beforeLastFm = candidates.size
             await collectLastFmCandidates(
                 queue,
                 requestedBy,
@@ -332,8 +338,18 @@ async function _replenishQueue(
                 candidates,
                 autoplayMode,
             )
+            debugLog({
+                message: 'Autoplay: last.fm candidates',
+                data: {
+                    guildId,
+                    added: candidates.size - beforeLastFm,
+                    total: candidates.size,
+                    source: 'lastfm',
+                },
+            })
         }
         if (requestedBy && guildSettings?.autoplayGenres?.length) {
+            const beforeGenre = candidates.size
             await collectGenreCandidates(
                 queue,
                 guildSettings.autoplayGenres,
@@ -351,6 +367,16 @@ async function _replenishQueue(
                     autoplayMode,
                 },
             )
+            debugLog({
+                message: 'Autoplay: genre candidates',
+                data: {
+                    guildId,
+                    added: candidates.size - beforeGenre,
+                    total: candidates.size,
+                    genres: guildSettings.autoplayGenres,
+                    source: 'genre',
+                },
+            })
         }
         if (candidates.size === 0 && currentTrack) {
             await collectBroadFallbackCandidates(
@@ -367,6 +393,10 @@ async function _replenishQueue(
                 candidates,
                 autoplayMode,
             )
+            debugLog({
+                message: 'Autoplay: broad fallback candidates',
+                data: { guildId, count: candidates.size, source: 'fallback' },
+            })
         }
 
         debugLog({

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -234,7 +234,8 @@ async function _replenishQueue(
         const missingTracks = AUTOPLAY_BUFFER_SIZE - queue.tracks.size
         if (missingTracks <= 0) return
 
-        const historyTracks = getHistoryTracks(queue)
+        const allHistoryTracks = getAllHistoryTracks(queue)
+        const historyTracks = allHistoryTracks.slice(0, HISTORY_SEED_LIMIT)
         const seedTracks = [currentTrack, ...historyTracks].slice(
             0,
             HISTORY_SEED_LIMIT + 1,
@@ -278,13 +279,13 @@ async function _replenishQueue(
         const excludedUrls = buildExcludedUrls(
             queue,
             currentTrack,
-            historyTracks,
+            allHistoryTracks,
             persistentHistory,
         )
         const excludedKeys = buildExcludedKeys(
             queue,
             currentTrack,
-            historyTracks,
+            allHistoryTracks,
             persistentHistory,
         )
         debugLog({
@@ -293,7 +294,8 @@ async function _replenishQueue(
                 guildId: queue.guild.id,
                 excludedUrlCount: excludedUrls.size,
                 excludedKeyCount: excludedKeys.size,
-                historyTracks: historyTracks.length,
+                queueHistoryTracks: allHistoryTracks.length,
+                seedHistoryTracks: historyTracks.length,
                 persistentHistory: persistentHistory.length,
             },
         })
@@ -367,7 +369,41 @@ async function _replenishQueue(
             )
         }
 
+        debugLog({
+            message: 'Autoplay: candidate pool ready',
+            data: {
+                guildId: queue.guild.id,
+                candidateCount: candidates.size,
+                missingTracks,
+                autoplayMode,
+                currentTrack: currentTrack.title,
+            },
+        })
+
         const selected = selectDiverseCandidates(candidates, missingTracks)
+
+        if (selected.length === 0) {
+            warnLog({
+                message: 'Autoplay: no candidates selected — queue may stall',
+                data: { guildId: queue.guild.id, candidatePoolSize: candidates.size },
+            })
+            replenishCounters.set(guildId, replenishCount + 1)
+            return
+        }
+
+        debugLog({
+            message: 'Autoplay: tracks selected for queue',
+            data: {
+                guildId: queue.guild.id,
+                tracks: selected.map((s) => ({
+                    title: s.track.title,
+                    author: s.track.author,
+                    score: s.score.toFixed(3),
+                    reason: s.reason,
+                    url: s.track.url,
+                })),
+            },
+        })
 
         await addSelectedTracks(
             queue,
@@ -380,14 +416,12 @@ async function _replenishQueue(
         // Increment replenish counter for next call's query variation
         replenishCounters.set(guildId, replenishCount + 1)
 
-        if (selected.length === 0) return
-
         debugLog({
-            message: 'Queue replenished successfully',
+            message: 'Autoplay: queue replenished successfully',
             data: {
                 guildId: queue.guild.id,
                 addedCount: selected.length,
-                queueSize: queue.tracks.size,
+                newQueueSize: queue.tracks.size,
             },
         })
     } catch (error) {
@@ -903,12 +937,12 @@ function selectDiverseCandidates(
 
         if ((artistCount.get(artistKey) ?? 0) >= maxPerArtist) continue
         if ((sourceCount.get(sourceKey) ?? 0) >= maxPerSource) continue
-        if (titleKey && selectedTitleKeys.has(titleKey)) continue
+        if (selectedTitleKeys.has(titleKey || artistKey)) continue
 
         selected.push(candidate)
         artistCount.set(artistKey, (artistCount.get(artistKey) ?? 0) + 1)
         sourceCount.set(sourceKey, (sourceCount.get(sourceKey) ?? 0) + 1)
-        if (titleKey) selectedTitleKeys.add(titleKey)
+        selectedTitleKeys.add(titleKey || artistKey)
         if (selected.length >= missingTracks) {
             break
         }
@@ -1052,18 +1086,20 @@ export async function rescueQueue(
     }
 }
 
-function getHistoryTracks(queue: GuildQueue): Track[] {
+function getAllHistoryTracks(queue: GuildQueue): Track[] {
     const history = queue.history as
         | { tracks?: { toArray?: () => Track[]; data?: Track[] } }
         | undefined
 
     if (!history?.tracks) return []
     if (typeof history.tracks.toArray === 'function')
-        return history.tracks.toArray().slice(0, HISTORY_SEED_LIMIT)
-    if (Array.isArray(history.tracks.data))
-        return history.tracks.data.slice(0, HISTORY_SEED_LIMIT)
-
+        return history.tracks.toArray()
+    if (Array.isArray(history.tracks.data)) return history.tracks.data
     return []
+}
+
+function getHistoryTracks(queue: GuildQueue): Track[] {
+    return getAllHistoryTracks(queue).slice(0, HISTORY_SEED_LIMIT)
 }
 
 function normalizeTrackKey(title?: string, author?: string): string {

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -94,8 +94,12 @@ const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
     /^(?:19|20)\d{2}$/,
 ]
 
+const VERSION_KEYWORD_RE =
+    /\b(?:remaster(?:ed)?|remix|acoustic|live|demo|extended|instrumental|deluxe|explicit|clean|bonus\s+track|radio\s+edit|single\s+version|album\s+version)\b/i
+
 function isVersionSuffix(suffix: string): boolean {
-    return HYPHENATED_VERSION_SUFFIXES.some((re) => re.test(suffix))
+    if (HYPHENATED_VERSION_SUFFIXES.some((re) => re.test(suffix))) return true
+    return suffix.length <= 40 && VERSION_KEYWORD_RE.test(suffix)
 }
 
 /**


### PR DESCRIPTION
## Root Cause

The same song was repeating because `getHistoryTracks()` was limited to **3 tracks** via `HISTORY_SEED_LIMIT`. When Redis was unavailable or slow, songs played more than 3 songs ago were not in any exclusion set and could be re-added by autoplay.

Additionally, songs with version suffixes like `"Song - Live At Arena"` or `"Song - 2024 Remaster HD"` didn't match the strict patterns in `HYPHENATED_VERSION_SUFFIXES`, causing them to normalize to different keys than the clean version.

## Changes

### `queueManipulation.ts`
- New `getAllHistoryTracks()`: returns the **full** GuildQueue session history (unbounded)
- `_replenishQueue` now uses the full history for exclusion sets, keeps only 3 tracks for seeding
- Improved debug logging: candidate pool size, selected tracks with scores/reasons, warn on empty pool
- Fixed empty `titleKey` guard in `selectDiverseCandidates` to prevent untitled tracks from bypassing dedup

### `searchQueryCleaner.ts`
- Added `VERSION_KEYWORD_RE` keyword-based suffix check alongside the exact-match patterns
- Catches `"Live At X Arena"`, `"2024 Remaster HD"`, `"Acoustic Live Session"`, and other free-form variants (≤40 chars containing known version keywords)

## Impact

Songs played in the current VC session are now fully excluded from autoplay candidates regardless of Redis availability. Redis remains the fallback for cross-session history (100 tracks).