### PR TITLE
fix(autoplay): penalise version variants, count seed artist, interleave queue

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -3351,3 +3351,99 @@ describe('queueManipulation — Spotify priority', () => {
         expect(firstCallQuery).toContain('ao pressão')
     })
 })
+
+describe('queueManipulation — diversity improvements', () => {
+    beforeEach(() => {
+        likedTrackWeightsMock.mockResolvedValue(new Map())
+        dislikedTrackWeightsMock.mockResolvedValue(new Map())
+        getPreferredArtistKeysMock.mockResolvedValue(new Set())
+        getBlockedArtistKeysMock.mockResolvedValue(new Set())
+        getImplicitDislikeKeysMock.mockResolvedValue(new Set())
+        getImplicitLikeKeysMock.mockResolvedValue(new Set())
+        consumeLastFmSeedSliceMock.mockResolvedValue([])
+        getSimilarTracksMock.mockResolvedValue([])
+        getTrackHistoryMock.mockResolvedValue([])
+        getTagTopTracksMock.mockResolvedValue([])
+        getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
+    })
+
+    it('penalises acoustic/live candidates so studio versions score higher', async () => {
+        const addedTracks: unknown[] = []
+        const studioTrack = {
+            title: 'Eu sei que é você',
+            author: 'ANATOMIA',
+            url: 'https://open.spotify.com/track/studio001',
+            source: 'spotify',
+            durationMS: 210000,
+        }
+        const acousticTrack = {
+            title: 'Eu sei que é você (Acoustic)',
+            author: 'ANATOMIA',
+            url: 'https://open.spotify.com/track/acoustic001',
+            source: 'spotify',
+            durationMS: 210000,
+        }
+
+        const queue = createQueueMock({
+            currentTrack: {
+                title: 'Outra Música',
+                author: 'Other Artist',
+                url: 'https://youtube.com/watch?v=seed002',
+                source: 'youtube',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            metadata: { requestedBy: { id: 'user-1' } },
+            tracks: { size: 7, toArray: jest.fn().mockReturnValue([]) },
+            addTrack: jest.fn((t: unknown) => addedTracks.push(t)),
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [acousticTrack, studioTrack],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const firstAdded = addedTracks[0] as { title?: string }
+        expect(firstAdded?.title).toBe('Eu sei que é você')
+    })
+
+    it('limits current-track artist to 1 more track when currentTrack counts as first', async () => {
+        const addedTracks: unknown[] = []
+        const makeTrack = (id: string, artist: string) => ({
+            title: `Song ${id}`,
+            author: artist,
+            url: `https://open.spotify.com/track/${id}`,
+            source: 'spotify',
+            durationMS: 210000,
+        })
+
+        const queue = createQueueMock({
+            currentTrack: {
+                title: 'First Song',
+                author: 'ANATOMIA',
+                url: 'https://youtube.com/watch?v=first',
+                source: 'youtube',
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            metadata: { requestedBy: { id: 'user-1' } },
+            tracks: { size: 7, toArray: jest.fn().mockReturnValue([]) },
+            addTrack: jest.fn((t: unknown) => addedTracks.push(t)),
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        makeTrack('a1', 'ANATOMIA'),
+                        makeTrack('a2', 'ANATOMIA'),
+                        makeTrack('b1', 'Other Artist'),
+                    ],
+                }),
+            },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        const artistsAdded = addedTracks.map((t) => (t as { author: string }).author)
+        const anatomiaCount = artistsAdded.filter((a) => a === 'ANATOMIA').length
+        expect(anatomiaCount).toBeLessThanOrEqual(1)
+    })
+})

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -506,7 +506,10 @@ async function _replenishQueue(
             },
         })
 
