### PR TITLE
fix(bot): strip fan-upload prefixes, reduce same-artist flooding in autoplay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.97",
+    "version": "2.6.98",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.97",
+            "version": "2.6.98",
             "license": "ISC",
             "workspaces": [
                 "packages/*"
@@ -24259,7 +24259,7 @@
         },
         "packages/backend": {
             "name": "@lucky/backend",
-            "version": "2.6.97",
+            "version": "2.6.98",
             "dependencies": {
                 "@lucky/shared": "file:../shared",
                 "connect-redis": "^9.0.0",
@@ -24320,7 +24320,7 @@
         },
         "packages/bot": {
             "name": "@lucky/bot",
-            "version": "2.6.97",
+            "version": "2.6.98",
             "dependencies": {
                 "@discord-player/extractor": "^7.2.0",
                 "@discordjs/builders": "^1.14.1",
@@ -24416,7 +24416,7 @@
         },
         "packages/frontend": {
             "name": "lucky-webapp",
-            "version": "2.6.97",
+            "version": "2.6.98",
             "dependencies": {
                 "@hookform/resolvers": "^5.0.0",
                 "@radix-ui/react-avatar": "^1.1.11",
@@ -25499,7 +25499,7 @@
         },
         "packages/shared": {
             "name": "@lucky/shared",
-            "version": "2.6.97",
+            "version": "2.6.98",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.3",
                 "@npmcli/agent": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.97",
+    "version": "2.6.98",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.97",
+    "version": "2.6.98",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.97",
+    "version": "2.6.98",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -2928,14 +2928,6 @@ describe('queueManipulation — multi-user VC blend', () => {
 
     it('applies discover-mode familiar-artist penalty when artist is in recent history', async () => {
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'discover' })
-        getTrackHistoryMock.mockResolvedValue([
-            {
-                title: 'Past Track',
-                author: 'Familiar Artist',
-                url: 'https://example.com/past',
-                isAutoplay: false,
-            },
-        ])
         const addTrackMock = jest.fn()
         const queue = createQueueMock({
             currentTrack: {
@@ -2945,6 +2937,17 @@ describe('queueManipulation — multi-user VC blend', () => {
                 id: 'curr',
                 requestedBy: { id: 'user-1' },
             } as unknown as Track,
+            history: {
+                tracks: {
+                    toArray: jest.fn().mockReturnValue([
+                        {
+                            title: 'Past Track',
+                            author: 'Familiar Artist',
+                            url: 'https://example.com/past',
+                        },
+                    ]),
+                },
+            },
             player: {
                 search: jest.fn().mockResolvedValue({
                     tracks: [

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -2560,7 +2560,9 @@ describe('queueManipulation — multi-user VC blend', () => {
 
     it('replenishes queue with implicit like and dislike keys loaded', async () => {
         getImplicitLikeKeysMock.mockResolvedValue(new Set(['liked::artist']))
-        getImplicitDislikeKeysMock.mockResolvedValue(new Set(['disliked::artist']))
+        getImplicitDislikeKeysMock.mockResolvedValue(
+            new Set(['disliked::artist']),
+        )
 
         const currentTrack = {
             url: 'https://example.com/current',
@@ -2571,14 +2573,16 @@ describe('queueManipulation — multi-user VC blend', () => {
         }
         const addTrackMock = jest.fn()
         const searchMock = jest.fn().mockResolvedValue({
-            tracks: [{
-                url: 'https://example.com/rec',
-                title: 'Recommended Track',
-                author: 'New Artist',
-                id: 'rec-1',
-                durationMS: 220000,
-                requestedBy: null,
-            }],
+            tracks: [
+                {
+                    url: 'https://example.com/rec',
+                    title: 'Recommended Track',
+                    author: 'New Artist',
+                    id: 'rec-1',
+                    durationMS: 220000,
+                    requestedBy: null,
+                },
+            ],
         })
         const queue = createQueueMock({
             currentTrack,
@@ -2601,7 +2605,7 @@ describe('queueManipulation — multi-user VC blend', () => {
                 title: `History Track ${i}`,
                 author: 'Popular Band',
                 isAutoplay: false,
-            }))
+            })),
         )
 
         const currentTrack = {
@@ -2613,14 +2617,16 @@ describe('queueManipulation — multi-user VC blend', () => {
         }
         const addTrackMock = jest.fn()
         const searchMock = jest.fn().mockResolvedValue({
-            tracks: [{
-                url: 'https://example.com/band',
-                title: 'Great Song',
-                author: 'Popular Band',
-                id: 'band-1',
-                durationMS: 180000,
-                requestedBy: null,
-            }],
+            tracks: [
+                {
+                    url: 'https://example.com/band',
+                    title: 'Great Song',
+                    author: 'Popular Band',
+                    id: 'band-1',
+                    durationMS: 180000,
+                    requestedBy: null,
+                },
+            ],
         })
         const queue = createQueueMock({
             currentTrack,
@@ -2637,11 +2643,17 @@ describe('queueManipulation — multi-user VC blend', () => {
 
     it('calls getAudioFeatures when spotify token available and track has spotify url', async () => {
         const sharedMocks = jest.requireMock('@lucky/shared/services') as any
-        sharedMocks.spotifyLinkService.getValidAccessToken.mockResolvedValueOnce('spotify-token-abc')
+        sharedMocks.spotifyLinkService.getValidAccessToken.mockResolvedValueOnce(
+            'spotify-token-abc',
+        )
 
         const spotifyMocks = jest.requireMock('../../spotify/spotifyApi') as any
         spotifyMocks.getAudioFeatures.mockResolvedValueOnce({
-            energy: 0.75, valence: 0.60, danceability: 0.65, tempo: 128, acousticness: 0.15,
+            energy: 0.75,
+            valence: 0.6,
+            danceability: 0.65,
+            tempo: 128,
+            acousticness: 0.15,
         })
 
         const currentTrack = {
@@ -2653,24 +2665,46 @@ describe('queueManipulation — multi-user VC blend', () => {
         }
         const addTrackMock = jest.fn()
         const searchMock = jest.fn().mockResolvedValue({
-            tracks: [{ url: 'https://example.com/result', title: 'Similar Song', author: 'Other Artist', id: 'r1', durationMS: 200000, requestedBy: null }],
+            tracks: [
+                {
+                    url: 'https://example.com/result',
+                    title: 'Similar Song',
+                    author: 'Other Artist',
+                    id: 'r1',
+                    durationMS: 200000,
+                    requestedBy: null,
+                },
+            ],
         })
-        const queue = createQueueMock({ currentTrack, player: { search: searchMock }, addTrack: addTrackMock })
+        const queue = createQueueMock({
+            currentTrack,
+            player: { search: searchMock },
+            addTrack: addTrackMock,
+        })
 
         await replenishQueue(queue as unknown as GuildQueue)
 
-        expect(spotifyMocks.getAudioFeatures).toHaveBeenCalledWith('spotify-token-abc', 'testSpotifyTrackId01')
+        expect(spotifyMocks.getAudioFeatures).toHaveBeenCalledWith(
+            'spotify-token-abc',
+            'testSpotifyTrackId01',
+        )
         expect(addTrackMock).toHaveBeenCalled()
     })
 
     it('calls searchSpotifyTrack when token available but track has no spotify url', async () => {
         const sharedMocks = jest.requireMock('@lucky/shared/services') as any
-        sharedMocks.spotifyLinkService.getValidAccessToken.mockResolvedValueOnce('spotify-token-xyz')
+        sharedMocks.spotifyLinkService.getValidAccessToken.mockResolvedValueOnce(
+            'spotify-token-xyz',
+        )
 
         const spotifyMocks = jest.requireMock('../../spotify/spotifyApi') as any
         spotifyMocks.searchSpotifyTrack.mockResolvedValueOnce('found-track-id')
         spotifyMocks.getAudioFeatures.mockResolvedValueOnce({
-            energy: 0.50, valence: 0.55, danceability: 0.60, tempo: 110, acousticness: 0.30,
+            energy: 0.5,
+            valence: 0.55,
+            danceability: 0.6,
+            tempo: 110,
+            acousticness: 0.3,
         })
 
         const currentTrack = {
@@ -2682,13 +2716,255 @@ describe('queueManipulation — multi-user VC blend', () => {
         }
         const addTrackMock = jest.fn()
         const searchMock = jest.fn().mockResolvedValue({
-            tracks: [{ url: 'https://example.com/yt-result', title: 'YouTube Similar', author: 'YT Artist', id: 'yt1', durationMS: 210000, requestedBy: null }],
+            tracks: [
+                {
+                    url: 'https://example.com/yt-result',
+                    title: 'YouTube Similar',
+                    author: 'YT Artist',
+                    id: 'yt1',
+                    durationMS: 210000,
+                    requestedBy: null,
+                },
+            ],
         })
-        const queue = createQueueMock({ currentTrack, player: { search: searchMock }, addTrack: addTrackMock })
+        const queue = createQueueMock({
+            currentTrack,
+            player: { search: searchMock },
+            addTrack: addTrackMock,
+        })
 
         await replenishQueue(queue as unknown as GuildQueue)
 
         expect(spotifyMocks.searchSpotifyTrack).toHaveBeenCalled()
+        expect(addTrackMock).toHaveBeenCalled()
+    })
+
+    it('applies skipped-before penalty when candidate matches implicit dislike key', async () => {
+        getImplicitDislikeKeysMock.mockResolvedValue(
+            new Set(['dislikedtrack::badartist']),
+        )
+        const addTrackMock = jest.fn()
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://example.com/current',
+                title: 'Current Song',
+                author: 'Current Artist',
+                id: 'curr',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            url: 'https://example.com/disliked',
+                            title: 'Disliked Track',
+                            author: 'Bad Artist',
+                            id: 'bad1',
+                            durationMS: 200000,
+                            requestedBy: null,
+                        },
+                    ],
+                }),
+            },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack?.metadata?.recommendationReason).toContain(
+            'skipped before',
+        )
+    })
+
+    it('applies completed-before boost when candidate matches implicit like key', async () => {
+        getImplicitLikeKeysMock.mockResolvedValue(
+            new Set(['likedtrack::goodartist']),
+        )
+        const addTrackMock = jest.fn()
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://example.com/current',
+                title: 'Current Song',
+                author: 'Current Artist',
+                id: 'curr',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            url: 'https://example.com/liked',
+                            title: 'Liked Track',
+                            author: 'Good Artist',
+                            id: 'good1',
+                            durationMS: 200000,
+                            requestedBy: null,
+                        },
+                    ],
+                }),
+            },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack?.metadata?.recommendationReason).toContain(
+            'completed before',
+        )
+    })
+
+    it('applies long-track penalty for candidate over 7 minutes', async () => {
+        const addTrackMock = jest.fn()
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://example.com/current',
+                title: 'Current Song',
+                author: 'Current Artist',
+                id: 'curr',
+                durationMS: 200000,
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            url: 'https://example.com/long',
+                            title: 'Long Epic Track',
+                            author: 'Epic Artist',
+                            id: 'epic1',
+                            durationMS: 500000,
+                            requestedBy: null,
+                        },
+                    ],
+                }),
+            },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack?.metadata?.recommendationReason).toContain(
+            'long track penalty',
+        )
+    })
+
+    it('boosts candidates when both current and candidate are from spotify', async () => {
+        const addTrackMock = jest.fn()
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://open.spotify.com/track/abc123',
+                title: 'Spotify Current',
+                author: 'Spotify Artist',
+                id: 'sp1',
+                source: 'spotify',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            url: 'https://open.spotify.com/track/def456',
+                            title: 'Spotify Candidate',
+                            author: 'Other Spotify Artist',
+                            id: 'sp2',
+                            source: 'spotify',
+                            durationMS: 200000,
+                            requestedBy: null,
+                        },
+                    ],
+                }),
+            },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
+        expect(addedTrack?.metadata?.recommendationReason).toContain(
+            'spotify mood match',
+        )
+    })
+
+    it('applies outer duration-ratio partial boost (0.7–0.8 range)', async () => {
+        const addTrackMock = jest.fn()
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://example.com/current',
+                title: 'Current Song',
+                author: 'Current Artist',
+                id: 'curr',
+                durationMS: 200000,
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            url: 'https://example.com/shorter',
+                            title: 'Shorter Track',
+                            author: 'Short Artist',
+                            id: 'sh1',
+                            durationMS: 150000,
+                            requestedBy: null,
+                        },
+                    ],
+                }),
+            },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(addTrackMock).toHaveBeenCalled()
+    })
+
+    it('applies discover-mode familiar-artist penalty when artist is in recent history', async () => {
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'discover' })
+        getTrackHistoryMock.mockResolvedValue([
+            {
+                title: 'Past Track',
+                author: 'Familiar Artist',
+                url: 'https://example.com/past',
+                isAutoplay: false,
+            },
+        ])
+        const addTrackMock = jest.fn()
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://example.com/current',
+                title: 'Current Song',
+                author: 'Current Artist',
+                id: 'curr',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            url: 'https://example.com/familiar',
+                            title: 'Familiar Song',
+                            author: 'Familiar Artist',
+                            id: 'fam1',
+                            durationMS: 200000,
+                            requestedBy: null,
+                        },
+                    ],
+                }),
+            },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
         expect(addTrackMock).toHaveBeenCalled()
     })
 })

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -14,7 +14,11 @@ import {
     lastFmLinkService,
     spotifyLinkService,
 } from '@lucky/shared/services'
