### PR TITLE
fix(autoplay): use title artist for spotify when author is cover channel

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -3383,4 +3383,71 @@ describe('queueManipulation — Spotify priority', () => {
         expect(firstCallQuery).not.toContain('Carlo Gatto')
         expect(firstCallQuery).toContain('Eu sei que é você')
     })
+
+    it('falls back to cleanedAuthor when title has no separator', async () => {
+        const searchMock = jest.fn().mockResolvedValue({
+            tracks: [
+                {
+                    title: 'Blinding Lights',
+                    author: 'The Weeknd',
+                    url: 'https://open.spotify.com/track/blight01',
+                    source: 'spotify',
+                    durationMS: 200000,
+                },
+            ],
+        })
+
+        const queue = createQueueMock({
+            currentTrack: {
+                title: 'Blinding Lights',
+                author: 'The Weeknd',
+                url: 'https://youtube.com/watch?v=blindinglight',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            metadata: { requestedBy: { id: 'user-1' } },
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            player: { search: searchMock },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const firstCallQuery: string = searchMock.mock.calls[0]?.[0] ?? ''
+        expect(firstCallQuery).toContain('The Weeknd')
+    })
+
+    it('uses right side as artist when song core is on the left of the separator', async () => {
+        const searchMock = jest.fn().mockResolvedValue({
+            tracks: [
+                {
+                    title: 'Halo',
+                    author: 'Beyoncé',
+                    url: 'https://open.spotify.com/track/halo002',
+                    source: 'spotify',
+                    durationMS: 241000,
+                },
+            ],
+        })
+
+        // Author "BeyoBeyoFan" overlaps with "Beyoncé" via the 4-char prefix "beyo",
+        // so extractSongCore returns "Halo" (left). extractTitleArtistFromSong then
+        // detects that the core is on the left and returns the right side "Beyoncé".
+        const queue = createQueueMock({
+            currentTrack: {
+                title: 'Halo - Beyoncé',
+                author: 'BeyoBeyoFan',
+                url: 'https://youtube.com/watch?v=halobeyonce',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            metadata: { requestedBy: { id: 'user-1' } },
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            player: { search: searchMock },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const firstCallQuery: string = searchMock.mock.calls[0]?.[0] ?? ''
+        expect(firstCallQuery).not.toContain('BeyoBeyoFan')
+        expect(firstCallQuery).toContain('Beyoncé')
+        expect(firstCallQuery).toContain('Halo')
+    })
 })

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -3350,4 +3350,37 @@ describe('queueManipulation — Spotify priority', () => {
         expect(firstCallQuery).toContain('ANATOMIA')
         expect(firstCallQuery).toContain('ao pressão')
     })
+
+    it('uses title artist (not cover channel author) in spotify query', async () => {
+        const searchMock = jest.fn().mockResolvedValue({
+            tracks: [
+                {
+                    title: 'Eu sei que é você',
+                    author: 'ANATOMIA',
+                    url: 'https://open.spotify.com/track/eusei001',
+                    source: 'spotify',
+                    durationMS: 195000,
+                },
+            ],
+        })
+
+        const queue = createQueueMock({
+            currentTrack: {
+                title: 'ANATOMIA - Eu sei que é você (Acústico ao vivo)',
+                author: 'Carlo Gatto',
+                url: 'https://youtube.com/watch?v=carlogatto01',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            metadata: { requestedBy: { id: 'user-1' } },
+            tracks: { size: 0, toArray: jest.fn().mockReturnValue([]) },
+            player: { search: searchMock },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const firstCallQuery: string = searchMock.mock.calls[0]?.[0] ?? ''
+        expect(firstCallQuery).toContain('ANATOMIA')
+        expect(firstCallQuery).not.toContain('Carlo Gatto')
+        expect(firstCallQuery).toContain('Eu sei que é você')
+    })
 })

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -769,6 +769,26 @@ async function collectRecommendationCandidates(
 const MAX_AUTOPLAY_DURATION_MS = 10 * 60 * 1000
 const QUERY_MODIFIERS = ['', 'similar', 'like', 'playlist', 'mix']
 
+function extractTitleArtistFromSong(
+    cleanedTitle: string,
+    songCore: string,
+): string | null {
+    const normCore = normalizeText(songCore)
+    const corePrefix = normCore.slice(0, Math.min(6, normCore.length))
+    for (const sep of [' - ', ' – ', ' — ']) {
+        const idx = cleanedTitle.indexOf(sep)
+        if (idx < 2 || idx > 60) continue
+        const left = cleanedTitle.slice(0, idx).trim()
+        if (/[()[\]]/.test(left) || left.length < 2) continue
+        const right = cleanedTitle.slice(idx + sep.length).trim()
+        if (corePrefix.length < 3) return left
+        if (normalizeText(right).startsWith(corePrefix)) return left
+        if (normalizeText(left).startsWith(corePrefix)) return right
+        return left
+    }
+    return null
+}
+
 async function searchSeedCandidates(
     queue: GuildQueue,
     seed: Track,
@@ -779,24 +799,27 @@ async function searchSeedCandidates(
     const modifier = QUERY_MODIFIERS[replenishCount % QUERY_MODIFIERS.length]
     const query = modifier ? `${baseQuery} ${modifier}` : baseQuery
 
-    // Build a cleaner Spotify query. Three cases:
-    // 1. Author already appears in the cleaned title (e.g. "ANATOMIA - ao pressão",
-    //    author "ANATOMIA") → use cleanedTitle directly; Spotify handles "Artist - Song".
-    // 2. Author not in title but extractSongCore finds a separator → "Song Author".
-    // 3. Fallback → original baseQuery.
     const cleanedTitle = cleanTitle(seed.title)
     const cleanedAuthor = cleanAuthor(seed.author)
     const authorNorm = normalizeText(cleanedAuthor)
-    const titleNorm = normalizeText(cleanedTitle)
     const authorInTitle =
         authorNorm.length >= 3 &&
-        titleNorm.includes(authorNorm.slice(0, Math.min(5, authorNorm.length)))
-    const songCore = authorInTitle ? null : extractSongCore(seed.title, seed.author)
-    const spotifyBase = authorInTitle
-        ? cleanedTitle
-        : songCore
-          ? `${songCore} ${cleanedAuthor}`.trim()
-          : baseQuery
+        normalizeText(cleanedTitle).includes(
+            authorNorm.slice(0, Math.min(5, authorNorm.length)),
+        )
+
+    let spotifyBase: string
+    if (authorInTitle) {
+        spotifyBase = cleanedTitle
+    } else {
+        const songCore = extractSongCore(seed.title, seed.author)
+        if (songCore) {
+            const titleArtist = extractTitleArtistFromSong(cleanedTitle, songCore)
+            spotifyBase = `${songCore} ${titleArtist ?? cleanedAuthor}`.trim()
+        } else {
+            spotifyBase = baseQuery
+        }
+    }
     const spotifyQuery = modifier ? `${spotifyBase} ${modifier}` : spotifyBase
 
     const engines: QueryType[] = [

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -781,9 +781,9 @@ function extractTitleArtistFromSong(
         const left = cleanedTitle.slice(0, idx).trim()
         if (/[()[\]]/.test(left) || left.length < 2) continue
         const right = cleanedTitle.slice(idx + sep.length).trim()
-        if (corePrefix.length < 3) return left
-        if (normalizeText(right).startsWith(corePrefix)) return left
-        if (normalizeText(left).startsWith(corePrefix)) return right
+        if (corePrefix.length >= 3 && normalizeText(left).startsWith(corePrefix)) {
+            return right
+        }
         return left
     }
     return null

--- a/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
@@ -386,3 +386,27 @@ describe('cleanTitle — hyphenated version suffixes', () => {
         )
     })
 })
+
+describe('cleanTitle — Acústico variants', () => {
+    it('strips "(Acústico ao vivo)" parenthetical', () => {
+        expect(cleanTitle('ANATOMIA - Eu sei que é você (Acústico ao vivo)')).toBe(
+            'ANATOMIA - Eu sei que é você',
+        )
+    })
+
+    it('strips "(Acústico)" parenthetical', () => {
+        expect(cleanTitle('Song Title (Acústico)')).toBe('Song Title')
+    })
+
+    it('strips "[Acústico]" bracketed', () => {
+        expect(cleanTitle('Song Title [Acústico]')).toBe('Song Title')
+    })
+
+    it('strips "- Acústico" when it is the direct suffix of a single-separator title', () => {
+        expect(cleanTitle('Música - Acústico')).toBe('Música')
+    })
+
+    it('strips "- Acústico ao vivo" when it is the direct suffix', () => {
+        expect(cleanTitle('Música - Acústico ao vivo')).toBe('Música')
+    })
+})

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -114,6 +114,8 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     /\[vers[aã]o\s{0,3}[^\]]*\]/gi,
     /\(ao\s{0,3}vivo[^)]*\)/gi,
     /\[ao\s{0,3}vivo[^\]]*\]/gi,
+    /\(ac[uú]stico[^)]*\)/gi,
+    /\[ac[uú]stico[^\]]*\]/gi,
 ]
 
 const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
