### PR TITLE
fix(autoplay): skip session novelty boost for last.fm candidates, improve Spotify logging

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -3230,7 +3230,7 @@ describe('queueManipulation — within-cycle dedup via extractSongCore', () => {
         }
         expect(warnLog).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: expect.stringContaining('fallback engine'),
+                message: expect.stringContaining('Spotify returned 0 results'),
             }),
         )
     })

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -883,12 +883,21 @@ async function searchSeedCandidates(
             if (tracks.length > 0) {
                 if (idx > 0) {
                     warnLog({
-                        message:
-                            'Autoplay: primary search returned no results, using fallback engine',
-                        data: { engine, query: engineQuery },
+                        message: 'Autoplay: Spotify returned 0 results, using fallback',
+                        data: {
+                            fallbackEngine: engine,
+                            spotifyQuery,
+                            fallbackQuery: engineQuery,
+                        },
                     })
                 }
                 return tracks
+            }
+            if (engine === QueryType.SPOTIFY_SEARCH) {
+                debugLog({
+                    message: 'Autoplay: Spotify search returned 0 results',
+                    data: { spotifyQuery },
+                })
             }
         } catch (error) {
             debugLog({
@@ -1082,6 +1091,7 @@ async function collectLastFmCandidates(
                 implicitLikeKeys,
                 dislikedWeights,
                 sessionMood,
+                true,
             )
             if (rec.score === -Infinity) continue
             upsertScoredCandidate(candidates, track, {
@@ -1121,6 +1131,8 @@ async function collectLastFmCandidates(
                     implicitDislikeKeys,
                     implicitLikeKeys,
                     dislikedWeights,
+                    null,
+                    true,
                 )
                 upsertScoredCandidate(candidates, track, {
                     score: (rec.score + LASTFM_SCORE_BOOST) * (s.match / 100),
@@ -1595,6 +1607,7 @@ function calculateRecommendationScore(
     implicitLikeKeys: Set<string> = new Set(),
     dislikedWeights: Map<string, number> = new Map(),
     sessionMood: SessionMood | null = null,
+    skipNoveltyBoost = false,
 ): { score: number; reason: string } {
     const currentArtist = currentTrack.author.toLowerCase()
     const candidateArtist = candidate.author.toLowerCase()
@@ -1659,7 +1672,7 @@ function calculateRecommendationScore(
             score += 0.12
             reasons.push('album match')
         }
-    } else if (!recentArtists.has(candidateArtist)) {
+    } else if (!skipNoveltyBoost && !recentArtists.has(candidateArtist)) {
         score += 0.15
         reasons.push('session novelty')
     }


### PR DESCRIPTION
## Summary

- **Session genre coherence**: Last.fm candidates (both seed-track search and similar-tracks) no longer receive the +0.15 `session novelty` boost. This boost was making off-genre Last.fm history tracks (e.g. Kanye West during a FNAF session) outscore on-session seed candidates. Seed-based search results continue to receive the boost.
- **Spotify diagnostics**: `searchSeedCandidates` now logs a `debugLog` when Spotify returns 0 results, and the fallback `warnLog` now includes `spotifyQuery` + `fallbackQuery` so production logs reveal which queries are failing Spotify.

## Why this matters

`session novelty` was designed to introduce variety. The problem: it rewarded *any* unfamiliar artist, including those from the user's global Last.fm history that have nothing to do with the current session mood. By skipping novelty for Last.fm candidates, only seed-similar tracks get the diversity boost — Last.fm still contributes candidates but can no longer beat session-coherent ones purely by being "new."

## Test plan

- [ ] All 2176 tests pass
- [ ] FNAF session stays in game/soundtrack genre — Kanye West from Last.fm history does not appear
- [ ] Spotify fallback warns visible in production logs (`"Autoplay: Spotify returned 0 results"`)
- [ ] Last.fm candidates can still appear when no seed-based candidate fills a slot