### PR TITLE
fix(bot): replace built-in SpotifyExtractor with discord-player-spotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.116] - 2026-04-14
+
+### Fixed
+- Replaced built-in `SpotifyExtractor` from `@discord-player/extractor` with the community-maintained `discord-player-spotify` package — the built-in extractor has a confirmed unfixed bug (discord-player#1988) where text searches return 0 results despite valid credentials, causing every `/play` text query to fall back to YouTube
+
 ## [2.6.115] - 2026-04-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.98",
+    "version": "2.6.115",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.98",
+            "version": "2.6.115",
             "license": "ISC",
             "workspaces": [
                 "packages/*"
@@ -14105,6 +14105,17 @@
                 "mediaplex": "^1"
             }
         },
+        "node_modules/discord-player-spotify": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/discord-player-spotify/-/discord-player-spotify-1.1.9.tgz",
+            "integrity": "sha512-LASyWjB/645/JyPLiN1gVKVjRrwDm6gHYgbG8ekq5dVWnsBQ1AU8B377b0kBnTuP2VzNl/bNO6wHctaNtI+n9A==",
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.16.0",
+                "node-html-parser": "^7.0.1",
+                "otpauth": "^9.3.6"
+            }
+        },
         "node_modules/discord-player-youtubei": {
             "version": "3.0.0-beta.4",
             "resolved": "https://registry.npmjs.org/discord-player-youtubei/-/discord-player-youtubei-3.0.0-beta.4.tgz",
@@ -19812,6 +19823,30 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/otpauth": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.0.tgz",
+            "integrity": "sha512-Ldhc6UYl4baR5toGr8nfKC+L/b8/RgHKoIixAebgoNGzUUCET02g04rMEZ2ZsPfeVQhMHcuaOgb28nwMr81zCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/hectorm/otpauth?sponsor=1"
+            }
+        },
+        "node_modules/otpauth/node_modules/@noble/hashes": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+            "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/p-cancelable": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
@@ -24259,7 +24294,7 @@
         },
         "packages/backend": {
             "name": "@lucky/backend",
-            "version": "2.6.98",
+            "version": "2.6.114",
             "dependencies": {
                 "@lucky/shared": "file:../shared",
                 "connect-redis": "^9.0.0",
@@ -24320,7 +24355,7 @@
         },
         "packages/bot": {
             "name": "@lucky/bot",
-            "version": "2.6.98",
+            "version": "2.6.115",
             "dependencies": {
                 "@discord-player/extractor": "^7.2.0",
                 "@discordjs/builders": "^1.14.1",
@@ -24329,6 +24364,7 @@
                 "@sentry/node": "^10.47.0",
                 "chalk": "^5.6.2",
                 "discord-player": "^7.1.0",
+                "discord-player-spotify": "^1.1.9",
                 "discord-player-youtubei": "^3.0.0-beta.4",
                 "discord.js": "^14.26.2",
                 "dotenv": "^17.4.1",
@@ -24416,7 +24452,7 @@
         },
         "packages/frontend": {
             "name": "lucky-webapp",
-            "version": "2.6.98",
+            "version": "2.6.115",
             "dependencies": {
                 "@hookform/resolvers": "^5.0.0",
                 "@radix-ui/react-avatar": "^1.1.11",
@@ -25499,7 +25535,7 @@
         },
         "packages/shared": {
             "name": "@lucky/shared",
-            "version": "2.6.98",
+            "version": "2.6.115",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.3",
                 "@npmcli/agent": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.115",
+    "version": "2.6.116",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.115",
+    "version": "2.6.116",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",
@@ -23,6 +23,7 @@
         "@sentry/node": "^10.47.0",
         "chalk": "^5.6.2",
         "discord-player": "^7.1.0",
+        "discord-player-spotify": "^1.1.9",
         "discord-player-youtubei": "^3.0.0-beta.4",
         "discord.js": "^14.26.2",
         "dotenv": "^17.4.1",

--- a/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.bridge.spec.ts
@@ -27,6 +27,10 @@ jest.mock('@discord-player/extractor', () => ({
     DefaultExtractors: [],
 }))
 
+jest.mock('discord-player-spotify', () => ({
+    SpotifyExtractor: class MockSpotifyExtractor {},
+}))
+
 jest.mock('play-dl', () => ({
     search: (...args: unknown[]) => playdlSearchMock(...args),
     stream: (...args: unknown[]) => playdlStreamMock(...args),

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -68,8 +68,8 @@ const registerExtractorsInOrder = async (player: Player): Promise<void> => {
 const registerSpotifyExtractor = async (player: Player): Promise<void> => {
     try {
         const registered = await player.extractors.register(SpotifyExtractor, {
-            clientId: process.env.SPOTIFY_CLIENT_ID ?? null,
-            clientSecret: process.env.SPOTIFY_CLIENT_SECRET ?? null,
+            clientId: process.env.SPOTIFY_CLIENT_ID ?? undefined,
+            clientSecret: process.env.SPOTIFY_CLIENT_SECRET ?? undefined,
             market: 'US',
         })
         if (!registered) {

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -1,12 +1,12 @@
 import { Player } from 'discord-player'
 import type { Track } from 'discord-player'
 import {
-    SpotifyExtractor,
     SoundCloudExtractor,
     AppleMusicExtractor,
     VimeoExtractor,
     AttachmentExtractor,
 } from '@discord-player/extractor'
+import { SpotifyExtractor } from 'discord-player-spotify'
 import * as playdl from 'play-dl'
 import { spawn } from 'child_process'
 import { PassThrough } from 'stream'
@@ -70,6 +70,7 @@ const registerSpotifyExtractor = async (player: Player): Promise<void> => {
         const registered = await player.extractors.register(SpotifyExtractor, {
             clientId: process.env.SPOTIFY_CLIENT_ID ?? null,
             clientSecret: process.env.SPOTIFY_CLIENT_SECRET ?? null,
+            market: 'US',
         })
         if (!registered) {
             warnLog({

--- a/packages/bot/tests/handlers/player/playerFactory.test.ts
+++ b/packages/bot/tests/handlers/player/playerFactory.test.ts
@@ -14,11 +14,14 @@ jest.mock('discord-player', () => {
 
 jest.mock('@discord-player/extractor', () => ({
     DefaultExtractors: [],
-    SpotifyExtractor: class MockSpotifyExtractor {},
     SoundCloudExtractor: class MockSoundCloudExtractor {},
     AppleMusicExtractor: class MockAppleMusicExtractor {},
     VimeoExtractor: class MockVimeoExtractor {},
     AttachmentExtractor: class MockAttachmentExtractor {},
+}))
+
+jest.mock('discord-player-spotify', () => ({
+    SpotifyExtractor: class MockSpotifyExtractor {},
 }))
 
 jest.mock('discord-player-youtubei', () => ({
@@ -185,7 +188,7 @@ describe('playerFactory', () => {
             }))
 
             const { SpotifyExtractor } = await import(
-                '@discord-player/extractor'
+                'discord-player-spotify'
             )
             jest.doMock('discord-player', () => {
                 const register = jest.fn().mockImplementation((ext) => {
@@ -275,7 +278,7 @@ describe('playerFactory', () => {
             }))
 
             const { SpotifyExtractor } = await import(
-                '@discord-player/extractor'
+                'discord-player-spotify'
             )
             jest.doMock('discord-player', () => {
                 const register = jest.fn().mockImplementation((ext) => {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.115",
+    "version": "2.6.116",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.115",
+    "version": "2.6.116",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- **Root cause**: The built-in `SpotifyExtractor` from `@discord-player/extractor@7.2.0` has a confirmed unfixed bug ([discord-player#1988](https://github.com/Androz2091/discord-player/issues/1988)) where text searches return 0 tracks despite valid credentials and a working Spotify API. The maintainers closed the issue as "not_planned" and recommended switching to the community package.
- **Fix**: Replace with `discord-player-spotify@1.1.9` — the maintainer-recommended replacement, actively maintained with Feb 2026 Spotify API changes already incorporated.
- **Verified**: Tested directly in the container — `SpotifyExtractor.handle("a cautionary tale laufey")` returned 0 tracks with the old package; Spotify API itself returned 3 results correctly.

## Test plan

- [x] All 2208 tests pass
- [x] Updated `playerFactory.test.ts` and `playerFactory.bridge.spec.ts` mocks to use `discord-player-spotify`
- [x] Version bumped to 2.6.116

🤖 Generated with [Claude Code](https://claude.com/claude-code)