### PR TITLE
fix: dedup same song across youtube title format variants

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -27,7 +27,12 @@ import {
 } from './autoplay/lastFmSeeds'
 import { detectSessionMood, type SessionMood } from './autoplay/sessionMood'
 import { getSimilarTracks, getTagTopTracks } from '../../lastfm'
-import { cleanSearchQuery, cleanTitle, cleanAuthor } from './searchQueryCleaner'
+import {
+    cleanSearchQuery,
+    cleanTitle,
+    cleanAuthor,
+    extractSongCore,
+} from './searchQueryCleaner'
 import type { QueueMetadata } from '../../types/QueueMetadata'
 
 const AUTOPLAY_BUFFER_SIZE = 8
@@ -54,27 +59,27 @@ async function getTrackAudioFeatures(
     userId: string,
 ): Promise<SpotifyAudioFeatures | null> {
     const cacheKey = normalizeTrackKey(track.title, track.author)
-    
+
     const cached = audioFeatureCache.get(cacheKey)
     if (cached !== undefined) {
         return cached
     }
-    
+
     const token = await spotifyLinkService.getValidAccessToken(userId)
     if (!token) {
         audioFeatureCache.set(cacheKey, null)
         return null
     }
-    
+
     let spotifyId: string | null = null
-    
+
     if (track.url && track.url.includes('open.spotify.com/track/')) {
         const match = track.url.match(/track\/([a-zA-Z0-9]+)/)
         if (match) {
             spotifyId = match[1]
         }
     }
-    
+
     if (!spotifyId) {
         spotifyId = await searchSpotifyTrack(
             token,
@@ -82,17 +87,16 @@ async function getTrackAudioFeatures(
             cleanAuthor(track.author ?? ''),
         )
     }
-    
+
     if (!spotifyId) {
         audioFeatureCache.set(cacheKey, null)
         return null
     }
-    
+
     const features = await getAudioFeatures(token, spotifyId).catch(() => null)
     audioFeatureCache.set(cacheKey, features)
     return features
 }
-
 
 type ScoredTrack = {
     track: Track
@@ -399,9 +403,10 @@ async function _replenishQueue(
             const beforeLastFm = candidates.size
             const metadata = queue.metadata as QueueMetadata | undefined
             const vcMemberIds = metadata?.vcMemberIds ?? []
-            const contributionWeights = vcMemberIds.length > 1
-                ? buildVcContributionWeights(allHistoryTracks, vcMemberIds)
-                : new Map<string, number>()
+            const contributionWeights =
+                vcMemberIds.length > 1
+                    ? buildVcContributionWeights(allHistoryTracks, vcMemberIds)
+                    : new Map<string, number>()
             await collectLastFmCandidates(
                 queue,
                 requestedBy,
@@ -517,9 +522,9 @@ async function _replenishQueue(
             (autoplayMode === 'discover' || autoplayMode === 'popular') &&
             requestedBy?.id
         ) {
-            const token = await Promise.resolve(spotifyLinkService
-                .getValidAccessToken(requestedBy.id))
-                .catch(() => null)
+            const token = await Promise.resolve(
+                spotifyLinkService.getValidAccessToken(requestedBy.id),
+            ).catch(() => null)
             if (token) {
                 await Promise.all(
                     enriched.slice(0, 3).map(async (track) => {
@@ -528,10 +533,7 @@ async function _replenishQueue(
                             track.track.author,
                         ).catch(() => null)
                         if (popularity === null) return
-                        if (
-                            autoplayMode === 'popular' &&
-                            popularity >= 70
-                        ) {
+                        if (autoplayMode === 'popular' && popularity >= 70) {
                             track.score += 0.12
                         } else if (
                             autoplayMode === 'discover' &&
@@ -548,7 +550,10 @@ async function _replenishQueue(
         if (enriched.length === 0) {
             warnLog({
                 message: 'Autoplay: no candidates selected — queue may stall',
-                data: { guildId: queue.guild.id, candidatePoolSize: candidates.size },
+                data: {
+                    guildId: queue.guild.id,
+                    candidatePoolSize: candidates.size,
+                },
             })
             replenishCounters.set(guildId, replenishCount + 1)
             return
@@ -662,6 +667,8 @@ function buildExcludedKeys(
     for (const t of allTracks) {
         keys.push(normalizeTrackKey(t.title, t.author))
         keys.push(normalizeTitleOnly(t.title))
+        const core = extractSongCore(t.title ?? '', t.author)
+        if (core) keys.push(normalizeText(core))
     }
     return new Set(keys)
 }
@@ -996,7 +1003,10 @@ async function collectLastFmCandidates(
             })
         }
 
-        const similar = await getSimilarTracks(seed.artist, cleanTitle(seed.title))
+        const similar = await getSimilarTracks(
+            seed.artist,
+            cleanTitle(seed.title),
+        )
         for (const s of similar.slice(0, MAX_SIMILAR_LOOKUPS)) {
             const query = cleanSearchQuery(s.title, s.artist)
             const tracks = await searchLastFmQuery(queue, query, requestedBy)
@@ -1096,8 +1106,7 @@ function addGenreTrackCandidate(
         return
     const key = normalizeTrackKey(track.title, track.author)
     const dislikedWeight = ctx.dislikedTrackKeys.get(key)
-    if (dislikedWeight !== undefined && dislikedWeight > 0.5)
-        return
+    if (dislikedWeight !== undefined && dislikedWeight > 0.5) return
     const rec = calculateRecommendationScore(
         track,
         ctx.currentTrack,
@@ -1139,7 +1148,6 @@ async function collectGenreCandidates(
     }
 }
 
-
 async function enrichWithAudioFeatures(
     tracks: ScoredTrack[],
     userId: string,
@@ -1147,7 +1155,9 @@ async function enrichWithAudioFeatures(
 ): Promise<ScoredTrack[]> {
     if (!currentFeatures || !userId) return tracks
 
-    const token = await Promise.resolve(spotifyLinkService.getValidAccessToken(userId)).catch(() => null)
+    const token = await Promise.resolve(
+        spotifyLinkService.getValidAccessToken(userId),
+    ).catch(() => null)
     if (!token) return tracks
 
     const spotifyIds: string[] = []
@@ -1439,7 +1449,9 @@ function isDuplicateCandidate(
     }
     if (excludedKeys.has(normalizeTrackKey(track.title, track.author)))
         return true
-    return excludedKeys.has(normalizeTitleOnly(track.title))
+    if (excludedKeys.has(normalizeTitleOnly(track.title))) return true
+    const core = extractSongCore(track.title ?? '', track.author)
+    return core !== null && excludedKeys.has(normalizeText(core))
 }
 
 function calculateRecommendationScore(

--- a/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
@@ -4,6 +4,7 @@ import {
     cleanAuthor,
     cleanSearchQuery,
     isSpamChannel,
+    extractSongCore,
 } from './searchQueryCleaner'
 
 describe('cleanTitle', () => {
@@ -114,6 +115,93 @@ describe('cleanSearchQuery', () => {
         expect(cleaned).not.toContain('[Download]')
         expect(cleaned).toContain('GOLDEN')
         expect(cleaned).toContain('HUNTR/X')
+    })
+})
+
+describe('cleanTitle — Brazilian noise', () => {
+    it('strips (Tradução) variants', () => {
+        expect(cleanTitle('Beyoncé - Halo (Tradução)')).toBe('Beyoncé - Halo')
+        expect(cleanTitle('Beyoncé - Halo (Tradução/Legendado)')).toBe(
+            'Beyoncé - Halo',
+        )
+        expect(cleanTitle('Beyoncé - Halo (Tradução PT-BR)')).toBe(
+            'Beyoncé - Halo',
+        )
+    })
+
+    it('strips standalone Legendado', () => {
+        expect(cleanTitle('Beyoncé - Halo Legendado')).toBe('Beyoncé - Halo')
+    })
+
+    it('strips (Clipe Oficial) variants', () => {
+        expect(cleanTitle('Beyoncé - Halo (Clipe Oficial)')).toBe(
+            'Beyoncé - Halo',
+        )
+        expect(cleanTitle('Beyoncé - Halo (Clipe Oficial HD)')).toBe(
+            'Beyoncé - Halo',
+        )
+    })
+
+    it('strips hashtags', () => {
+        expect(cleanTitle('Beyoncé - Halo #music #lyrics')).toBe(
+            'Beyoncé - Halo',
+        )
+    })
+
+    it('strips bare Lyrics word', () => {
+        expect(cleanTitle('Beyoncé - Halo Lyrics')).toBe('Beyoncé - Halo')
+    })
+
+    it('strips combined Brazilian noise', () => {
+        expect(
+            cleanTitle('Beyonce - Halo (Tradução)( legendado)(Clipe Oficial)'),
+        ).toBe('Beyonce - Halo')
+    })
+})
+
+describe('extractSongCore', () => {
+    it('extracts right side of Artist - Song', () => {
+        expect(extractSongCore('Beyoncé - Halo')).toBe('Halo')
+    })
+
+    it('extracts left side when author matches right side (inverted format)', () => {
+        expect(
+            extractSongCore('Halo - Beyoncé (Lyrics)', 'Beyoncé - Topic'),
+        ).toBe('Halo')
+    })
+
+    it('extracts right side when author matches left side', () => {
+        expect(
+            extractSongCore('Beyoncé - Halo (Tradução)', 'Beyoncé - Topic'),
+        ).toBe('Halo')
+    })
+
+    it('trims secondary separators from the extracted core', () => {
+        expect(
+            extractSongCore(
+                'Beyoncé - Halo - VERSÃO FORROZINHO',
+                'Beyoncé - Topic',
+            ),
+        ).toBe('Halo')
+    })
+
+    it('returns null when no separator is found', () => {
+        expect(extractSongCore('Bohemian Rhapsody')).toBeNull()
+    })
+
+    it('strips noise from title before extracting', () => {
+        expect(
+            extractSongCore(
+                'Beyoncé - Halo (Tradução/Legendado)',
+                'Beyoncé - Topic',
+            ),
+        ).toBe('Halo')
+    })
+
+    it('defaults to right side when author does not match either part', () => {
+        expect(extractSongCore('Beyoncé - Halo', 'someuploader123')).toBe(
+            'Halo',
+        )
     })
 })
 

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -99,6 +99,15 @@ const NOISE_PATTERNS: readonly RegExp[] = [
 
     // YouTube auto-generated "Topic" channel suffix
     /\s{0,3}-\s{0,3}topic\b/gi,
+
+    // Brazilian/Portuguese YouTube title noise
+    /#\S+/g,
+    /\(tradu[çc][aã]o[^)]*\)/gi,
+    /\[tradu[çc][aã]o[^\]]*\]/gi,
+    /\blegendado\b/gi,
+    /\(clipe\s+oficial[^)]*\)/gi,
+    /\[clipe\s+oficial[^\]]*\]/gi,
+    /\blyrics\b/gi,
 ]
 
 const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
@@ -198,6 +207,56 @@ export function cleanSearchQuery(title: string, author: string): string {
     if (!cleanedAuthor) return cleanedTitle
     if (!cleanedTitle) return cleanedAuthor
     return `${cleanedTitle} ${cleanedAuthor}`.trim()
+}
+
+/**
+ * Extract the song-title core from a YouTube-style "Artist - Song" title.
+ * Uses the author field to determine which side of the separator is the artist
+ * (handles both "Artist - Song" and inverted "Song - Artist" formats).
+ * Strips secondary separators from the core (e.g. "Halo - VERSÃO FORROZINHO" → "Halo").
+ * Returns null when no separator is found in the cleaned title.
+ */
+export function extractSongCore(title: string, author?: string): string | null {
+    const cleaned = cleanTitle(title)
+    for (const sep of [' - ', ' – ', ' — ']) {
+        const idx = cleaned.indexOf(sep)
+        if (idx < 2 || idx > 60) continue
+        const left = cleaned.slice(0, idx).trim()
+        if (/[()[\]]/.test(left)) continue
+        const right = cleaned.slice(idx + sep.length).trim()
+        if (left.length < 2 || right.length < 2) continue
+
+        let songPart: string
+        if (author) {
+            const norm = (s: string) =>
+                s.toLowerCase().replaceAll(/[^a-z0-9]+/g, '')
+            const authNorm = norm(cleanAuthor(author))
+            const overlaps = (a: string, b: string) =>
+                a.length >= 3 &&
+                b.length >= 3 &&
+                (a.includes(b.slice(0, 4)) || b.includes(a.slice(0, 4)))
+            if (overlaps(authNorm, norm(left))) {
+                songPart = right
+            } else if (overlaps(authNorm, norm(right))) {
+                songPart = left
+            } else {
+                songPart = right
+            }
+        } else {
+            songPart = right
+        }
+
+        for (const innerSep of [' - ', ' – ', ' — ']) {
+            const innerIdx = songPart.indexOf(innerSep)
+            if (innerIdx > 0) {
+                songPart = songPart.slice(0, innerIdx).trim()
+                break
+            }
+        }
+
+        return songPart.length >= 2 ? songPart : null
+    }
+    return null
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add Brazilian/Portuguese noise patterns to `NOISE_PATTERNS`: `(Tradução...)`, `Legendado`, `(Clipe Oficial)`, hashtags `#\S+`, bare `Lyrics`
- Export `extractSongCore(title, author?)` from `searchQueryCleaner.ts` — extracts the song portion from "Artist - Song" or inverted "Song - Artist" formats using the author field to disambiguate; trims secondary separators (e.g. "Halo - VERSÃO FORROZINHO" → "Halo")
- `buildExcludedKeys` and `isDuplicateCandidate` now include a third core-title key per track, so all variants of the same song dedup correctly

## Root cause

`normalizeTitleOnly("Beyoncé - Halo (Tradução/Legendado)")` produced `"beyonchalotraduolegendado"` which never matched history entry `normalizeTitleOnly("Beyoncé - Halo")` = `"beyonchalo"`. Nine variants of the same Beyoncé song were added to history within minutes.

## Production log evidence (before fix)

```
[04:20:20] Beyoncé - Halo
[04:21:15] Beyoncé - Halo (Tradução/Legendado)       ← not deduped
[04:21:15] Halo - Beyoncé (Lyrics)                   ← not deduped
[04:21:15] Beyoncé - Halo Lyrics #music #lyrics #lmc ← not deduped
[04:25:01] Beyonce - Halo (Tradução)( legendado)(Clipe Oficial) ← not deduped
[04:25:01] Beyoncé - Halo - VERSÃO FORROZINHO        ← not deduped
[04:25:04] Halo - Beyoncé - (Tradução) Legendado Lyrics ← not deduped
[04:25:04] Beyoncé - Halo (Tradução)                 ← not deduped
```

## Test plan

- [x] `searchQueryCleaner.spec.ts` — 13 new tests for Brazilian noise patterns and `extractSongCore` (62 total, all passing)
- [x] `queueManipulation.spec.ts` — 77 existing tests, all passing
- [x] Full bot suite — 2140 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music queue duplicate detection to more accurately identify duplicate songs using song core information, reducing false positives.

* **Improvements**
  * Enhanced title parsing to better handle Portuguese/Brazilian YouTube metadata, including translation indicators, official clip labels, hashtags, and lyric markers, resulting in cleaner song identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->