### PR TITLE
fix(play): log Spotify errors, add fallback chain to executePlayAtTop, fix Last.fm artist parsing

### DIFF
--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -159,10 +159,6 @@ export default new Command({
                     playOptions,
                 )
             } catch (primaryError) {
-                // Primary search failed — fall back through YouTube then AUTO.
-                // Always fall back regardless of which provider was requested;
-                // surfacing a hard error is worse than playing the song from a
-                // different source. We log the fallback so it shows up in traces.
                 if (searchEngine !== QueryType.AUTO) {
                     warnLog({
                         message:
@@ -171,6 +167,7 @@ export default new Command({
                             query,
                             requestedProvider: provider ?? 'default',
                             searchEngine: String(searchEngine),
+                            error: String(primaryError),
                         },
                     })
                     try {

--- a/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
@@ -1,4 +1,16 @@
-import { describe, expect, it, jest } from '@jest/globals'
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+const requireVoiceChannelMock = jest.fn()
+const requireDJRoleMock = jest.fn()
+const resolveGuildQueueMock = jest.fn()
+const buildPlayResponseEmbedMock = jest.fn()
+const createMusicControlButtonsMock = jest.fn()
+const interactionReplyMock = jest.fn()
+const createErrorEmbedMock = jest.fn()
+const createUserFriendlyErrorMock = jest.fn()
+const warnLogMock = jest.fn()
+const errorLogMock = jest.fn()
+const debugLogMock = jest.fn()
 
 jest.mock('discord-player', () => ({
     QueryType: {
@@ -10,20 +22,39 @@ jest.mock('discord-player', () => ({
     },
 }))
 jest.mock('discord.js', () => ({}))
-jest.mock('../../../../utils/command/commandValidations', () => ({}))
-jest.mock('../../../../utils/music/queueResolver', () => ({}))
-jest.mock('../../../../utils/music/nowPlayingEmbed', () => ({}))
-jest.mock('../../../../utils/music/buttonComponents', () => ({}))
-jest.mock('../../../../utils/general/embeds', () => ({}))
-jest.mock('../../../../utils/general/interactionReply', () => ({}))
-jest.mock('../../../../utils/general/errorSanitizer', () => ({}))
+jest.mock('../../../../utils/command/commandValidations', () => ({
+    requireVoiceChannel: (...args: unknown[]) =>
+        requireVoiceChannelMock(...args),
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args),
+}))
+jest.mock('../../../../utils/music/queueResolver', () => ({
+    resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
+}))
+jest.mock('../../../../utils/music/nowPlayingEmbed', () => ({
+    buildPlayResponseEmbed: (...args: unknown[]) =>
+        buildPlayResponseEmbedMock(...args),
+}))
+jest.mock('../../../../utils/music/buttonComponents', () => ({
+    createMusicControlButtons: (...args: unknown[]) =>
+        createMusicControlButtonsMock(...args),
+}))
+jest.mock('../../../../utils/general/embeds', () => ({
+    createErrorEmbed: (...args: unknown[]) => createErrorEmbedMock(...args),
+}))
+jest.mock('../../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+jest.mock('../../../../utils/general/errorSanitizer', () => ({
+    createUserFriendlyError: (...args: unknown[]) =>
+        createUserFriendlyErrorMock(...args),
+}))
 jest.mock('@lucky/shared/utils', () => ({
-    errorLog: jest.fn(),
-    debugLog: jest.fn(),
-    warnLog: jest.fn(),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+    debugLog: (...args: unknown[]) => debugLogMock(...args),
+    warnLog: (...args: unknown[]) => warnLogMock(...args),
 }))
 
-import { normalizeSoundCloudUrl, isUrl } from './queryUtils'
+import { normalizeSoundCloudUrl, isUrl, executePlayAtTop } from './queryUtils'
 
 describe('normalizeSoundCloudUrl', () => {
     it('strips ?in= playlist context from SoundCloud track URLs', () => {
@@ -80,5 +111,98 @@ describe('isUrl', () => {
 
     it('returns false for plain text', () => {
         expect(isUrl('some song title')).toBe(false)
+    })
+})
+
+describe('executePlayAtTop — fallback chain', () => {
+    const fakeTrack = { id: 'track-1', title: 'Test Song', author: 'Artist' }
+    const fakeQueue = {
+        tracks: { toArray: () => [fakeTrack] },
+        node: { remove: jest.fn(), skip: jest.fn() },
+        insertTrack: jest.fn(),
+    }
+
+    function makeInteraction(query = 'test song') {
+        return {
+            guildId: 'guild-1',
+            user: { id: 'user-1' },
+            member: { voice: { channel: { id: 'vc-1' } } },
+            options: { getString: jest.fn(() => query) },
+            deferReply: jest.fn(),
+            reply: jest.fn(),
+        } as unknown as Parameters<typeof executePlayAtTop>[0]['interaction']
+    }
+
+    function makeClient(
+        playImpl: (...args: unknown[]) => unknown,
+    ): Parameters<typeof executePlayAtTop>[0]['client'] {
+        return { player: { play: jest.fn(playImpl) } } as unknown as Parameters<
+            typeof executePlayAtTop
+        >[0]['client']
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        requireVoiceChannelMock.mockResolvedValue(true)
+        requireDJRoleMock.mockResolvedValue(true)
+        resolveGuildQueueMock.mockReturnValue({ queue: fakeQueue })
+        buildPlayResponseEmbedMock.mockReturnValue({ title: 'Now Playing' })
+        createMusicControlButtonsMock.mockReturnValue([])
+        interactionReplyMock.mockResolvedValue(undefined)
+        createUserFriendlyErrorMock.mockReturnValue('friendly error')
+        createErrorEmbedMock.mockReturnValue({ title: 'error' })
+    })
+
+    it('falls back to YouTube when Spotify search throws', async () => {
+        const successResult = { track: fakeTrack }
+        const client = makeClient((_, __, opts: unknown) => {
+            const o = opts as { searchEngine: string }
+            if (o.searchEngine === 'spotifySearch') {
+                return Promise.reject(new Error('Spotify unavailable'))
+            }
+            return Promise.resolve(successResult)
+        })
+
+        await executePlayAtTop({
+            client,
+            interaction: makeInteraction(),
+            skipCurrent: false,
+            commandName: 'playtop',
+        })
+
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Primary search failed, falling back to YouTube',
+            }),
+        )
+        expect(interactionReplyMock).toHaveBeenCalled()
+    })
+
+    it('falls back to SoundCloud when both Spotify and YouTube throw', async () => {
+        const successResult = { track: fakeTrack }
+        const client = makeClient((_, __, opts: unknown) => {
+            const o = opts as { searchEngine: string }
+            if (
+                o.searchEngine === 'spotifySearch' ||
+                o.searchEngine === 'youtubeSearch'
+            ) {
+                return Promise.reject(new Error('unavailable'))
+            }
+            return Promise.resolve(successResult)
+        })
+
+        await executePlayAtTop({
+            client,
+            interaction: makeInteraction(),
+            skipCurrent: false,
+            commandName: 'playtop',
+        })
+
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'YouTube search failed, falling back to SoundCloud',
+            }),
+        )
+        expect(interactionReplyMock).toHaveBeenCalled()
     })
 })

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -106,9 +106,39 @@ export async function executePlayAtTop({
 
     try {
         const searchEngine = resolveSearchEngine(query)
-        const result = await client.player.play(voiceChannel, query, {
-            searchEngine,
-        })
+        let result
+        try {
+            result = await client.player.play(voiceChannel, query, {
+                searchEngine,
+            })
+        } catch (primaryError) {
+            if (searchEngine !== QueryType.AUTO) {
+                warnLog({
+                    message: 'Primary search failed, falling back to YouTube',
+                    data: {
+                        query,
+                        searchEngine: String(searchEngine),
+                        error: String(primaryError),
+                    },
+                })
+                try {
+                    result = await client.player.play(voiceChannel, query, {
+                        searchEngine: QueryType.YOUTUBE_SEARCH,
+                    })
+                } catch (youtubeError) {
+                    warnLog({
+                        message:
+                            'YouTube search failed, falling back to SoundCloud',
+                        data: { query, error: String(youtubeError) },
+                    })
+                    result = await client.player.play(voiceChannel, query, {
+                        searchEngine: QueryType.SOUNDCLOUD_SEARCH,
+                    })
+                }
+            } else {
+                throw primaryError
+            }
+        }
         const track = result.track
 
         const { queue } = resolveGuildQueue(client, interaction.guildId)

--- a/packages/bot/src/lastfm/lastFmApi.spec.ts
+++ b/packages/bot/src/lastfm/lastFmApi.spec.ts
@@ -280,6 +280,31 @@ describe('lastFmApi', () => {
             expect(tracks[1].artist).toBe('Artist B')
         })
 
+        it('handles artist as #text object (actual Last.fm API format)', async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    recenttracks: {
+                        track: [
+                            {
+                                name: 'Song A',
+                                artist: { '#text': 'Oasis', mbid: '' },
+                            },
+                            {
+                                name: 'Song B',
+                                artist: { '#text': 'Blur', mbid: '123' },
+                            },
+                        ],
+                    },
+                }),
+            })
+
+            const tracks = await getRecentTracks('username')
+
+            expect(tracks[0].artist).toBe('Oasis')
+            expect(tracks[1].artist).toBe('Blur')
+        })
+
         it('uses default limit when not specified', async () => {
             fetchMock.mockResolvedValueOnce({
                 ok: true,
@@ -534,6 +559,26 @@ describe('lastFmApi', () => {
             fetchMock.mockRejectedValueOnce(new Error('network'))
             const result = await getLovedTracks('testuser')
             expect(result).toEqual([])
+        })
+
+        it('handles artist as #text object (actual Last.fm API format)', async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    lovedtracks: {
+                        track: [
+                            {
+                                name: 'Wonderwall',
+                                artist: { '#text': 'Oasis', mbid: '' },
+                            },
+                        ],
+                    },
+                }),
+            })
+
+            const result = await getLovedTracks('testuser')
+
+            expect(result).toEqual([{ artist: 'Oasis', title: 'Wonderwall' }])
         })
     })
 })

