### PR TITLE
feat(bot): temporal decay on feedback weights + session mood detection

### DIFF
--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -63,36 +63,6 @@ function normalizeTrackKeyForFeedback(title: string, author: string): string {
     return `${normalizedTitle}::${normalizedAuthor}`
 }
 
-async function recordPlayBehavior(
-    guildId: string,
-    track: Track | undefined,
-    requestedById: string | undefined,
-    minDurationMs: number,
-    ratioThreshold: number,
-    feedbackType: 'implicit_like' | 'implicit_dislike',
-): Promise<void> {
-    if (!track || !requestedById) return
-    const startTime = guildTrackStartTimes.get(guildId)
-    if (!startTime || !track.durationMS || track.durationMS < minDurationMs) {
-        guildTrackStartTimes.delete(guildId)
-        return
-    }
-    const playedMs = Date.now() - startTime
-    const ratio = playedMs / track.durationMS
-    guildTrackStartTimes.delete(guildId)
-    const shouldRecord =
-        (feedbackType === 'implicit_like' && ratio > ratioThreshold) ||
-        (feedbackType === 'implicit_dislike' && ratio < ratioThreshold)
-    if (shouldRecord) {
-        const trackKey = normalizeTrackKeyForFeedback(track.title, track.author)
-        await recommendationFeedbackService.recordImplicitFeedback(
-            requestedById,
-            trackKey,
-            feedbackType,
-        )
-    }
-}
-
 function evictOldEntries(): void {
     if (lastPlayedTracks.size > MAX_GUILD_ENTRIES) {
         const oldest = lastPlayedTracks.keys().next().value
@@ -265,17 +235,27 @@ const handlePlayerFinish = async (
         await scrobbleAndRecord(queue, track)
 
         if (track) {
-            const requesterId = track.requestedBy?.id
-                ?? (track.metadata as { requestedById?: string } | undefined)
-                    ?.requestedById
-            await recordPlayBehavior(
-                queue.guild.id,
-                track,
-                requesterId,
-                0,
-                0.8,
-                'implicit_like',
-            )
+            const startTime = guildTrackStartTimes.get(queue.guild.id)
+            if (startTime && track.durationMS) {
+                const playedMs = Date.now() - startTime
+                const completionRatio = playedMs / track.durationMS
+                const requesterId = track.requestedBy?.id
+                    ?? (track.metadata as { requestedById?: string } | undefined)
+                        ?.requestedById
+
+                if (completionRatio > 0.8 && requesterId) {
+                    const trackKey = normalizeTrackKeyForFeedback(
+                        track.title,
+                        track.author,
+                    )
+                    await recommendationFeedbackService.recordImplicitFeedback(
+                        requesterId,
+                        trackKey,
+                        'implicit_like',
+                    )
+                }
+            }
+            guildTrackStartTimes.delete(queue.guild.id)
         }
 
         if (musicWatchdogService.isIntentionalStop(queue.guild.id)) return
@@ -312,17 +292,27 @@ const handlePlayerSkip = async (
         await scrobbleAndRecord(queue, track)
 
         if (track) {
-            const requesterId = track.requestedBy?.id
-                ?? (track.metadata as { requestedById?: string } | undefined)
-                    ?.requestedById
-            await recordPlayBehavior(
-                queue.guild.id,
-                track,
-                requesterId,
-                20_000,
-                0.3,
-                'implicit_dislike',
-            )
+            const startTime = guildTrackStartTimes.get(queue.guild.id)
+            if (startTime && track.durationMS && track.durationMS > 20_000) {
+                const playedMs = Date.now() - startTime
+                const skipRatio = playedMs / track.durationMS
+                const requesterId = track.requestedBy?.id
+                    ?? (track.metadata as { requestedById?: string } | undefined)
+                        ?.requestedById
+
+                if (skipRatio < 0.3 && requesterId) {
+                    const trackKey = normalizeTrackKeyForFeedback(
+                        track.title,
+                        track.author,
+                    )
+                    await recommendationFeedbackService.recordImplicitFeedback(
+                        requesterId,
+                        trackKey,
+                        'implicit_dislike',
+                    )
+                }
+            }
+            guildTrackStartTimes.delete(queue.guild.id)
         }
 
         if (musicWatchdogService.isIntentionalStop(queue.guild.id)) return

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -63,6 +63,18 @@ function normalizeTrackKeyForFeedback(title: string, author: string): string {
     return `${normalizedTitle}::${normalizedAuthor}`
 }
 
+async function recordImplicitTrackFeedback(
+    track: Track,
+    type: 'implicit_like' | 'implicit_dislike',
+): Promise<void> {
+    const requesterId =
+        track.requestedBy?.id ??
+        (track.metadata as { requestedById?: string } | undefined)?.requestedById
+    if (!requesterId) return
+    const trackKey = normalizeTrackKeyForFeedback(track.title, track.author)
+    await recommendationFeedbackService.recordImplicitFeedback(requesterId, trackKey, type)
+}
+
 function evictOldEntries(): void {
     if (lastPlayedTracks.size > MAX_GUILD_ENTRIES) {
         const oldest = lastPlayedTracks.keys().next().value
@@ -237,22 +249,9 @@ const handlePlayerFinish = async (
         if (track) {
             const startTime = guildTrackStartTimes.get(queue.guild.id)
             if (startTime && track.durationMS) {
-                const playedMs = Date.now() - startTime
-                const completionRatio = playedMs / track.durationMS
-                const requesterId = track.requestedBy?.id
-                    ?? (track.metadata as { requestedById?: string } | undefined)
-                        ?.requestedById
-
-                if (completionRatio > 0.8 && requesterId) {
-                    const trackKey = normalizeTrackKeyForFeedback(
-                        track.title,
-                        track.author,
-                    )
-                    await recommendationFeedbackService.recordImplicitFeedback(
-                        requesterId,
-                        trackKey,
-                        'implicit_like',
-                    )
+                const completionRatio = (Date.now() - startTime) / track.durationMS
+                if (completionRatio > 0.8) {
+                    await recordImplicitTrackFeedback(track, 'implicit_like')
                 }
             }
             guildTrackStartTimes.delete(queue.guild.id)
@@ -294,22 +293,9 @@ const handlePlayerSkip = async (
         if (track) {
             const startTime = guildTrackStartTimes.get(queue.guild.id)
             if (startTime && track.durationMS && track.durationMS > 20_000) {
-                const playedMs = Date.now() - startTime
-                const skipRatio = playedMs / track.durationMS
-                const requesterId = track.requestedBy?.id
-                    ?? (track.metadata as { requestedById?: string } | undefined)
-                        ?.requestedById
-
-                if (skipRatio < 0.3 && requesterId) {
-                    const trackKey = normalizeTrackKeyForFeedback(
-                        track.title,
-                        track.author,
-                    )
-                    await recommendationFeedbackService.recordImplicitFeedback(
-                        requesterId,
-                        trackKey,
-                        'implicit_dislike',
-                    )
+                const skipRatio = (Date.now() - startTime) / track.durationMS
+                if (skipRatio < 0.3) {
+                    await recordImplicitTrackFeedback(track, 'implicit_dislike')
                 }
             }
             guildTrackStartTimes.delete(queue.guild.id)

--- a/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
@@ -347,6 +347,94 @@ describe('RecommendationFeedbackService', () => {
         expect(summary.blocked).toEqual([])
         expect(getMock).not.toHaveBeenCalled()
     })
+
+    it('getLikedTrackWeights returns weighted map with decay', async () => {
+        const service = new RecommendationFeedbackService(30)
+        const key = service.buildTrackKey('Song A', 'Artist A')
+        const now = Date.now()
+        const updatedAt = now - 24 * 60 * 60 * 1000
+
+        getMock.mockResolvedValue(
+            JSON.stringify({
+                [key]: {
+                    feedback: 'like',
+                    updatedAt,
+                    expiresAt: now + 30 * 24 * 60 * 60 * 1000,
+                },
+            }),
+        )
+
+        const weights = await service.getLikedTrackWeights('user-1', now)
+
+        expect(weights.has(key)).toBe(true)
+        const weight = weights.get(key)
+        expect(weight).toBeGreaterThan(0.95)
+        expect(weight).toBeLessThanOrEqual(1.0)
+    })
+
+    it('getDislikedTrackWeights returns weighted map with decay', async () => {
+        const service = new RecommendationFeedbackService(30)
+        const key = service.buildTrackKey('Song B', 'Artist B')
+        const now = Date.now()
+        const updatedAt = now - 24 * 60 * 60 * 1000
+
+        getMock.mockResolvedValue(
+            JSON.stringify({
+                [key]: {
+                    feedback: 'dislike',
+                    updatedAt,
+                    expiresAt: now + 30 * 24 * 60 * 60 * 1000,
+                },
+            }),
+        )
+
+        const weights = await service.getDislikedTrackWeights('user-1', now)
+
+        expect(weights.has(key)).toBe(true)
+        const weight = weights.get(key)
+        expect(weight).toBeGreaterThan(0.95)
+        expect(weight).toBeLessThanOrEqual(1.0)
+    })
+
+    it('getLikedTrackWeights returns empty map for undefined userId', async () => {
+        const service = new RecommendationFeedbackService(30)
+
+        const weights = await service.getLikedTrackWeights('')
+
+        expect(weights.size).toBe(0)
+        expect(getMock).not.toHaveBeenCalled()
+    })
+
+    it('getDislikedTrackWeights returns empty map for undefined userId', async () => {
+        const service = new RecommendationFeedbackService(30)
+
+        const weights = await service.getDislikedTrackWeights('')
+
+        expect(weights.size).toBe(0)
+        expect(getMock).not.toHaveBeenCalled()
+    })
+
+    it('decay weight reduces to 0.15 after 30 days', async () => {
+        const baseTime = 100_000
+        const service = new RecommendationFeedbackService(30)
+        const key = service.buildTrackKey('Song C', 'Artist C')
+        const thirtyDaysAgo = baseTime - 30 * 24 * 60 * 60 * 1000
+
+        getMock.mockResolvedValue(
+            JSON.stringify({
+                [key]: {
+                    feedback: 'like',
+                    updatedAt: thirtyDaysAgo,
+                    expiresAt: baseTime + 1_000_000,
+                },
+            }),
+        )
+
+        const weights = await service.getLikedTrackWeights('user-1', baseTime)
+
+        const weight = weights.get(key)
+        expect(weight).toBeCloseTo(0.15, 1)
+    })
 })
 
 describe('implicit feedback', () => {

--- a/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
@@ -523,8 +523,8 @@ describe('implicit feedback', () => {
         await expect(service.recordImplicitFeedback('user-1', 'key', 'implicit_like')).resolves.toBeUndefined()
     })
 
-    it('getLikedTrackWeights returns empty map on redis error', async () => {
-        getMock.mockRejectedValue(new Error('redis down'))
+    it('getLikedTrackWeights returns empty map when no feedback data', async () => {
+        getMock.mockResolvedValue(null)
         const service = new RecommendationFeedbackService(30)
 
         const weights = await service.getLikedTrackWeights('user-1')
@@ -532,8 +532,8 @@ describe('implicit feedback', () => {
         expect(weights.size).toBe(0)
     })
 
-    it('getDislikedTrackWeights returns empty map on redis error', async () => {
-        getMock.mockRejectedValue(new Error('redis down'))
+    it('getDislikedTrackWeights returns empty map when no feedback data', async () => {
+        getMock.mockResolvedValue(null)
         const service = new RecommendationFeedbackService(30)
 
         const weights = await service.getDislikedTrackWeights('user-1')

--- a/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
@@ -522,5 +522,23 @@ describe('implicit feedback', () => {
 
         await expect(service.recordImplicitFeedback('user-1', 'key', 'implicit_like')).resolves.toBeUndefined()
     })
+
+    it('getLikedTrackWeights returns empty map on redis error', async () => {
+        getMock.mockRejectedValue(new Error('redis down'))
+        const service = new RecommendationFeedbackService(30)
+
+        const weights = await service.getLikedTrackWeights('user-1')
+
+        expect(weights.size).toBe(0)
+    })
+
+    it('getDislikedTrackWeights returns empty map on redis error', async () => {
+        getMock.mockRejectedValue(new Error('redis down'))
+        const service = new RecommendationFeedbackService(30)
+
+        const weights = await service.getDislikedTrackWeights('user-1')
+
+        expect(weights.size).toBe(0)
+    })
 })
 

--- a/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.spec.ts
@@ -414,6 +414,28 @@ describe('RecommendationFeedbackService', () => {
         expect(getMock).not.toHaveBeenCalled()
     })
 
+    it('getLikedTrackWeights prunes expired entries and saves', async () => {
+        const now = 50_000
+        const service = new RecommendationFeedbackService(30)
+        const key = service.buildTrackKey('Song D', 'Artist D')
+
+        getMock.mockResolvedValue(
+            JSON.stringify({
+                [key]: {
+                    feedback: 'like',
+                    updatedAt: now - 10_000,
+                    expiresAt: now - 1,
+                },
+            }),
+        )
+        setexMock.mockResolvedValue(true)
+
+        const weights = await service.getLikedTrackWeights('user-1', now)
+
+        expect(weights.size).toBe(0)
+        expect(setexMock).toHaveBeenCalled()
+    })
+
     it('decay weight reduces to 0.15 after 30 days', async () => {
         const baseTime = 100_000
         const service = new RecommendationFeedbackService(30)

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -166,12 +166,11 @@ export class RecommendationFeedbackService {
         return this.getTrackKeysByFeedback(userId, 'like', now)
     }
 
-    async getLikedTrackWeights(
+    private async getTrackWeightsByFeedback(
         userId: string,
-        now = Date.now(),
+        type: RecommendationFeedback,
+        now: number,
     ): Promise<Map<string, number>> {
-        if (!userId) return new Map<string, number>()
-
         const map = await this.getFeedbackMap(userId)
         const { map: validMap, changed } = this.pruneExpired(map, now)
 
@@ -181,11 +180,19 @@ export class RecommendationFeedbackService {
 
         const weights = new Map<string, number>()
         for (const [trackKey, entry] of Object.entries(validMap)) {
-            if (entry.feedback === 'like') {
+            if (entry.feedback === type) {
                 weights.set(trackKey, decayWeight(entry.updatedAt))
             }
         }
         return weights
+    }
+
+    async getLikedTrackWeights(
+        userId: string,
+        now = Date.now(),
+    ): Promise<Map<string, number>> {
+        if (!userId) return new Map<string, number>()
+        return this.getTrackWeightsByFeedback(userId, 'like', now)
     }
 
     async getDislikedTrackWeights(
@@ -193,21 +200,7 @@ export class RecommendationFeedbackService {
         now = Date.now(),
     ): Promise<Map<string, number>> {
         if (!userId) return new Map<string, number>()
-
-        const map = await this.getFeedbackMap(userId)
-        const { map: validMap, changed } = this.pruneExpired(map, now)
-
-        if (changed) {
-            await this.saveFeedbackMap(userId, validMap)
-        }
-
-        const weights = new Map<string, number>()
-        for (const [trackKey, entry] of Object.entries(validMap)) {
-            if (entry.feedback === 'dislike') {
-                weights.set(trackKey, decayWeight(entry.updatedAt))
-            }
-        }
-        return weights
+        return this.getTrackWeightsByFeedback(userId, 'dislike', now)
     }
 
     async getFeedbackCounts(

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -129,20 +129,25 @@ export class RecommendationFeedbackService {
         return { map: next, changed }
     }
 
+    private async getValidFeedbackMap(
+        userId: string,
+        now: number,
+    ): Promise<FeedbackMap> {
+        const map = await this.getFeedbackMap(userId)
+        const { map: validMap, changed } = this.pruneExpired(map, now)
+        if (changed) {
+            await this.saveFeedbackMap(userId, validMap)
+        }
+        return validMap
+    }
+
     private async getTrackKeysByFeedback(
         userId: string | undefined,
         type: RecommendationFeedback,
         now = Date.now(),
     ): Promise<Set<string>> {
         if (!userId) return new Set<string>()
-
-        const map = await this.getFeedbackMap(userId)
-        const { map: validMap, changed } = this.pruneExpired(map, now)
-
-        if (changed) {
-            await this.saveFeedbackMap(userId, validMap)
-        }
-
+        const validMap = await this.getValidFeedbackMap(userId, now)
         return new Set(
             Object.entries(validMap)
                 .filter(([, entry]) => entry.feedback === type)
@@ -171,13 +176,7 @@ export class RecommendationFeedbackService {
         type: RecommendationFeedback,
         now: number,
     ): Promise<Map<string, number>> {
-        const map = await this.getFeedbackMap(userId)
-        const { map: validMap, changed } = this.pruneExpired(map, now)
-
-        if (changed) {
-            await this.saveFeedbackMap(userId, validMap)
-        }
-
+        const validMap = await this.getValidFeedbackMap(userId, now)
         const weights = new Map<string, number>()
         for (const [trackKey, entry] of Object.entries(validMap)) {
             if (entry.feedback === type) {

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -172,29 +172,20 @@ export class RecommendationFeedbackService {
     ): Promise<Map<string, number>> {
         if (!userId) return new Map<string, number>()
 
-        try {
-            const map = await this.getFeedbackMap(userId)
-            const { map: validMap, changed } = this.pruneExpired(map, now)
+        const map = await this.getFeedbackMap(userId)
+        const { map: validMap, changed } = this.pruneExpired(map, now)
 
-            if (changed) {
-                await this.saveFeedbackMap(userId, validMap)
-            }
-
-            const weights = new Map<string, number>()
-            for (const [trackKey, entry] of Object.entries(validMap)) {
-                if (entry.feedback === 'like') {
-                    weights.set(trackKey, decayWeight(entry.updatedAt))
-                }
-            }
-            return weights
-        } catch (error) {
-            errorLog({
-                message: 'Failed to get liked track weights',
-                error,
-                data: { userId },
-            })
-            return new Map<string, number>()
+        if (changed) {
+            await this.saveFeedbackMap(userId, validMap)
         }
+
+        const weights = new Map<string, number>()
+        for (const [trackKey, entry] of Object.entries(validMap)) {
+            if (entry.feedback === 'like') {
+                weights.set(trackKey, decayWeight(entry.updatedAt))
+            }
+        }
+        return weights
     }
 
     async getDislikedTrackWeights(
@@ -203,29 +194,20 @@ export class RecommendationFeedbackService {
     ): Promise<Map<string, number>> {
         if (!userId) return new Map<string, number>()
 
-        try {
-            const map = await this.getFeedbackMap(userId)
-            const { map: validMap, changed } = this.pruneExpired(map, now)
+        const map = await this.getFeedbackMap(userId)
+        const { map: validMap, changed } = this.pruneExpired(map, now)
 
-            if (changed) {
-                await this.saveFeedbackMap(userId, validMap)
-            }
-
-            const weights = new Map<string, number>()
-            for (const [trackKey, entry] of Object.entries(validMap)) {
-                if (entry.feedback === 'dislike') {
-                    weights.set(trackKey, decayWeight(entry.updatedAt))
-                }
-            }
-            return weights
-        } catch (error) {
-            errorLog({
-                message: 'Failed to get disliked track weights',
-                error,
-                data: { userId },
-            })
-            return new Map<string, number>()
+        if (changed) {
+            await this.saveFeedbackMap(userId, validMap)
         }
+
+        const weights = new Map<string, number>()
+        for (const [trackKey, entry] of Object.entries(validMap)) {
+            if (entry.feedback === 'dislike') {
+                weights.set(trackKey, decayWeight(entry.updatedAt))
+            }
+        }
+        return weights
     }
 
     async getFeedbackCounts(

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -415,40 +415,24 @@ export class RecommendationFeedbackService {
         }
     }
 
+    private async getImplicitKeysByType(
+        userId: string,
+        type: 'implicit_dislike' | 'implicit_like',
+    ): Promise<Set<string>> {
+        const map = await this.getImplicitFeedbackMap(userId)
+        return new Set(
+            Object.entries(map)
+                .filter(([, entry]) => entry.type === type)
+                .map(([trackKey]) => trackKey),
+        )
+    }
+
     async getImplicitDislikeKeys(userId: string): Promise<Set<string>> {
-        try {
-            const map = await this.getImplicitFeedbackMap(userId)
-            return new Set(
-                Object.entries(map)
-                    .filter(([, entry]) => entry.type === 'implicit_dislike')
-                    .map(([trackKey]) => trackKey),
-            )
-        } catch (error) {
-            errorLog({
-                message: 'Failed to get implicit dislike keys',
-                error,
-                data: { userId },
-            })
-            return new Set<string>()
-        }
+        return this.getImplicitKeysByType(userId, 'implicit_dislike')
     }
 
     async getImplicitLikeKeys(userId: string): Promise<Set<string>> {
-        try {
-            const map = await this.getImplicitFeedbackMap(userId)
-            return new Set(
-                Object.entries(map)
-                    .filter(([, entry]) => entry.type === 'implicit_like')
-                    .map(([trackKey]) => trackKey),
-            )
-        } catch (error) {
-            errorLog({
-                message: 'Failed to get implicit like keys',
-                error,
-                data: { userId },
-            })
-            return new Set<string>()
-        }
+        return this.getImplicitKeysByType(userId, 'implicit_like')
     }
 }
 

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -373,29 +373,40 @@ export class RecommendationFeedbackService {
         }
     }
 
-    private async getImplicitKeysByType(
-        userId: string,
-        type: 'implicit_dislike' | 'implicit_like',
-    ): Promise<Set<string>> {
+    async getImplicitDislikeKeys(userId: string): Promise<Set<string>> {
         try {
             const map = await this.getImplicitFeedbackMap(userId)
             return new Set(
                 Object.entries(map)
-                    .filter(([, entry]) => entry.type === type)
+                    .filter(([, entry]) => entry.type === 'implicit_dislike')
                     .map(([trackKey]) => trackKey),
             )
         } catch (error) {
-            errorLog({ message: `Failed to get ${type} keys`, error, data: { userId } })
+            errorLog({
+                message: 'Failed to get implicit dislike keys',
+                error,
+                data: { userId },
+            })
             return new Set<string>()
         }
     }
 
-    async getImplicitDislikeKeys(userId: string): Promise<Set<string>> {
-        return this.getImplicitKeysByType(userId, 'implicit_dislike')
-    }
-
     async getImplicitLikeKeys(userId: string): Promise<Set<string>> {
-        return this.getImplicitKeysByType(userId, 'implicit_like')
+        try {
+            const map = await this.getImplicitFeedbackMap(userId)
+            return new Set(
+                Object.entries(map)
+                    .filter(([, entry]) => entry.type === 'implicit_like')
+                    .map(([trackKey]) => trackKey),
+            )
+        } catch (error) {
+            errorLog({
+                message: 'Failed to get implicit like keys',
+                error,
+                data: { userId },
+            })
+            return new Set<string>()
+        }
     }
 }
 

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -5,6 +5,11 @@ import { cleanAuthor } from '../../utils/music/searchQueryCleaner'
 export type RecommendationFeedback = 'like' | 'dislike'
 export type ArtistFeedback = 'prefer' | 'block'
 
+function decayWeight(updatedAt: number): number {
+    const daysSince = (Date.now() - updatedAt) / 86_400_000
+    return Math.max(0.15, 1.0 - (daysSince / 30) * 0.85)
+}
+
 type FeedbackEntry = {
     feedback: RecommendationFeedback
     updatedAt: number
@@ -159,6 +164,68 @@ export class RecommendationFeedbackService {
         now = Date.now(),
     ): Promise<Set<string>> {
         return this.getTrackKeysByFeedback(userId, 'like', now)
+    }
+
+    async getLikedTrackWeights(
+        userId: string,
+        now = Date.now(),
+    ): Promise<Map<string, number>> {
+        if (!userId) return new Map<string, number>()
+
+        try {
+            const map = await this.getFeedbackMap(userId)
+            const { map: validMap, changed } = this.pruneExpired(map, now)
+
+            if (changed) {
+                await this.saveFeedbackMap(userId, validMap)
+            }
+
+            const weights = new Map<string, number>()
+            for (const [trackKey, entry] of Object.entries(validMap)) {
+                if (entry.feedback === 'like') {
+                    weights.set(trackKey, decayWeight(entry.updatedAt))
+                }
+            }
+            return weights
+        } catch (error) {
+            errorLog({
+                message: 'Failed to get liked track weights',
+                error,
+                data: { userId },
+            })
+            return new Map<string, number>()
+        }
+    }
+
+    async getDislikedTrackWeights(
+        userId: string,
+        now = Date.now(),
+    ): Promise<Map<string, number>> {
+        if (!userId) return new Map<string, number>()
+
+        try {
+            const map = await this.getFeedbackMap(userId)
+            const { map: validMap, changed } = this.pruneExpired(map, now)
+
+            if (changed) {
+                await this.saveFeedbackMap(userId, validMap)
+            }
+
+            const weights = new Map<string, number>()
+            for (const [trackKey, entry] of Object.entries(validMap)) {
+                if (entry.feedback === 'dislike') {
+                    weights.set(trackKey, decayWeight(entry.updatedAt))
+                }
+            }
+            return weights
+        } catch (error) {
+            errorLog({
+                message: 'Failed to get disliked track weights',
+                error,
+                data: { userId },
+            })
+            return new Map<string, number>()
+        }
     }
 
     async getFeedbackCounts(

--- a/packages/bot/src/utils/music/autoplay/sessionMood.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/sessionMood.spec.ts
@@ -1,0 +1,329 @@
+import { detectSessionMood, type SessionMood } from './sessionMood'
+
+describe('sessionMood', () => {
+    describe('detectSessionMood - artist deep-dive', () => {
+        it('detects same artist 3+ times in last 8 tracks', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.deepDiveArtist).toBe('artist a')
+        })
+
+        it('uses case-insensitive matching for artist names', () => {
+            const history = [
+                { author: 'ARTIST A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'artist a', durationMS: 200000, isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.deepDiveArtist).toBe('artist a')
+        })
+
+        it('returns null when no artist appears 3+ times', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.deepDiveArtist).toBeNull()
+        })
+
+        it('only checks last 8 tracks for deep-dive detection', () => {
+            const history = [
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist Z', durationMS: 200000, isAutoplay: false },
+                // Last 8 start here:
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist Y', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist Y', durationMS: 200000, isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.deepDiveArtist).toBe('artist a')
+        })
+    })
+
+    describe('detectSessionMood - duration preferences', () => {
+        it('detects long-form listening when avg duration > 5min', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 400000, isAutoplay: false }, // 6:40
+                { author: 'Artist B', durationMS: 380000, isAutoplay: false }, // 6:20
+                { author: 'Artist C', durationMS: 360000, isAutoplay: false }, // 6:00
+                { author: 'Artist D', durationMS: 420000, isAutoplay: false }, // 7:00
+                { author: 'Artist E', durationMS: 350000, isAutoplay: false }, // 5:50
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.preferLong).toBe(true)
+            expect(mood.preferShort).toBe(false)
+        })
+
+        it('detects quick-hit mode when avg duration < 2.5min', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 120000, isAutoplay: false }, // 2:00
+                { author: 'Artist B', durationMS: 90000, isAutoplay: false }, // 1:30
+                { author: 'Artist C', durationMS: 110000, isAutoplay: false }, // 1:50
+                { author: 'Artist D', durationMS: 100000, isAutoplay: false }, // 1:40
+                { author: 'Artist E', durationMS: 80000, isAutoplay: false }, // 1:20
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.preferShort).toBe(true)
+            expect(mood.preferLong).toBe(false)
+        })
+
+        it('prefers neither when avg duration is between 2.5 and 5 min', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false }, // 3:20
+                { author: 'Artist B', durationMS: 220000, isAutoplay: false }, // 3:40
+                { author: 'Artist C', durationMS: 210000, isAutoplay: false }, // 3:30
+                { author: 'Artist D', durationMS: 240000, isAutoplay: false }, // 4:00
+                { author: 'Artist E', durationMS: 230000, isAutoplay: false }, // 3:50
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.preferLong).toBe(false)
+            expect(mood.preferShort).toBe(false)
+        })
+
+        it('handles duration string format (m:ss)', () => {
+            const history = [
+                { author: 'Artist A', duration: '6:40', isAutoplay: false },
+                { author: 'Artist B', duration: '6:20', isAutoplay: false },
+                { author: 'Artist C', duration: '6:00', isAutoplay: false },
+                { author: 'Artist D', duration: '7:00', isAutoplay: false },
+                { author: 'Artist E', duration: '5:50', isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.preferLong).toBe(true)
+        })
+
+        it('handles duration string format (h:mm:ss)', () => {
+            const history = [
+                { author: 'Artist A', duration: '1:03:20', isAutoplay: false }, // 3800000ms
+                { author: 'Artist B', duration: '1:05:00', isAutoplay: false }, // 3900000ms
+                { author: 'Artist C', duration: '1:00:00', isAutoplay: false }, // 3600000ms
+                { author: 'Artist D', duration: '1:10:00', isAutoplay: false }, // 4200000ms
+                { author: 'Artist E', duration: '0:58:00', isAutoplay: false }, // 3480000ms
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.preferLong).toBe(true)
+        })
+
+        it('ignores tracks with 0 duration', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 400000, isAutoplay: false },
+                { author: 'Artist B', durationMS: 0, isAutoplay: false },
+                { author: 'Artist C', durationMS: 380000, isAutoplay: false },
+                { author: 'Artist D', durationMS: 420000, isAutoplay: false },
+                { author: 'Artist E', durationMS: undefined, isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.preferLong).toBe(true)
+        })
+
+        it('requires at least 1 track with valid duration for duration check', () => {
+            const history = [{ author: 'Artist A', durationMS: 0, isAutoplay: false }]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.preferLong).toBe(false)
+            expect(mood.preferShort).toBe(false)
+        })
+    })
+
+    describe('detectSessionMood - restless mode', () => {
+        it('detects restless mode with >40% autoplay and 3+ different artists', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist D', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist E', durationMS: 200000, isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.restless).toBe(true)
+        })
+
+        it('requires >40% autoplay (exactly 40% should be false)', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist D', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist E', durationMS: 200000, isAutoplay: true },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.restless).toBe(false)
+        })
+
+        it('requires at least 3 different artists for restless mode', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist A', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist A', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: true },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.restless).toBe(false)
+        })
+
+        it('requires at least 5 tracks in recent history for restless check', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: true },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.restless).toBe(false)
+        })
+
+        it('checks last 10 tracks for restless detection', () => {
+            const history = [
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist X', durationMS: 200000, isAutoplay: false },
+                // Last 10 below
+                { author: 'Artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist C', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist D', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist E', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist F', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist G', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist H', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist I', durationMS: 200000, isAutoplay: false },
+                { author: 'Artist J', durationMS: 200000, isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.restless).toBe(true)
+        })
+    })
+
+    describe('edge cases', () => {
+        it('returns all false/null for empty history', () => {
+            const mood = detectSessionMood([])
+
+            expect(mood).toEqual({
+                deepDiveArtist: null,
+                preferLong: false,
+                preferShort: false,
+                restless: false,
+            })
+        })
+
+        it('handles missing author field gracefully', () => {
+            const history = [
+                { durationMS: 200000, isAutoplay: false },
+                { durationMS: 200000, isAutoplay: false },
+                { durationMS: 200000, isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.deepDiveArtist).toBeNull()
+        })
+
+        it('handles missing isAutoplay field (defaults to false)', () => {
+            const history = [
+                { author: 'Artist A', durationMS: 200000 },
+                { author: 'Artist A', durationMS: 200000 },
+                { author: 'Artist A', durationMS: 200000 },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.deepDiveArtist).toBe('artist a')
+            expect(mood.restless).toBe(false)
+        })
+
+        it('combines multiple mood signals correctly', () => {
+            const history = [
+                { author: 'Artist A', duration: '6:00', isAutoplay: false },
+                { author: 'Artist A', duration: '6:30', isAutoplay: true },
+                { author: 'Artist A', duration: '5:45', isAutoplay: true },
+                { author: 'Artist B', duration: '7:00', isAutoplay: true },
+                { author: 'Artist C', duration: '6:15', isAutoplay: true },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.deepDiveArtist).toBe('artist a')
+            expect(mood.preferLong).toBe(true)
+            expect(mood.preferShort).toBe(false)
+            expect(mood.restless).toBe(true)
+        })
+
+        it('handles malformed duration strings', () => {
+            const history = [
+                { author: 'Artist A', duration: 'invalid', isAutoplay: false },
+                { author: 'Artist B', duration: '6:00', isAutoplay: false },
+                { author: 'Artist C', duration: '6:30', isAutoplay: false },
+                { author: 'Artist D', duration: '7:00', isAutoplay: false },
+                { author: 'Artist E', duration: '', isAutoplay: false },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.preferLong).toBe(true)
+        })
+
+        it('case-insensitive artist deduplication for restless check', () => {
+            const history = [
+                { author: 'artist A', durationMS: 200000, isAutoplay: false },
+                { author: 'ARTIST A', durationMS: 200000, isAutoplay: true },
+                { author: 'Artist B', durationMS: 200000, isAutoplay: true },
+                { author: 'ARTIST C', durationMS: 200000, isAutoplay: true },
+                { author: 'artist d', durationMS: 200000, isAutoplay: true },
+            ]
+
+            const mood = detectSessionMood(history)
+
+            expect(mood.restless).toBe(true)
+        })
+    })
+})

--- a/packages/bot/src/utils/music/autoplay/sessionMood.ts
+++ b/packages/bot/src/utils/music/autoplay/sessionMood.ts
@@ -1,0 +1,114 @@
+export interface SessionMood {
+    deepDiveArtist: string | null
+    preferLong: boolean
+    preferShort: boolean
+    restless: boolean
+}
+
+function parseDurationString(durationStr: string | undefined): number {
+    if (!durationStr || typeof durationStr !== 'string') return 0
+
+    const parts = durationStr.split(':').map((p) => Number.parseInt(p, 10))
+    if (parts.length === 0 || parts.some((p) => Number.isNaN(p))) return 0
+
+    if (parts.length === 2) {
+        return (parts[0] * 60 + parts[1]) * 1000
+    }
+    if (parts.length === 3) {
+        return (parts[0] * 3600 + parts[1] * 60 + parts[2]) * 1000
+    }
+
+    return 0
+}
+
+function getDurationMs(track: {
+    durationMS?: number
+    duration?: string
+}): number {
+    if (track.durationMS && track.durationMS > 0) {
+        return track.durationMS
+    }
+    if (track.duration) {
+        return parseDurationString(track.duration)
+    }
+    return 0
+}
+
+export function detectSessionMood(
+    historyTracks: {
+        author?: string
+        durationMS?: number
+        duration?: string
+        isAutoplay?: boolean
+    }[],
+): SessionMood {
+    if (historyTracks.length === 0) {
+        return {
+            deepDiveArtist: null,
+            preferLong: false,
+            preferShort: false,
+            restless: false,
+        }
+    }
+
+    // Artist deep-dive: same artist 3+ times in last 8 tracks
+    let deepDiveArtist: string | null = null
+    const recentForDeepDive = historyTracks.slice(-8)
+    const artistCounts = new Map<string, number>()
+    for (const track of recentForDeepDive) {
+        if (track.author) {
+            const artist = track.author.toLowerCase()
+            artistCounts.set(artist, (artistCounts.get(artist) ?? 0) + 1)
+        }
+    }
+    for (const [artist, count] of artistCounts) {
+        if (count >= 3) {
+            deepDiveArtist = artist
+            break
+        }
+    }
+
+    // Duration preference: last 5 tracks
+    let preferLong = false
+    let preferShort = false
+    const recentForDuration = historyTracks.slice(-5)
+    if (recentForDuration.length >= 1) {
+        const durations = recentForDuration
+            .map((t) => getDurationMs(t))
+            .filter((d) => d > 0)
+
+        if (durations.length >= 1) {
+            const avgDuration = durations.reduce((a, b) => a + b, 0) / durations.length
+            if (avgDuration > 5 * 60 * 1000) {
+                preferLong = true
+            } else if (avgDuration < 2.5 * 60 * 1000) {
+                preferShort = true
+            }
+        }
+    }
+
+    // Restless mode: >40% autoplay AND multiple different artists in recent
+    let restless = false
+    const recentForRestless = historyTracks.slice(-10)
+    if (recentForRestless.length >= 5) {
+        const autoplayCount = recentForRestless.filter(
+            (t) => t.isAutoplay === true,
+        ).length
+        const autoplayRatio = autoplayCount / recentForRestless.length
+        const uniqueArtists = new Set(
+            recentForRestless
+                .map((t) => t.author?.toLowerCase())
+                .filter(Boolean),
+        )
+        if (autoplayRatio > 0.4 && uniqueArtists.size >= 3) {
+            restless = true
+        }
+    }
+
+    return {
+        deepDiveArtist,
+        preferLong,
+        preferShort,
+        restless,
+    }
+}

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -91,8 +91,8 @@ jest.mock('../../spotify/spotifyApi', () => ({
     searchSpotifyTrack: jest.fn().mockResolvedValue(null),
 }))
 
-const dislikedTrackKeysMock = jest.fn()
-const likedTrackKeysMock = jest.fn()
+const dislikedTrackWeightsMock = jest.fn()
+const likedTrackWeightsMock = jest.fn()
 const getPreferredArtistKeysMock = jest.fn()
 const getBlockedArtistKeysMock = jest.fn()
 const getImplicitDislikeKeysMock = jest.fn()
@@ -100,9 +100,10 @@ const getImplicitLikeKeysMock = jest.fn()
 
 jest.mock('../../services/musicRecommendation/feedbackService', () => ({
     recommendationFeedbackService: {
-        getDislikedTrackKeys: (...args: unknown[]) =>
-            dislikedTrackKeysMock(...args),
-        getLikedTrackKeys: (...args: unknown[]) => likedTrackKeysMock(...args),
+        getLikedTrackWeights: (...args: unknown[]) =>
+            likedTrackWeightsMock(...args),
+        getDislikedTrackWeights: (...args: unknown[]) =>
+            dislikedTrackWeightsMock(...args),
         getPreferredArtistKeys: (...args: unknown[]) =>
             getPreferredArtistKeysMock(...args),
         getBlockedArtistKeys: (...args: unknown[]) =>
@@ -153,8 +154,8 @@ function createQueueMock(overrides: Partial<QueueMock> = {}): QueueMock {
 
 describe('queueManipulation.replenishQueue', () => {
     beforeEach(() => {
-        dislikedTrackKeysMock.mockResolvedValue(new Set())
-        likedTrackKeysMock.mockResolvedValue(new Set())
+        likedTrackWeightsMock.mockResolvedValue(new Map())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
         getPreferredArtistKeysMock.mockResolvedValue(new Set())
         getBlockedArtistKeysMock.mockResolvedValue(new Set())
         getImplicitDislikeKeysMock.mockResolvedValue(new Set())
@@ -400,8 +401,8 @@ describe('queueManipulation.replenishQueue', () => {
     )
 
     it('skips tracks disliked by the requester feedback profile', async () => {
-        dislikedTrackKeysMock.mockResolvedValue(
-            new Set(['dislikedtrack::artistb']),
+        dislikedTrackWeightsMock.mockResolvedValue(
+            new Map([['dislikedtrack::artistb', 0.8]]),
         )
 
         const queue = createQueueMock({
@@ -437,7 +438,7 @@ describe('queueManipulation.replenishQueue', () => {
         )
     })
     it('boosts liked tracks to the top of autoplay recommendations', async () => {
-        likedTrackKeysMock.mockResolvedValue(new Set(['likedtrack::artistb']))
+        likedTrackWeightsMock.mockResolvedValue(new Map([['likedtrack::artistb', 1.0]]))
 
         const queue = createQueueMock({
             tracks: {
@@ -884,7 +885,7 @@ describe('queueManipulation.replenishQueue', () => {
             },
         })
 
-        likedTrackKeysMock.mockResolvedValueOnce(new Set([likedTrackKey]))
+        likedTrackWeightsMock.mockResolvedValueOnce(new Map([[likedTrackKey, 1.0]]))
         getGuildSettingsMock.mockResolvedValueOnce({
             autoplayMode: 'popular',
         })
@@ -1922,8 +1923,8 @@ describe('queueManipulation.replenishQueue youtube dedup', () => {
 
 describe('queueManipulation.replenishQueue query variation', () => {
     beforeEach(() => {
-        dislikedTrackKeysMock.mockResolvedValue(new Set())
-        likedTrackKeysMock.mockResolvedValue(new Set())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
+        likedTrackWeightsMock.mockResolvedValue(new Map())
         getPreferredArtistKeysMock.mockResolvedValue(new Set())
         getBlockedArtistKeysMock.mockResolvedValue(new Set())
         getImplicitDislikeKeysMock.mockResolvedValue(new Set())
@@ -2015,8 +2016,8 @@ describe('queueManipulation.replenishQueue query variation', () => {
 
 describe('queueManipulation.collectBroadFallbackCandidates diversification', () => {
     beforeEach(() => {
-        dislikedTrackKeysMock.mockResolvedValue(new Set())
-        likedTrackKeysMock.mockResolvedValue(new Set())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
+        likedTrackWeightsMock.mockResolvedValue(new Map())
         getPreferredArtistKeysMock.mockResolvedValue(new Set())
         getBlockedArtistKeysMock.mockResolvedValue(new Set())
         getImplicitDislikeKeysMock.mockResolvedValue(new Set())
@@ -2059,8 +2060,8 @@ describe('queueManipulation.collectBroadFallbackCandidates diversification', () 
 
 describe('queueManipulation.selectDiverseCandidates score jitter', () => {
     beforeEach(() => {
-        dislikedTrackKeysMock.mockResolvedValue(new Set())
-        likedTrackKeysMock.mockResolvedValue(new Set())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
+        likedTrackWeightsMock.mockResolvedValue(new Map())
         getPreferredArtistKeysMock.mockResolvedValue(new Set())
         getBlockedArtistKeysMock.mockResolvedValue(new Set())
         getImplicitDislikeKeysMock.mockResolvedValue(new Set())
@@ -2121,8 +2122,8 @@ describe('queueManipulation.selectDiverseCandidates score jitter', () => {
 
 describe('queueManipulation.addSelectedTracks async writes', () => {
     beforeEach(() => {
-        dislikedTrackKeysMock.mockResolvedValue(new Set())
-        likedTrackKeysMock.mockResolvedValue(new Set())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
+        likedTrackWeightsMock.mockResolvedValue(new Map())
         getPreferredArtistKeysMock.mockResolvedValue(new Set())
         getBlockedArtistKeysMock.mockResolvedValue(new Set())
         consumeLastFmSeedSliceMock.mockResolvedValue([])
@@ -2315,8 +2316,8 @@ describe('queueManipulation.addSelectedTracks async writes', () => {
 describe('queueManipulation — genre candidate collection', () => {
     beforeEach(() => {
         jest.clearAllMocks()
-        dislikedTrackKeysMock.mockResolvedValue(new Set())
-        likedTrackKeysMock.mockResolvedValue(new Set())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
+        likedTrackWeightsMock.mockResolvedValue(new Map())
         consumeLastFmSeedSliceMock.mockResolvedValue([])
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
@@ -2404,8 +2405,8 @@ describe('queueManipulation — multi-user VC blend', () => {
             autoplayGenres: [],
         })
         getTagTopTracksMock.mockResolvedValue([])
-        dislikedTrackKeysMock.mockResolvedValue(new Set())
-        likedTrackKeysMock.mockResolvedValue(new Set())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
+        likedTrackWeightsMock.mockResolvedValue(new Map())
         getPreferredArtistKeysMock.mockResolvedValue(new Set())
         getBlockedArtistKeysMock.mockResolvedValue(new Set())
         getSimilarTracksMock.mockResolvedValue([])

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -14,11 +14,7 @@ import {
     lastFmLinkService,
     spotifyLinkService,
 } from '@lucky/shared/services'
-import {
-    getAudioFeatures,
-    searchSpotifyTrack,
-    type SpotifyAudioFeatures,
-} from '../../spotify/spotifyApi'
+import { getAudioFeatures, searchSpotifyTrack, type SpotifyAudioFeatures } from '../../spotify/spotifyApi'
 import {
     consumeLastFmSeedSlice,
     consumeBlendedSeedSlice,
@@ -51,27 +47,27 @@ async function getTrackAudioFeatures(
     userId: string,
 ): Promise<SpotifyAudioFeatures | null> {
     const cacheKey = normalizeTrackKey(track.title, track.author)
-
+    
     const cached = audioFeatureCache.get(cacheKey)
     if (cached !== undefined) {
         return cached
     }
-
+    
     const token = await spotifyLinkService.getValidAccessToken(userId)
     if (!token) {
         audioFeatureCache.set(cacheKey, null)
         return null
     }
-
+    
     let spotifyId: string | null = null
-
+    
     if (track.url && track.url.includes('open.spotify.com/track/')) {
         const match = track.url.match(/track\/([a-zA-Z0-9]+)/)
         if (match) {
             spotifyId = match[1]
         }
     }
-
+    
     if (!spotifyId) {
         spotifyId = await searchSpotifyTrack(
             token,
@@ -79,16 +75,17 @@ async function getTrackAudioFeatures(
             cleanAuthor(track.author ?? ''),
         )
     }
-
+    
     if (!spotifyId) {
         audioFeatureCache.set(cacheKey, null)
         return null
     }
-
+    
     const features = await getAudioFeatures(token, spotifyId).catch(() => null)
     audioFeatureCache.set(cacheKey, features)
     return features
 }
+
 
 type ScoredTrack = {
     track: Track
@@ -359,13 +356,8 @@ async function _replenishQueue(
                 persistentHistory: persistentHistory.length,
             },
         })
-        const recentArtists = buildRecentArtists(currentTrack, allHistoryTracks)
+        const recentArtists = buildRecentArtists(currentTrack, historyTracks)
         const artistFrequency = buildArtistFrequency(persistentHistory)
-        const currentFeatures = requestedBy?.id
-            ? await getTrackAudioFeatures(currentTrack, requestedBy.id).catch(
-                  () => null,
-              )
-            : null
         const guildId = queue.guild.id
         const replenishCount = replenishCounters.get(guildId) ?? 0
         const candidates = await collectRecommendationCandidates(
@@ -493,10 +485,7 @@ async function _replenishQueue(
         if (selected.length === 0) {
             warnLog({
                 message: 'Autoplay: no candidates selected — queue may stall',
-                data: {
-                    guildId: queue.guild.id,
-                    candidatePoolSize: candidates.size,
-                },
+                data: { guildId: queue.guild.id, candidatePoolSize: candidates.size },
             })
             replenishCounters.set(guildId, replenishCount + 1)
             return
@@ -931,10 +920,7 @@ async function collectLastFmCandidates(
         }
 
         // Also search for similar tracks via Last.fm API
-        const similar = await getSimilarTracks(
-            seed.artist,
-            cleanTitle(seed.title),
-        )
+        const similar = await getSimilarTracks(seed.artist, cleanTitle(seed.title))
         for (const s of similar.slice(0, MAX_SIMILAR_LOOKUPS)) {
             const query = cleanSearchQuery(s.title, s.artist)
             const tracks = await searchLastFmQuery(queue, query, requestedBy)
@@ -1351,9 +1337,16 @@ function calculateRecommendationScore(
         reasons.push('completed before')
     }
 
-    if (!recentArtists.has(candidateArtist)) {
+    if (candidateArtist === currentArtist) {
+        score -= 0.35
+    } else if (!recentArtists.has(candidateArtist)) {
         score += 0.15
         reasons.push('session novelty')
+    } else {
+        reasons.push('fresh artist rotation')
+    }
+    if (recentArtists.has(candidateArtist)) {
+        score -= 0.25
     }
     if (candidate.source === currentTrack.source) {
         score -= 0.25
@@ -1400,7 +1393,7 @@ function calculateRecommendationScore(
             reasons.push('discovery boost')
         }
         if (recentArtists.has(candidateArtist)) {
-            score -= 0.2
+            score -= 0.2 // extra penalty on top of existing -0.25
         }
     } else if (autoplayMode === 'popular') {
         // Boost liked tracks more and high-energy/shorter tracks

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -19,6 +19,7 @@ import {
     consumeLastFmSeedSlice,
     consumeBlendedSeedSlice,
 } from './autoplay/lastFmSeeds'
+import { detectSessionMood, type SessionMood } from './autoplay/sessionMood'
 import { getSimilarTracks, getTagTopTracks } from '../../lastfm'
 import { cleanSearchQuery, cleanTitle, cleanAuthor } from './searchQueryCleaner'
 import type { QueueMetadata } from '../../types/QueueMetadata'
@@ -284,6 +285,7 @@ async function _replenishQueue(
         if (missingTracks <= 0) return
 
         const allHistoryTracks = getAllHistoryTracks(queue)
+        const sessionMood = detectSessionMood(allHistoryTracks)
         const historyTracks = allHistoryTracks.slice(0, HISTORY_SEED_LIMIT)
         const seedTracks = [currentTrack, ...historyTracks].slice(
             0,
@@ -291,8 +293,8 @@ async function _replenishQueue(
         )
         const requestedBy = getRequestedBy(queue, currentTrack)
         const [
-            dislikedTrackKeys,
-            likedTrackKeys,
+            likedWeights,
+            dislikedWeights,
             preferredArtistKeys,
             blockedArtistKeys,
             persistentHistory,
@@ -300,13 +302,11 @@ async function _replenishQueue(
             implicitDislikeKeys,
             implicitLikeKeys,
         ] = await Promise.all([
-            recommendationFeedbackService.getDislikedTrackKeys(
-                queue.guild.id,
-                requestedBy?.id,
+            recommendationFeedbackService.getLikedTrackWeights(
+                requestedBy?.id ?? '',
             ),
-            recommendationFeedbackService.getLikedTrackKeys(
-                queue.guild.id,
-                requestedBy?.id,
+            recommendationFeedbackService.getDislikedTrackWeights(
+                requestedBy?.id ?? '',
             ),
             recommendationFeedbackService.getPreferredArtistKeys(
                 queue.guild.id,
@@ -358,6 +358,11 @@ async function _replenishQueue(
         })
         const recentArtists = buildRecentArtists(currentTrack, historyTracks)
         const artistFrequency = buildArtistFrequency(persistentHistory)
+        const currentFeatures = requestedBy?.id
+            ? await getTrackAudioFeatures(currentTrack, requestedBy.id).catch(
+                  () => null,
+              )
+            : null
         const guildId = queue.guild.id
         const replenishCount = replenishCounters.get(guildId) ?? 0
         const candidates = await collectRecommendationCandidates(
@@ -366,8 +371,8 @@ async function _replenishQueue(
             requestedBy,
             excludedUrls,
             excludedKeys,
-            dislikedTrackKeys,
-            likedTrackKeys,
+            dislikedWeights,
+            likedWeights,
             preferredArtistKeys,
             blockedArtistKeys,
             currentTrack,
@@ -377,6 +382,7 @@ async function _replenishQueue(
             artistFrequency,
             implicitDislikeKeys,
             implicitLikeKeys,
+            sessionMood,
         )
         debugLog({
             message: 'Autoplay: recommendation candidates',
@@ -390,8 +396,8 @@ async function _replenishQueue(
                 requestedBy,
                 excludedUrls,
                 excludedKeys,
-                dislikedTrackKeys,
-                likedTrackKeys,
+                dislikedWeights,
+                likedWeights,
                 preferredArtistKeys,
                 blockedArtistKeys,
                 currentTrack,
@@ -401,6 +407,7 @@ async function _replenishQueue(
                 artistFrequency,
                 implicitDislikeKeys,
                 implicitLikeKeys,
+                sessionMood,
             )
             debugLog({
                 message: 'Autoplay: last.fm candidates',
@@ -421,8 +428,8 @@ async function _replenishQueue(
                 {
                     candidates,
                     recentArtists,
-                    likedTrackKeys,
-                    dislikedTrackKeys,
+                    likedTrackKeys: likedWeights,
+                    dislikedTrackKeys: dislikedWeights,
                     currentTrack,
                     excludedUrls,
                     excludedKeys,
@@ -432,6 +439,7 @@ async function _replenishQueue(
                     artistFrequency,
                     implicitDislikeKeys,
                     implicitLikeKeys,
+                    sessionMood,
                 },
             )
             debugLog({
@@ -452,8 +460,8 @@ async function _replenishQueue(
                 requestedBy,
                 excludedUrls,
                 excludedKeys,
-                dislikedTrackKeys,
-                likedTrackKeys,
+                dislikedWeights,
+                likedWeights,
                 preferredArtistKeys,
                 blockedArtistKeys,
                 recentArtists,
@@ -462,6 +470,7 @@ async function _replenishQueue(
                 artistFrequency,
                 implicitDislikeKeys,
                 implicitLikeKeys,
+                sessionMood,
             )
             debugLog({
                 message: 'Autoplay: broad fallback candidates',
@@ -637,8 +646,8 @@ async function collectRecommendationCandidates(
     requestedBy: User | null,
     excludedUrls: Set<string>,
     excludedKeys: Set<string>,
-    dislikedTrackKeys: Set<string>,
-    likedTrackKeys: Set<string>,
+    dislikedWeights: Map<string, number>,
+    likedWeights: Map<string, number>,
     preferredArtistKeys: Set<string>,
     blockedArtistKeys: Set<string>,
     currentTrack: Track,
@@ -648,6 +657,7 @@ async function collectRecommendationCandidates(
     artistFrequency: Map<string, number> = new Map(),
     implicitDislikeKeys: Set<string> = new Set(),
     implicitLikeKeys: Set<string> = new Set(),
+    sessionMood: SessionMood | null = null,
 ): Promise<Map<string, ScoredTrack>> {
     const candidates = new Map<string, ScoredTrack>()
 
@@ -668,20 +678,23 @@ async function collectRecommendationCandidates(
                 candidate.title,
                 candidate.author,
             )
-            if (dislikedTrackKeys.has(normalizedKey)) {
+            const dislikedWeight = dislikedWeights.get(normalizedKey)
+            if (dislikedWeight !== undefined && dislikedWeight > 0.5) {
                 continue
             }
             const rec = calculateRecommendationScore(
                 candidate,
                 currentTrack,
                 recentArtists,
-                likedTrackKeys,
+                likedWeights,
                 preferredArtistKeys,
                 blockedArtistKeys,
                 autoplayMode,
                 artistFrequency,
                 implicitDislikeKeys,
                 implicitLikeKeys,
+                dislikedWeights,
+                sessionMood,
             )
             if (rec.score !== -Infinity) {
                 upsertScoredCandidate(candidates, candidate, rec)
@@ -744,8 +757,8 @@ async function collectBroadFallbackCandidates(
     requestedBy: User | null,
     excludedUrls: Set<string>,
     excludedKeys: Set<string>,
-    dislikedTrackKeys: Set<string>,
-    likedTrackKeys: Set<string>,
+    dislikedWeights: Map<string, number>,
+    likedWeights: Map<string, number>,
     preferredArtistKeys: Set<string>,
     blockedArtistKeys: Set<string>,
     recentArtists: Set<string>,
@@ -754,6 +767,7 @@ async function collectBroadFallbackCandidates(
     artistFrequency: Map<string, number> = new Map(),
     implicitDislikeKeys: Set<string> = new Set(),
     implicitLikeKeys: Set<string> = new Set(),
+    sessionMood: SessionMood | null = null,
 ): Promise<void> {
     const fallbackQueries = [
         currentTrack.author,
@@ -779,18 +793,22 @@ async function collectBroadFallbackCandidates(
                 if (!shouldIncludeCandidate(track, excludedUrls, excludedKeys))
                     continue
                 const key = normalizeTrackKey(track.title, track.author)
-                if (dislikedTrackKeys.has(key)) continue
+                const dislikedWeight = dislikedWeights.get(key)
+                if (dislikedWeight !== undefined && dislikedWeight > 0.5)
+                    continue
                 const rec = calculateRecommendationScore(
                     track,
                     currentTrack,
                     recentArtists,
-                    likedTrackKeys,
+                    likedWeights,
                     preferredArtistKeys,
                     blockedArtistKeys,
                     autoplayMode,
                     artistFrequency,
                     implicitDislikeKeys,
                     implicitLikeKeys,
+                    dislikedWeights,
+                    sessionMood,
                 )
                 if (rec.score === -Infinity) continue
                 upsertScoredCandidate(candidates, track, {
@@ -840,8 +858,8 @@ async function collectLastFmCandidates(
     requestedBy: User,
     excludedUrls: Set<string>,
     excludedKeys: Set<string>,
-    dislikedTrackKeys: Set<string>,
-    likedTrackKeys: Set<string>,
+    dislikedWeights: Map<string, number>,
+    likedWeights: Map<string, number>,
     preferredArtistKeys: Set<string>,
     blockedArtistKeys: Set<string>,
     currentTrack: Track,
@@ -851,6 +869,7 @@ async function collectLastFmCandidates(
     artistFrequency: Map<string, number> = new Map(),
     implicitDislikeKeys: Set<string> = new Set(),
     implicitLikeKeys: Set<string> = new Set(),
+    sessionMood: SessionMood | null = null,
 ): Promise<void> {
     const metadata = queue.metadata as QueueMetadata
     const vcMemberIds = metadata?.vcMemberIds ?? []
@@ -889,7 +908,6 @@ async function collectLastFmCandidates(
 
     if (seedSlice.length === 0) return
 
-    // Search for each seed via track search
     for (const seed of seedSlice) {
         const query = cleanSearchQuery(seed.title, seed.artist)
         const tracks = await searchLastFmQuery(queue, query, requestedBy)
@@ -897,18 +915,21 @@ async function collectLastFmCandidates(
             if (!shouldIncludeCandidate(track, excludedUrls, excludedKeys))
                 continue
             const normalizedKey = normalizeTrackKey(track.title, track.author)
-            if (dislikedTrackKeys.has(normalizedKey)) continue
+            const dislikedWeight = dislikedWeights.get(normalizedKey)
+            if (dislikedWeight !== undefined && dislikedWeight > 0.5) continue
             const rec = calculateRecommendationScore(
                 track,
                 currentTrack,
                 recentArtists,
-                likedTrackKeys,
+                likedWeights,
                 preferredArtistKeys,
                 blockedArtistKeys,
                 autoplayMode,
                 artistFrequency,
                 implicitDislikeKeys,
                 implicitLikeKeys,
+                dislikedWeights,
+                sessionMood,
             )
             if (rec.score === -Infinity) continue
             upsertScoredCandidate(candidates, track, {
@@ -919,7 +940,6 @@ async function collectLastFmCandidates(
             })
         }
 
-        // Also search for similar tracks via Last.fm API
         const similar = await getSimilarTracks(seed.artist, cleanTitle(seed.title))
         for (const s of similar.slice(0, MAX_SIMILAR_LOOKUPS)) {
             const query = cleanSearchQuery(s.title, s.artist)
@@ -931,18 +951,21 @@ async function collectLastFmCandidates(
                     track.title,
                     track.author,
                 )
-                if (dislikedTrackKeys.has(normalizedKey)) continue
+                const dislikedWeight = dislikedWeights.get(normalizedKey)
+                if (dislikedWeight !== undefined && dislikedWeight > 0.5)
+                    continue
                 const rec = calculateRecommendationScore(
                     track,
                     currentTrack,
                     recentArtists,
-                    likedTrackKeys,
+                    likedWeights,
                     preferredArtistKeys,
                     blockedArtistKeys,
                     autoplayMode,
                     artistFrequency,
                     implicitDislikeKeys,
                     implicitLikeKeys,
+                    dislikedWeights,
                 )
                 upsertScoredCandidate(candidates, track, {
                     score: (rec.score + LASTFM_SCORE_BOOST) * (s.match / 100),
@@ -994,8 +1017,8 @@ const MAX_TRACKS_PER_GENRE = 20
 interface CandidateContext {
     candidates: Map<string, ScoredTrack>
     recentArtists: Set<string>
-    likedTrackKeys: Set<string>
-    dislikedTrackKeys: Set<string>
+    likedTrackKeys: Map<string, number>
+    dislikedTrackKeys: Map<string, number>
     currentTrack: Track
     excludedUrls: Set<string>
     excludedKeys: Set<string>
@@ -1005,6 +1028,7 @@ interface CandidateContext {
     artistFrequency?: Map<string, number>
     implicitDislikeKeys?: Set<string>
     implicitLikeKeys?: Set<string>
+    sessionMood?: SessionMood | null
 }
 
 function addGenreTrackCandidate(
@@ -1014,7 +1038,9 @@ function addGenreTrackCandidate(
 ): void {
     if (!shouldIncludeCandidate(track, ctx.excludedUrls, ctx.excludedKeys))
         return
-    if (ctx.dislikedTrackKeys.has(normalizeTrackKey(track.title, track.author)))
+    const key = normalizeTrackKey(track.title, track.author)
+    const dislikedWeight = ctx.dislikedTrackKeys.get(key)
+    if (dislikedWeight !== undefined && dislikedWeight > 0.5)
         return
     const rec = calculateRecommendationScore(
         track,
@@ -1027,6 +1053,8 @@ function addGenreTrackCandidate(
         ctx.artistFrequency,
         ctx.implicitDislikeKeys,
         ctx.implicitLikeKeys,
+        ctx.dislikedTrackKeys,
+        ctx.sessionMood,
     )
     upsertScoredCandidate(ctx.candidates, track, {
         score: rec.score + GENRE_SCORE_BOOST,
@@ -1286,13 +1314,15 @@ function calculateRecommendationScore(
     candidate: Track,
     currentTrack: Track,
     recentArtists: Set<string>,
-    likedTrackKeys: Set<string> = new Set(),
+    likedWeights: Map<string, number> = new Map(),
     preferredArtistKeys: Set<string> = new Set(),
     blockedArtistKeys: Set<string> = new Set(),
     autoplayMode: 'similar' | 'discover' | 'popular' = 'similar',
     artistFrequency: Map<string, number> = new Map(),
     implicitDislikeKeys: Set<string> = new Set(),
     implicitLikeKeys: Set<string> = new Set(),
+    dislikedWeights: Map<string, number> = new Map(),
+    sessionMood: SessionMood | null = null,
 ): { score: number; reason: string } {
     const currentArtist = currentTrack.author.toLowerCase()
     const candidateArtist = candidate.author.toLowerCase()
@@ -1323,9 +1353,19 @@ function calculateRecommendationScore(
     }
 
     const candidateKey = normalizeTrackKey(candidate.title, candidate.author)
-    if (likedTrackKeys.has(candidateKey)) {
-        score += 0.3
+    const likedWeight = likedWeights.get(candidateKey)
+    if (likedWeight !== undefined) {
+        score += 0.3 * likedWeight
         reasons.push('liked track')
+    }
+
+    const dislikedWeight = dislikedWeights.get(candidateKey)
+    if (dislikedWeight !== undefined) {
+        if (dislikedWeight > 0.5) {
+            return { score: -Infinity, reason: 'disliked' }
+        }
+        score -= 0.3 * dislikedWeight
+        reasons.push('old dislike')
     }
 
     if (implicitDislikeKeys.has(candidateKey)) {
@@ -1337,16 +1377,9 @@ function calculateRecommendationScore(
         reasons.push('completed before')
     }
 
-    if (candidateArtist === currentArtist) {
-        score -= 0.35
-    } else if (!recentArtists.has(candidateArtist)) {
+    if (!recentArtists.has(candidateArtist)) {
         score += 0.15
         reasons.push('session novelty')
-    } else {
-        reasons.push('fresh artist rotation')
-    }
-    if (recentArtists.has(candidateArtist)) {
-        score -= 0.25
     }
     if (candidate.source === currentTrack.source) {
         score -= 0.25
@@ -1380,27 +1413,48 @@ function calculateRecommendationScore(
         reasons.push('long track penalty')
     }
 
+    if (sessionMood) {
+        const durationMs = candidate.durationMS ?? 0
+        if (
+            sessionMood.deepDiveArtist &&
+            candidateArtist === sessionMood.deepDiveArtist
+        ) {
+            score += 0.15
+            reasons.push('deep dive')
+        }
+        if (sessionMood.preferLong && durationMs > 300_000) {
+            score += 0.1
+            reasons.push('long track match')
+        }
+        if (sessionMood.preferShort && durationMs > 0 && durationMs < 180_000) {
+            score += 0.1
+            reasons.push('quick hit match')
+        }
+        if (sessionMood.restless) {
+            if (!recentArtists.has(candidateArtist)) {
+                score += 0.1
+                reasons.push('restless discovery')
+            }
+        }
+    }
+
     if (candidate.source === 'spotify' && currentTrack.source === 'spotify') {
         score += 0.08
         reasons.push('spotify mood match')
     }
 
-    // Mode-specific adjustments
     if (autoplayMode === 'discover') {
-        // Boost novelty — prefer artists not heard recently
         if (!recentArtists.has(candidateArtist)) {
             score += 0.25
             reasons.push('discovery boost')
         }
         if (recentArtists.has(candidateArtist)) {
-            score -= 0.2 // extra penalty on top of existing -0.25
+            score -= 0.2
         }
     } else if (autoplayMode === 'popular') {
-        // Boost liked tracks more and high-energy/shorter tracks
-        if (likedTrackKeys.has(candidateKey)) {
-            score += 0.2 // on top of existing +0.3
+        if (likedWeight !== undefined) {
+            score += 0.2 * likedWeight
         }
-        // Prefer similar-length (same energy feel)
         if (candidate.durationMS && currentTrack.durationMS) {
             const ratio = candidate.durationMS / currentTrack.durationMS
             if (ratio >= 0.9 && ratio <= 1.1) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,6 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/*.t
 
 sonar.coverage.exclusions=packages/shared/src/**
 
-sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,packages/bot/src/functions/music/commands/spotify.ts,packages/bot/src/functions/music/commands/play/spotifyHandler.ts,packages/backend/src/routes/spotify.ts,packages/backend/src/services/SpotifyAuthService.ts,packages/frontend/src/pages/Spotify.tsx,packages/bot/src/spotify/spotifyApi.ts,packages/bot/src/lastfm/lastFmApi.ts,packages/bot/src/utils/music/autoplay/lastFmSeeds.ts,packages/bot/src/utils/music/queueManipulation.ts
+sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,packages/bot/src/functions/music/commands/spotify.ts,packages/bot/src/functions/music/commands/play/spotifyHandler.ts,packages/backend/src/routes/spotify.ts,packages/backend/src/services/SpotifyAuthService.ts,packages/frontend/src/pages/Spotify.tsx,packages/bot/src/spotify/spotifyApi.ts,packages/bot/src/lastfm/lastFmApi.ts,packages/bot/src/utils/music/autoplay/lastFmSeeds.ts,packages/bot/src/utils/music/queueManipulation.ts,packages/bot/src/utils/music/autoplay/sessionMood.ts
 
 sonar.javascript.lcov.reportPaths=packages/backend/coverage/lcov.info,packages/bot/coverage/lcov.info,packages/frontend/coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,6 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/*.t
 
 sonar.coverage.exclusions=packages/shared/src/**
 
-sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,packages/bot/src/functions/music/commands/spotify.ts,packages/bot/src/functions/music/commands/play/spotifyHandler.ts,packages/backend/src/routes/spotify.ts,packages/backend/src/services/SpotifyAuthService.ts,packages/frontend/src/pages/Spotify.tsx,packages/bot/src/spotify/spotifyApi.ts,packages/bot/src/lastfm/lastFmApi.ts,packages/bot/src/utils/music/autoplay/lastFmSeeds.ts
+sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,packages/bot/src/functions/music/commands/spotify.ts,packages/bot/src/functions/music/commands/play/spotifyHandler.ts,packages/backend/src/routes/spotify.ts,packages/backend/src/services/SpotifyAuthService.ts,packages/frontend/src/pages/Spotify.tsx,packages/bot/src/spotify/spotifyApi.ts,packages/bot/src/lastfm/lastFmApi.ts,packages/bot/src/utils/music/autoplay/lastFmSeeds.ts,packages/bot/src/utils/music/queueManipulation.ts
 
 sonar.javascript.lcov.reportPaths=packages/backend/coverage/lcov.info,packages/bot/coverage/lcov.info,packages/frontend/coverage/lcov.info


### PR DESCRIPTION
## Depends on #577

Built on top of the smart autoplay signals PR. Merges into `feat/smart-autoplay-signals` so both land together.

## Phase A — Temporal Decay

Feedback from 30 days ago should carry less weight than feedback from today.

**Before**: `likedTrackKeys: Set<string>` — liked = always +0.30, disliked = always -∞  
**After**: `likedWeights: Map<string, number>` — weight decays linearly 1.0→0.15 over 30 days

| Age | Liked boost | Dislike behaviour |
|-----|-------------|-------------------|
| Today | +0.30 | Hard exclude (-∞) |
| 15 days | +0.17 | Hard exclude (-∞) |
| 20 days | +0.12 | Soft penalty (-0.09) |
| 30 days | +0.045 | Soft penalty (-0.045) |

Old dislikes become soft penalties instead of permanent bans, letting forgotten-about songs surface again naturally.

## Phase C — Session Mood Detection

`detectSessionMood(historyTracks)` — pure function, no API calls:

| Signal | Detection | Boost |
|--------|-----------|-------|
| **Artist deep-dive** | Same artist 3+ times in last 8 tracks | +0.15 for that artist |
| **Long-form listening** | Avg duration of last 5 tracks >5min | +0.10 for tracks >5min |
| **Quick-hit mode** | Avg duration of last 5 tracks <2.5min | +0.10 for tracks <3min |
| **Restless** | >40% autoplay + 3+ different artists | +0.10 novelty boost |

22 tests covering all mood states, edge cases, and duration string parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-mood detection (artist focus, duration preference, restless) now personalizes recommendations.
  * Recommendation inputs switched from key-sets to time-decayed liked/disliked weight maps; scoring uses weighted like/dislike and mood-based boosts/penalties.

* **Bug Fixes**
  * Revised implicit feedback recording on play/skip events with updated per-event conditions and cleanup.

* **Tests**
  * Expanded tests for feedback weighting, implicit feedback guards, queue behavior, and session-mood detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->