### PR TITLE
fix(autoplay): fuzzy title dedup + extend history window to 150

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -2902,6 +2902,41 @@ describe('queueManipulation — multi-user VC blend', () => {
         )
     })
 
+    it('fuzzy-deduplicates candidates with misspelled titles (>82% similarity)', async () => {
+        const addTrackMock = jest.fn()
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://example.com/sirens',
+                title: 'Pearl Jam - Sirens',
+                author: 'Pearl Jam',
+                id: 'sirens1',
+                durationMS: 312000,
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            url: 'https://example.com/sirens-misspelled',
+                            // 'Syrens' vs 'Sirens' → 1-char diff → ~94% similarity
+                            title: 'Pearl Jam - Syrens',
+                            author: 'FanChannel',
+                            id: 'sirens-mis',
+                            durationMS: 315000,
+                            requestedBy: null,
+                        },
+                    ],
+                }),
+            },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(addTrackMock).not.toHaveBeenCalled()
+    })
+
     it('rejects candidates over 15 minutes as track too long', async () => {
         const addTrackMock = jest.fn()
         const queue = createQueueMock({

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -33,6 +33,7 @@ import {
     cleanAuthor,
     extractSongCore,
 } from './searchQueryCleaner'
+import { calculateStringSimilarity } from './duplicateDetection/similarityChecker'
 import type { QueueMetadata } from '../../types/QueueMetadata'
 
 const AUTOPLAY_BUFFER_SIZE = 8
@@ -328,7 +329,7 @@ async function _replenishQueue(
                 queue.guild.id,
                 requestedBy?.id,
             ),
-            trackHistoryService.getTrackHistory(queue.guild.id, 100),
+            trackHistoryService.getTrackHistory(queue.guild.id, 150),
             guildSettingsService.getGuildSettings(queue.guild.id),
             recommendationFeedbackService.getImplicitDislikeKeys(
                 requestedBy?.id ?? '',
@@ -1590,6 +1591,8 @@ function getTrackKey(track: Track): string {
     return track.id || track.url || normalizeTrackKey(track.title, track.author)
 }
 
+const FUZZY_TITLE_THRESHOLD = 0.82
+
 function isDuplicateCandidate(
     track: Track,
     excludedUrls: Set<string>,
@@ -1604,7 +1607,23 @@ function isDuplicateCandidate(
         return true
     if (excludedKeys.has(normalizeTitleOnly(track.title))) return true
     const core = extractSongCore(track.title ?? '', track.author)
-    return core !== null && excludedKeys.has(normalizeText(core))
+    if (core !== null && excludedKeys.has(normalizeText(core))) return true
+
+    // Fuzzy fallback: catch variants not stripped by noise patterns
+    // (e.g. novel language annotations, unenumerated descriptors)
+    const candidateTitle = normalizeTitleOnly(track.title)
+    if (candidateTitle.length >= 5) {
+        for (const key of excludedKeys) {
+            if (key.includes('::') || key.length < 5) continue
+            if (
+                calculateStringSimilarity(candidateTitle, key) >=
+                FUZZY_TITLE_THRESHOLD
+            ) {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 function calculateRecommendationScore(


### PR DESCRIPTION
## What

Two improvements based on research into music recommendation best practices.

### Fuzzy title matching in `isDuplicateCandidate`

The existing `calculateStringSimilarity` (Levenshtein) function in `similarityChecker.ts` was never wired into the main dedup path — this connects it.

After all exact-key checks fail, the candidate's normalized title is compared against every title-only key in `excludedKeys` using `calculateStringSimilarity`. Threshold: **0.82** (82% similarity).

What this catches that exact matching misses:
- Misspellings: `"Pearl Jam - Syrens"` deduped against `"Pearl Jam - Sirens"` (~94% similarity)
- Minor character-level variations not covered by noise patterns
- Safety net for any unenumerated decorators that survive noise stripping

Keys containing `::` (full `title::author` format) are skipped to avoid false positives from partial matches across different songs.

### Persistent history window 100 → 150 tracks

`getTrackHistory(guildId, 100)` → `150`. At ~3-4 min/song this covers roughly 7-10 hours of playback, preventing songs from the earlier part of a long session from being re-queued.

## Tests
1 new test — 2189 total, all green.