-        const selected = selectDiverseCandidates(candidates, missingTracks)
+        const seedArtistKey = currentTrack.author.toLowerCase()
+        const selected = interleaveByArtist(
+            selectDiverseCandidates(candidates, missingTracks, MAX_TRACKS_PER_ARTIST, MAX_TRACKS_PER_SOURCE, seedArtistKey),
+        )
 
         const currentAudioFeatures = await getTrackAudioFeatures(
             currentTrack,
@@ -1229,11 +1232,36 @@ async function enrichWithAudioFeatures(
     return tracks.sort((a, b) => b.score - a.score)
 }
 
+function interleaveByArtist(tracks: ScoredTrack[]): ScoredTrack[] {
+    const groups = new Map<string, ScoredTrack[]>()
+    for (const t of tracks) {
+        const key = cleanAuthor(t.track.author).toLowerCase()
+        const group = groups.get(key) ?? []
+        group.push(t)
+        groups.set(key, group)
+    }
+    const result: ScoredTrack[] = []
+    let added = true
+    let round = 0
+    while (added) {
+        added = false
+        for (const group of groups.values()) {
+            if (round < group.length) {
+                result.push(group[round]!)
+                added = true
+            }
+        }
+        round++
+    }
+    return result
+}
+
 function selectDiverseCandidates(
     candidates: Map<string, ScoredTrack>,
     missingTracks: number,
     maxPerArtist = MAX_TRACKS_PER_ARTIST,
     maxPerSource = MAX_TRACKS_PER_SOURCE,
+    seedArtistKey = '',
 ): ScoredTrack[] {
     const jitteredCandidates = Array.from(candidates.values()).map((c) => ({
         ...c,
@@ -1244,7 +1272,9 @@ function selectDiverseCandidates(
         (a, b) => b.jitteredScore - a.jitteredScore,
     )
     const selected: ScoredTrack[] = []
-    const artistCount = new Map<string, number>()
+    const artistCount = new Map<string, number>(
+        seedArtistKey ? [[seedArtistKey, 1]] : [],
+    )
     const sourceCount = new Map<string, number>()
     const selectedTitleKeys = new Set<string>()
 
@@ -1641,6 +1671,15 @@ function calculateRecommendationScore(
     if (candidate.source === 'spotify') {
         score += 0.15
         reasons.push('spotify preferred')
+    }
+
+    if (
+        /\b(?:acoustic|live|ao\s{0,3}vivo|ac[uú]stico|cover|karaoke|instrumental)\b/i.test(
+            candidate.title ?? '',
+        )
+    ) {
+        score -= 0.2
+        reasons.push('version variant')
     }
 
     if (autoplayMode === 'discover') {


### PR DESCRIPTION
## Problems addressed

### 1. Acoustic/live versions preferred over studio recordings
The bot was queuing acoustic, live, cover and ao-vivo versions of songs instead of studio recordings because they were getting the same score as originals.

**Fix:** `-0.2` penalty for candidates whose title contains `acoustic`, `live`, `ao vivo`, `acústico`, `cover`, `karaoke`, or `instrumental`. Studio versions now consistently outscore versions.

### 2. Same artist appearing 3+ times (currentTrack not counted)
`selectDiverseCandidates` limited to `MAX_TRACKS_PER_ARTIST = 2` but only counted candidates selected **in this call** — not the currently playing track. So: 1 playing + 2 selected = 3 from the same artist.

**Fix:** Pre-seed `artistCount` with `currentTrack.author.toLowerCase()` so the currently playing track counts as the first slot. Now at most 1 more track from the same artist is added.

### 3. Same artist grouped together in queue
Even with the per-artist limit, all same-artist tracks appeared consecutively. The user sees ANATOMIA, ANATOMIA, OTHER, OTHER... instead of ANATOMIA, OTHER, ANATOMIA, OTHER...

**Fix:** `interleaveByArtist()` reorders selected tracks in a round-robin fashion by artist before adding to queue.

## Tests
- New test: acoustic candidate loses to studio recording of same song
- New test: currentTrack artist counts toward MAX_TRACKS_PER_ARTIST limit
- 84/84 passing