@@ -129,6 +131,7 @@ const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
     /^vers[aã]o/i,
     /^ao\s+vivo/i,
     /^forr[oó]/i,
+    /^ac[uú]stico/i,
 ]
 
 const VERSION_KEYWORD_RE =


### PR DESCRIPTION
## Problem

When a song is uploaded by a cover channel (e.g. title `"ANATOMIA - Eu sei que é você (Acústico ao vivo)"` by author `"Carlo Gatto"`), the Spotify query was assembled as `"Eu sei que é você (Acústico ao vivo) Carlo Gatto"`. Spotify can't find this because:
1. "Carlo Gatto" is a YouTube cover channel, not the song's artist
2. "(Acústico ao vivo)" is a version qualifier Spotify doesn't use in search

This caused Spotify search to fail → fell back to YouTube → bot kept queuing YouTube cover versions of the same song.

## Fixes

### 1. Title artist extraction (`extractTitleArtistFromSong`)
New helper that identifies the real artist from the title's separator structure. When the YouTube author doesn't match either side of the ` - ` separator, the LEFT side is treated as the real artist (e.g. `"ANATOMIA"`), not the channel name.

- `"ANATOMIA - Eu sei que é você"` by `"Carlo Gatto"` → Spotify query: `"Eu sei que é você ANATOMIA"` ✓
- `"Ed Sheeran - Shape of You"` by `"Ed SheeranVEVO"` → author matches title → use `cleanedTitle` directly ✓
- `"Shape of You"` by `"Ed Sheeran"` → no separator → fallback to `baseQuery` ✓

### 2. Strip `(Acústico...)` variants from noise patterns
Added `(Acústico ao vivo)`, `(Acústico)`, `[Acústico]` to NOISE_PATTERNS and `- Acústico` to HYPHENATED_VERSION_SUFFIXES. This means:
- `"ANATOMIA - Eu sei que é você (Acústico ao vivo)"` → coreKey `"eu sei que e voce"` — same as the plain version → **dedup catches it**

## Tests
- 5 new `cleanTitle — Acústico variants` tests
- 1 new Spotify priority test: cover channel author NOT included in Spotify query
- 158/158 passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spotify search accuracy by prioritizing original artist information over cover uploader metadata when constructing queries.
  * Enhanced query filtering by removing Portuguese and Spanish acoustic/live version indicators (e.g., "Acústico," "ao vivo") in various formats.

* **Tests**
  * Added coverage for artist-based query construction.
  * Added coverage for acoustic version suffix removal across multiple format variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->