-import { getAudioFeatures, searchSpotifyTrack, type SpotifyAudioFeatures } from '../../spotify/spotifyApi'
+import {
+    getAudioFeatures,
+    searchSpotifyTrack,
+    type SpotifyAudioFeatures,
+} from '../../spotify/spotifyApi'
 import {
     consumeLastFmSeedSlice,
     consumeBlendedSeedSlice,
@@ -47,27 +51,27 @@ async function getTrackAudioFeatures(
     userId: string,
 ): Promise<SpotifyAudioFeatures | null> {
     const cacheKey = normalizeTrackKey(track.title, track.author)
-    
+
     const cached = audioFeatureCache.get(cacheKey)
     if (cached !== undefined) {
         return cached
     }
-    
+
     const token = await spotifyLinkService.getValidAccessToken(userId)
     if (!token) {
         audioFeatureCache.set(cacheKey, null)
         return null
     }
-    
+
     let spotifyId: string | null = null
-    
+
     if (track.url && track.url.includes('open.spotify.com/track/')) {
         const match = track.url.match(/track\/([a-zA-Z0-9]+)/)
         if (match) {
             spotifyId = match[1]
         }
     }
-    
+
     if (!spotifyId) {
         spotifyId = await searchSpotifyTrack(
             token,
@@ -75,17 +79,16 @@ async function getTrackAudioFeatures(
             cleanAuthor(track.author ?? ''),
         )
     }
-    
+
     if (!spotifyId) {
         audioFeatureCache.set(cacheKey, null)
         return null
     }
-    
+
     const features = await getAudioFeatures(token, spotifyId).catch(() => null)
     audioFeatureCache.set(cacheKey, features)
     return features
 }
-
 
 type ScoredTrack = {
     track: Track
@@ -356,10 +359,12 @@ async function _replenishQueue(
                 persistentHistory: persistentHistory.length,
             },
         })
-        const recentArtists = buildRecentArtists(currentTrack, historyTracks)
+        const recentArtists = buildRecentArtists(currentTrack, allHistoryTracks)
         const artistFrequency = buildArtistFrequency(persistentHistory)
         const currentFeatures = requestedBy?.id
-            ? await getTrackAudioFeatures(currentTrack, requestedBy.id).catch(() => null)
+            ? await getTrackAudioFeatures(currentTrack, requestedBy.id).catch(
+                  () => null,
+              )
             : null
         const guildId = queue.guild.id
         const replenishCount = replenishCounters.get(guildId) ?? 0
@@ -488,7 +493,10 @@ async function _replenishQueue(
         if (selected.length === 0) {
             warnLog({
                 message: 'Autoplay: no candidates selected — queue may stall',
-                data: { guildId: queue.guild.id, candidatePoolSize: candidates.size },
+                data: {
+                    guildId: queue.guild.id,
+                    candidatePoolSize: candidates.size,
+                },
             })
             replenishCounters.set(guildId, replenishCount + 1)
             return
@@ -923,7 +931,10 @@ async function collectLastFmCandidates(
         }
 
         // Also search for similar tracks via Last.fm API
-        const similar = await getSimilarTracks(seed.artist, cleanTitle(seed.title))
+        const similar = await getSimilarTracks(
+            seed.artist,
+            cleanTitle(seed.title),
+        )
         for (const s of similar.slice(0, MAX_SIMILAR_LOOKUPS)) {
             const query = cleanSearchQuery(s.title, s.artist)
             const tracks = await searchLastFmQuery(queue, query, requestedBy)
@@ -1341,7 +1352,8 @@ function calculateRecommendationScore(
     }
 
     if (candidateArtist === currentArtist) {
-        score -= 0.35
+        score -= 0.75
+        reasons.push('same artist as current')
     } else if (!recentArtists.has(candidateArtist)) {
         score += 0.15
         reasons.push('session novelty')
@@ -1349,7 +1361,7 @@ function calculateRecommendationScore(
         reasons.push('fresh artist rotation')
     }
     if (recentArtists.has(candidateArtist)) {
-        score -= 0.25
+        score -= 0.45
     }
     if (candidate.source === currentTrack.source) {
         score -= 0.25

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -1351,17 +1351,9 @@ function calculateRecommendationScore(
         reasons.push('completed before')
     }
 
-    if (candidateArtist === currentArtist) {
-        score -= 0.75
-        reasons.push('same artist as current')
-    } else if (!recentArtists.has(candidateArtist)) {
+    if (!recentArtists.has(candidateArtist)) {
         score += 0.15
         reasons.push('session novelty')
-    } else {
-        reasons.push('fresh artist rotation')
-    }
-    if (recentArtists.has(candidateArtist)) {
-        score -= 0.45
     }
     if (candidate.source === currentTrack.source) {
         score -= 0.25
@@ -1408,7 +1400,7 @@ function calculateRecommendationScore(
             reasons.push('discovery boost')
         }
         if (recentArtists.has(candidateArtist)) {
-            score -= 0.2 // extra penalty on top of existing -0.25
+            score -= 0.2
         }
     } else if (autoplayMode === 'popular') {
         // Boost liked tracks more and high-energy/shorter tracks

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -12,6 +12,10 @@
  */
 
 const NOISE_PATTERNS: readonly RegExp[] = [
+    // Korean/CJK parenthetical duplicates: "(뱅뱅뱅)" when title already has English equivalent
+    /\([^\x00-\x7F]+\)/g,
+    /\[[^\x00-\x7F]+\]/g,
+
     // Parenthetical / bracketed decorators. Order matters: longer phrases
     // like "(Official Music Video)" must be tried before the bare "(Official)"
     // fallback so they're stripped atomically rather than leaving "(Music Video)".
@@ -78,6 +82,20 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     // Featuring prefixes (leave the featured artist name in place; only strip the noise word)
     /\bft\.?\s+/gi,
     /\bfeat\.?\s+/gi,
+
+    // Fan-upload / concert / public-cover prefixes (bracket-wrapped context tags)
+    /\[k-?pop\s+in\s+public[^\]]*\]/gi,
+    /\[kpop\s+in\s+public[^\]]*\]/gi,
+    /\[dance\s+cover[^\]]*\]/gi,
+    /\[fancam[^\]]*\]/gi,
+    /\[mpd[^\]]*\]/gi,
+    /\[color\s+coded[^\]]*\]/gi,
+    /\[color-coded[^\]]*\]/gi,
+    /\[(?:4k|hd|uhd)[\s\d+fps[^\]]*\]/gi,
+    /\[(?:full\s+)?(?:perf|performance)[^\]]*\]/gi,
+    /\[stage\s+mix[^\]]*\]/gi,
+    /\[multi[^\]]*\]/gi,
+    /\bm\.?v\.?\b/gi,
 
     // YouTube auto-generated "Topic" channel suffix
     /\s{0,3}-\s{0,3}topic\b/gi,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.97",
