### PR TITLE
feat(bot): spotify recommendations as autoplay candidates (v2.6.114)

### DIFF
--- a/packages/bot/src/spotify/spotifyApi.spec.ts
+++ b/packages/bot/src/spotify/spotifyApi.spec.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals'
+import {
+    describe,
+    it,
+    expect,
+    beforeEach,
+    jest,
+    afterEach,
+} from '@jest/globals'
 import {
     getAudioFeatures,
     searchSpotifyTrack,
     getBatchAudioFeatures,
     getArtistPopularity,
+    getSpotifyRecommendations,
 } from './spotifyApi'
 
 type MockFetchResponse = {
@@ -11,9 +19,13 @@ type MockFetchResponse = {
     json?: () => Promise<unknown>
 }
 
-const fetchMock = jest.fn<
-    (input: RequestInfo | URL, init?: RequestInit) => Promise<MockFetchResponse>
->()
+const fetchMock =
+    jest.fn<
+        (
+            input: RequestInfo | URL,
+            init?: RequestInit,
+        ) => Promise<MockFetchResponse>
+    >()
 
 describe('spotifyApi', () => {
     let originalFetch: typeof global.fetch
@@ -84,7 +96,9 @@ describe('spotifyApi', () => {
         it('returns null when json parsing fails', async () => {
             fetchMock.mockResolvedValue({
                 ok: true,
-                json: async () => { throw new Error('JSON parse error') },
+                json: async () => {
+                    throw new Error('JSON parse error')
+                },
             })
 
             const result = await getAudioFeatures('test-token', 'track-123')
@@ -132,7 +146,11 @@ describe('spotifyApi', () => {
                 }),
             })
 
-            const result = await searchSpotifyTrack('test-token', 'Song Title', 'Artist Name')
+            const result = await searchSpotifyTrack(
+                'test-token',
+                'Song Title',
+                'Artist Name',
+            )
 
             expect(result).toBe('spotify:track:abc123')
         })
@@ -143,7 +161,11 @@ describe('spotifyApi', () => {
                 json: async () => ({ tracks: { items: [] } }),
             })
 
-            const result = await searchSpotifyTrack('test-token', 'Unknown Song', 'Unknown Artist')
+            const result = await searchSpotifyTrack(
+                'test-token',
+                'Unknown Song',
+                'Unknown Artist',
+            )
 
             expect(result).toBeNull()
         })
@@ -154,7 +176,11 @@ describe('spotifyApi', () => {
                 json: async () => ({}),
             })
 
-            const result = await searchSpotifyTrack('test-token', 'Song', 'Artist')
+            const result = await searchSpotifyTrack(
+                'test-token',
+                'Song',
+                'Artist',
+            )
 
             expect(result).toBeNull()
         })
