### PR TITLE
refactor(autoplay): move noise terms to JSON, add sped-up/slowed/reverb/8d-audio

### DIFF
--- a/packages/bot/src/utils/music/noiseTerms.json
+++ b/packages/bot/src/utils/music/noiseTerms.json
@@ -1,0 +1,36 @@
+{
+    "versionVariants": [
+        "sped up",
+        "speed up",
+        "slowed",
+        "reverb",
+        "slowed reverb",
+        "nightcore",
+        "8d audio",
+        "bass boosted",
+        "live",
+        "acoustic",
+        "demo",
+        "remix",
+        "instrumental",
+        "karaoke",
+        "cover",
+        "extended",
+        "explicit",
+        "clean",
+        "remaster",
+        "remastered",
+        "deluxe",
+        "original mix",
+        "original version",
+        "radio edit",
+        "bonus track",
+        "single version",
+        "album version"
+    ],
+    "bareTitleNoise": [
+        "lyrics",
+        "legendado",
+        "traduzido"
+    ]
+}

--- a/packages/bot/src/utils/music/noiseTerms.json
+++ b/packages/bot/src/utils/music/noiseTerms.json
@@ -5,7 +5,6 @@
         "slowed",
         "reverb",
         "slowed reverb",
-        "nightcore",
         "8d audio",
         "bass boosted",
         "live",

--- a/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
@@ -82,8 +82,7 @@ describe('cleanTitle', () => {
         expect(cleanTitle('Flowers [Reverb]')).toBe('Flowers')
     })
 
