### PR TITLE
fix(webapp): sidebar active tab + track history pagination

### DIFF
--- a/packages/backend/src/routes/trackHistory.ts
+++ b/packages/backend/src/routes/trackHistory.ts
@@ -13,6 +13,7 @@ function p(val: string | string[]): string {
 
 const historyQuery = z.object({
     limit: z.coerce.number().int().min(1).max(100).optional(),
+    offset: z.coerce.number().int().min(0).optional(),
 })
 
 const topQuery = z.object({
@@ -28,11 +29,15 @@ export function setupTrackHistoryRoutes(app: Express): void {
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
             const limit = Number(req.query.limit) || 10
+            const offset = Number(req.query.offset) || 0
             const history = await trackHistoryService.getTrackHistory(
                 guildId,
                 limit,
+                offset,
             )
-            res.json({ history })
+            const total =
+                await trackHistoryService.getTrackHistoryCount(guildId)
+            res.json({ history, total })
         }),
     )
 

--- a/packages/backend/tests/integration/routes/trackHistory.test.ts
+++ b/packages/backend/tests/integration/routes/trackHistory.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../../src/services/SessionService', () => ({
 }))
 
 const mockGetHistory = jest.fn<any>()
+const mockGetHistoryCount = jest.fn<any>().mockResolvedValue(1)
 const mockGenerateStats = jest.fn<any>()
 const mockGetTopTracks = jest.fn<any>()
 const mockGetTopArtists = jest.fn<any>()
