### PR TITLE
fix(autoplay): use clean title for spotify when author is in title

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -3317,4 +3317,37 @@ describe('queueManipulation — Spotify priority', () => {
         const selected = addedTracks[0] as { source?: string }
         expect(selected?.source).toBe('spotify')
     })
+
+    it('uses cleaned title directly when author already appears in the title', async () => {
+        const searchMock = jest.fn().mockResolvedValue({
+            tracks: [
+                {
+                    title: 'ao pressão',
+                    author: 'ANATOMIA',
+                    url: 'https://open.spotify.com/track/aopressao',
+                    source: 'spotify',
+                    durationMS: 210000,
+                },
+            ],
+        })
+
+        const queue = createQueueMock({
+            currentTrack: {
+                title: 'ANATOMIA - ao pressão (Visualizer)',
+                author: 'ANATOMIA',
+                url: 'https://youtube.com/watch?v=aopressao',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            metadata: { requestedBy: { id: 'user-1' } },
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            player: { search: searchMock },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const firstCallQuery: string = searchMock.mock.calls[0]?.[0] ?? ''
+        expect(firstCallQuery).not.toBe('ao pressão ANATOMIA')
+        expect(firstCallQuery).toContain('ANATOMIA')
+        expect(firstCallQuery).toContain('ao pressão')
+    })
 })

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -779,13 +779,24 @@ async function searchSeedCandidates(
     const modifier = QUERY_MODIFIERS[replenishCount % QUERY_MODIFIERS.length]
     const query = modifier ? `${baseQuery} ${modifier}` : baseQuery
 
-    // Build a cleaner query for Spotify by separating song from artist,
-    // avoiding duplicates like "Beyoncé - Halo Beyoncé" → "Halo Beyoncé".
-    const songCore = extractSongCore(seed.title, seed.author)
+    // Build a cleaner Spotify query. Three cases:
+    // 1. Author already appears in the cleaned title (e.g. "ANATOMIA - ao pressão",
+    //    author "ANATOMIA") → use cleanedTitle directly; Spotify handles "Artist - Song".
+    // 2. Author not in title but extractSongCore finds a separator → "Song Author".
+    // 3. Fallback → original baseQuery.
+    const cleanedTitle = cleanTitle(seed.title)
     const cleanedAuthor = cleanAuthor(seed.author)
-    const spotifyBase = songCore
-        ? `${songCore} ${cleanedAuthor}`.trim()
-        : baseQuery
+    const authorNorm = normalizeText(cleanedAuthor)
+    const titleNorm = normalizeText(cleanedTitle)
+    const authorInTitle =
+        authorNorm.length >= 3 &&
+        titleNorm.includes(authorNorm.slice(0, Math.min(5, authorNorm.length)))
+    const songCore = authorInTitle ? null : extractSongCore(seed.title, seed.author)
+    const spotifyBase = authorInTitle
+        ? cleanedTitle
+        : songCore
+          ? `${songCore} ${cleanedAuthor}`.trim()
+          : baseQuery
     const spotifyQuery = modifier ? `${spotifyBase} ${modifier}` : spotifyBase
 
     const engines: QueryType[] = [


### PR DESCRIPTION
## Problem

When a YouTube channel name equals the artist name (e.g. title `"ANATOMIA - ao pressão (Visualizer)"`, author `"ANATOMIA"`), `extractSongCore` correctly identifies the song side but then the query was reassembled as `"ao pressão ANATOMIA"` — flipped. Spotify couldn't find it and fell back to YouTube, continuing to play the same YouTube variant.

## Fix

In `searchSeedCandidates`, before calling `extractSongCore`, detect if the cleaned author already appears in the cleaned title. Three cases:

1. **Author in title** (e.g. `"ANATOMIA - ao pressão"` by `"ANATOMIA"`) → pass `cleanedTitle` directly. Spotify natively parses `"Artist - Song"` format.
2. **Author not in title, separator found** → `"${songCore} ${cleanedAuthor}"` (existing behavior, e.g. `"Shape of You Ed Sheeran"`).
3. **Fallback** → original `baseQuery`.

## Tests

- New test: seed `"ANATOMIA - ao pressão (Visualizer)"` by author `"ANATOMIA"` → Spotify query is NOT `"ao pressão ANATOMIA"` and still contains both artist and song.
- All 82 existing `queueManipulation.spec.ts` tests pass.

## Checklist
- [x] Lint clean
- [x] 82/82 tests passing
- [x] No new TS errors introduced