### PR TITLE
feat: add stop, clear queue, and clear autoplay buttons

### DIFF
--- a/packages/backend/src/services/SpotifyAuthService.ts
+++ b/packages/backend/src/services/SpotifyAuthService.ts
@@ -6,7 +6,9 @@ export type SpotifyTokenResponse = {
     spotifyUsername: string
 }
 
-export async function exchangeCodeForToken(code: string): Promise<SpotifyTokenResponse | null> {
+export async function exchangeCodeForToken(
+    code: string,
+): Promise<SpotifyTokenResponse | null> {
     const clientId = process.env.SPOTIFY_CLIENT_ID
     const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
     const redirectUri = process.env.SPOTIFY_REDIRECT_URI
@@ -21,7 +23,7 @@ export async function exchangeCodeForToken(code: string): Promise<SpotifyTokenRe
         const res = await fetch('https://accounts.spotify.com/api/token', {
             method: 'POST',
             headers: {
-                'Authorization': `Basic ${auth}`,
+                Authorization: `Basic ${auth}`,
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
             body: new URLSearchParams({
@@ -35,20 +37,25 @@ export async function exchangeCodeForToken(code: string): Promise<SpotifyTokenRe
             return null
         }
 
-        const data = (await res.json().catch(() => null)) as {
+        const tokenData = (await res.json().catch(() => null)) as {
             access_token?: string
             refresh_token?: string
             expires_in?: number
             error?: string
         }
 
-        if (data?.error || !data?.access_token || !data?.refresh_token) {
+        if (
+            !tokenData ||
+            tokenData.error ||
+            !tokenData.access_token ||
+            !tokenData.refresh_token
+        ) {
             return null
         }
 
         const userRes = await fetch('https://api.spotify.com/v1/me', {
             headers: {
-                'Authorization': `Bearer ${data.access_token}`,
+                Authorization: `Bearer ${tokenData.access_token}`,
             },
         })
 
@@ -62,14 +69,14 @@ export async function exchangeCodeForToken(code: string): Promise<SpotifyTokenRe
             error?: string
         }
 
-        if (userData?.error || !userData?.id) {
+        if (!userData || userData.error || !userData.id) {
             return null
         }
 
         return {
-            accessToken: data.access_token,
-            refreshToken: data.refresh_token,
-            expiresIn: data.expires_in ?? 3600,
+            accessToken: tokenData.access_token,
+            refreshToken: tokenData.refresh_token,
+            expiresIn: tokenData.expires_in ?? 3600,
             spotifyId: userData.id,
             spotifyUsername: userData.display_name ?? userData.id,
         }

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -7,7 +7,10 @@ import {
 } from '../../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../../utils/music/queueResolver'
 import { buildPlayResponseEmbed } from '../../../../utils/music/nowPlayingEmbed'
-import { createMusicControlButtons } from '../../../../utils/music/buttonComponents'
+import {
+    createMusicControlButtons,
+    createMusicActionButtons,
+} from '../../../../utils/music/buttonComponents'
 import { createErrorEmbed } from '../../../../utils/general/embeds'
 import { interactionReply } from '../../../../utils/general/interactionReply'
 import { createUserFriendlyError } from '../../../../utils/general/errorSanitizer'
@@ -177,7 +180,10 @@ export async function executePlayAtTop({
             interaction,
             content: {
                 embeds: [embed],
-                components: [createMusicControlButtons(queue)],
+                components: [
+                    createMusicControlButtons(queue),
+                    createMusicActionButtons(queue),
+                ],
             },
         })
 

--- a/packages/bot/src/functions/music/commands/queue/queueEmbed.spec.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueEmbed.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 jest.mock('../../../../utils/music/buttonComponents', () => ({
     createQueuePaginationButtons: jest.fn().mockReturnValue(null),
     createMusicControlButtons: jest.fn().mockReturnValue({}),
+    createMusicActionButtons: jest.fn().mockReturnValue({}),
 }))
 
 import {

--- a/packages/bot/src/functions/music/commands/queue/queueEmbed.ts
+++ b/packages/bot/src/functions/music/commands/queue/queueEmbed.ts
@@ -16,6 +16,7 @@ import type { QueueDisplayOptions } from './types'
 import {
     createQueuePaginationButtons,
     createMusicControlButtons,
+    createMusicActionButtons,
 } from '../../../../utils/music/buttonComponents'
 
 export type QueueEmbedResult = {
@@ -131,8 +132,8 @@ export async function createQueueEmbed(
     const totalPages = Math.ceil(totalTracks / options.maxTracksToShow)
     const components: ActionRowBuilder<ButtonBuilder>[] = []
 
-    // Add music control buttons
     components.push(createMusicControlButtons(queue))
+    components.push(createMusicActionButtons(queue))
 
     // Add pagination buttons if needed
     const paginationRow = createQueuePaginationButtons(page, totalPages)

--- a/packages/bot/src/handlers/musicButtonHandler.spec.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.spec.ts
@@ -164,8 +164,7 @@ describe('handleMusicButtonInteraction', () => {
     it('pauses when PAUSE_RESUME and queue is playing', async () => {
         const queue = createMockQueue({ isPaused: false })
         const interaction = createInteraction(MUSIC_BUTTON_IDS.PAUSE_RESUME)
-        const buttons = { type: 1 }
-        createMusicControlButtonsMock.mockReturnValue(buttons)
+        createMusicControlButtonsMock.mockReturnValue({ type: 1 })
         resolveGuildQueueMock.mockReturnValue({ queue, source: 'nodes.get' })
 
         await handleMusicButtonInteraction(interaction as never)
@@ -173,15 +172,14 @@ describe('handleMusicButtonInteraction', () => {
         expect(queue.node.pause).toHaveBeenCalled()
         expect(createMusicControlButtonsMock).toHaveBeenCalledWith(queue)
         expect(interaction.editReply).toHaveBeenCalledWith(
-            expect.objectContaining({ components: [buttons] }),
+            expect.objectContaining({ components: expect.any(Array) }),
         )
     })
 
     it('resumes when PAUSE_RESUME and queue is paused', async () => {
         const queue = createMockQueue({ isPaused: true })
         const interaction = createInteraction(MUSIC_BUTTON_IDS.PAUSE_RESUME)
-        const buttons = { type: 1 }
-        createMusicControlButtonsMock.mockReturnValue(buttons)
+        createMusicControlButtonsMock.mockReturnValue({ type: 1 })
         resolveGuildQueueMock.mockReturnValue({ queue, source: 'nodes.get' })
 
         await handleMusicButtonInteraction(interaction as never)
@@ -189,7 +187,53 @@ describe('handleMusicButtonInteraction', () => {
         expect(queue.node.resume).toHaveBeenCalled()
         expect(createMusicControlButtonsMock).toHaveBeenCalledWith(queue)
         expect(interaction.editReply).toHaveBeenCalledWith(
-            expect.objectContaining({ components: [buttons] }),
+            expect.objectContaining({ components: expect.any(Array) }),
+        )
+    })
+
+    it('stops playback and clears queue for STOP button', async () => {
+        const queue = { ...createMockQueue(), delete: jest.fn() }
+        const interaction = createInteraction(MUSIC_BUTTON_IDS.STOP)
+        resolveGuildQueueMock.mockReturnValue({ queue, source: 'nodes.get' })
+
+        await handleMusicButtonInteraction(interaction as never)
+
+        expect(queue.delete).toHaveBeenCalled()
+        expect(interaction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                components: [],
+                embeds: expect.any(Array),
+            }),
+        )
+    })
+
+    it('clears upcoming tracks for CLEAR_QUEUE button', async () => {
+        const queue = {
+            ...createMockQueue(),
+            tracks: { size: 3, clear: jest.fn() },
+        }
+        const interaction = createInteraction(MUSIC_BUTTON_IDS.CLEAR_QUEUE)
+        resolveGuildQueueMock.mockReturnValue({ queue, source: 'nodes.get' })
+
+        await handleMusicButtonInteraction(interaction as never)
+
+        expect(queue.tracks.clear).toHaveBeenCalled()
+        expect(interaction.followUp).toHaveBeenCalledWith(
+            expect.objectContaining({ ephemeral: true }),
+        )
+    })
+
+    it('sets repeat mode to OFF for CLEAR_AUTOPLAY button', async () => {
+        const queue = createMockQueue({ repeatMode: 3 })
+        const interaction = createInteraction(MUSIC_BUTTON_IDS.CLEAR_AUTOPLAY)
+        resolveGuildQueueMock.mockReturnValue({ queue, source: 'nodes.get' })
+
+        await handleMusicButtonInteraction(interaction as never)
+
+        expect(queue.setRepeatMode).toHaveBeenCalledWith(0)
+        expect(interaction.editReply).toHaveBeenCalled()
+        expect(interaction.followUp).toHaveBeenCalledWith(
+            expect.objectContaining({ ephemeral: true }),
         )
     })
 
@@ -286,6 +330,7 @@ describe('handleMusicButtonInteraction', () => {
     it('uses resolver-backed queue lookup so music buttons still work after queue cache fallback', async () => {
         const queue = createMockQueue({ isPaused: false })
         const interaction = createInteraction(MUSIC_BUTTON_IDS.PAUSE_RESUME)
+        createMusicControlButtonsMock.mockReturnValue({ type: 1 })
         resolveGuildQueueMock.mockReturnValue({
             queue,
             source: 'cache.guild',

--- a/packages/bot/src/handlers/musicButtonHandler.spec.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.spec.ts
@@ -31,6 +31,7 @@ const createLeaderboardPaginationButtonsMock = jest.fn()
 jest.mock('../utils/music/buttonComponents', () => ({
     createMusicControlButtons: (...args: unknown[]) =>
         createMusicControlButtonsMock(...args),
+    createMusicActionButtons: jest.fn().mockReturnValue({}),
     createLeaderboardPaginationButtons: (...args: unknown[]) =>
         createLeaderboardPaginationButtonsMock(...args),
 }))

--- a/packages/bot/src/handlers/musicButtonHandler.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.ts
@@ -9,6 +9,7 @@ import {
 } from '../types/musicButtons'
 import {
     createMusicControlButtons,
+    createMusicActionButtons,
     createLeaderboardPaginationButtons,
 } from '../utils/music/buttonComponents'
 import { createQueueEmbed } from '../functions/music/commands/queue/queueEmbed'
@@ -107,6 +108,12 @@ async function routeButtonAction(
             return handleShuffle(interaction, queue)
         case MUSIC_BUTTON_IDS.LOOP:
             return handleLoop(interaction, queue)
+        case MUSIC_BUTTON_IDS.STOP:
+            return handleStop(interaction, queue)
+        case MUSIC_BUTTON_IDS.CLEAR_QUEUE:
+            return handleClearQueue(interaction, queue)
+        case MUSIC_BUTTON_IDS.CLEAR_AUTOPLAY:
+            return handleClearAutoplay(interaction, queue)
         default:
             if (customId.startsWith(QUEUE_BUTTON_PREFIX)) {
                 return handleQueuePage(interaction, queue)
@@ -136,7 +143,10 @@ async function handlePauseResume(
     }
 
     await interaction.editReply({
-        components: [createMusicControlButtons(queue)],
+        components: [
+            createMusicControlButtons(queue),
+            createMusicActionButtons(queue),
+        ],
     })
 }
 
@@ -184,6 +194,50 @@ async function handleLoop(
         content: `\u{1F501} Loop mode: **${modeName}**`,
         ephemeral: true,
     })
+}
+
+async function handleStop(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    queue.delete()
+    await interaction.editReply({
+        embeds: [
+            createErrorEmbed('Stopped', 'Playback stopped and queue cleared'),
+        ],
+        components: [],
+    })
+    debugLog({ message: 'Playback stopped via button' })
+}
+
+async function handleClearQueue(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    queue.tracks.clear()
+    await interaction.followUp({
+        content: '🗑️ Queue cleared',
+        ephemeral: true,
+    })
+    debugLog({ message: 'Queue cleared via button' })
+}
+
+async function handleClearAutoplay(
+    interaction: ButtonInteraction,
+    queue: NonNullQueue,
+): Promise<void> {
+    queue.setRepeatMode(QueueRepeatMode.OFF)
+    await interaction.editReply({
+        components: [
+            createMusicControlButtons(queue),
+            createMusicActionButtons(queue),
+        ],
+    })
+    await interaction.followUp({
+        content: '🤖 Autoplay disabled',
+        ephemeral: true,
+    })
+    debugLog({ message: 'Autoplay cleared via button' })
 }
 
 async function handleQueuePage(

--- a/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
@@ -33,6 +33,7 @@ jest.mock('../../utils/general/embeds', () => ({
 jest.mock('../../utils/music/buttonComponents', () => ({
     createMusicControlButtons: (...args: unknown[]) =>
         createMusicControlButtonsMock(...args),
+    createMusicActionButtons: jest.fn().mockReturnValue({}),
 }))
 
 jest.mock('../../utils/music/autoplayManager', () => ({

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -4,7 +4,10 @@ import { debugLog, errorLog, warnLog } from '@lucky/shared/utils'
 import { createEmbed, EMBED_COLORS } from '../../utils/general/embeds'
 import { getAutoplayCount } from '../../utils/music/autoplayManager'
 import { constants } from '@lucky/shared/config'
-import { createMusicControlButtons } from '../../utils/music/buttonComponents'
+import {
+    createMusicControlButtons,
+    createMusicActionButtons,
+} from '../../utils/music/buttonComponents'
 import type { QueueMetadata } from '../../types/QueueMetadata'
 import {
     isLastFmConfigured,
@@ -116,11 +119,13 @@ export async function sendNowPlayingEmbed(
             const message = await metadata.channel.messages.fetch(
                 previousMessage.messageId,
             )
-            const buttons = createMusicControlButtons(queue)
             await message.edit({
                 content: null,
                 embeds: [embed],
-                components: [buttons],
+                components: [
+                    createMusicControlButtons(queue),
+                    createMusicActionButtons(queue),
+                ],
             })
             debugLog({
                 message: 'Updated now playing message in channel',
@@ -144,10 +149,12 @@ export async function sendNowPlayingEmbed(
         }
     }
 
-    const controlButtons = createMusicControlButtons(queue)
     const message = await metadata.channel.send({
         embeds: [embed],
-        components: [controlButtons],
+        components: [
+            createMusicControlButtons(queue),
+            createMusicActionButtons(queue),
+        ],
     })
 
     songInfoMessages.set(queue.guild.id, {

--- a/packages/bot/src/types/musicButtons.ts
+++ b/packages/bot/src/types/musicButtons.ts
@@ -4,6 +4,9 @@ export const MUSIC_BUTTON_IDS = {
     SKIP: 'music_skip',
     SHUFFLE: 'music_shuffle',
     LOOP: 'music_loop',
+    STOP: 'music_stop',
+    CLEAR_QUEUE: 'music_clear_queue',
+    CLEAR_AUTOPLAY: 'music_clear_autoplay',
 } as const
 
 export const QUEUE_BUTTON_PREFIX = 'queue_page'

--- a/packages/bot/src/utils/music/buttonComponents.spec.ts
+++ b/packages/bot/src/utils/music/buttonComponents.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import {
     createMusicControlButtons,
+    createMusicActionButtons,
     createQueuePaginationButtons,
     createLeaderboardPaginationButtons,
 } from './buttonComponents'
@@ -19,26 +20,46 @@ jest.mock('discord.js', () => {
     return {
         ActionRowBuilder: jest.fn(() => rowInner),
         ButtonBuilder: MockButtonBuilder,
-        ButtonStyle: { Primary: 'PRIMARY', Secondary: 'SECONDARY' },
+        ButtonStyle: {
+            Primary: 'PRIMARY',
+            Secondary: 'SECONDARY',
+            Danger: 'DANGER',
+        },
     }
 })
 
+jest.mock('discord-player', () => ({
+    QueueRepeatMode: { OFF: 0, TRACK: 1, QUEUE: 2, AUTOPLAY: 3 },
+}))
+
 function getRow(): { addComponents: jest.Mock } {
-    const { ActionRowBuilder } = jest.requireMock('discord.js') as { ActionRowBuilder: jest.Mock }
-    return ActionRowBuilder.mock.results[0]?.value as { addComponents: jest.Mock }
+    const { ActionRowBuilder } = jest.requireMock('discord.js') as {
+        ActionRowBuilder: jest.Mock
+    }
+    return ActionRowBuilder.mock.results[0]?.value as {
+        addComponents: jest.Mock
+    }
 }
 
-function createMockQueue(isPaused: boolean, historyLength: number, tracksSize: number) {
+function createMockQueue(
+    isPaused: boolean,
+    historyLength: number,
+    tracksSize: number,
+    repeatMode = 0,
+) {
     return {
         node: { isPaused: jest.fn(() => isPaused) },
         history: { tracks: { data: new Array(historyLength).fill({}) } },
         tracks: { size: tracksSize },
+        repeatMode,
     }
 }
 
 // Restore addComponents after each resetMocks cycle
 beforeEach(() => {
-    const { ActionRowBuilder } = jest.requireMock('discord.js') as { ActionRowBuilder: jest.Mock }
+    const { ActionRowBuilder } = jest.requireMock('discord.js') as {
+        ActionRowBuilder: jest.Mock
+    }
     // Build a fresh rowInner per test since resetMocks clears implementations
     const rowInner = { addComponents: jest.fn().mockReturnThis() }
     ActionRowBuilder.mockReturnValue(rowInner)
@@ -68,6 +89,26 @@ describe('createMusicControlButtons', () => {
         expect(() => createMusicControlButtons(queue as never)).not.toThrow()
         const row = getRow()
         expect(row.addComponents).toHaveBeenCalled()
+    })
+})
+
+describe('createMusicActionButtons', () => {
+    it('calls addComponents with 3 buttons', () => {
+        const queue = createMockQueue(false, 0, 0)
+        createMusicActionButtons(queue as never)
+        const row = getRow()
+        const [call] = row.addComponents.mock.calls
+        expect((call as unknown[]).length).toBe(3)
+    })
+
+    it('does not throw when autoplay is active', () => {
+        const queue = createMockQueue(false, 0, 0, 3)
+        expect(() => createMusicActionButtons(queue as never)).not.toThrow()
+    })
+
+    it('does not throw when autoplay is off', () => {
+        const queue = createMockQueue(false, 0, 0, 0)
+        expect(() => createMusicActionButtons(queue as never)).not.toThrow()
     })
 })
 

--- a/packages/bot/src/utils/music/buttonComponents.ts
+++ b/packages/bot/src/utils/music/buttonComponents.ts
@@ -1,6 +1,11 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js'
 import type { GuildQueue } from 'discord-player'
-import { MUSIC_BUTTON_IDS, QUEUE_BUTTON_PREFIX, LEADERBOARD_BUTTON_PREFIX } from '../../types/musicButtons'
+import { QueueRepeatMode } from 'discord-player'
+import {
+    MUSIC_BUTTON_IDS,
+    QUEUE_BUTTON_PREFIX,
+    LEADERBOARD_BUTTON_PREFIX,
+} from '../../types/musicButtons'
 
 export function createMusicControlButtons(
     queue: GuildQueue,
@@ -43,6 +48,37 @@ export function createMusicControlButtons(
         skipButton,
         shuffleButton,
         loopButton,
+    )
+}
+
+export function createMusicActionButtons(
+    queue: GuildQueue,
+): ActionRowBuilder<ButtonBuilder> {
+    const isAutoplay = queue.repeatMode === QueueRepeatMode.AUTOPLAY
+
+    const stopButton = new ButtonBuilder()
+        .setCustomId(MUSIC_BUTTON_IDS.STOP)
+        .setEmoji('⏹️')
+        .setLabel('Stop')
+        .setStyle(ButtonStyle.Danger)
+
+    const clearQueueButton = new ButtonBuilder()
+        .setCustomId(MUSIC_BUTTON_IDS.CLEAR_QUEUE)
+        .setEmoji('🗑️')
+        .setLabel('Clear')
+        .setStyle(ButtonStyle.Secondary)
+
+    const clearAutoplayButton = new ButtonBuilder()
+        .setCustomId(MUSIC_BUTTON_IDS.CLEAR_AUTOPLAY)
+        .setEmoji('🤖')
+        .setLabel('Clear Autoplay')
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(!isAutoplay)
+
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+        stopButton,
+        clearQueueButton,
+        clearAutoplayButton,
     )
 }
 


### PR DESCRIPTION
## Summary
- Adds a second row of action buttons to the music player: ⏹️ Stop, 🗑️ Clear, 🤖 Clear Autoplay
- Stop (red): calls `queue.delete()`, stops playback and clears the queue entirely
- Clear (grey): calls `queue.tracks.clear()`, removes upcoming tracks without stopping playback
- Clear Autoplay (grey, disabled when not in autoplay mode): sets repeat mode to OFF and updates button state
- All now-playing messages (on track start, `/play`, `/queue`) show both rows
- Pause/Resume button refresh also re-renders both rows

## Test plan
- [x] All 2310 existing tests pass
- [x] Updated 3 spec mocks (`queueEmbed`, `trackNowPlaying`, `musicButtonHandler`) to include new mock
- [x] Build passes with no TS errors