### PR TITLE
fix(bot): Spotify-first provider order + Queue Error recovery

### DIFF
--- a/packages/bot/src/functions/music/commands/play/processor.ts
+++ b/packages/bot/src/functions/music/commands/play/processor.ts
@@ -1,7 +1,11 @@
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import { detectQueryType } from './queryDetector'
 import { handleSpotifyTrack, handleSpotifyPlaylist } from './spotifyHandler'
-import { handleYouTubePlaylist, handleYouTubeSearch } from './youtubeHandler'
+import {
+    handleYouTubePlaylist,
+    handleYouTubeSearch,
+    handleSpotifySearch,
+} from './youtubeHandler'
 import { manageQueue } from './queueManager'
 import type { PlayCommandOptions, PlayCommandResult } from './types'
 
@@ -92,6 +96,15 @@ export class PlayCommandProcessor {
         options: PlayCommandOptions,
     ): Promise<PlayCommandResult> {
         const { query, user, guildId, channelId, player } = options
+
+        const spotifyResult = await handleSpotifySearch(
+            query,
+            user,
+            guildId,
+            channelId,
+            player,
+        )
+        if (spotifyResult.success) return spotifyResult
 
         return handleYouTubeSearch(query, user, guildId, channelId, player)
     }

--- a/packages/bot/src/functions/music/commands/play/youtubeHandler.ts
+++ b/packages/bot/src/functions/music/commands/play/youtubeHandler.ts
@@ -1,9 +1,46 @@
 /**
- * YouTube track and playlist handlers
+ * YouTube and Spotify search handlers
  */
 
+import { QueryType } from 'discord-player'
 import type { PlayCommandResult, PlayCommandOptions } from './types'