-    it('strips Nightcore / 8D Audio / Bass Boosted tags', () => {
-        expect(cleanTitle('Flowers (Nightcore)')).toBe('Flowers')
+    it('strips 8D Audio / Bass Boosted tags', () => {
         expect(cleanTitle('Flowers [8D Audio]')).toBe('Flowers')
         expect(cleanTitle('Flowers (Bass Boosted)')).toBe('Flowers')
     })

--- a/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.spec.ts
@@ -64,6 +64,34 @@ describe('cleanTitle', () => {
     it('handles non-ASCII titles without mangling them', () => {
         expect(cleanTitle('夜に駆ける (Official Video)')).toBe('夜に駆ける')
     })
+
+    it('strips (Sped Up) / (Speed Up) variants', () => {
+        expect(cleanTitle('Flowers (Sped Up)')).toBe('Flowers')
+        expect(cleanTitle('Flowers [Speed Up Version]')).toBe('Flowers')
+        expect(cleanTitle('Flowers - Sped Up')).toBe('Flowers')
+    })
+
+    it('strips (Slowed) and (Slowed + Reverb) variants', () => {
+        expect(cleanTitle('Flowers (Slowed)')).toBe('Flowers')
+        expect(cleanTitle('Flowers [Slowed Reverb]')).toBe('Flowers')
+        expect(cleanTitle('Flowers - Slowed')).toBe('Flowers')
+    })
+
+    it('strips (Reverb) variants', () => {
+        expect(cleanTitle('Flowers (Reverb)')).toBe('Flowers')
+        expect(cleanTitle('Flowers [Reverb]')).toBe('Flowers')
+    })
+
+    it('strips Nightcore / 8D Audio / Bass Boosted tags', () => {
+        expect(cleanTitle('Flowers (Nightcore)')).toBe('Flowers')
+        expect(cleanTitle('Flowers [8D Audio]')).toBe('Flowers')
+        expect(cleanTitle('Flowers (Bass Boosted)')).toBe('Flowers')
+    })
+
+    it('strips legendado and traduzido bare words', () => {
+        expect(cleanTitle('Song legendado')).toBe('Song')
+        expect(cleanTitle('Song traduzido')).toBe('Song')
+    })
 })
 
 describe('cleanAuthor', () => {

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -20,36 +20,37 @@ function escapeRegex(s: string): string {
     return s.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-function termToWordBoundaryRe(term: string): RegExp {
-    const inner = escapeRegex(term).replaceAll(/\s+/g, '\\s{0,3}')
-    return new RegExp(`\\b${inner}\\b`, 'gi')
+function termInner(term: string): string {
+    return escapeRegex(term).replaceAll(/\s+/g, '\\s{0,3}')
 }
 
-function termToParenRe(term: string): RegExp {
-    const inner = escapeRegex(term).replaceAll(/\s+/g, '\\s{0,3}')
-    return new RegExp(`\\(${inner}[^)]*\\)`, 'gi')
-}
+type TermPattern = 'word' | 'paren' | 'bracket' | 'suffix'
 
-function termToBracketRe(term: string): RegExp {
-    const inner = escapeRegex(term).replaceAll(/\s+/g, '\\s{0,3}')
-    return new RegExp(`\\[${inner}[^\\]]*\\]`, 'gi')
+function buildTermRe(term: string, type: TermPattern): RegExp {
+    const inner = termInner(term)
+    switch (type) {
+        case 'paren': return new RegExp(`\\(${inner}[^)]*\\)`, 'gi') // NOSONAR
+        case 'bracket': return new RegExp(`\\[${inner}[^\\]]*\\]`, 'gi') // NOSONAR
+        case 'suffix': return new RegExp(`^${inner}(?:\\s{0,3}(?:version|edit|mix))?$`, 'i') // NOSONAR
+        default: return new RegExp(`\\b${inner}\\b`, 'gi') // NOSONAR
+    }
 }
 
 const DYNAMIC_NOISE_PATTERNS: RegExp[] = [
     ...noiseTerms.versionVariants.flatMap((t) => [
-        termToParenRe(t),
-        termToBracketRe(t),
+        buildTermRe(t, 'paren'),
+        buildTermRe(t, 'bracket'),
     ]),
-    ...noiseTerms.bareTitleNoise.map(termToWordBoundaryRe),
+    ...noiseTerms.bareTitleNoise.map((t) => buildTermRe(t, 'word')),
 ]
 
-const DYNAMIC_VERSION_KEYWORD_RE = new RegExp(
-    `\\b(?:${noiseTerms.versionVariants.map((t) => escapeRegex(t).replaceAll(/\s+/g, '\\s+')).join('|')})\\b`,
+const DYNAMIC_VERSION_KEYWORD_RE = new RegExp( // NOSONAR
+    `\\b(?:${noiseTerms.versionVariants.map(termInner).join('|')})\\b`,
     'i',
 )
 
 const DYNAMIC_HYPHENATED_SUFFIXES: RegExp[] = noiseTerms.versionVariants.map(
-    (t) => new RegExp(`^${escapeRegex(t).replaceAll(/\s+/g, '\\s+')}(?:\\s+(?:version|edit|mix))?$`, 'i'),
+    (t) => buildTermRe(t, 'suffix'),
 )
 
 const NOISE_PATTERNS: readonly RegExp[] = [

--- a/packages/bot/src/utils/music/searchQueryCleaner.ts
+++ b/packages/bot/src/utils/music/searchQueryCleaner.ts
@@ -9,7 +9,48 @@
  * The goal is to strip YouTube-style noise ("(Official Video)", "[Download]",
  * uploader-channel junk like "- Topic", feat./ft., trailing tags) so downstream
  * searches find the actual track, not the uploader's decorated listing.
+ *
+ * Simple word/phrase noise terms live in noiseTerms.json so they can be
+ * extended without touching regex logic.
  */
+
+import noiseTerms from './noiseTerms.json'
+
+function escapeRegex(s: string): string {
+    return s.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function termToWordBoundaryRe(term: string): RegExp {
+    const inner = escapeRegex(term).replaceAll(/\s+/g, '\\s{0,3}')
+    return new RegExp(`\\b${inner}\\b`, 'gi')
+}
+
+function termToParenRe(term: string): RegExp {
+    const inner = escapeRegex(term).replaceAll(/\s+/g, '\\s{0,3}')
+    return new RegExp(`\\(${inner}[^)]*\\)`, 'gi')
+}
+
+function termToBracketRe(term: string): RegExp {
+    const inner = escapeRegex(term).replaceAll(/\s+/g, '\\s{0,3}')
+    return new RegExp(`\\[${inner}[^\\]]*\\]`, 'gi')
+}
+
+const DYNAMIC_NOISE_PATTERNS: RegExp[] = [
+    ...noiseTerms.versionVariants.flatMap((t) => [
+        termToParenRe(t),
+        termToBracketRe(t),
+    ]),
+    ...noiseTerms.bareTitleNoise.map(termToWordBoundaryRe),
+]
+
+const DYNAMIC_VERSION_KEYWORD_RE = new RegExp(
+    `\\b(?:${noiseTerms.versionVariants.map((t) => escapeRegex(t).replaceAll(/\s+/g, '\\s+')).join('|')})\\b`,
+    'i',
+)
+
+const DYNAMIC_HYPHENATED_SUFFIXES: RegExp[] = noiseTerms.versionVariants.map(
+    (t) => new RegExp(`^${escapeRegex(t).replaceAll(/\s+/g, '\\s+')}(?:\\s+(?:version|edit|mix))?$`, 'i'),
+)
 
 const NOISE_PATTERNS: readonly RegExp[] = [
     // Korean/CJK parenthetical duplicates: "(뱅뱅뱅)" when title already has English equivalent
@@ -51,24 +92,10 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     /\[download\]/gi,
     /\[free\s{0,3}download\]/gi,
 
-    // Version variants: live, acoustic, cover, remix, etc.
+    // Version variants with richer context (live at venue, etc.) — kept here
+    // because they go beyond a simple \bterm\b match.
     /\(live(?:\s{0,3}(?:version|session|performance|at\s[^)]+))?\)/gi,
     /\[live(?:\s{0,3}(?:version|session|performance|at\s[^\]]+))?\]/gi,
-    /\(acoustic(?:\s{0,3}version)?\)/gi,
-    /\[acoustic(?:\s{0,3}version)?\]/gi,
-    /\(cover[^)]*\)/gi,
-    /\[cover[^\]]*\]/gi,
-    /\(remix(?:\s{0,3}(?:version|edit))?\)/gi,
-    /\[remix(?:\s{0,3}(?:version|edit))?\]/gi,
-    /\(instrumental(?:\s{0,3}version)?\)/gi,
-    /\[instrumental(?:\s{0,3}version)?\]/gi,
-    /\(karaoke(?:\s{0,3}version)?\)/gi,
-    /\(explicit(?:\s{0,3}version)?\)/gi,
-    /\(clean(?:\s{0,3}version)?\)/gi,
-    /\(single(?:\s{0,3}version)?\)/gi,
-    /\(album\s{0,3}version\)/gi,
-    /\(deluxe(?:\s{0,3}(?:version|edition))?\)/gi,
-    /\(bonus\s{0,3}track\)/gi,
 
     // Bare decorators that weren't wrapped in brackets
     /\bofficial\s{0,3}music\s{0,3}video\b/gi,
@@ -105,11 +132,8 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     /\(tradu[çc][aã]o[^)]*\)/gi,
     /\[tradu[çc][aã]o[^\]]*\]/gi,
     /\btradu[çc][aã]o\b/gi,
-    /\btraduzido\b/gi,
-    /\blegendado\b/gi,
     /\(clipe\s+oficial[^)]*\)/gi,
     /\[clipe\s+oficial[^\]]*\]/gi,
-    /\blyrics\b/gi,
 
     // Brazilian version qualifiers inside brackets
     /\(vers[aã]o\s{0,3}[^)]*\)/gi,
@@ -118,26 +142,26 @@ const NOISE_PATTERNS: readonly RegExp[] = [
     /\[ao\s{0,3}vivo[^\]]*\]/gi,
     /\(ac[uú]stico[^)]*\)/gi,
     /\[ac[uú]stico[^\]]*\]/gi,