--- a/packages/bot/src/lastfm/lastFmApi.ts
+++ b/packages/bot/src/lastfm/lastFmApi.ts
@@ -215,7 +215,12 @@ export async function getRecentTracks(
         return (data.recenttracks?.track ?? [])
             .filter((t) => !t['@attr']?.nowplaying)
             .map((t) => ({
-                artist: typeof t.artist === 'string' ? t.artist : t.artist.name,
+                artist:
+                    typeof t.artist === 'string'
+                        ? t.artist
+                        : ((t.artist as Record<string, string>)['#text'] ??
+                          t.artist.name ??
+                          ''),
                 title: t.name,
             }))
     } catch {
@@ -299,7 +304,10 @@ export async function getLovedTracks(
             }
         }
         return (data.lovedtracks?.track ?? []).map((t) => ({
-            artist: t.artist.name,
+            artist:
+                (t.artist as Record<string, string>)['#text'] ??
+                t.artist.name ??
+                '',
             title: t.name,
         }))
     } catch {

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeds.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeds.spec.ts
@@ -144,6 +144,24 @@ describe('getLastFmSeedTracks', () => {
             { artist: 'Artist B', title: 'Song B' },
         ])
     })
+
+    it('filters out tracks with undefined artist or title', async () => {
+        getByDiscordIdMock.mockResolvedValue({ lastFmUsername: 'user123' })
+        getTopTracksMock.mockResolvedValue([
+            { artist: 'Artist A', title: 'Good Song', playCount: 5 },
+        ])
+        getRecentTracksMock.mockResolvedValue([
+            { artist: undefined as unknown as string, title: 'No Artist' },
+            { artist: 'Artist B', title: undefined as unknown as string },
+        ])
+        getLovedTracksMock.mockResolvedValue([])
+
+        const tracks = await getLastFmSeedTracks('discord-user-guard')
+
+        expect(tracks.every((t) => t.artist && t.title)).toBe(true)
+        expect(tracks).toHaveLength(1)
+        expect(tracks[0]).toEqual({ artist: 'Artist A', title: 'Good Song' })
+    })
 })
 
 describe('getLastFmSeedSlice', () => {

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeds.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeds.ts
@@ -30,6 +30,7 @@ function deduplicateTracks(
 ): { artist: string; title: string }[] {
     const seen = new Set<string>()
     return tracks.filter((t) => {
+        if (!t.artist || !t.title) return false
         const normalizedTitle = cleanTitle(t.title).toLowerCase().trim()
         const key = `${t.artist.toLowerCase()}|${normalizedTitle}`
         if (seen.has(key)) return false


### PR DESCRIPTION
## Summary

- **Log the actual Spotify error** in `/play` primary search catch block so we can diagnose why SpotifyExtractor fails
- **Add Spotify → YouTube → SoundCloud fallback chain** to `executePlayAtTop` (`/playnow`, `/playtop`) — previously had no fallback at all
- **Fix Last.fm artist field parsing**: `user.getrecenttracks` returns `artist: { '#text': '...' }` not `{ name: '...' }`, causing `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` that broke all Last.fm seed track loading

## Root cause of same-song loop
The Last.fm TypeError caused `getLastFmSeedTracks` to always return `[]`, disabling the personalized seed diversity entirely. Without Last.fm seeds, autoplay falls back to searching YouTube for "Don't Look Back In Anger" variants and keeps recommending the same Oasis tracks.

## Test plan
- [ ] PR CI passes
- [ ] Deploy v2.6.108
- [ ] Check production logs: "Failed to load Last.fm seed tracks" should disappear
- [ ] Check production logs: Spotify errors now show actual error message
- [ ] Autoplay queues diverse songs instead of Oasis variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved music playback reliability with automatic fallback to alternative search engines when the primary search fails.
  * Enhanced handling of artist data from Last.fm to support different response formats, ensuring consistent track information extraction.
  * Fixed autoplay functionality to exclude tracks with missing artist or title information, preventing playback errors.

* **Tests**
  * Added test coverage for alternative Last.fm artist data formats and malformed track handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->