### PR TITLE
fix(queue): clamp embed field to 1024 chars, truncate track titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.117] - 2026-04-14
+
+### Fixed
+- `/queue` command crash: embed field value is now clamped to Discord's 1024-character limit — Spotify track URLs are longer than YouTube URLs so queues with many tracks overflowed the limit and were rejected by `EmbedBuilder.addFields` with "Received one or more errors"
+- Queue track titles truncated to 40 chars in the track list to keep lines compact
+
 ## [2.6.116] - 2026-04-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.116",
+    "version": "2.6.117",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.116",
+    "version": "2.6.117",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/src/functions/music/commands/queue/queueDisplay.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueDisplay.ts
@@ -48,7 +48,7 @@ function formatSingleTrack(info: TrackDisplayInfo, index: number): string {
     }
     const by = info.requestedBy ? ` \u2022 ${info.requestedBy}` : ''
     const title =
-        info.title.length > 40 ? info.title.slice(0, 38) + '\u2026' : info.title
+        info.title.length > 40 ? info.title.slice(0, 39) + '\u2026' : info.title
     const link =
         info.url && info.url.startsWith('http')
             ? `[${title}](${info.url})`

--- a/packages/bot/src/functions/music/commands/queue/queueDisplay.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueDisplay.ts
@@ -47,7 +47,13 @@ function formatSingleTrack(info: TrackDisplayInfo, index: number): string {
         }
     }
     const by = info.requestedBy ? ` \u2022 ${info.requestedBy}` : ''
-    return `${marker} ${index + 1}. [${info.title}](${info.url}) - ${info.author} (${info.duration})${by}${reason}`
+    const title =
+        info.title.length > 40 ? info.title.slice(0, 38) + '\u2026' : info.title
+    const link =
+        info.url && info.url.startsWith('http')
+            ? `[${title}](${info.url})`
+            : title
+    return `${marker} ${index + 1}. ${link} - ${info.author} (${info.duration})${by}${reason}`
 }
 
 export async function createTrackListDisplay(

--- a/packages/bot/src/functions/music/commands/queue/queueEmbed.spec.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueEmbed.spec.ts
@@ -248,6 +248,27 @@ describe('queueEmbed', () => {
             expect(upcomingCall).toBeUndefined()
         })
 
+        it('truncates track list value to 1024 chars when it exceeds Discord embed limit', async () => {
+            createTrackListDisplayMock.mockResolvedValue('x'.repeat(2000))
+            const track = createTrack()
+            const queue = createQueue({
+                currentTrack: null,
+                tracks: { toArray: () => [track] },
+            })
+
+            await createQueueEmbed(queue as any, defaultOptions)
+
+            const upcomingCall = addFieldsMock.mock.calls.find((call) =>
+                String((call[0] as any).name ?? '').startsWith(
+                    '📋 Upcoming Tracks (',
+                ),
+            )
+            expect(upcomingCall).toBeDefined()
+            expect((upcomingCall![0] as any).value.length).toBeLessThanOrEqual(
+                1024,
+            )
+        })
+
         it('returns the embed instance', async () => {
             const queue = createQueue()
 

--- a/packages/bot/src/functions/music/commands/queue/queueEmbed.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueEmbed.ts
@@ -62,9 +62,11 @@ async function addUpcomingTracks(
 
     if (allTracks.length > 0) {
         const trackList = await createTrackListDisplay(allTracks, options, page)
+        const raw = trackList || 'No displayable tracks'
+        const value = raw.length > 1024 ? raw.slice(0, 1021) + '…' : raw
         embed.addFields({
             name: `\u{1F4CB} Upcoming Tracks (${allTracks.length})`,
-            value: trackList || 'No displayable tracks',
+            value,
             inline: false,
         })
     } else {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.116",
+    "version": "2.6.117",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.116",
+    "version": "2.6.117",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- **Root cause**: `/queue` was crashing with "Received one or more errors" from `EmbedBuilder.addFields` — Discord.js (via `@sapphire/shapeshift`) validates embed field values ≤1024 chars. Spotify track URLs (`https://open.spotify.com/track/xxx`) are ~50 chars longer than YouTube URLs, pushing a 10-track page over the limit after the v2.6.116 extractor switch.
- **Fix 1**: Clamp the track list `value` to 1024 chars before passing to `addFields` (`raw.slice(0, 1021) + '…'`)
- **Fix 2**: Truncate track titles to 40 chars in the list display to keep lines compact
- **Fix 3**: Only render hyperlinks for `http` URLs — guards against any non-URL values slipping through

## Test plan

- [x] Added regression test: track list of 2000 chars is truncated to ≤1024 in the embed field
- [x] All 2208 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved `/queue` command crashes caused by Discord embed field character limits when displaying tracks with long Spotify URLs
  * Track titles in the queue are now truncated for improved display compactness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->