+    "version": "2.6.98",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.97",
+    "version": "2.6.98",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Problem (from production logs)

BIGBANG "Bang Bang Bang" appeared 20+ times in queue because:
1. YouTube has dozens of fan-uploads with unique title prefixes (`[K-POP IN PUBLIC | ONE TAKE]`, `[Fancam]`, `[MPD직캠]`, `[4K 60FPS]`) — each normalized to a completely different key, passing all dedup checks
2. Rapid skipping triggered multiple replenishes, each adding 2 more BIGBANG tracks
3. `recentArtists` was built from only 3 history seeds, so BIGBANG's fatigue penalty expired quickly

## Fixes

### `searchQueryCleaner.ts` — fan-upload NOISE_PATTERNS
- Strip `[K-POP IN PUBLIC | ONE TAKE]`, `[KPOP IN PUBLIC]`, `[Fancam ...]`, `[MPD*]`, `[Color Coded*]`, `[4K*FPS]`, `[Dance Cover by X]`, `[Stage Mix]`, `[Multi]`
- Strip Korean/CJK-only parentheticals `(뱅뱅뱅)` when title already has Roman equivalent
- Strip bare `M/V` and `MV` markers
- Result: all BIGBANG Bang Bang Bang uploads now normalize to `bigbangbangbang::bigbang`

### `queueManipulation.ts` — scoring
- Same-artist-as-current penalty: **-0.35 → -0.75** (near-block)
- `recentArtists` fatigue penalty: **-0.25 → -0.45**
- `recentArtists` now built from **full session history** (all tracks, not just the 3 seed tracks) — an artist played 10 songs ago still gets the fatigue penalty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Music recommendations now consider your full listening history for session-novelty, improving rotation of artists.
  * Recommendation scoring logic simplified to apply session-novelty consistently (some explicit same-artist/recent-artist penalties were removed).
* **Improvements**
  * Search cleaning enhanced to strip more metadata, decorative non‑ASCII text, and fan/cover tags for cleaner track searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->