### PR TITLE
feat(bot): prioritize Spotify source in autoplay search and scoring

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -2899,7 +2899,7 @@ describe('queueManipulation — multi-user VC blend', () => {
 
         const addedTrack = queue.addTrack.mock.calls[0]?.[0] as Track
         expect(addedTrack?.metadata?.recommendationReason).toContain(
-            'spotify mood match',
+            'spotify preferred',
         )
     })
 
@@ -3234,5 +3234,87 @@ describe('queueManipulation — within-cycle dedup via extractSongCore', () => {
                 message: expect.stringContaining('fallback engine'),
             }),
         )
+    })
+})
+
+describe('queueManipulation — Spotify priority', () => {
+    beforeEach(() => {
+        likedTrackWeightsMock.mockResolvedValue(new Map())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
+        getPreferredArtistKeysMock.mockResolvedValue(new Set())
+        getBlockedArtistKeysMock.mockResolvedValue(new Set())
+        getImplicitDislikeKeysMock.mockResolvedValue(new Set())
+        getImplicitLikeKeysMock.mockResolvedValue(new Set())
+        consumeLastFmSeedSliceMock.mockResolvedValue([])
+        getSimilarTracksMock.mockResolvedValue([])
+        getTrackHistoryMock.mockResolvedValue([])
+        getTagTopTracksMock.mockResolvedValue([])
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
+    })
+
+    it('uses song-core query for Spotify engine when seed has artist-song format', async () => {
+        const searchMock = jest
+            .fn()
+            .mockResolvedValue({ tracks: [{ title: 'Shape of You', author: 'Ed Sheeran', url: 'https://open.spotify.com/track/abc', source: 'spotify', durationMS: 234000 }] })
+
+        const queue = createQueueMock({
+            currentTrack: {
+                title: 'Ed Sheeran - Shape of You',
+                author: 'Ed SheeranVEVO',
+                url: 'https://youtube.com/watch?v=seed001',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            metadata: { requestedBy: { id: 'user-1' } },
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            player: { search: searchMock },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const firstCallQuery: string = searchMock.mock.calls[0]?.[0] ?? ''
+        expect(firstCallQuery).not.toContain('Ed Sheeran - Shape of You Ed Sheeran')
+        expect(firstCallQuery).toContain('Shape of You')
+        expect(firstCallQuery).toContain('Ed Sheeran')
+    })
+
+    it('prefers Spotify candidate over YouTube candidate of the same song', async () => {
+        const addedTracks: unknown[] = []
+        const ytTrack = {
+            title: 'Halo',
+            author: 'Beyoncé',
+            url: 'https://youtube.com/watch?v=haloyt',
+            source: 'youtube',
+            durationMS: 241000,
+        }
+        const spotifyTrack = {
+            title: 'Halo',
+            author: 'Beyoncé',
+            url: 'https://open.spotify.com/track/halo001',
+            source: 'spotify',
+            durationMS: 241000,
+        }
+
+        const queue = createQueueMock({
+            currentTrack: {
+                title: 'Crazy In Love',
+                author: 'Beyoncé',
+                url: 'https://youtube.com/watch?v=seed001',
+                source: 'youtube',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            metadata: { requestedBy: { id: 'user-1' } },
+            tracks: { size: 7, toArray: jest.fn().mockReturnValue([]) },
+            addTrack: jest.fn((t: unknown) => addedTracks.push(t)),
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [ytTrack, spotifyTrack],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const selected = addedTracks[0] as { source?: string }
+        expect(selected?.source).toBe('spotify')
     })
 })

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -779,6 +779,15 @@ async function searchSeedCandidates(
     const modifier = QUERY_MODIFIERS[replenishCount % QUERY_MODIFIERS.length]
     const query = modifier ? `${baseQuery} ${modifier}` : baseQuery
 
+    // Build a cleaner query for Spotify by separating song from artist,
+    // avoiding duplicates like "Beyoncé - Halo Beyoncé" → "Halo Beyoncé".
+    const songCore = extractSongCore(seed.title, seed.author)
+    const cleanedAuthor = cleanAuthor(seed.author)
+    const spotifyBase = songCore
+        ? `${songCore} ${cleanedAuthor}`.trim()
+        : baseQuery
+    const spotifyQuery = modifier ? `${spotifyBase} ${modifier}` : spotifyBase
+
     const engines: QueryType[] = [
         QueryType.SPOTIFY_SEARCH,
         QueryType.YOUTUBE_SEARCH,
@@ -786,8 +795,10 @@ async function searchSeedCandidates(
     ]
 
     for (const [idx, engine] of engines.entries()) {
+        const engineQuery =
+            engine === QueryType.SPOTIFY_SEARCH ? spotifyQuery : query
         try {
-            const searchResult = await queue.player.search(query, {
+            const searchResult = await queue.player.search(engineQuery, {
                 requestedBy: requestedBy ?? undefined,
                 searchEngine: engine,
             })
@@ -805,7 +816,7 @@ async function searchSeedCandidates(
                     warnLog({
                         message:
                             'Autoplay: primary search returned no results, using fallback engine',
-                        data: { engine, query },
+                        data: { engine, query: engineQuery },
                     })
                 }
                 return tracks
@@ -813,7 +824,7 @@ async function searchSeedCandidates(
         } catch (error) {
             debugLog({
                 message: 'Search failed for seed, trying next engine',
-                data: { query, engine, error: String(error) },
+                data: { query: engineQuery, engine, error: String(error) },
             })
         }
     }
@@ -1556,9 +1567,12 @@ function calculateRecommendationScore(
         score += 0.15
         reasons.push('session novelty')
     }
-    if (candidate.source === currentTrack.source) {
+    if (
+        candidate.source === currentTrack.source &&
+        candidate.source !== 'spotify'
+    ) {
         score -= 0.25
-    } else if (candidate.source) {
+    } else if (candidate.source && candidate.source !== currentTrack.source) {
         reasons.push('source variety')
     }
     const tokenScore = sharedTitleTokenScore(
@@ -1613,9 +1627,9 @@ function calculateRecommendationScore(
         }
     }
 
-    if (candidate.source === 'spotify' && currentTrack.source === 'spotify') {
-        score += 0.08
-        reasons.push('spotify mood match')
+    if (candidate.source === 'spotify') {
+        score += 0.15
+        reasons.push('spotify preferred')
     }
 
     if (autoplayMode === 'discover') {


### PR DESCRIPTION
## Problem

Autoplay was falling back to YouTube silently because:
1. The Spotify search query contained duplicated artist names (e.g. `"Beyoncé - Halo Beyoncé"` for seed title `"Beyoncé - Halo"`) → Spotify returned 0 results → silent YouTube fallback
2. Spotify-sourced tracks had no score advantage over equivalent YouTube tracks — and were even penalized (-0.25) when the current track was also from Spotify

## Changes

### Better Spotify query (`searchSeedCandidates`)
Uses `extractSongCore + cleanAuthor` to build a clean query for the Spotify engine:
- `"Ed Sheeran - Shape of You"` → Spotify query: `"Shape of You Ed Sheeran"` (was: `"Ed Sheeran - Shape of You Ed Sheeran"`)
- `"Beyoncé - Halo"` (author: BeyoncéVEVO) → Spotify query: `"Halo Beyoncé"` (was: `"Beyoncé - Halo Beyoncé"`)
- YouTube/AUTO fallback engines still use the original query

### Spotify source preference in scoring (`calculateRecommendationScore`)
- **Removed** the same-source penalty (`-0.25`) when both current and candidate are Spotify — this was actively penalizing Spotify tracks
- **Replaced** the narrow `+0.08` "spotify mood match" (only when both tracks were Spotify) with a **general `+0.15` "spotify preferred"** boost for any Spotify candidate

Net effect: Spotify candidates now score +0.15 higher than equivalent YouTube candidates. When Spotify has the track, it wins.

## Tests

- New: Spotify engine receives clean song-core query for artist-prefixed seed titles
- New: Spotify candidate is selected over identical YouTube candidate
- Updated: existing "boosts candidates when both current and candidate are from spotify" test updated to reflect new reason label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Spotify search query construction and track prioritization behavior.

* **Improvements**
  * Enhanced Spotify search query handling for better track matching.
  * Updated recommendation scoring to prioritize Spotify sources in queue selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->