@@ -162,7 +188,11 @@ describe('spotifyApi', () => {
         it('returns null when response is not ok', async () => {
             fetchMock.mockResolvedValue({ ok: false })
 
-            const result = await searchSpotifyTrack('test-token', 'Song', 'Artist')
+            const result = await searchSpotifyTrack(
+                'test-token',
+                'Song',
+                'Artist',
+            )
 
             expect(result).toBeNull()
         })
@@ -170,10 +200,16 @@ describe('spotifyApi', () => {
         it('returns null when json parsing fails', async () => {
             fetchMock.mockResolvedValue({
                 ok: true,
-                json: async () => { throw new Error('JSON parse error') },
+                json: async () => {
+                    throw new Error('JSON parse error')
+                },
             })
 
-            const result = await searchSpotifyTrack('test-token', 'Song', 'Artist')
+            const result = await searchSpotifyTrack(
+                'test-token',
+                'Song',
+                'Artist',
+            )
 
             expect(result).toBeNull()
         })
@@ -181,7 +217,11 @@ describe('spotifyApi', () => {
         it('catches and returns null on fetch error', async () => {
             fetchMock.mockRejectedValue(new Error('Network error'))
 
-            const result = await searchSpotifyTrack('test-token', 'Song', 'Artist')
+            const result = await searchSpotifyTrack(
+                'test-token',
+                'Song',
+                'Artist',
+            )
 
             expect(result).toBeNull()
         })
@@ -198,17 +238,46 @@ describe('spotifyApi', () => {
                 ok: true,
                 json: async () => ({
                     audio_features: [
-                        { id: 'track1', energy: 0.8, valence: 0.7, danceability: 0.6, tempo: 120, acousticness: 0.1 },
-                        { id: 'track2', energy: 0.5, valence: 0.6, danceability: 0.7, tempo: 100, acousticness: 0.3 },
+                        {
+                            id: 'track1',
+                            energy: 0.8,
+                            valence: 0.7,
+                            danceability: 0.6,
+                            tempo: 120,
+                            acousticness: 0.1,
+                        },
+                        {
+                            id: 'track2',
+                            energy: 0.5,
+                            valence: 0.6,
+                            danceability: 0.7,
+                            tempo: 100,
+                            acousticness: 0.3,
+                        },
                     ],
                 }),
             })
 
-            const result = await getBatchAudioFeatures('token', ['track1', 'track2'])
+            const result = await getBatchAudioFeatures('token', [
+                'track1',
+                'track2',
+            ])
 
             expect(result.size).toBe(2)
-            expect(result.get('track1')).toEqual({ energy: 0.8, valence: 0.7, danceability: 0.6, tempo: 120, acousticness: 0.1 })
-            expect(result.get('track2')).toEqual({ energy: 0.5, valence: 0.6, danceability: 0.7, tempo: 100, acousticness: 0.3 })
+            expect(result.get('track1')).toEqual({
+                energy: 0.8,
+                valence: 0.7,
+                danceability: 0.6,
+                tempo: 120,
+                acousticness: 0.1,
+            })
+            expect(result.get('track2')).toEqual({
+                energy: 0.5,
+                valence: 0.6,
+                danceability: 0.7,
+                tempo: 100,
+                acousticness: 0.3,
+            })
         })
 
         it('skips null entries in audio_features array', async () => {
@@ -216,14 +285,32 @@ describe('spotifyApi', () => {
                 ok: true,
                 json: async () => ({
                     audio_features: [
-                        { id: 'track1', energy: 0.8, valence: 0.7, danceability: 0.6, tempo: 120, acousticness: 0.1 },
+                        {
+                            id: 'track1',
+                            energy: 0.8,
+                            valence: 0.7,
+                            danceability: 0.6,
+                            tempo: 120,
+                            acousticness: 0.1,
+                        },
                         null,
-                        { id: 'track3', energy: 0.5, valence: 0.6, danceability: 0.7, tempo: 100, acousticness: 0.3 },
+                        {
+                            id: 'track3',
+                            energy: 0.5,
+                            valence: 0.6,
+                            danceability: 0.7,
+                            tempo: 100,
+                            acousticness: 0.3,
+                        },
                     ],
                 }),
             })
 
-            const result = await getBatchAudioFeatures('token', ['track1', 'invalid', 'track3'])
+            const result = await getBatchAudioFeatures('token', [
+                'track1',
+                'invalid',
+                'track3',
+            ])
 
             expect(result.size).toBe(2)
             expect(result.has('track1')).toBe(true)
@@ -240,7 +327,9 @@ describe('spotifyApi', () => {
         it('returns empty map on json parse error', async () => {
             fetchMock.mockResolvedValue({
                 ok: true,
-                json: async () => { throw new Error('JSON error') },
+                json: async () => {
+                    throw new Error('JSON error')
+                },
             })
 
             const result = await getBatchAudioFeatures('token', ['track1'])
@@ -251,12 +340,20 @@ describe('spotifyApi', () => {
             fetchMock.mockResolvedValue({
                 ok: true,
                 json: async () => ({
-                    audio_features: [{ id: 'track1', energy: 0.8, valence: 0.7 }],
+                    audio_features: [
+                        { id: 'track1', energy: 0.8, valence: 0.7 },
+                    ],
                 }),
             })
 
             const result = await getBatchAudioFeatures('token', ['track1'])
-            expect(result.get('track1')).toEqual({ energy: 0.8, valence: 0.7, danceability: 0, tempo: 0, acousticness: 0 })
+            expect(result.get('track1')).toEqual({
+                energy: 0.8,
+                valence: 0.7,
+                danceability: 0,
+                tempo: 0,
+                acousticness: 0,
+            })
         })
     })
 
@@ -264,7 +361,9 @@ describe('spotifyApi', () => {
         it('returns artist popularity from search', async () => {
             fetchMock.mockResolvedValue({
                 ok: true,
-                json: async () => ({ artists: { items: [{ popularity: 75 }] } }),
+                json: async () => ({
+                    artists: { items: [{ popularity: 75 }] },
+                }),
             })
 
             const result = await getArtistPopularity('token', 'The Beatles')
@@ -298,11 +397,126 @@ describe('spotifyApi', () => {
         it('returns null on json parse error', async () => {
             fetchMock.mockResolvedValue({
                 ok: true,
-                json: async () => { throw new Error('JSON error') },
+                json: async () => {
+                    throw new Error('JSON error')
+                },
             })
 
             const result = await getArtistPopularity('token', 'Some Artist')
             expect(result).toBeNull()
+        })
+    })
+
+    describe('getSpotifyRecommendations', () => {
+        it('returns empty array when seedTrackIds is empty', async () => {
+            const result = await getSpotifyRecommendations('token', [])
+            expect(result).toEqual([])
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        it('returns tracks on successful response', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    tracks: [
+                        {
+                            id: 'rec1',
+                            name: 'Recommended Track',
+                            artists: [{ name: 'Artist A' }],
+                            duration_ms: 200000,
+                        },
+                        {
+                            id: 'rec2',
+                            name: 'Another Track',
+                            artists: [
+                                { name: 'Artist B' },
+                                { name: 'Artist C' },
+                            ],
+                            duration_ms: 180000,
+                        },
+                    ],
+                }),
+            })
+
+            const result = await getSpotifyRecommendations(
+                'token',
+                ['seed1', 'seed2'],
+                10,
+            )
+
+            expect(result).toHaveLength(2)
+            expect(result[0]).toEqual({
+                id: 'rec1',
+                name: 'Recommended Track',
+                artists: [{ name: 'Artist A' }],
+                duration_ms: 200000,
+            })
+            expect(result[1].artists).toHaveLength(2)
+        })
+
+        it('slices seed track ids to max 5', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: async () => ({ tracks: [] }),
+            })
+
+            await getSpotifyRecommendations('token', [
+                'a',
+                'b',
+                'c',
+                'd',
+                'e',
+                'f',
+                'g',
+            ])
+
+            const url = fetchMock.mock.calls[0]?.[0] as string
+            const params = new URLSearchParams(url.split('?')[1])
+            expect(params.get('seed_tracks')?.split(',').length).toBe(5)
+        })
+
+        it('returns empty array when response is not ok', async () => {
+            fetchMock.mockResolvedValue({ ok: false })
+            const result = await getSpotifyRecommendations('token', ['seed1'])
+            expect(result).toEqual([])
+        })
+
+        it('returns empty array on network error', async () => {
+            fetchMock.mockRejectedValue(new Error('network error'))
+            const result = await getSpotifyRecommendations('token', ['seed1'])
+            expect(result).toEqual([])
+        })
+
+        it('filters out tracks missing id or name', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    tracks: [
+                        {
+                            id: 'good',
+                            name: 'Good Track',
+                            artists: [],
+                            duration_ms: 200000,
+                        },
+                        {
+                            id: null,
+                            name: 'No ID',
+                            artists: [],
+                            duration_ms: 100000,
+                        },
+                        {
+                            id: 'noid2',
+                            name: null,
+                            artists: [],
+                            duration_ms: 100000,
+                        },
+                    ],
+                }),
+            })
+
+            const result = await getSpotifyRecommendations('token', ['seed1'])
+            expect(result).toHaveLength(1)
+            expect(result[0].id).toBe('good')
         })
     })
 })

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -1,3 +1,47 @@
+export interface SpotifyRecommendationTrack {
+    id: string
+    name: string
+    artists: { name: string }[]
+    duration_ms: number
+}
+
+export async function getSpotifyRecommendations(
+    accessToken: string,
+    seedTrackIds: string[],
+    limit = 10,
+): Promise<SpotifyRecommendationTrack[]> {
+    if (seedTrackIds.length === 0) return []
+    try {
+        const params = new URLSearchParams({
+            seed_tracks: seedTrackIds.slice(0, 5).join(','),
+            limit: String(Math.min(limit, 100)),
+        })
+        const res = await fetch(
+            `https://api.spotify.com/v1/recommendations?${params.toString()}`,
+            { headers: { Authorization: `Bearer ${accessToken}` } },
+        )
+        if (!res.ok) return []
+        const data = (await res.json().catch(() => null)) as {
+            tracks?: Array<{
+                id?: string
+                name?: string
+                artists?: Array<{ name?: string }>
+                duration_ms?: number
+            }>
+        }
+        return (data?.tracks ?? [])
+            .filter((t) => t.id && t.name)
+            .map((t) => ({
+                id: t.id!,
+                name: t.name!,
+                artists: (t.artists ?? []).map((a) => ({ name: a.name ?? '' })),
+                duration_ms: t.duration_ms ?? 0,
+            }))
+    } catch {
+        return []
+    }
+}
+
 export interface SpotifyAudioFeatures {
     energy: number
     valence: number

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -92,6 +92,7 @@ jest.mock('../../spotify/spotifyApi', () => ({
     searchSpotifyTrack: jest.fn().mockResolvedValue(null),
     getBatchAudioFeatures: jest.fn().mockResolvedValue(new Map()),
     getArtistPopularity: jest.fn().mockResolvedValue(null),
+    getSpotifyRecommendations: jest.fn().mockResolvedValue([]),
 }))
 
 const dislikedTrackWeightsMock = jest.fn()
@@ -2918,7 +2919,6 @@ describe('queueManipulation — multi-user VC blend', () => {
                     tracks: [
                         {
                             url: 'https://example.com/sirens-misspelled',
-                            // 'Syrens' vs 'Sirens' → 1-char diff → ~94% similarity
                             title: 'Pearl Jam - Syrens',
                             author: 'FanChannel',
                             id: 'sirens-mis',
@@ -2935,6 +2935,69 @@ describe('queueManipulation — multi-user VC blend', () => {
         await replenishQueue(queue as unknown as GuildQueue)
 
         expect(addTrackMock).not.toHaveBeenCalled()
+    })
+
+    it('calls Spotify recommendations API when user has linked account and seed has Spotify URL', async () => {
+        const spotifyApiMock = jest.requireMock('../../spotify/spotifyApi') as {
+            getSpotifyRecommendations: jest.Mock
+        }
+        const sharedMocks = jest.requireMock('@lucky/shared/services') as {
+            spotifyLinkService: { getValidAccessToken: jest.Mock }
+        }
+        sharedMocks.spotifyLinkService.getValidAccessToken.mockResolvedValue(
+            'tok-abc',
+        )
+        spotifyApiMock.getSpotifyRecommendations.mockResolvedValue([])
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://open.spotify.com/track/seedid123',
+                title: 'Seed Song',
+                author: 'Seed Artist',
+                id: 'seed1',
+                source: 'spotify',
+                durationMS: 200000,
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({ tracks: [] }),
+            },
+            addTrack: jest.fn(),
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(spotifyApiMock.getSpotifyRecommendations).toHaveBeenCalledWith(
+            'tok-abc',
+            ['seedid123'],
+            15,
+        )
+    })
+
+    it('skips Spotify recommendations when no access token is available', async () => {
+        const spotifyApiMock = jest.requireMock('../../spotify/spotifyApi') as {
+            getSpotifyRecommendations: jest.Mock
+        }
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://open.spotify.com/track/seedid',
+                title: 'Seed Song',
+                author: 'Seed Artist',
+                id: 'seed1',
+                source: 'spotify',
+                durationMS: 200000,
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({ tracks: [] }),
+            },
+            addTrack: jest.fn(),
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(spotifyApiMock.getSpotifyRecommendations).not.toHaveBeenCalled()
     })
 
     it('rejects candidates over 15 minutes as track too long', async () => {
@@ -3091,6 +3154,7 @@ describe('queueManipulation — multi-user VC blend', () => {
         const sharedMocks = jest.requireMock('@lucky/shared/services') as any
         sharedMocks.spotifyLinkService.getValidAccessToken
             .mockResolvedValueOnce('token-for-current')
+            .mockResolvedValueOnce(null) // collectSpotifyRecommendationCandidates
             .mockResolvedValueOnce('token-for-enrich')
 
         const spotifyMocks = jest.requireMock('../../spotify/spotifyApi') as any

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -3000,6 +3000,152 @@ describe('queueManipulation — multi-user VC blend', () => {
         expect(spotifyApiMock.getSpotifyRecommendations).not.toHaveBeenCalled()
     })
 
+    it('uses searchSpotifyTrack to resolve seed IDs when current track has no Spotify URL', async () => {
+        const spotifyApiMock = jest.requireMock('../../spotify/spotifyApi') as {
+            getSpotifyRecommendations: jest.Mock
+            searchSpotifyTrack: jest.Mock
+        }
+        const sharedMocks = jest.requireMock('@lucky/shared/services') as {
+            spotifyLinkService: { getValidAccessToken: jest.Mock }
+        }
+        sharedMocks.spotifyLinkService.getValidAccessToken.mockResolvedValue(
+            'tok-resolve',
+        )
+        spotifyApiMock.searchSpotifyTrack.mockResolvedValue(
+            'resolved-spotify-id',
+        )
+        spotifyApiMock.getSpotifyRecommendations.mockResolvedValue([])
+
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://www.youtube.com/watch?v=abc',
+                title: 'Some Song',
+                author: 'Some Artist',
+                id: 'yt1',
+                durationMS: 200000,
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({ tracks: [] }),
+            },
+            addTrack: jest.fn(),
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(spotifyApiMock.searchSpotifyTrack).toHaveBeenCalled()
+        expect(spotifyApiMock.getSpotifyRecommendations).toHaveBeenCalledWith(
+            'tok-resolve',
+            ['resolved-spotify-id'],
+            15,
+        )
+    })
+
+    it('adds spotify recommendation results as scored candidates', async () => {
+        const spotifyApiMock = jest.requireMock('../../spotify/spotifyApi') as {
+            getSpotifyRecommendations: jest.Mock
+        }
+        const sharedMocks = jest.requireMock('@lucky/shared/services') as {
+            spotifyLinkService: { getValidAccessToken: jest.Mock }
+        }
+        sharedMocks.spotifyLinkService.getValidAccessToken.mockResolvedValue(
+            'tok-recs',
+        )
+        spotifyApiMock.getSpotifyRecommendations.mockResolvedValue([
+            {
+                id: 'rectrack1',
+                name: 'Recommended Song',
+                artists: [{ name: 'Rec Artist' }],
+                duration_ms: 200000,
+            },
+        ])
+
+        const addTrackMock = jest.fn()
+        const searchMock = jest.fn().mockResolvedValue({
+            tracks: [
+                {
+                    url: 'https://open.spotify.com/track/rectrack1',
+                    title: 'Recommended Song',
+                    author: 'Rec Artist',
+                    id: 'rectrack1',
+                    durationMS: 200000,
+                    requestedBy: null,
+                },
+            ],
+        })
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://open.spotify.com/track/seedid',
+                title: 'Seed Song',
+                author: 'Seed Artist',
+                id: 'seed1',
+                source: 'spotify',
+                durationMS: 200000,
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: { search: searchMock },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(addTrackMock).toHaveBeenCalled()
+    })
+
+    it('skips spotify recommendation result when track is too long', async () => {
+        const spotifyApiMock = jest.requireMock('../../spotify/spotifyApi') as {
+            getSpotifyRecommendations: jest.Mock
+        }
+        const sharedMocks = jest.requireMock('@lucky/shared/services') as {
+            spotifyLinkService: { getValidAccessToken: jest.Mock }
+        }
+        sharedMocks.spotifyLinkService.getValidAccessToken.mockResolvedValue(
+            'tok-long',
+        )
+        spotifyApiMock.getSpotifyRecommendations.mockResolvedValue([
+            {
+                id: 'longtrack',
+                name: 'Hour Long Mix',
+                artists: [{ name: 'DJ' }],
+                duration_ms: 3600000,
+            },
+        ])
+
+        const addTrackMock = jest.fn()
+        const queue = createQueueMock({
+            currentTrack: {
+                url: 'https://open.spotify.com/track/seedid',
+                title: 'Seed Song',
+                author: 'Seed Artist',
+                id: 'seed1',
+                durationMS: 200000,
+                requestedBy: { id: 'user-1' },
+            } as unknown as Track,
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            url: 'https://open.spotify.com/track/longtrack',
+                            title: 'Hour Long Mix',
+                            author: 'DJ',
+                            id: 'longtrack',
+                            durationMS: 3600000,
+                            requestedBy: null,
+                        },
+                    ],
+                }),
+            },
+            addTrack: addTrackMock,
+            metadata: { requestedBy: { id: 'user-1' } },
+        })
+
+        await replenishQueue(queue as unknown as GuildQueue)
+
+        expect(addTrackMock).not.toHaveBeenCalled()
+    })
+
     it('rejects candidates over 15 minutes as track too long', async () => {
         const addTrackMock = jest.fn()
         const queue = createQueueMock({

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -19,6 +19,7 @@ import {
     searchSpotifyTrack,
     getBatchAudioFeatures,
     getArtistPopularity,
+    getSpotifyRecommendations,
     type SpotifyAudioFeatures,
 } from '../../spotify/spotifyApi'
 import {
@@ -743,6 +744,110 @@ function buildArtistFrequency(
     return freq
 }
 
+function extractSpotifyTrackId(track: Track): string | null {
+    const match =
+        track.url?.match(/open\.spotify\.com\/track\/([A-Za-z0-9]+)/) ??
+        track.url?.match(/^spotify:track:([A-Za-z0-9]+)/)
+    return match?.[1] ?? null
+}
+
+async function collectSpotifyRecommendationCandidates(
+    queue: GuildQueue,
+    seedTracks: Track[],
+    requestedBy: User | null,
+    excludedUrls: Set<string>,
+    excludedKeys: Set<string>,
+    dislikedWeights: Map<string, number>,
+    likedWeights: Map<string, number>,
+    preferredArtistKeys: Set<string>,
+    blockedArtistKeys: Set<string>,
+    currentTrack: Track,
+    recentArtists: Set<string>,
+    candidates: Map<string, ScoredTrack>,
+    autoplayMode: 'similar' | 'discover' | 'popular',
+    artistFrequency: Map<string, number>,
+    implicitDislikeKeys: Set<string>,
+    implicitLikeKeys: Set<string>,
+    sessionMood: SessionMood | null,
+): Promise<void> {
+    if (!requestedBy) return
+    const token = await Promise.resolve(
+        spotifyLinkService.getValidAccessToken(requestedBy.id),
+    ).catch(() => null)
+    if (!token) return
+
+    const seedIds = seedTracks
+        .map(extractSpotifyTrackId)
+        .filter((id): id is string => id !== null)
+        .slice(0, 5)
+
+    if (seedIds.length === 0) {
+        const resolved = await Promise.allSettled(
+            seedTracks.slice(0, 3).map((s) => {
+                const core = extractSongCore(s.title ?? '', s.author)
+                return searchSpotifyTrack(
+                    token,
+                    core ?? cleanTitle(s.title ?? ''),
+                    cleanAuthor(s.author),
+                )
+            }),
+        )
+        resolved.forEach((r) => {
+            if (r.status === 'fulfilled' && r.value) seedIds.push(r.value)
+        })
+    }
+
+    if (seedIds.length === 0) return
+    const recs = await getSpotifyRecommendations(token, seedIds, 15)
+    if (recs.length === 0) return
+
+    debugLog({
+        message: 'Autoplay: Spotify recommendations fetched',
+        data: { count: recs.length, seedCount: seedIds.length },
+    })
+
+    const searchResults = await Promise.allSettled(
+        recs.map((rec) => {
+            const spotifyUrl = `https://open.spotify.com/track/${rec.id}`
+            return queue.player.search(spotifyUrl, {
+                requestedBy: requestedBy ?? undefined,
+                searchEngine: QueryType.SPOTIFY_SEARCH,
+            })
+        }),
+    )
+
+    for (const result of searchResults) {
+        if (result.status !== 'fulfilled') continue
+        const track = result.value.tracks.find(
+            (t) => !t.durationMS || t.durationMS <= MAX_AUTOPLAY_DURATION_MS,
+        )
+        if (!track) continue
+        if (!shouldIncludeCandidate(track, excludedUrls, excludedKeys)) continue
+        const normalizedKey = normalizeTrackKey(track.title, track.author)
+        const dislikedWeight = dislikedWeights.get(normalizedKey)
+        if (dislikedWeight !== undefined && dislikedWeight > 0.5) continue
+        const rec = calculateRecommendationScore(
+            track,
+            currentTrack,
+            recentArtists,
+            likedWeights,
+            preferredArtistKeys,
+            blockedArtistKeys,
+            autoplayMode,
+            artistFrequency,
+            implicitDislikeKeys,
+            implicitLikeKeys,
+            dislikedWeights,
+            sessionMood,
+        )
+        if (rec.score === -Infinity) continue
+        upsertScoredCandidate(candidates, track, {
+            score: rec.score + 0.3,
+            reason: rec.reason ? `${rec.reason} • spotify rec` : 'spotify rec',
+        })
+    }
+}
+
 async function collectRecommendationCandidates(
     queue: GuildQueue,
     seedTracks: Track[],
@@ -763,6 +868,26 @@ async function collectRecommendationCandidates(
     sessionMood: SessionMood | null = null,
 ): Promise<Map<string, ScoredTrack>> {
     const candidates = new Map<string, ScoredTrack>()
+
+    await collectSpotifyRecommendationCandidates(
+        queue,
+        seedTracks,
+        requestedBy,
+        excludedUrls,
+        excludedKeys,
+        dislikedWeights,
+        likedWeights,
+        preferredArtistKeys,
+        blockedArtistKeys,
+        currentTrack,
+        recentArtists,
+        candidates,
+        autoplayMode,
+        artistFrequency,
+        implicitDislikeKeys,
+        implicitLikeKeys,
+        sessionMood,
+    )
 
     for (const seed of seedTracks) {
         const seedCandidates = await searchSeedCandidates(


### PR DESCRIPTION
## Summary

- Adds `getSpotifyRecommendations()` in `spotifyApi.ts` — calls `/v1/recommendations` with up to 5 seed track IDs and a configurable limit
- `collectSpotifyRecommendationCandidates()` in `queueManipulation.ts` — extracts Spotify track IDs from recent queue history, fetches recommendations using the user's linked OAuth token, searches discord-player for each result, and adds them as scored candidates (+0.3 boost over standard)
- Seeds are resolved from current + history tracks; unlinked tracks are resolved via `searchSpotifyTrack` (title/artist lookup)
- Runs as the first step in `collectRecommendationCandidates`, before YouTube/SoundCloud seed searches
- 2 new tests covering the happy path and the no-token skip path

## Why

The main driver of duplicate/off-genre tracks was the autoplay loop finding only YouTube candidates that match a text query. Spotify's recommendation engine understands musical similarity (energy, valence, BPM) and can surface contextually relevant tracks that text search would never find.

## Test plan

- [x] `npx jest queueManipulation --no-coverage` — 93/93
- [x] Full bot suite — 2190/2190
- [x] `tsc --noEmit` — clean
- [ ] CI green
- [ ] Deploy v2.6.114