### PR TITLE
fix(bot): strip Brazilian version qualifiers from track titles for dedup

### DIFF
--- a/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
@@ -349,4 +349,40 @@ describe('cleanTitle — hyphenated version suffixes', () => {
     it('preserves normal title: "Song Name" → "Song Name"', () => {
         expect(cleanTitle('Song Name')).toBe('Song Name')
     })
+
+    it('strips " - Versão Forró" suffix', () => {
+        expect(cleanTitle('Halo - Versão Forró')).toBe('Halo')
+    })
+
+    it('strips " - Versão Acústica" suffix', () => {
+        expect(cleanTitle('Let Her Go - Versão Acústica')).toBe('Let Her Go')
+    })
+
+    it('strips "(Versão Forró)" parenthetical', () => {
+        expect(cleanTitle('Halo (Versão Forró)')).toBe('Halo')
+    })
+
+    it('strips " - Ao Vivo" suffix', () => {
+        expect(cleanTitle('Evidências - Ao Vivo')).toBe('Evidências')
+    })
+
+    it('strips " - Ao Vivo em São Paulo" long suffix', () => {
+        expect(cleanTitle('Garota de Ipanema - Ao Vivo em São Paulo')).toBe(
+            'Garota de Ipanema',
+        )
+    })
+
+    it('strips "(Ao Vivo)" parenthetical', () => {
+        expect(cleanTitle('Evidências (Ao Vivo)')).toBe('Evidências')
+    })
+
+    it('strips " - Forró" suffix', () => {
+        expect(cleanTitle('Shape of You - Forró')).toBe('Shape of You')
+    })
+
+    it('leaves artist-prefixed title unchanged when second suffix is not standalone', () => {
+        expect(cleanTitle('Beyoncé - Halo - Versão Forró')).toBe(
+            'Beyoncé - Halo - Versão Forró',
+        )
+    })
 })

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -108,6 +108,12 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     /\(clipe\s+oficial[^)]*\)/gi,
     /\[clipe\s+oficial[^\]]*\]/gi,
     /\blyrics\b/gi,
+
+    // Brazilian version qualifiers inside brackets
+    /\(vers[aã]o\s+[^)]+\)/gi,
+    /\[vers[aã]o\s+[^\]]+\]/gi,
+    /\(ao\s+vivo[^)]*\)/gi,
+    /\[ao\s+vivo[^\]]*\]/gi,
 ]
 
 const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
@@ -119,6 +125,10 @@ const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
     /^(?:deluxe|deluxe\s+(?:version|edition))$/i,
     /^(?:explicit|clean|explicit\s+version|clean\s+version)$/i,
     /^(?:19|20)\d{2}$/,
+    // Brazilian/Portuguese version descriptors after " - "
+    /^vers[aã]o/i,
+    /^ao\s+vivo/i,
+    /^forr[oó]/i,
 ]
 
 const VERSION_KEYWORD_RE =

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -110,10 +110,10 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     /\blyrics\b/gi,
 
     // Brazilian version qualifiers inside brackets
-    /\(vers[aã]o\s+[^)]+\)/gi,
-    /\[vers[aã]o\s+[^\]]+\]/gi,
-    /\(ao\s+vivo[^)]*\)/gi,
-    /\[ao\s+vivo[^\]]*\]/gi,
+    /\(vers[aã]o\s{0,3}[^)]*\)/gi,
+    /\[vers[aã]o\s{0,3}[^\]]*\]/gi,
+    /\(ao\s{0,3}vivo[^)]*\)/gi,
+    /\[ao\s{0,3}vivo[^\]]*\]/gi,
 ]
 
 const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [


### PR DESCRIPTION
## Problem

Autoplay was playing different versions of the same song — e.g. the original "Halo" followed by "Halo (Versão Forró)" or "Halo - Versão Forró". These have the same song core but the dedup system treated them as distinct tracks.

## Root Cause

`cleanTitle` didn't strip Brazilian/Portuguese version descriptors, so:
- `"Halo (Versão Forró)"` → normalized to `"haloversoforró"` (≠ `"halo"`)
- `"Halo - Versão Forró"` → normalized to `"haloversoforró"` (≠ `"halo"`)
- `"Evidências - Ao Vivo"` → normalized to `"evidenciasaovivo"` (≠ `"evidencias"`)

## Fix

Two additions to `searchQueryCleaner.ts`:

**NOISE_PATTERNS** — strip parenthetical forms:
- `(Versão Forró)`, `(Versão Acústica)`, `[Versão ...]`
- `(Ao Vivo)`, `[Ao Vivo]`

**HYPHENATED_VERSION_SUFFIXES** — strip hyphenated forms:
- `Song - Versão Forró` → `Song`
- `Song - Ao Vivo em São Paulo` → `Song`
- `Song - Forró` → `Song`

The `"Beyoncé - Halo - Versão Forró"` (artist-prefix) case was already handled by `extractSongCore`'s inner-sep trim — no change needed there.

## Tests

8 new `cleanTitle` tests covering each new pattern. All 2149 bot tests pass.

Builds on #583 (merged).