@@ -22,6 +23,7 @@ const mockClearHistory = jest.fn<any>()
 jest.mock('@lucky/shared/services', () => ({
     trackHistoryService: {
         getTrackHistory: (...args: any[]) => mockGetHistory(...args),
+        getTrackHistoryCount: (...args: any[]) => mockGetHistoryCount(...args),
         generateStats: (...args: any[]) => mockGenerateStats(...args),
         getTopTracks: (...args: any[]) => mockGetTopTracks(...args),
         getTopArtists: (...args: any[]) => mockGetTopArtists(...args),
@@ -70,7 +72,8 @@ describe('Track History Routes', () => {
 
             expect(res.status).toBe(200)
             expect(res.body.history).toHaveLength(1)
-            expect(mockGetHistory).toHaveBeenCalledWith(GUILD_ID, 10)
+            expect(res.body.total).toBe(1)
+            expect(mockGetHistory).toHaveBeenCalledWith(GUILD_ID, 10, 0)
         })
 
         test('should accept limit query param', async () => {
@@ -82,7 +85,7 @@ describe('Track History Routes', () => {
                 .set('Cookie', ['sessionId=valid_session_id'])
 
             expect(res.status).toBe(200)
-            expect(mockGetHistory).toHaveBeenCalledWith(GUILD_ID, 25)
+            expect(mockGetHistory).toHaveBeenCalledWith(GUILD_ID, 25, 0)
         })
 
         test('should return 401 when not authenticated', async () => {

--- a/packages/frontend/src/components/Layout/Sidebar.test.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.test.tsx
@@ -120,6 +120,14 @@ describe('Sidebar', () => {
         expect(dashboardLink).toHaveAttribute('data-active', 'false')
     })
 
+    test('activates parent route for sub-routes using slash boundary', () => {
+        renderSidebar('/music/history')
+
+        const musicLink = screen.getByText('Music Player').closest('a')
+        expect(musicLink).toHaveAttribute('data-active', 'true')
+        expect(musicLink).toHaveAttribute('aria-current', 'page')
+    })
+
     test('shows server selector dropdown with guilds', async () => {
         const user = userEvent.setup()
         renderSidebar()

--- a/packages/frontend/src/components/Layout/Sidebar.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.tsx
@@ -479,7 +479,10 @@ function Sidebar() {
 
     const isActive = (path: string) => {
         if (path === '/') return location.pathname === '/'
-        return location.pathname.startsWith(path)
+        return (
+            location.pathname === path ||
+            location.pathname.startsWith(path + '/')
+        )
     }
 
     const effectiveAccess =

--- a/packages/frontend/src/pages/TrackHistory.test.tsx
+++ b/packages/frontend/src/pages/TrackHistory.test.tsx
@@ -233,4 +233,49 @@ describe('TrackHistoryPage', () => {
             'noopener noreferrer',
         )
     })
+
+    test('shows load-more button and track count when more tracks available', async () => {
+        const user = userEvent.setup()
+        mockGuildSelection(mockGuild)
+        vi.mocked(api.trackHistory.getHistory)
+            .mockResolvedValueOnce({
+                data: { history: mockHistory, total: 10 },
+            } as any)
+            .mockResolvedValueOnce({
+                data: { history: [], total: 10 },
+            } as any)
+        vi.mocked(api.trackHistory.getStats).mockResolvedValue({
+            data: { stats: mockStats },
+        } as any)
+
+        renderPage()
+
+        await waitFor(() => {
+            expect(screen.getByText('Load More Tracks')).toBeInTheDocument()
+        })
+
+        expect(screen.getByText(/Showing 2 of 10/)).toBeInTheDocument()
+
+        await user.click(screen.getByText('Load More Tracks'))
+
+        expect(api.trackHistory.getHistory).toHaveBeenCalledTimes(2)
+    })
+
+    test('hides load-more button when all tracks are loaded', async () => {
+        mockGuildSelection(mockGuild)
+        vi.mocked(api.trackHistory.getHistory).mockResolvedValue({
+            data: { history: mockHistory, total: 2 },
+        } as any)
+        vi.mocked(api.trackHistory.getStats).mockResolvedValue({
+            data: { stats: mockStats },
+        } as any)
+
+        renderPage()
+
+        await waitFor(() => {
+            expect(screen.getByText('Recent Tracks')).toBeInTheDocument()
+        })
+
+        expect(screen.queryByText('Load More Tracks')).not.toBeInTheDocument()
+    })
 })

--- a/packages/frontend/src/pages/TrackHistory.tsx
+++ b/packages/frontend/src/pages/TrackHistory.tsx
@@ -40,35 +40,64 @@ function formatTimeAgo(timestamp: number): string {
     return `${Math.floor(hrs / 24)}d ago`
 }
 
+const PAGE_SIZE = 50
+
 export default function TrackHistoryPage() {
     const { selectedGuild } = useGuildSelection()
     const guildId = selectedGuild?.id
     const [history, setHistory] = useState<TrackEntry[]>([])
     const [stats, setStats] = useState<Stats | null>(null)
     const [isLoading, setIsLoading] = useState(false)
+    const [isLoadingMore, setIsLoadingMore] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [page, setPage] = useState(1)
+    const [total, setTotal] = useState(0)
 
-    const loadData = useCallback(async () => {
-        if (!guildId) return
-        setIsLoading(true)
-        setError(null)
-        try {
-            const [histRes, statsRes] = await Promise.all([
-                api.trackHistory.getHistory(guildId, 50),
-                api.trackHistory.getStats(guildId),
-            ])
-            setHistory(histRes.data.history)
-            setStats(statsRes.data.stats)
-        } catch {
-            setError('Failed to load track history')
-        } finally {
-            setIsLoading(false)
-        }
+    const loadData = useCallback(
+        async (reset = true) => {
+            if (!guildId) return
+            if (reset) {
+                setIsLoading(true)
+                setHistory([])
+                setPage(1)
+            } else {
+                setIsLoadingMore(true)
+            }
+            setError(null)
+            try {
+                const offset = reset ? 0 : (page - 1) * PAGE_SIZE
+                const [histRes, statsRes] = await Promise.all([
+                    api.trackHistory.getHistory(guildId, PAGE_SIZE, offset),
+                    reset
+                        ? api.trackHistory.getStats(guildId)
+                        : Promise.resolve(null),
+                ])
+                if (reset) {
+                    setHistory(histRes.data.history)
+                    setStats(statsRes?.data.stats ?? null)
+                } else {
+                    setHistory((prev) => [...prev, ...histRes.data.history])
+                }
+                setTotal(histRes.data.total)
+            } catch {
+                setError('Failed to load track history')
+            } finally {
+                setIsLoading(false)
+                setIsLoadingMore(false)
+            }
+        },
+        [guildId, page],
+    )
+
+    useEffect(() => {
+        loadData(true)
     }, [guildId])
 
     useEffect(() => {
-        loadData()
-    }, [loadData])
+        if (page > 1) {
+            loadData(false)
+        }
+    }, [page])
 
     const handleClear = async () => {
         if (!guildId) return
@@ -76,9 +105,15 @@ export default function TrackHistoryPage() {
             await api.trackHistory.clearHistory(guildId)
             setHistory([])
             setStats(null)
+            setTotal(0)
+            setPage(1)
         } catch {
             setError('Failed to clear history')
         }
+    }
+
+    const handleLoadMore = () => {
+        setPage((prev) => prev + 1)
     }
 
     if (!selectedGuild) {
@@ -177,12 +212,24 @@ export default function TrackHistoryPage() {
                     )}
 
                     <div className='space-y-1'>
-                        <h2 className='type-meta text-lucky-text-tertiary uppercase tracking-wider px-1'>
-                            Recent Tracks
-                        </h2>
+                        <div className='flex items-center justify-between px-1 mb-3'>
+                            <h2 className='type-meta text-lucky-text-tertiary uppercase tracking-wider'>
+                                Recent Tracks
+                            </h2>
+                            {total > 0 && (
+                                <span className='type-body-sm text-lucky-text-tertiary'>
+                                    Showing {history.length} of {total}
+                                </span>
+                            )}
+                        </div>
                         {history.length === 0 ? (
                             <EmptyState
-                                icon={<History className='h-10 w-10' aria-hidden='true' />}
+                                icon={
+                                    <History
+                                        className='h-10 w-10'
+                                        aria-hidden='true'
+                                    />
+                                }
                                 title='No tracks played yet'
                                 description='Play some music to see your history here'
                                 className='min-h-[180px]'
@@ -209,7 +256,9 @@ export default function TrackHistoryPage() {
                                             <p className='type-body-sm text-lucky-text-tertiary truncate'>
                                                 {track.author} ·{' '}
                                                 {track.duration}
-                                                {track.playedBy ? ` · Played by ${track.playedBy}` : ''}
+                                                {track.playedBy
+                                                    ? ` · Played by ${track.playedBy}`
+                                                    : ''}
                                             </p>
                                         </div>
                                         <span className='type-body-sm text-lucky-text-tertiary shrink-0'>
@@ -217,6 +266,17 @@ export default function TrackHistoryPage() {
                                         </span>
                                     </div>
                                 ))}
+                                {history.length < total && (
+                                    <button
+                                        onClick={handleLoadMore}
+                                        disabled={isLoadingMore}
+                                        className='w-full mt-4 px-3 py-2 rounded-lg border border-lucky-border text-lucky-text-secondary hover:text-lucky-text-primary hover:bg-lucky-bg-tertiary transition-colors disabled:opacity-50 disabled:cursor-not-allowed type-body-sm font-medium'
+                                    >
+                                        {isLoadingMore
+                                            ? 'Loading...'
+                                            : 'Load More Tracks'}
+                                    </button>
+                                )}
                             </div>
                         )}
                     </div>

--- a/packages/frontend/src/services/api.test.ts
+++ b/packages/frontend/src/services/api.test.ts
@@ -256,9 +256,8 @@ describe('api service bootstrap', () => {
         const authResponse = await module.api.auth.getUser()
         const guildResponse = await module.api.guilds.get('guild-1')
         const featuresResponse = await module.api.features.list()
-        const togglesResponse = await module.api.features.getServerToggles(
-            'guild-1',
-        )
+        const togglesResponse =
+            await module.api.features.getServerToggles('guild-1')
 
         expect(authResponse.data.user).toEqual({
             id: 'user-1',
@@ -342,9 +341,12 @@ describe('api service bootstrap', () => {
         expect(apiClient.get).toHaveBeenCalledWith('/guilds/guild-1/invite')
         expect(apiClient.get).toHaveBeenCalledWith('/guilds/guild-1/channels')
         expect(apiClient.get).toHaveBeenCalledWith('/guilds/guild-1/settings')
-        expect(apiClient.post).toHaveBeenCalledWith('/guilds/guild-1/settings', {
-            commandPrefix: '!',
-        })
+        expect(apiClient.post).toHaveBeenCalledWith(
+            '/guilds/guild-1/settings',
+            {
+                commandPrefix: '!',
+            },
+        )
         expect(apiClient.post).toHaveBeenCalledWith(
             '/guilds/guild-1/automation/presets/criativaria/apply',
         )
@@ -354,7 +356,9 @@ describe('api service bootstrap', () => {
             description: 'Guild listing',
         })
         expect(apiClient.get).toHaveBeenCalledWith('/guilds/guild-1/modules')
-        expect(apiClient.get).toHaveBeenCalledWith('/guilds/guild-1/modules/music')
+        expect(apiClient.get).toHaveBeenCalledWith(
+            '/guilds/guild-1/modules/music',
+        )
         expect(apiClient.post).toHaveBeenCalledWith(
             '/guilds/guild-1/modules/music/toggle',
             { enabled: true },
@@ -387,7 +391,7 @@ describe('api service bootstrap', () => {
             { enabled: false },
         )
         expect(apiClient.get).toHaveBeenCalledWith(
-            '/guilds/guild-1/music/history?limit=10',
+            '/guilds/guild-1/music/history?limit=10&offset=0',
         )
         expect(apiClient.get).toHaveBeenCalledWith(
             '/guilds/guild-1/music/history/stats',
@@ -398,7 +402,9 @@ describe('api service bootstrap', () => {
         expect(apiClient.get).toHaveBeenCalledWith(
             '/guilds/guild-1/music/history/top-artists?limit=10',
         )
-        expect(apiClient.delete).toHaveBeenCalledWith('/guilds/guild-1/music/history')
+        expect(apiClient.delete).toHaveBeenCalledWith(
+            '/guilds/guild-1/music/history',
+        )
         expect(apiClient.get).toHaveBeenCalledWith('/twitch/users?login=lucky')
         expect(apiClient.get).toHaveBeenCalledWith(
             '/guilds/guild-1/twitch/notifications',

--- a/packages/frontend/src/services/api.test.ts
+++ b/packages/frontend/src/services/api.test.ts
@@ -391,7 +391,7 @@ describe('api service bootstrap', () => {
             { enabled: false },
         )
         expect(apiClient.get).toHaveBeenCalledWith(
-            '/guilds/guild-1/music/history?limit=10&offset=0',
+            '/guilds/guild-1/music/history?limit=50&offset=0',
         )
         expect(apiClient.get).toHaveBeenCalledWith(
             '/guilds/guild-1/music/history/stats',

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -298,7 +298,7 @@ export const api = {
     },
 
     trackHistory: {
-        getHistory: (guildId: string, limit = 10) =>
+        getHistory: (guildId: string, limit = 50, offset = 0) =>
             apiClient.get<{
                 history: Array<{
                     trackId: string
@@ -309,7 +309,10 @@ export const api = {
                     timestamp: number
                     playedBy?: string
                 }>
-            }>(`/guilds/${guildId}/music/history?limit=${limit}`),
+                total: number
+            }>(
+                `/guilds/${guildId}/music/history?limit=${limit}&offset=${offset}`,
+            ),
         getStats: (guildId: string) =>
             apiClient.get<{
                 stats: {

--- a/packages/shared/src/services/TrackHistoryService.ts
+++ b/packages/shared/src/services/TrackHistoryService.ts
@@ -93,12 +93,15 @@ export class TrackHistoryService {
     async getTrackHistory(
         guildId: string,
         limit = 10,
+        offset = 0,
     ): Promise<TrackHistoryEntry[]> {
         try {
+            const start = offset
+            const end = offset + limit - 1
             const historyData = await redisClient.lrange(
                 this.getRedisKey(guildId),
-                0,
-                limit - 1,
+                start,
+                end,
             )
             return historyData.map(
                 (data) => JSON.parse(data) as TrackHistoryEntry,
@@ -121,6 +124,15 @@ export class TrackHistoryService {
         } catch (error) {
             errorLog({ message: 'Failed to get last track', error })
             return null
+        }
+    }
+
+    async getTrackHistoryCount(guildId: string): Promise<number> {
+        try {
+            return await redisClient.llen(this.getRedisKey(guildId))
+        } catch (error) {
+            errorLog({ message: 'Failed to get track history count', error })
+            return 0
         }
     }
 


### PR DESCRIPTION
## Changes

- **Sidebar:** Fix active tab highlighting — `startsWith` was causing both `/music` and `/music/history` to appear active simultaneously. Now uses exact match or `path + '/'` prefix check.
- **Track History:** Remove hardcoded 50-track cap. Add load-more pagination so all tracks can be browsed. Backend now supports `offset` param and returns total track count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)