-import { debugLog, errorLog } from '@lucky/shared/utils'
+import { debugLog, errorLog, warnLog } from '@lucky/shared/utils'
+
+/**
+ * Search Spotify first. Returns success=false (no error thrown) when no
+ * results are found so the caller can silently fall through to YouTube.
+ */
+export async function handleSpotifySearch(
+    query: string,
+    user: PlayCommandOptions['user'],
+    guildId: string,
+    _channelId: string,
+    player: PlayCommandOptions['player'],
+): Promise<PlayCommandResult> {
+    try {
+        const searchResult = await player.search(query, {
+            requestedBy: user,
+            searchEngine: QueryType.SPOTIFY_SEARCH,
+        })
+
+        if (!searchResult.hasTracks()) {
+            return { success: false, error: '' }
+        }
+
+        debugLog({
+            message: `Spotify search found ${searchResult.tracks.length} tracks`,
+            data: { guildId, query },
+        })
+
+        return { success: true, tracks: searchResult.tracks, isPlaylist: false }
+    } catch (error) {
+        warnLog({
+            message: 'Spotify search failed, falling back to YouTube',
+            data: { query, guildId, error: (error as Error).message },
+        })
+        return { success: false, error: '' }
+    }
+}
 
 export async function handleYouTubeSearch(
     query: string,

--- a/packages/bot/src/handlers/player/errorHandlers.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.ts
@@ -321,7 +321,8 @@ const handlePlayerError = async (
         const isStreamExtractionError =
             error.message.includes('Could not extract stream') ||
             error.message.includes('Streaming data not available') ||
-            error.message.includes('chooseFormat')
+            error.message.includes('chooseFormat') ||
+            error.message.includes('Bridge exhausted')
 
         if (isStreamExtractionError) {
             debugLog({

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -1,6 +1,12 @@
 import { Player } from 'discord-player'
 import type { Track } from 'discord-player'
-import { DefaultExtractors } from '@discord-player/extractor'
+import {
+    SpotifyExtractor,
+    SoundCloudExtractor,
+    AppleMusicExtractor,
+    VimeoExtractor,
+    AttachmentExtractor,
+} from '@discord-player/extractor'
 import * as playdl from 'play-dl'
 import { spawn } from 'child_process'
 import { PassThrough } from 'stream'
@@ -36,37 +42,61 @@ export const createPlayer = ({ client }: CreatePlayerParams): Player => {
 }
 
 const registerExtractors = (player: Player): void => {
-    // Register DefaultExtractors synchronously (loadMulti is sync in this version).
-    // Errors are caught so a single bad extractor does not block the others.
-    try {
-        void player.extractors.loadMulti(DefaultExtractors)
-        infoLog({
-            message:
-                'Extractors: SoundCloud, Spotify, Apple Music, Vimeo, Attachments',
-        })
-    } catch (error) {
+    // Register all extractors asynchronously in priority order:
+    //   Spotify → YouTube → SoundCloud → Apple Music → Vimeo → Attachments
+    // Fire without awaiting so createPlayer() returns synchronously.
+    registerExtractorsInOrder(player).catch((error) => {
         errorLog({
-            message:
-                'DefaultExtractors failed to load — music features degraded',
-            error,
-        })
-    }
-
-    // Async: SoundCloud client ID + YouTube extractor.  Fire without awaiting so
-    // createPlayer() returns synchronously, but log any failures so they are not
-    // silently swallowed.
-    initPlayDlAndRegisterYoutubei(player).catch((error) => {
-        errorLog({
-            message:
-                'Async extractor init failed — SoundCloud/YouTube may be unavailable',
+            message: 'Extractor init failed — music features degraded',
             error,
         })
     })
 }
 
-const initPlayDlAndRegisterYoutubei = async (player: Player): Promise<void> => {
+const registerExtractorsInOrder = async (player: Player): Promise<void> => {
+    // 1. Spotify — first priority for searches and Spotify URLs
+    await registerSpotifyExtractor(player)
+
+    // 2. YouTube — via resilient yt-dlp bridge
     await initPlayDlSoundCloud()
     await loadYoutubeExtractor(player)
+
+    // 3. SoundCloud, Apple Music, Vimeo, Attachments
+    await registerRemainingExtractors(player)
+}
+
+const registerSpotifyExtractor = async (player: Player): Promise<void> => {
+    try {
+        await player.extractors.register(SpotifyExtractor, {
+            clientId: process.env.SPOTIFY_CLIENT_ID ?? null,
+            clientSecret: process.env.SPOTIFY_CLIENT_SECRET ?? null,
+        })
+        infoLog({ message: 'Registered SpotifyExtractor (priority 1)' })
+    } catch (error) {
+        warnLog({
+            message: 'SpotifyExtractor failed to register — Spotify searches degraded',
+            error,
+        })
+    }
+}
+
+const registerRemainingExtractors = async (player: Player): Promise<void> => {
+    const extractors = [
+        { extractor: SoundCloudExtractor, name: 'SoundCloud' },
+        { extractor: AppleMusicExtractor, name: 'Apple Music' },
+        { extractor: VimeoExtractor, name: 'Vimeo' },
+        { extractor: AttachmentExtractor, name: 'Attachments' },
+    ]
+
+    for (const { extractor, name } of extractors) {
+        try {
+            await player.extractors.register(extractor, {})
+        } catch (error) {
+            warnLog({ message: `${name} extractor failed to register`, error })
+        }
+    }
+
+    infoLog({ message: 'Registered: SoundCloud, Apple Music, Vimeo, Attachments' })
 }
 
 const initPlayDlSoundCloud = async (): Promise<void> => {

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -67,10 +67,16 @@ const registerExtractorsInOrder = async (player: Player): Promise<void> => {
 
 const registerSpotifyExtractor = async (player: Player): Promise<void> => {
     try {
-        await player.extractors.register(SpotifyExtractor, {
+        const registered = await player.extractors.register(SpotifyExtractor, {
             clientId: process.env.SPOTIFY_CLIENT_ID ?? null,
             clientSecret: process.env.SPOTIFY_CLIENT_SECRET ?? null,
         })
+        if (!registered) {
+            warnLog({
+                message: 'SpotifyExtractor registration returned null — Spotify searches degraded',
+            })
+            return
+        }
         infoLog({ message: 'Registered SpotifyExtractor (priority 1)' })
     } catch (error) {
         warnLog({
@@ -90,7 +96,10 @@ const registerRemainingExtractors = async (player: Player): Promise<void> => {
 
     for (const { extractor, name } of extractors) {
         try {
-            await player.extractors.register(extractor, {})
+            const registered = await player.extractors.register(extractor, {})
+            if (!registered) {
+                warnLog({ message: `${name} extractor registration returned null` })
+            }
         } catch (error) {
             warnLog({ message: `${name} extractor failed to register`, error })
         }

--- a/packages/bot/tests/functions/music/commands/play/processor.test.ts
+++ b/packages/bot/tests/functions/music/commands/play/processor.test.ts
@@ -1,0 +1,90 @@
+jest.mock('../../../../../src/functions/music/commands/play/youtubeHandler', () => ({
+    handleSpotifySearch: jest.fn(),
+    handleYouTubeSearch: jest.fn(),
+    handleYouTubePlaylist: jest.fn(),
+}))
+
+jest.mock('../../../../../src/functions/music/commands/play/spotifyHandler', () => ({
+    handleSpotifyTrack: jest.fn(),
+    handleSpotifyPlaylist: jest.fn(),
+}))
+
+jest.mock('../../../../../src/functions/music/commands/play/queueManager', () => ({
+    manageQueue: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+    errorLog: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
+import { PlayCommandProcessor } from '../../../../../src/functions/music/commands/play/processor'
+import {
+    handleSpotifySearch,
+    handleYouTubeSearch,
+} from '../../../../../src/functions/music/commands/play/youtubeHandler'
+
+const makeOptions = (query: string) => ({
+    query,
+    user: { id: 'user-1' } as any,
+    guildId: 'guild-1',
+    channelId: 'channel-1',
+    player: {} as any,
+    queue: {} as any,
+})
+
+describe('PlayCommandProcessor.processPlayCommand', () => {
+    let processor: PlayCommandProcessor
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        processor = new PlayCommandProcessor()
+    })
+
+    describe('handleSearchQuery (plain text queries)', () => {
+        it('returns Spotify result directly when Spotify search succeeds', async () => {
+            const tracks = [{ title: 'Spotify Track' }] as any[]
+            ;(handleSpotifySearch as jest.Mock).mockResolvedValue({
+                success: true,
+                tracks,
+                isPlaylist: false,
+            })
+
+            const result = await processor.processPlayCommand(
+                makeOptions('some song'),
+            )
+
+            expect(result.success).toBe(true)
+            expect(result.tracks).toBe(tracks)
+            expect(handleYouTubeSearch).not.toHaveBeenCalled()
+        })
+
+        it('falls back to YouTube when Spotify search returns no results', async () => {
+            const tracks = [{ title: 'YT Track' }] as any[]
+            ;(handleSpotifySearch as jest.Mock).mockResolvedValue({
+                success: false,
+                error: '',
+            })
+            ;(handleYouTubeSearch as jest.Mock).mockResolvedValue({
+                success: true,
+                tracks,
+                isPlaylist: false,
+            })
+
+            const result = await processor.processPlayCommand(
+                makeOptions('some song'),
+            )
+
+            expect(result.success).toBe(true)
+            expect(result.tracks).toBe(tracks)
+            expect(handleYouTubeSearch).toHaveBeenCalledWith(
+                'some song',
+                expect.anything(),
+                'guild-1',
+                'channel-1',
+                expect.anything(),
+            )
+        })
+    })
+})

--- a/packages/bot/tests/functions/music/commands/play/youtubeHandler.test.ts
+++ b/packages/bot/tests/functions/music/commands/play/youtubeHandler.test.ts
@@ -1,0 +1,81 @@
+import { QueryType } from 'discord-player'
+import { handleSpotifySearch } from '../../../../../src/functions/music/commands/play/youtubeHandler'
+
+jest.mock('discord-player', () => ({
+    QueryType: { SPOTIFY_SEARCH: 'spotifySearch' },
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+    warnLog: jest.fn(),
+    errorLog: jest.fn(),
+}))
+
+const makePlayer = (searchResult: unknown) => ({
+    search: jest.fn().mockResolvedValue(searchResult),
+})
+
+const makeUser = () => ({ id: 'user-1' } as any)
+
+describe('handleSpotifySearch', () => {
+    beforeEach(() => jest.clearAllMocks())
+
+    it('returns success with tracks when Spotify search finds results', async () => {
+        const tracks = [{ title: 'Track A' }, { title: 'Track B' }]
+        const player = makePlayer({ hasTracks: () => true, tracks })
+        const user = makeUser()
+
+        const result = await handleSpotifySearch(
+            'some song',
+            user,
+            'guild-1',
+            'channel-1',
+            player as any,
+        )
+
+        expect(result.success).toBe(true)
+        expect(result.tracks).toBe(tracks)
+        expect(result.isPlaylist).toBe(false)
+        expect(player.search).toHaveBeenCalledWith('some song', {
+            requestedBy: user,
+            searchEngine: QueryType.SPOTIFY_SEARCH,
+        })
+    })
+
+    it('returns success=false when Spotify search returns no tracks', async () => {
+        const player = makePlayer({ hasTracks: () => false, tracks: [] })
+
+        const result = await handleSpotifySearch(
+            'unknown track',
+            makeUser(),
+            'guild-1',
+            'channel-1',
+            player as any,
+        )
+
+        expect(result.success).toBe(false)
+        expect(result.tracks).toBeUndefined()
+    })
+
+    it('returns success=false and logs warning when search throws', async () => {
+        const { warnLog } = await import('@lucky/shared/utils')
+        const player = {
+            search: jest.fn().mockRejectedValue(new Error('Spotify API down')),
+        }
+
+        const result = await handleSpotifySearch(
+            'any query',
+            makeUser(),
+            'guild-2',
+            'channel-2',
+            player as any,
+        )
+
+        expect(result.success).toBe(false)
+        expect(warnLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Spotify search failed, falling back to YouTube',
+            }),
+        )
+    })
+})

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -149,6 +149,127 @@ describe('playerFactory', () => {
             expect(player.extractors.register).toHaveBeenCalled()
         })
 
+        it('registers SpotifyExtractor as the first extractor', async () => {
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+
+            const player = createPlayer({
+                client: { user: { id: '123' } } as any,
+            }) as unknown as { extractors: { register: jest.Mock } }
+
+            for (let i = 0; i < 50; i++) {
+                const hasSpotify = player.extractors.register.mock.calls.some(
+                    ([ExtractorClass]: [unknown]) => {
+                        const name = (ExtractorClass as { name?: string })?.name
+                        return (
+                            name === 'MockSpotifyExtractor' ||
+                            typeof ExtractorClass === 'function'
+                        )
+                    },
+                )
+                if (
+                    hasSpotify &&
+                    player.extractors.register.mock.calls.length >= 2
+                )
+                    break
+                await new Promise((resolve) => setTimeout(resolve, 10))
+            }
+
+            expect(player.extractors.register).toHaveBeenCalled()
+            const firstCall = player.extractors.register.mock.calls[0]
+            expect(firstCall).toBeDefined()
+        })
+
+        it('logs warn when SpotifyExtractor registration fails', async () => {
+            jest.resetModules()
+            jest.doMock('@lucky/shared/utils', () => ({
+                errorLog: jest.fn(),
+                infoLog: jest.fn(),
+                warnLog: jest.fn(),
+                debugLog: jest.fn(),
+            }))
+
+            const { SpotifyExtractor } = await import(
+                '@discord-player/extractor'
+            )
+            jest.doMock('discord-player', () => {
+                const register = jest.fn().mockImplementation((ext) => {
+                    if (ext === SpotifyExtractor) {
+                        throw new Error('Spotify registration failed')
+                    }
+                    return Promise.resolve(true)
+                })
+                const MockPlayer = jest.fn().mockImplementation(function (
+                    this: any,
+                ) {
+                    this.extractors = { register }
+                    this.setMaxListeners = jest.fn()
+                    this.events = { on: jest.fn(), removeAllListeners: jest.fn() }
+                })
+                return { Player: MockPlayer }
+            })
+
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+            const { warnLog } = await import('@lucky/shared/utils')
+
+            createPlayer({ client: { user: { id: '123' } } as any })
+            await new Promise((resolve) => setTimeout(resolve, 200))
+
+            expect(
+                (warnLog as jest.Mock).mock.calls.some((call) =>
+                    (call[0]?.message as string)?.includes(
+                        'SpotifyExtractor failed to register',
+                    ),
+                ),
+            ).toBe(true)
+        })
+
+        it('logs warn when a remaining extractor registration fails', async () => {
+            jest.resetModules()
+            jest.doMock('@lucky/shared/utils', () => ({
+                errorLog: jest.fn(),
+                infoLog: jest.fn(),
+                warnLog: jest.fn(),
+                debugLog: jest.fn(),
+            }))
+
+            const { SoundCloudExtractor } = await import(
+                '@discord-player/extractor'
+            )
+            jest.doMock('discord-player', () => {
+                const register = jest.fn().mockImplementation((ext) => {
+                    if (ext === SoundCloudExtractor) {
+                        throw new Error('SoundCloud registration failed')
+                    }
+                    return Promise.resolve(true)
+                })
+                const MockPlayer = jest.fn().mockImplementation(function (
+                    this: any,
+                ) {
+                    this.extractors = { register }
+                    this.setMaxListeners = jest.fn()
+                    this.events = { on: jest.fn(), removeAllListeners: jest.fn() }
+                })
+                return { Player: MockPlayer }
+            })
+
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+            const { warnLog } = await import('@lucky/shared/utils')
+
+            createPlayer({ client: { user: { id: '123' } } as any })
+            await new Promise((resolve) => setTimeout(resolve, 200))
+
+            expect(
+                (warnLog as jest.Mock).mock.calls.some((call) =>
+                    (call[0]?.message as string)?.includes(
+                        'SoundCloud extractor failed to register',
+                    ),
+                ),
+            ).toBe(true)
+        })
+
         it('logs warn and skips registration when no extractor export is found', async () => {
             jest.resetModules()
             jest.doMock('discord-player-youtubei', () => ({}))

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -14,6 +14,11 @@ jest.mock('discord-player', () => {
 
 jest.mock('@discord-player/extractor', () => ({
     DefaultExtractors: [],
+    SpotifyExtractor: class MockSpotifyExtractor {},
+    SoundCloudExtractor: class MockSoundCloudExtractor {},
+    AppleMusicExtractor: class MockAppleMusicExtractor {},
+    VimeoExtractor: class MockVimeoExtractor {},
+    AttachmentExtractor: class MockAttachmentExtractor {},
 }))
 
 jest.mock('discord-player-youtubei', () => ({
@@ -76,13 +81,22 @@ describe('playerFactory', () => {
             }) as unknown as { extractors: { register: jest.Mock } }
 
             for (let i = 0; i < 50; i++) {
-                if (player.extractors.register.mock.calls.length > 0) break
+                const hasYoutube = player.extractors.register.mock.calls.some(
+                    ([, opts]: [unknown, Record<string, unknown>]) =>
+                        typeof opts?.createStream === 'function',
+                )
+                if (hasYoutube) break
                 await new Promise((resolve) => setTimeout(resolve, 10))
             }
 
             expect(player.extractors.register).toHaveBeenCalled()
 
-            const [, options] = player.extractors.register.mock.calls[0]
+            const youtubeCall = player.extractors.register.mock.calls.find(
+                ([, opts]: [unknown, Record<string, unknown>]) =>
+                    typeof opts?.createStream === 'function',
+            )
+            expect(youtubeCall).toBeDefined()
+            const [, options] = youtubeCall!
             expect(typeof options.createStream).toBe('function')
             // v3 API: streamOptions/generateWithPoToken removed
             expect(options.streamOptions).toBeUndefined()
@@ -98,11 +112,20 @@ describe('playerFactory', () => {
             }) as unknown as { extractors: { register: jest.Mock } }
 
             for (let i = 0; i < 50; i++) {
-                if (player.extractors.register.mock.calls.length > 0) break
+                const hasYoutube = player.extractors.register.mock.calls.some(
+                    ([, opts]: [unknown, Record<string, unknown>]) =>
+                        typeof opts?.createStream === 'function',
+                )
+                if (hasYoutube) break
                 await new Promise((resolve) => setTimeout(resolve, 10))
             }
 
-            const [, options] = player.extractors.register.mock.calls[0]
+            const youtubeCall = player.extractors.register.mock.calls.find(
+                ([, opts]: [unknown, Record<string, unknown>]) =>
+                    typeof opts?.createStream === 'function',
+            )
+            expect(youtubeCall).toBeDefined()
+            const [, options] = youtubeCall!
             expect(typeof options.createStream).toBe('function')
         })
 
@@ -153,7 +176,13 @@ describe('playerFactory', () => {
                     ),
                 ),
             ).toBe(true)
-            expect(player.extractors.register).not.toHaveBeenCalled()
+            // YouTube extractor specifically should NOT have been registered
+            // (identified by the createStream option it carries)
+            const youtubeCall = player.extractors.register.mock.calls.find(
+                ([, opts]: [unknown, Record<string, unknown>]) =>
+                    typeof opts?.createStream === 'function',
+            )
+            expect(youtubeCall).toBeUndefined()
         })
     })
 })

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -1,6 +1,6 @@
 jest.mock('discord-player', () => {
     const loadMulti = jest.fn().mockResolvedValue(undefined)
-    const register = jest.fn().mockResolvedValue(undefined)
+    const register = jest.fn().mockResolvedValue(true)
     const MockPlayer = jest.fn().mockImplementation(function (this: any) {
         this.extractors = { loadMulti, register }
         this.setMaxListeners = jest.fn()
@@ -159,25 +159,20 @@ describe('playerFactory', () => {
 
             for (let i = 0; i < 50; i++) {
                 const hasSpotify = player.extractors.register.mock.calls.some(
-                    ([ExtractorClass]: [unknown]) => {
-                        const name = (ExtractorClass as { name?: string })?.name
-                        return (
-                            name === 'MockSpotifyExtractor' ||
-                            typeof ExtractorClass === 'function'
-                        )
-                    },
+                    ([ExtractorClass]: [unknown]) =>
+                        (ExtractorClass as { name?: string })?.name ===
+                        'MockSpotifyExtractor',
                 )
-                if (
-                    hasSpotify &&
-                    player.extractors.register.mock.calls.length >= 2
-                )
-                    break
+                if (hasSpotify) break
                 await new Promise((resolve) => setTimeout(resolve, 10))
             }
 
             expect(player.extractors.register).toHaveBeenCalled()
             const firstCall = player.extractors.register.mock.calls[0]
             expect(firstCall).toBeDefined()
+            expect((firstCall[0] as { name?: string })?.name).toBe(
+                'MockSpotifyExtractor',
+            )
         })
 
         it('logs warn when SpotifyExtractor registration fails', async () => {
@@ -265,6 +260,92 @@ describe('playerFactory', () => {
                 (warnLog as jest.Mock).mock.calls.some((call) =>
                     (call[0]?.message as string)?.includes(
                         'SoundCloud extractor failed to register',
+                    ),
+                ),
+            ).toBe(true)
+        })
+
+        it('logs warn when SpotifyExtractor registration returns null', async () => {
+            jest.resetModules()
+            jest.doMock('@lucky/shared/utils', () => ({
+                errorLog: jest.fn(),
+                infoLog: jest.fn(),
+                warnLog: jest.fn(),
+                debugLog: jest.fn(),
+            }))
+
+            const { SpotifyExtractor } = await import(
+                '@discord-player/extractor'
+            )
+            jest.doMock('discord-player', () => {
+                const register = jest.fn().mockImplementation((ext) => {
+                    if (ext === SpotifyExtractor) return Promise.resolve(null)
+                    return Promise.resolve(true)
+                })
+                const MockPlayer = jest.fn().mockImplementation(function (
+                    this: any,
+                ) {
+                    this.extractors = { register }
+                    this.setMaxListeners = jest.fn()
+                    this.events = { on: jest.fn(), removeAllListeners: jest.fn() }
+                })
+                return { Player: MockPlayer }
+            })
+
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+            const { warnLog } = await import('@lucky/shared/utils')
+
+            createPlayer({ client: { user: { id: '123' } } as any })
+            await new Promise((resolve) => setTimeout(resolve, 200))
+
+            expect(
+                (warnLog as jest.Mock).mock.calls.some((call) =>
+                    (call[0]?.message as string)?.includes(
+                        'SpotifyExtractor registration returned null',
+                    ),
+                ),
+            ).toBe(true)
+        })
+
+        it('logs warn when a remaining extractor registration returns null', async () => {
+            jest.resetModules()
+            jest.doMock('@lucky/shared/utils', () => ({
+                errorLog: jest.fn(),
+                infoLog: jest.fn(),
+                warnLog: jest.fn(),
+                debugLog: jest.fn(),
+            }))
+
+            const { SoundCloudExtractor } = await import(
+                '@discord-player/extractor'
+            )
+            jest.doMock('discord-player', () => {
+                const register = jest.fn().mockImplementation((ext) => {
+                    if (ext === SoundCloudExtractor) return Promise.resolve(null)
+                    return Promise.resolve(true)
+                })
+                const MockPlayer = jest.fn().mockImplementation(function (
+                    this: any,
+                ) {
+                    this.extractors = { register }
+                    this.setMaxListeners = jest.fn()
+                    this.events = { on: jest.fn(), removeAllListeners: jest.fn() }
+                })
+                return { Player: MockPlayer }
+            })
+
+            const { createPlayer } =
+                await import('../../../src/handlers/player/playerFactory')
+            const { warnLog } = await import('@lucky/shared/utils')
+
+            createPlayer({ client: { user: { id: '123' } } as any })
+            await new Promise((resolve) => setTimeout(resolve, 200))
+
+            expect(
+                (warnLog as jest.Mock).mock.calls.some((call) =>
+                    (call[0]?.message as string)?.includes(
+                        'SoundCloud extractor registration returned null',
                     ),
                 ),
             ).toBe(true)


### PR DESCRIPTION
## Problem

1. **YouTube default provider** — text searches always resolved to YouTube even though Spotify produces cleaner metadata with far fewer duplicate entries. The `handleSearchQuery` path hardcoded `handleYouTubeSearch`.

2. **Queue Error not recovering** — when `createResilientStream` exhausted all fallbacks it threw `Bridge exhausted: no stream for "..."`. The `isStreamExtractionError` check in `errorHandlers.ts` didn't match that message, so no YouTube retry was attempted and Discord showed the raw "Queue Error" embed.

## Fixes

### `playerFactory.ts` — extractor registration order
**Before:** `loadMulti(DefaultExtractors)` → SoundCloud, Spotify, Apple Music, Vimeo, Attachments → YouTube (async, last)

**After:** Spotify → YouTube → SoundCloud → Apple Music → Vimeo → Attachments

- `SpotifyExtractor` registered first with `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` so `spsearch:` queries resolve
- YouTube stays second with the resilient yt-dlp bridge
- Other extractors registered in sequence after YouTube

### `processor.ts` + `youtubeHandler.ts` — Spotify-first search
Text query flow (`/play some song name`):
1. Try `QueryType.SPOTIFY_SEARCH` — silently returns `success: false` on no results
2. Fall back to YouTube search if Spotify finds nothing

### `errorHandlers.ts` — Queue Error fix
Added `error.message.includes('Bridge exhausted')` to `isStreamExtractionError` so bridge exhaustion triggers the same YouTube retry + channel notification flow as other stream failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Music search now attempts Spotify lookups before falling back to YouTube, providing faster results for Spotify-indexed tracks.

* **Bug Fixes**
  * Improved stream extraction error detection to handle additional failure patterns, enabling better recovery and fallback behavior.

* **Tests**
  * Added comprehensive test coverage for Spotify and YouTube search handlers, plus music source initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->