### PR TITLE
test(coverage): add tests for recommendation, mappers, giveaway, and utilities

### DIFF
--- a/packages/bot/src/functions/general/commands/giveaway.spec.ts
+++ b/packages/bot/src/functions/general/commands/giveaway.spec.ts
@@ -1,9 +1,26 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals'
-import giveawayCommand, { parseDuration } from './giveaway'
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+    jest,
+    afterEach,
+} from '@jest/globals'
+import giveawayCommand, { parseDuration, activeGiveaways } from './giveaway'
 
 const interactionReplyMock = jest.fn()
-const createSuccessEmbedMock = jest.fn((title: string, description: string) => ({ type: 'success', title, description }))
-const createErrorEmbedMock = jest.fn((title: string, description: string) => ({ type: 'error', title, description }))
+const createSuccessEmbedMock = jest.fn(
+    (title: string, description: string) => ({
+        type: 'success',
+        title,
+        description,
+    }),
+)
+const createErrorEmbedMock = jest.fn((title: string, description: string) => ({
+    type: 'error',
+    title,
+    description,
+}))
 const requireGuildMock = jest.fn()
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -23,7 +40,10 @@ jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
 }))
 
-function createInteraction(subcommand: string, opts: Record<string, unknown> = {}) {
+function createInteraction(
+    subcommand: string,
+    opts: Record<string, unknown> = {},
+) {
     return {
         guild: { id: 'guild-1' },
         channelId: 'channel-1',
@@ -46,6 +66,12 @@ describe('giveaway command', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         requireGuildMock.mockResolvedValue(true)
+        activeGiveaways.clear()
+    })
+
+    afterEach(() => {
+        activeGiveaways.forEach((g) => clearTimeout(g.timeoutId))
+        activeGiveaways.clear()
     })
 
     it('should be a valid command', () => {
@@ -76,7 +102,8 @@ describe('giveaway command', () => {
 
     it('should start a giveaway', async () => {
         const interaction = createInteraction('start', { value: '1h' }) as any
-        interaction.options.getString = jest.fn()
+        interaction.options.getString = jest
+            .fn()
             .mockReturnValueOnce('1h')
             .mockReturnValueOnce('Discord Nitro')
 
@@ -112,5 +139,138 @@ describe('giveaway command', () => {
         })
 
         expect(interactionReplyMock).toHaveBeenCalled()
+    })
+
+    it('starts giveaway when channel is text-based', async () => {
+        jest.useFakeTimers()
+        const sendMock = jest.fn().mockResolvedValue({
+            id: 'msg-1',
+            url: 'https://discord.com/channels/g/c/msg-1',
+            react: jest.fn().mockResolvedValue(undefined),
+        })
+        const interaction = {
+            guild: { id: 'guild-1' },
+            channelId: 'ch-1',
+            channel: { isTextBased: () => true, send: sendMock },
+            options: {
+                getSubcommand: () => 'start',
+                getString: jest
+                    .fn()
+                    .mockReturnValueOnce('1h')
+                    .mockReturnValueOnce('Nitro'),
+                getInteger: jest.fn().mockReturnValue(2),
+            },
+        }
+        await giveawayCommand.execute({ interaction: interaction as never })
+        expect(sendMock).toHaveBeenCalled()
+        expect(activeGiveaways.size).toBe(1)
+        expect(interactionReplyMock).toHaveBeenCalled()
+        jest.useRealTimers()
+    })
+
+    it('errors when channel is not text-based', async () => {
+        const interaction = {
+            guild: { id: 'guild-1' },
+            channelId: 'ch-1',
+            channel: { isTextBased: () => false },
+            options: {
+                getSubcommand: () => 'start',
+                getString: jest
+                    .fn()
+                    .mockReturnValueOnce('1h')
+                    .mockReturnValueOnce('Prize'),
+                getInteger: jest.fn().mockReturnValue(1),
+            },
+        }
+        await giveawayCommand.execute({ interaction: interaction as never })
+        expect(createErrorEmbedMock).toHaveBeenCalledWith(
+            'Error',
+            expect.stringContaining('not text-based'),
+        )
+    })
+
+    it('ends existing giveaway successfully', async () => {
+        const timeoutId = setTimeout(() => {}, 999999)
+        activeGiveaways.set('existing-msg', {
+            messageId: 'existing-msg',
+            channelId: 'ch-1',
+            guildId: 'guild-1',
+            prize: 'Test Prize',
+            winnersCount: 1,
+            endTime: Date.now() + 60000,
+            entries: new Set(['user-1']),
+            timeoutId,
+        })
+        const interaction = {
+            guild: { id: 'guild-1' },
+            options: {
+                getSubcommand: () => 'end',
+                getString: jest.fn().mockReturnValue('existing-msg'),
+            },
+        }
+        await giveawayCommand.execute({ interaction: interaction as never })
+        expect(createSuccessEmbedMock).toHaveBeenCalledWith(
+            'Giveaway Ended',
+            expect.any(String),
+        )
+    })
+
+    it('reports error when ending nonexistent giveaway', async () => {
+        const interaction = {
+            guild: { id: 'guild-1' },
+            options: {
+                getSubcommand: () => 'end',
+                getString: jest.fn().mockReturnValue('no-such-msg'),
+            },
+        }
+        await giveawayCommand.execute({ interaction: interaction as never })
+        expect(createErrorEmbedMock).toHaveBeenCalledWith(
+            'Not Found',
+            expect.any(String),
+        )
+    })
+
+    it('rerolls existing giveaway', async () => {
+        const timeoutId = setTimeout(() => {}, 999999)
+        activeGiveaways.set('reroll-msg', {
+            messageId: 'reroll-msg',
+            channelId: 'ch-1',
+            guildId: 'guild-1',
+            prize: 'Reroll Prize',
+            winnersCount: 1,
+            endTime: Date.now() + 60000,
+            entries: new Set(['user-1', 'user-2']),
+            timeoutId,
+        })
+        const interaction = {
+            guild: { id: 'guild-1' },
+            options: {
+                getSubcommand: () => 'reroll',
+                getString: jest.fn().mockReturnValue('reroll-msg'),
+            },
+        }
+        await giveawayCommand.execute({ interaction: interaction as never })
+        expect(createSuccessEmbedMock).toHaveBeenCalledWith(
+            'Rerolled',
+            expect.any(String),
+        )
+    })
+
+    it('handles execute errors gracefully', async () => {
+        const interaction = {
+            guild: { id: 'guild-1' },
+            options: {
+                getSubcommand: () => 'start',
+                getString: jest.fn().mockImplementation(() => {
+                    throw new Error('unexpected')
+                }),
+                getInteger: jest.fn().mockReturnValue(1),
+            },
+        }
+        await giveawayCommand.execute({ interaction: interaction as never })
+        expect(createErrorEmbedMock).toHaveBeenCalledWith(
+            'Error',
+            expect.any(String),
+        )
     })
 })

--- a/packages/bot/src/handlers/webMusic/mappers.spec.ts
+++ b/packages/bot/src/handlers/webMusic/mappers.spec.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, jest } from '@jest/globals'
+
+jest.mock('discord-player', () => ({
+    QueueRepeatMode: {
+        OFF: 0,
+        TRACK: 1,
+        QUEUE: 2,
+        AUTOPLAY: 3,
+    },
+}))
+
+jest.mock('../../utils/music/queueResolver', () => ({
+    resolveGuildQueue: jest.fn(),
+}))
+
+import {
+    mapTrack,
+    repeatModeToString,
+    repeatModeToEnum,
+    buildQueueState,
+} from './mappers'
+import { QueueRepeatMode } from 'discord-player'
+import { resolveGuildQueue } from '../../utils/music/queueResolver'
+
+const resolveGuildQueueMock = resolveGuildQueue as jest.MockedFunction<
+    typeof resolveGuildQueue
+>
+
+function makeRawTrack(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'track-1',
+        title: 'Song',
+        author: 'Artist',
+        url: 'https://example.com/song',
+        thumbnail: 'https://example.com/thumb.jpg',
+        duration: { toString: () => '3:21' },
+        durationMS: 201000,
+        requestedBy: { username: 'user1' },
+        source: 'youtube',
+        ...overrides,
+    }
+}
+
+describe('mapTrack', () => {
+    it('maps all fields from a raw track', () => {
+        const track = mapTrack(makeRawTrack())
+        expect(track).toEqual({
+            id: 'track-1',
+            title: 'Song',
+            author: 'Artist',
+            url: 'https://example.com/song',
+            thumbnail: 'https://example.com/thumb.jpg',
+            duration: 201000,
+            durationFormatted: '3:21',
+            requestedBy: 'user1',
+            source: 'youtube',
+        })
+    })
+
+    it('maps spotify source correctly', () => {
+        const track = mapTrack(makeRawTrack({ source: 'spotify' }))
+        expect(track.source).toBe('spotify')
+    })
+
+    it('maps soundcloud source correctly', () => {
+        const track = mapTrack(makeRawTrack({ source: 'soundcloud' }))
+        expect(track.source).toBe('soundcloud')
+    })
+
+    it('maps unknown source to "unknown"', () => {
+        const track = mapTrack(makeRawTrack({ source: 'bandcamp' }))
+        expect(track.source).toBe('unknown')
+    })
+
+    it('maps undefined source to "unknown"', () => {
+        const track = mapTrack(makeRawTrack({ source: undefined }))
+        expect(track.source).toBe('unknown')
+    })
+
+    it('handles null requestedBy', () => {
+        const track = mapTrack(makeRawTrack({ requestedBy: null }))
+        expect(track.requestedBy).toBeUndefined()
+    })
+})
+
+describe('repeatModeToString', () => {
+    it('converts TRACK mode', () => {
+        expect(repeatModeToString(QueueRepeatMode.TRACK)).toBe('track')
+    })
+
+    it('converts QUEUE mode', () => {
+        expect(repeatModeToString(QueueRepeatMode.QUEUE)).toBe('queue')
+    })
+
+    it('converts AUTOPLAY mode', () => {
+        expect(repeatModeToString(QueueRepeatMode.AUTOPLAY)).toBe('autoplay')
+    })
+
+    it('converts OFF mode to "off"', () => {
+        expect(repeatModeToString(QueueRepeatMode.OFF)).toBe('off')
+    })
+
+    it('converts unknown mode to "off"', () => {
+        expect(repeatModeToString(99 as QueueRepeatMode)).toBe('off')
+    })
+})
+
+describe('repeatModeToEnum', () => {
+    it('converts "track" to TRACK', () => {
+        expect(repeatModeToEnum('track')).toBe(QueueRepeatMode.TRACK)
+    })
+
+    it('converts "queue" to QUEUE', () => {
+        expect(repeatModeToEnum('queue')).toBe(QueueRepeatMode.QUEUE)
+    })
+
+    it('converts "autoplay" to AUTOPLAY', () => {
+        expect(repeatModeToEnum('autoplay')).toBe(QueueRepeatMode.AUTOPLAY)
+    })
+
+    it('converts "off" to OFF', () => {
+        expect(repeatModeToEnum('off')).toBe(QueueRepeatMode.OFF)
+    })
+
+    it('converts unknown string to OFF', () => {
+        expect(repeatModeToEnum('unknown')).toBe(QueueRepeatMode.OFF)
+    })
+})
+
+describe('buildQueueState', () => {
+    it('returns empty queue state when queue is null', async () => {
+        resolveGuildQueueMock.mockReturnValue({ queue: null } as never)
+        const state = await buildQueueState({} as never, 'guild-1')
+        expect(state).toEqual({
+            guildId: 'guild-1',
+            currentTrack: null,
+            tracks: [],
+            isPlaying: false,
+            isPaused: false,
+            volume: 50,
+            repeatMode: 'off',
+            shuffled: false,
+            position: 0,
+            voiceChannelId: null,
+            voiceChannelName: null,
+            timestamp: expect.any(Number),
+        })
+    })
+
+    it('returns populated queue state when queue exists', async () => {
+        const mockQueue = {
+            currentTrack: makeRawTrack(),
+            tracks: {
+                toArray: () => [
+                    makeRawTrack({ id: 'track-2', title: 'Next Song' }),
+                ],
+            },
+            node: {
+                isPlaying: () => true,
+                isPaused: () => false,
+                volume: 80,
+                streamTime: 12000,
+            },
+            repeatMode: QueueRepeatMode.QUEUE,
+            channel: { id: 'vc-1', name: 'Music' },
+        }
+        resolveGuildQueueMock.mockReturnValue({ queue: mockQueue } as never)
+        const state = await buildQueueState({} as never, 'guild-1')
+        expect(state.guildId).toBe('guild-1')
+        expect(state.currentTrack?.title).toBe('Song')
+        expect(state.tracks).toHaveLength(1)
+        expect(state.isPlaying).toBe(true)
+        expect(state.volume).toBe(80)
+        expect(state.repeatMode).toBe('queue')
+        expect(state.position).toBe(12000)
+        expect(state.voiceChannelId).toBe('vc-1')
+    })
+
+    it('handles queue with null currentTrack', async () => {
+        const mockQueue = {
+            currentTrack: null,
+            tracks: { toArray: () => [] },
+            node: {
+                isPlaying: () => false,
+                isPaused: () => false,
+                volume: 50,
+                streamTime: 0,
+            },
+            repeatMode: QueueRepeatMode.OFF,
+            channel: null,
+        }
+        resolveGuildQueueMock.mockReturnValue({ queue: mockQueue } as never)
+        const state = await buildQueueState({} as never, 'guild-1')
+        expect(state.currentTrack).toBeNull()
+        expect(state.voiceChannelId).toBeNull()
+    })
+})

--- a/packages/bot/src/services/musicRecommendation/similarityCalculator.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/similarityCalculator.spec.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it } from '@jest/globals'
+import type { Track } from 'discord-player'
+import type { RecommendationConfig } from './types'
+import {
+    calculateTrackSimilarity,
+    calculateDiversityScore,
+} from './similarityCalculator'
+
+const createMockTrack = (overrides?: Partial<Track>): Track => ({
+    id: 'mock-track-id',
+    title: 'Test Track',
+    author: 'Test Artist',
+    duration: 180000,
+    description: '',
+    thumbnail: '',
+    views: 1000,
+    url: 'https://example.com/track',
+    source: 'youtube',
+    source_url: 'https://example.com',
+    rawTitle: 'Test Track',
+    durationMS: 180000,
+    playlist: null,
+    isStream: false,
+    ...overrides,
+})
+
+const createMockConfig = (
+    overrides?: Partial<RecommendationConfig>,
+): RecommendationConfig => ({
+    maxRecommendations: 10,
+    similarityThreshold: 0.5,
+    genreWeight: 0.2,
+    tagWeight: 0.15,
+    artistWeight: 0.25,
+    durationWeight: 0.2,
+    popularityWeight: 0.1,
+    diversityFactor: 1.0,
+    maxTracksPerArtist: 2,
+    maxTracksPerSource: 3,
+    ...overrides,
+})
+
+describe('similarityCalculator', () => {
+    describe('calculateTrackSimilarity', () => {
+        it('returns high score for identical tracks', () => {
+            const track = createMockTrack({
+                title: 'Amazing Song',
+                author: 'Great Artist',
+                duration: 240000,
+            })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(track, track, config)
+            expect(similarity).toBeGreaterThan(0.79)
+        })
+
+        it('returns lower score when titles are completely different', () => {
+            const trackA = createMockTrack({ title: 'Song A' })
+            const trackB = createMockTrack({
+                title: 'Completely Different Title',
+            })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeLessThan(0.6)
+        })
+
+        it('returns higher score when artists match exactly', () => {
+            const trackA = createMockTrack({
+                title: 'Song A',
+                author: 'Same Artist',
+            })
+            const trackB = createMockTrack({
+                title: 'Different Song',
+                author: 'Same Artist',
+            })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeGreaterThan(0.5)
+        })
+
+        it('handles artist substring matches with 0.8 partial match', () => {
+            const trackA = createMockTrack({
+                title: 'Song',
+                author: 'Artist Name Full',
+            })
+            const trackB = createMockTrack({
+                title: 'Song',
+                author: 'Artist Name',
+            })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeGreaterThan(0.7)
+        })
+
+        it('handles duration ratio: same duration gives 1.0', () => {
+            const trackA = createMockTrack({
+                title: 'Song',
+                author: 'Artist',
+                duration: 240000,
+            })
+            const trackB = createMockTrack({
+                title: 'Song',
+                author: 'Artist',
+                duration: 240000,
+            })
+            const config = createMockConfig({ durationWeight: 1.0 })
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeGreaterThan(0.8)
+        })
+
+        it('handles wildly different durations with lower score', () => {
+            const trackA = createMockTrack({ duration: 60000 })
+            const trackB = createMockTrack({ duration: 600000 })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            const identicalTrackScore = calculateTrackSimilarity(
+                trackA,
+                trackA,
+                config,
+            )
+            expect(similarity).toBeLessThan(identicalTrackScore)
+        })
+
+        it('handles duration 0 as neutral (0.5)', () => {
+            const trackA = createMockTrack({
+                duration: 0,
+                title: 'X',
+                author: 'Y',
+            })
+            const trackB = createMockTrack({
+                duration: 120000,
+                title: 'X',
+                author: 'Y',
+            })
+            const config = createMockConfig({ durationWeight: 1.0 })
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeCloseTo(1.095, 1)
+        })
+
+        it('handles title word overlap (Jaccard): 2 common out of 4 union = 0.5', () => {
+            const trackA = createMockTrack({ title: 'Hello World Song' })
+            const trackB = createMockTrack({ title: 'Hello World Different' })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeGreaterThan(0.1)
+        })
+
+        it('returns 0.0 title component when no common words', () => {
+            const trackA = createMockTrack({ title: 'AAA BBB' })
+            const trackB = createMockTrack({ title: 'XXX YYY' })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeLessThan(0.6)
+        })
+
+        it('correctly parses numeric duration strings', () => {
+            const trackA = createMockTrack({ duration: '240000' as never })
+            const trackB = createMockTrack({ duration: '240000' as never })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeCloseTo(0.795, 1)
+        })
+
+        it('applies config weights correctly', () => {
+            const trackA = createMockTrack({
+                title: 'Song A',
+                author: 'Artist A',
+                duration: 180000,
+            })
+            const trackB = createMockTrack({
+                title: 'Song B',
+                author: 'Artist B',
+                duration: 180000,
+            })
+
+            const configHighArtist = createMockConfig({
+                artistWeight: 0.6,
+                durationWeight: 0.1,
+            })
+            const configHighDuration = createMockConfig({
+                artistWeight: 0.1,
+                durationWeight: 0.6,
+            })
+
+            const scoreHighArtist = calculateTrackSimilarity(
+                trackA,
+                trackB,
+                configHighArtist,
+            )
+            const scoreHighDuration = calculateTrackSimilarity(
+                trackA,
+                trackB,
+                configHighDuration,
+            )
+
+            expect(scoreHighDuration).toBeGreaterThan(scoreHighArtist)
+        })
+
+        it('is case-insensitive for title and artist comparison', () => {
+            const trackA = createMockTrack({
+                title: 'Amazing Song',
+                author: 'Great Artist',
+            })
+            const trackB = createMockTrack({
+                title: 'amazing song',
+                author: 'great artist',
+            })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeGreaterThan(0.75)
+        })
+
+        it('handles whitespace normalization', () => {
+            const trackA = createMockTrack({
+                title: '  Amazing   Song  ',
+                author: '  Artist   Name  ',
+            })
+            const trackB = createMockTrack({
+                title: 'Amazing Song',
+                author: 'Artist Name',
+            })
+            const config = createMockConfig()
+
+            const similarity = calculateTrackSimilarity(trackA, trackB, config)
+            expect(similarity).toBeGreaterThan(0.65)
+        })
+    })
+
+    describe('calculateDiversityScore', () => {
+        it('returns 1.0 for empty array', () => {
+            const config = createMockConfig()
+            const score = calculateDiversityScore([], config)
+            expect(score).toBe(1.0)
+        })
+
+        it('returns 1.0 for single track', () => {
+            const track = createMockTrack()
+            const config = createMockConfig()
+            const score = calculateDiversityScore([track], config)
+            expect(score).toBe(1.0)
+        })
+
+        it('returns low score for two identical tracks', () => {
+            const track = createMockTrack()
+            const config = createMockConfig()
+            const score = calculateDiversityScore([track, track], config)
+            expect(score).toBeLessThan(0.3)
+        })
+
+        it('returns high score for two very different tracks', () => {
+            const trackA = createMockTrack({
+                title: 'Rock Song',
+                author: 'Rock Band',
+                duration: 240000,
+            })
+            const trackB = createMockTrack({
+                title: 'Classical Composition',
+                author: 'Orchestra',
+                duration: 600000,
+            })
+            const config = createMockConfig()
+            const score = calculateDiversityScore([trackA, trackB], config)
+            expect(score).toBeGreaterThan(0.5)
+        })
+
+        it('correctly calculates diversity for multiple tracks', () => {
+            const trackA = createMockTrack({
+                title: 'Song A',
+                author: 'Artist A',
+                duration: 180000,
+            })
+            const trackB = createMockTrack({
+                title: 'Song B',
+                author: 'Artist B',
+                duration: 200000,
+            })
+            const trackC = createMockTrack({
+                title: 'Song C',
+                author: 'Artist C',
+                duration: 220000,
+            })
+            const config = createMockConfig()
+
+            const score = calculateDiversityScore(
+                [trackA, trackB, trackC],
+                config,
+            )
+            expect(score).toBeGreaterThan(0.0)
+            expect(score).toBeLessThanOrEqual(1.0)
+        })
+
+        it('diversity decreases when adding more similar tracks', () => {
+            const trackA = createMockTrack({
+                title: 'Song A',
+                author: 'Artist A',
+            })
+            const trackB = createMockTrack({
+                title: 'Song B',
+                author: 'Artist B',
+            })
+            const trackC = createMockTrack({
+                title: 'Song A Remix',
+                author: 'Artist A',
+            })
+            const config = createMockConfig()
+
+            const scoreTwoTracks = calculateDiversityScore(
+                [trackA, trackB],
+                config,
+            )
+            const scoreThreeTracksWithSimilar = calculateDiversityScore(
+                [trackA, trackB, trackC],
+                config,
+            )
+
+            expect(scoreThreeTracksWithSimilar).toBeLessThan(scoreTwoTracks)
+        })
+    })
+})

--- a/packages/bot/src/services/musicRecommendation/similarityCalculator.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/similarityCalculator.spec.ts
@@ -80,7 +80,7 @@ describe('similarityCalculator', () => {
             expect(similarity).toBeGreaterThan(0.5)
         })
 
-        it('handles artist substring matches with 0.8 partial match', () => {
+        it('handles artist substring matches with 0.8 partial', () => {
             const trackA = createMockTrack({
                 title: 'Song',
                 author: 'Artist Name Full',
@@ -95,7 +95,7 @@ describe('similarityCalculator', () => {
             expect(similarity).toBeGreaterThan(0.7)
         })
 
-        it('handles duration ratio: same duration gives 1.0', () => {
+        it('handles duration ratio: same duration = 1.0', () => {
             const trackA = createMockTrack({
                 title: 'Song',
                 author: 'Artist',
@@ -112,7 +112,7 @@ describe('similarityCalculator', () => {
             expect(similarity).toBeGreaterThan(0.8)
         })
 
-        it('handles wildly different durations with lower score', () => {
+        it('wildly different durations lower the score', () => {
             const trackA = createMockTrack({ duration: 60000 })
             const trackB = createMockTrack({ duration: 600000 })
             const config = createMockConfig()
@@ -126,7 +126,7 @@ describe('similarityCalculator', () => {
             expect(similarity).toBeLessThan(identicalTrackScore)
         })
 
-        it('handles duration 0 as neutral (0.5)', () => {
+        it('duration 0 treated as neutral (0.5)', () => {
             const trackA = createMockTrack({
                 duration: 0,
                 title: 'X',
@@ -143,7 +143,7 @@ describe('similarityCalculator', () => {
             expect(similarity).toBeCloseTo(1.095, 1)
         })
 
-        it('handles title word overlap (Jaccard): 2 common out of 4 union = 0.5', () => {
+        it('Jaccard: 2 common out of 4 union = 0.5', () => {
             const trackA = createMockTrack({ title: 'Hello World Song' })
             const trackB = createMockTrack({ title: 'Hello World Different' })
             const config = createMockConfig()
@@ -152,7 +152,7 @@ describe('similarityCalculator', () => {
             expect(similarity).toBeGreaterThan(0.1)
         })
 
-        it('returns 0.0 title component when no common words', () => {
+        it('no common words in title = 0.0 component', () => {
             const trackA = createMockTrack({ title: 'AAA BBB' })
             const trackB = createMockTrack({ title: 'XXX YYY' })
             const config = createMockConfig()
@@ -161,7 +161,7 @@ describe('similarityCalculator', () => {
             expect(similarity).toBeLessThan(0.6)
         })
 
-        it('correctly parses numeric duration strings', () => {
+        it('parses numeric duration strings correctly', () => {
             const trackA = createMockTrack({ duration: '240000' as never })
             const trackB = createMockTrack({ duration: '240000' as never })
             const config = createMockConfig()
@@ -205,7 +205,7 @@ describe('similarityCalculator', () => {
             expect(scoreHighDuration).toBeGreaterThan(scoreHighArtist)
         })
 
-        it('is case-insensitive for title and artist comparison', () => {
+        it('is case-insensitive for comparison', () => {
             const trackA = createMockTrack({
                 title: 'Amazing Song',
                 author: 'Great Artist',
@@ -250,14 +250,14 @@ describe('similarityCalculator', () => {
             expect(score).toBe(1.0)
         })
 
-        it('returns low score for two identical tracks', () => {
+        it('returns low score for identical tracks', () => {
             const track = createMockTrack()
             const config = createMockConfig()
             const score = calculateDiversityScore([track, track], config)
             expect(score).toBeLessThan(0.3)
         })
 
-        it('returns high score for two very different tracks', () => {
+        it('returns high score for very different tracks', () => {
             const trackA = createMockTrack({
                 title: 'Rock Song',
                 author: 'Rock Band',
@@ -273,7 +273,7 @@ describe('similarityCalculator', () => {
             expect(score).toBeGreaterThan(0.5)
         })
 
-        it('correctly calculates diversity for multiple tracks', () => {
+        it('calculates diversity for multiple tracks', () => {
             const trackA = createMockTrack({
                 title: 'Song A',
                 author: 'Artist A',
@@ -299,7 +299,7 @@ describe('similarityCalculator', () => {
             expect(score).toBeLessThanOrEqual(1.0)
         })
 
-        it('diversity decreases when adding more similar tracks', () => {
+        it('diversity decreases with similar tracks', () => {
             const trackA = createMockTrack({
                 title: 'Song A',
                 author: 'Artist A',

--- a/packages/bot/src/services/musicRecommendation/vectorOperations.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/vectorOperations.spec.ts
@@ -69,7 +69,7 @@ describe('vectorOperations', () => {
             expect(vector.trackId).toBe('unique-id-123')
         })
 
-        it('falls back to track.url when track.id is missing', () => {
+        it('falls back to track.url when id missing', () => {
             const track = createMockTrack({
                 id: undefined,
                 url: 'https://example.com/song',
@@ -82,7 +82,7 @@ describe('vectorOperations', () => {
             expect(vector.trackId).toBe('https://example.com/song')
         })
 
-        it('sets title and artist from track properties', () => {
+        it('sets title and artist from track', () => {
             const track = createMockTrack({
                 title: 'My Awesome Song',
                 author: 'Great Artist Name',
@@ -107,7 +107,7 @@ describe('vectorOperations', () => {
             expect(vector.vector.every((v) => typeof v === 'number')).toBe(true)
         })
 
-        it('has duration, views, genre, tags fields set correctly', () => {
+        it('has duration, views, genre, tags fields set', () => {
             const track = createMockTrack({
                 duration: 240000,
                 views: 5000000,
@@ -157,7 +157,7 @@ describe('vectorOperations', () => {
     })
 
     describe('calculateCosineSimilarity', () => {
-        it('returns 1.0 for identical non-zero vectors', () => {
+        it('returns 1.0 for identical vectors', () => {
             const vector = [1, 2, 3, 4]
             const similarity = calculateCosineSimilarity(vector, vector)
             expect(similarity).toBeCloseTo(1.0, 5)
@@ -170,7 +170,7 @@ describe('vectorOperations', () => {
             expect(similarity).toBeCloseTo(0.0, 5)
         })
 
-        it('returns 0.0 for vectors of different lengths', () => {
+        it('returns 0.0 for different lengths', () => {
             const vectorA = [1, 2, 3]
             const vectorB = [1, 2, 3, 4]
             const similarity = calculateCosineSimilarity(vectorA, vectorB)
@@ -183,7 +183,7 @@ describe('vectorOperations', () => {
             expect(similarity).toBe(0)
         })
 
-        it('calculates realistic partial similarity correctly', () => {
+        it('calculates partial similarity correctly', () => {
             const vectorA = [1, 2, 3]
             const vectorB = [2, 4, 6]
             const similarity = calculateCosineSimilarity(vectorA, vectorB)
@@ -212,14 +212,14 @@ describe('vectorOperations', () => {
             expect(distance).toBeCloseTo(0.0, 5)
         })
 
-        it('returns Infinity for vectors of different lengths', () => {
+        it('returns Infinity for different lengths', () => {
             const vectorA = [1, 2, 3]
             const vectorB = [1, 2, 3, 4]
             const distance = calculateEuclideanDistance(vectorA, vectorB)
             expect(distance).toBe(Infinity)
         })
 
-        it('calculates correct distance [0,0] vs [3,4] = 5.0', () => {
+        it('calculates [0,0] vs [3,4] = 5.0', () => {
             const vectorA = [0, 0]
             const vectorB = [3, 4]
             const distance = calculateEuclideanDistance(vectorA, vectorB)
@@ -277,7 +277,7 @@ describe('vectorOperations', () => {
             ).toBe(true)
         })
 
-        it('already normalized vector stays nearly identical', () => {
+        it('already normalized vector stays identical', () => {
             const vector = [1, 0, 0]
             const normalized = normalizeVector(vector)
             expect(normalized[0]).toBeCloseTo(1.0, 5)
@@ -316,7 +316,7 @@ describe('vectorOperations', () => {
             expect(similarity).toBeGreaterThan(0.1)
         })
 
-        it('applies no bonus when genres are different', () => {
+        it('applies no bonus for different genres', () => {
             const track1 = createMockTrack()
             const track2 = createMockTrack()
             const vectorA = createTrackVector(track1)
@@ -338,7 +338,7 @@ describe('vectorOperations', () => {
             expect(similarity).toBeLessThanOrEqual(1.0)
         })
 
-        it('applies no bonus when genre is missing on either vector', () => {
+        it('no bonus when genre missing', () => {
             const track1 = createMockTrack()
             const track2 = createMockTrack()
             const vectorA = createTrackVector(track1)
@@ -360,7 +360,7 @@ describe('vectorOperations', () => {
             expect(similarity).toBeLessThanOrEqual(1.0)
         })
 
-        it('clamps result to max 1.0 even with bonus', () => {
+        it('result clamped to max 1.0 with bonus', () => {
             const track1 = createMockTrack()
             const track2 = createMockTrack()
             const vectorA = createTrackVector(track1)
@@ -384,7 +384,7 @@ describe('vectorOperations', () => {
             expect(similarity).toBeLessThanOrEqual(1.0)
         })
 
-        it('returns value between 0 and 1 for different vectors', () => {
+        it('value between 0 and 1 for different vectors', () => {
             const track1 = createMockTrack()
             const track2 = createMockTrack()
             const vectorA = createTrackVector(track1)
@@ -407,7 +407,7 @@ describe('vectorOperations', () => {
             expect(similarity).toBeLessThanOrEqual(1.0)
         })
 
-        it('returns higher similarity for very similar vectors with same genre', () => {
+        it('higher similarity for similar vectors same genre', () => {
             const track1 = createMockTrack()
             const track2 = createMockTrack()
             const vectorA = createTrackVector(track1)

--- a/packages/bot/src/services/musicRecommendation/vectorOperations.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/vectorOperations.spec.ts
@@ -1,0 +1,441 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import type { Track } from 'discord-player'
+import type { TrackVector, RecommendationConfig } from './types'
+import {
+    createTrackVector,
+    calculateCosineSimilarity,
+    calculateEuclideanDistance,
+    normalizeVector,
+    calculateVectorSimilarity,
+} from './vectorOperations'
+
+const extractTagsMock = jest.fn()
+const extractGenreMock = jest.fn()
+
+jest.mock('../../utils/music/duplicateDetection/tagExtractor', () => ({
+    extractTags: (...args: unknown[]) => extractTagsMock(...args),
+    extractGenre: (...args: unknown[]) => extractGenreMock(...args),
+}))
+
+const createMockTrack = (overrides?: Partial<Track>): Track => ({
+    id: 'mock-track-id',
+    title: 'Test Track',
+    author: 'Test Artist',
+    duration: 180000,
+    description: '',
+    thumbnail: '',
+    views: 1000000,
+    url: 'https://example.com/track',
+    source: 'youtube',
+    source_url: 'https://example.com',
+    rawTitle: 'Test Track',
+    durationMS: 180000,
+    playlist: null,
+    isStream: false,
+    ...overrides,
+})
+
+const createMockConfig = (
+    overrides?: Partial<RecommendationConfig>,
+): RecommendationConfig => ({
+    maxRecommendations: 10,
+    similarityThreshold: 0.5,
+    genreWeight: 0.2,
+    tagWeight: 0.15,
+    artistWeight: 0.25,
+    durationWeight: 0.2,
+    popularityWeight: 0.1,
+    diversityFactor: 1.0,
+    maxTracksPerArtist: 2,
+    maxTracksPerSource: 3,
+    ...overrides,
+})
+
+describe('vectorOperations', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        extractTagsMock.mockReturnValue([])
+        extractGenreMock.mockReturnValue(undefined)
+    })
+
+    describe('createTrackVector', () => {
+        it('returns correct trackId from track.id', () => {
+            const track = createMockTrack({ id: 'unique-id-123' })
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            const vector = createTrackVector(track)
+
+            expect(vector.trackId).toBe('unique-id-123')
+        })
+
+        it('falls back to track.url when track.id is missing', () => {
+            const track = createMockTrack({
+                id: undefined,
+                url: 'https://example.com/song',
+            })
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            const vector = createTrackVector(track)
+
+            expect(vector.trackId).toBe('https://example.com/song')
+        })
+
+        it('sets title and artist from track properties', () => {
+            const track = createMockTrack({
+                title: 'My Awesome Song',
+                author: 'Great Artist Name',
+            })
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            const vector = createTrackVector(track)
+
+            expect(vector.title).toBe('My Awesome Song')
+            expect(vector.artist).toBe('Great Artist Name')
+        })
+
+        it('vector is an array of numbers', () => {
+            const track = createMockTrack()
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            const vector = createTrackVector(track)
+
+            expect(Array.isArray(vector.vector)).toBe(true)
+            expect(vector.vector.every((v) => typeof v === 'number')).toBe(true)
+        })
+
+        it('has duration, views, genre, tags fields set correctly', () => {
+            const track = createMockTrack({
+                duration: 240000,
+                views: 5000000,
+            })
+            extractTagsMock.mockReturnValue(['rock', 'instrumental'])
+            extractGenreMock.mockReturnValue('rock')
+
+            const vector = createTrackVector(track)
+
+            expect(vector.duration).toBe(240000)
+            expect(vector.views).toBe(5000000)
+            expect(vector.genre).toBe('rock')
+            expect(vector.tags).toEqual(['rock', 'instrumental'])
+        })
+
+        it('handles string duration correctly', () => {
+            const track = createMockTrack({ duration: '300000' as never })
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            const vector = createTrackVector(track)
+
+            expect(vector.duration).toBe(300000)
+        })
+
+        it('includes genre in vector calculations', () => {
+            const track = createMockTrack()
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue('pop')
+
+            const vector = createTrackVector(track)
+
+            expect(vector.genre).toBe('pop')
+            expect(vector.vector.length).toBeGreaterThan(10)
+        })
+
+        it('includes tags in vector calculations', () => {
+            const track = createMockTrack()
+            extractTagsMock.mockReturnValue(['acoustic', 'indie'])
+            extractGenreMock.mockReturnValue('indie')
+
+            const vector = createTrackVector(track)
+
+            expect(vector.tags).toContain('acoustic')
+            expect(vector.tags).toContain('indie')
+        })
+    })
+
+    describe('calculateCosineSimilarity', () => {
+        it('returns 1.0 for identical non-zero vectors', () => {
+            const vector = [1, 2, 3, 4]
+            const similarity = calculateCosineSimilarity(vector, vector)
+            expect(similarity).toBeCloseTo(1.0, 5)
+        })
+
+        it('returns 0.0 for orthogonal vectors', () => {
+            const vectorA = [1, 0, 0, 0]
+            const vectorB = [0, 1, 0, 0]
+            const similarity = calculateCosineSimilarity(vectorA, vectorB)
+            expect(similarity).toBeCloseTo(0.0, 5)
+        })
+
+        it('returns 0.0 for vectors of different lengths', () => {
+            const vectorA = [1, 2, 3]
+            const vectorB = [1, 2, 3, 4]
+            const similarity = calculateCosineSimilarity(vectorA, vectorB)
+            expect(similarity).toBe(0)
+        })
+
+        it('returns 0.0 for both zero vectors', () => {
+            const zeroVector = [0, 0, 0, 0]
+            const similarity = calculateCosineSimilarity(zeroVector, zeroVector)
+            expect(similarity).toBe(0)
+        })
+
+        it('calculates realistic partial similarity correctly', () => {
+            const vectorA = [1, 2, 3]
+            const vectorB = [2, 4, 6]
+            const similarity = calculateCosineSimilarity(vectorA, vectorB)
+            expect(similarity).toBeCloseTo(1.0, 5)
+        })
+
+        it('handles vectors with negative values', () => {
+            const vectorA = [1, -1, 0]
+            const vectorB = [1, -1, 0]
+            const similarity = calculateCosineSimilarity(vectorA, vectorB)
+            expect(similarity).toBeCloseTo(1.0, 5)
+        })
+
+        it('handles one zero norm gracefully', () => {
+            const vectorA = [0, 0, 0]
+            const vectorB = [1, 2, 3]
+            const similarity = calculateCosineSimilarity(vectorA, vectorB)
+            expect(similarity).toBe(0)
+        })
+    })
+
+    describe('calculateEuclideanDistance', () => {
+        it('returns 0.0 for identical vectors', () => {
+            const vector = [1, 2, 3, 4]
+            const distance = calculateEuclideanDistance(vector, vector)
+            expect(distance).toBeCloseTo(0.0, 5)
+        })
+
+        it('returns Infinity for vectors of different lengths', () => {
+            const vectorA = [1, 2, 3]
+            const vectorB = [1, 2, 3, 4]
+            const distance = calculateEuclideanDistance(vectorA, vectorB)
+            expect(distance).toBe(Infinity)
+        })
+
+        it('calculates correct distance [0,0] vs [3,4] = 5.0', () => {
+            const vectorA = [0, 0]
+            const vectorB = [3, 4]
+            const distance = calculateEuclideanDistance(vectorA, vectorB)
+            expect(distance).toBeCloseTo(5.0, 5)
+        })
+
+        it('handles distance between far vectors', () => {
+            const vectorA = [0, 0, 0]
+            const vectorB = [10, 10, 10]
+            const distance = calculateEuclideanDistance(vectorA, vectorB)
+            expect(distance).toBeCloseTo(Math.sqrt(300), 5)
+        })
+
+        it('is symmetric', () => {
+            const vectorA = [1, 2, 3]
+            const vectorB = [4, 5, 6]
+            const distanceAB = calculateEuclideanDistance(vectorA, vectorB)
+            const distanceBA = calculateEuclideanDistance(vectorB, vectorA)
+            expect(distanceAB).toBeCloseTo(distanceBA, 5)
+        })
+    })
+
+    describe('normalizeVector', () => {
+        it('returns same vector unchanged for zero vector', () => {
+            const zeroVector = [0, 0, 0]
+            const normalized = normalizeVector(zeroVector)
+            expect(normalized).toEqual([0, 0, 0])
+        })
+
+        it('correctly normalizes [3,4] to [0.6, 0.8]', () => {
+            const vector = [3, 4]
+            const normalized = normalizeVector(vector)
+            expect(normalized[0]).toBeCloseTo(0.6, 5)
+            expect(normalized[1]).toBeCloseTo(0.8, 5)
+        })
+
+        it('magnitude of normalized vector equals 1.0', () => {
+            const vector = [3, 4, 5]
+            const normalized = normalizeVector(vector)
+            const magnitude = Math.sqrt(
+                normalized.reduce((sum, val) => sum + val * val, 0),
+            )
+            expect(magnitude).toBeCloseTo(1.0, 5)
+        })
+
+        it('preserves direction of original vector', () => {
+            const vector = [2, 3, 6]
+            const normalized = normalizeVector(vector)
+            const originalMagnitude = Math.sqrt(
+                vector.reduce((sum, val) => sum + val * val, 0),
+            )
+            const ratios = vector.map((val, i) => val / normalized[i])
+            expect(
+                ratios.every((r) => Math.abs(r - originalMagnitude) < 0.001),
+            ).toBe(true)
+        })
+
+        it('already normalized vector stays nearly identical', () => {
+            const vector = [1, 0, 0]
+            const normalized = normalizeVector(vector)
+            expect(normalized[0]).toBeCloseTo(1.0, 5)
+            expect(normalized[1]).toBeCloseTo(0.0, 5)
+            expect(normalized[2]).toBeCloseTo(0.0, 5)
+        })
+
+        it('normalizes negative values correctly', () => {
+            const vector = [-3, 4]
+            const normalized = normalizeVector(vector)
+            const magnitude = Math.sqrt(normalized[0] ** 2 + normalized[1] ** 2)
+            expect(magnitude).toBeCloseTo(1.0, 5)
+        })
+    })
+
+    describe('calculateVectorSimilarity', () => {
+        it('returns max score when genres match', () => {
+            const track1 = createMockTrack()
+            const track2 = createMockTrack()
+            const vectorA = createTrackVector(track1)
+            const vectorB = createTrackVector(track2)
+
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue('rock')
+
+            vectorA.genre = 'rock'
+            vectorB.genre = 'rock'
+
+            const config = createMockConfig()
+            const similarity = calculateVectorSimilarity(
+                vectorA,
+                vectorB,
+                config,
+            )
+
+            expect(similarity).toBeGreaterThan(0.1)
+        })
+
+        it('applies no bonus when genres are different', () => {
+            const track1 = createMockTrack()
+            const track2 = createMockTrack()
+            const vectorA = createTrackVector(track1)
+            const vectorB = createTrackVector(track2)
+
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            vectorA.genre = 'rock'
+            vectorB.genre = 'pop'
+
+            const config = createMockConfig()
+            const similarity = calculateVectorSimilarity(
+                vectorA,
+                vectorB,
+                config,
+            )
+
+            expect(similarity).toBeLessThanOrEqual(1.0)
+        })
+
+        it('applies no bonus when genre is missing on either vector', () => {
+            const track1 = createMockTrack()
+            const track2 = createMockTrack()
+            const vectorA = createTrackVector(track1)
+            const vectorB = createTrackVector(track2)
+
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            vectorA.genre = undefined
+            vectorB.genre = 'rock'
+
+            const config = createMockConfig()
+            const similarity = calculateVectorSimilarity(
+                vectorA,
+                vectorB,
+                config,
+            )
+
+            expect(similarity).toBeLessThanOrEqual(1.0)
+        })
+
+        it('clamps result to max 1.0 even with bonus', () => {
+            const track1 = createMockTrack()
+            const track2 = createMockTrack()
+            const vectorA = createTrackVector(track1)
+            const vectorB = createTrackVector(track2)
+
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            vectorA.genre = 'rock'
+            vectorB.genre = 'rock'
+            vectorA.vector = [1, 0, 0]
+            vectorB.vector = [1, 0, 0]
+
+            const config = createMockConfig()
+            const similarity = calculateVectorSimilarity(
+                vectorA,
+                vectorB,
+                config,
+            )
+
+            expect(similarity).toBeLessThanOrEqual(1.0)
+        })
+
+        it('returns value between 0 and 1 for different vectors', () => {
+            const track1 = createMockTrack()
+            const track2 = createMockTrack()
+            const vectorA = createTrackVector(track1)
+            const vectorB = createTrackVector(track2)
+
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            vectorA.genre = 'rock'
+            vectorB.genre = 'pop'
+
+            const config = createMockConfig()
+            const similarity = calculateVectorSimilarity(
+                vectorA,
+                vectorB,
+                config,
+            )
+
+            expect(similarity).toBeGreaterThanOrEqual(0)
+            expect(similarity).toBeLessThanOrEqual(1.0)
+        })
+
+        it('returns higher similarity for very similar vectors with same genre', () => {
+            const track1 = createMockTrack()
+            const track2 = createMockTrack()
+            const vectorA = createTrackVector(track1)
+            const vectorB = createTrackVector(track2)
+
+            extractTagsMock.mockReturnValue([])
+            extractGenreMock.mockReturnValue(undefined)
+
+            vectorA.genre = 'rock'
+            vectorB.genre = 'rock'
+            vectorA.vector = [1, 2, 3, 4]
+            vectorB.vector = [1.1, 2.1, 3.1, 4.1]
+
+            const config = createMockConfig()
+            const similarityWithGenre = calculateVectorSimilarity(
+                vectorA,
+                vectorB,
+                config,
+            )
+
+            vectorB.genre = 'pop'
+            const similarityWithoutGenre = calculateVectorSimilarity(
+                vectorA,
+                vectorB,
+                config,
+            )
+
+            expect(similarityWithGenre).toBeGreaterThan(similarityWithoutGenre)
+        })
+    })
+})

--- a/packages/bot/src/utils/general/deferredInteractionReply.spec.ts
+++ b/packages/bot/src/utils/general/deferredInteractionReply.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+
+const errorLogMock = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+}))
+
+import { deferredInteractionReply } from './deferredInteractionReply'
+
+function makeInteraction(
+    overrides: Partial<{
+        deferred: boolean
+        replied: boolean
+        deferReply: jest.Mock
+        followUp: jest.Mock
+        editReply: jest.Mock
+    }> = {},
+) {
+    return {
+        deferred: false,
+        replied: false,
+        deferReply: jest.fn().mockResolvedValue(undefined),
+        followUp: jest.fn().mockResolvedValue(undefined),
+        editReply: jest.fn().mockResolvedValue(undefined),
+        ...overrides,
+    }
+}
+
+describe('deferredInteractionReply', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('defers then edits when not deferred and not replied', async () => {
+        const interaction = makeInteraction({ deferred: false, replied: false })
+        await deferredInteractionReply(interaction as never, {
+            content: 'Hello',
+        })
+        expect(interaction.deferReply).toHaveBeenCalled()
+        expect(interaction.editReply).toHaveBeenCalledWith({ content: 'Hello' })
+        expect(interaction.followUp).not.toHaveBeenCalled()
+    })
+
+    it('passes ephemeral flag when deferring', async () => {
+        const interaction = makeInteraction({ deferred: false, replied: false })
+        await deferredInteractionReply(interaction as never, {
+            content: 'Hi',
+            ephemeral: true,
+        })
+        expect(interaction.deferReply).toHaveBeenCalledWith({ flags: 64 })
+    })
+
+    it('defers without flags for non-ephemeral', async () => {
+        const interaction = makeInteraction({ deferred: false, replied: false })
+        await deferredInteractionReply(interaction as never, { content: 'Hi' })
+        expect(interaction.deferReply).toHaveBeenCalledWith({
+            flags: undefined,
+        })
+    })
+
+    it('calls followUp when already replied', async () => {
+        const interaction = makeInteraction({ deferred: true, replied: true })
+        await deferredInteractionReply(interaction as never, {
+            content: 'Follow up',
+        })
+        expect(interaction.deferReply).not.toHaveBeenCalled()
+        expect(interaction.followUp).toHaveBeenCalledWith({
+            content: 'Follow up',
+        })
+        expect(interaction.editReply).not.toHaveBeenCalled()
+    })
+
+    it('calls editReply when deferred but not replied', async () => {
+        const interaction = makeInteraction({ deferred: true, replied: false })
+        await deferredInteractionReply(interaction as never, {
+            content: 'Edit',
+        })
+        expect(interaction.deferReply).not.toHaveBeenCalled()
+        expect(interaction.editReply).toHaveBeenCalledWith({ content: 'Edit' })
+        expect(interaction.followUp).not.toHaveBeenCalled()
+    })
+
+    it('logs error and does not throw when interaction throws', async () => {
+        const interaction = makeInteraction({
+            deferred: true,
+            replied: false,
+            editReply: jest
+                .fn()
+                .mockRejectedValue(new Error('interaction expired')),
+        })
+        await expect(
+            deferredInteractionReply(interaction as never, { content: 'x' }),
+        ).resolves.not.toThrow()
+        expect(errorLogMock).toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/utils/misc/pathUtils.spec.ts
+++ b/packages/bot/src/utils/misc/pathUtils.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from '@jest/globals'
+import { getDirname, getFilename, normalizePath } from './pathUtils'
+
+describe('getDirname', () => {
+    it('returns the directory part of a file URL', () => {
+        const result = getDirname('file:///home/user/project/src/index.ts')
+        expect(result).toBe('/home/user/project/src')
+    })
+
+    it('works with nested directories', () => {
+        const result = getDirname('file:///a/b/c/d/file.ts')
+        expect(result).toBe('/a/b/c/d')
+    })
+})
+
+describe('getFilename', () => {
+    it('converts file URL to absolute path', () => {
+        const result = getFilename('file:///home/user/project/src/index.ts')
+        expect(result).toBe('/home/user/project/src/index.ts')
+    })
+})
+
+describe('normalizePath', () => {
+    it('returns path unchanged on non-Windows platform', () => {
+        expect(normalizePath('/home/user/file.ts')).toBe('/home/user/file.ts')
+    })
+
+    it('returns path unchanged when not starting with slash', () => {
+        expect(normalizePath('relative/path')).toBe('relative/path')
+    })
+})


### PR DESCRIPTION
## Summary
- similarityCalculator.ts: calculateTrackSimilarity + calculateDiversityScore
- vectorOperations.ts: cosine/euclidean/vector similarity, createTrackVector, normalizeVector
- webMusic/mappers: mapTrack, repeatModeToString/Enum, buildQueueState
- deferredInteractionReply: all branches (deferred, replied, followUp, error)
- pathUtils: getDirname, getFilename, normalizePath

## Test plan
- [x] npx jest "recommendation|mappers|deferredInteraction|pathUtils" --no-coverage → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)