+
+    // Dynamic patterns built from noiseTerms.json at module init
+    ...DYNAMIC_NOISE_PATTERNS,
 ]
 
 const HYPHENATED_VERSION_SUFFIXES: RegExp[] = [
     /^(?:\d{4}\s+)?remaster(?:ed)?(?:\s+(?:version|\d{4}))?(?:\s+\d{4})?$/i,
     /^official\s+(?:audio|video|music\s+video)$/i,
-    /^(?:live|acoustic|demo|extended|instrumental|karaoke|cover)(?:\s+(?:version|edit|session|mix))?$/i,
-    /^(?:radio\s+edit|album\s+version|single\s+version|bonus\s+track)$/i,
-    /^(?:original\s+(?:mix|version)|original)$/i,
-    /^(?:deluxe|deluxe\s+(?:version|edition))$/i,
-    /^(?:explicit|clean|explicit\s+version|clean\s+version)$/i,
+    /^original$/i,
     /^(?:19|20)\d{2}$/,
     // Brazilian/Portuguese version descriptors after " - "
     /^vers[aã]o/i,
     /^ao\s+vivo/i,
     /^forr[oó]/i,
     /^ac[uú]stico/i,
+    // Dynamic entries built from noiseTerms.json versionVariants
+    ...DYNAMIC_HYPHENATED_SUFFIXES,
 ]
 
-const VERSION_KEYWORD_RE =
-    /\b(?:remaster(?:ed)?|remix|acoustic|live|demo|extended|instrumental|deluxe|explicit|clean|bonus\s+track|radio\s+edit|single\s+version|album\s+version)\b/i
+const VERSION_KEYWORD_RE = DYNAMIC_VERSION_KEYWORD_RE
 
 function isVersionSuffix(suffix: string): boolean {
     if (HYPHENATED_VERSION_SUFFIXES.some((re) => re.test(suffix))) return true


### PR DESCRIPTION
## Summary

- **noiseTerms.json**: new file holding version variant and bare-title noise as plain strings — add new terms by editing the JSON, no regex knowledge required
- **Adds**: `sped up`, `speed up`, `slowed`, `reverb`, `slowed reverb`, `8d audio`, `bass boosted`, `original version`
- **Removes** hardcoded duplicate patterns that are now covered by JSON
- **Keeps** complex accent-aware patterns (Brazilian Portuguese) and extended live-at-venue patterns inline — they can't be expressed as plain strings
- **Nightcore excluded** — it's a genre (Nightcore - Song Name), not a version decorator

## How to add new terms going forward

Edit `packages/bot/src/utils/music/noiseTerms.json`:
```json
{
  "versionVariants": ["sped up", "slowed", "your new term"],
  "bareTitleNoise": ["lyrics", "legendado", "your new noise word"]
}
```

Patterns for `(term...)`, `[term...]`, and `\bterm\b` are built automatically at startup.

## Test plan

- [ ] All 2181 tests pass
- [ ] `cleanTitle('Flowers (Sped Up)')` → `'Flowers'`
- [ ] `cleanTitle('Flowers [Slowed Reverb]')` → `'Flowers'`  
- [ ] `cleanTitle('Flowers - Slowed')` → `'Flowers'`
- [ ] `cleanTitle('Flowers (Bass Boosted)')` → `'Flowers'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced music search title normalization to better handle and remove common decorators such as speed variations, audio effects (reverb, 8D audio, bass boosted), and language-specific tags for more accurate search results.

* **Tests**
  * Extended test coverage for additional title-cleaning patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->