### PR TITLE
feat(feature-toggles): persist per-guild toggles in db

### DIFF
--- a/packages/backend/src/routes/toggles.ts
+++ b/packages/backend/src/routes/toggles.ts
@@ -168,11 +168,13 @@ export function setupToggleRoutes(app: Express): void {
                 throw AppError.badRequest('Invalid toggle name')
             }
 
-            res.json({
-                success: true,
-                message: 'Toggle updated via Unleash admin API',
-                note: 'Use Unleash admin API to update toggles per guild',
-            })
+            await featureToggleService.setGuildFeatureToggle(
+                guildId,
+                toggleName as FeatureToggleName,
+                enabled,
+            )
+
+            res.json({ success: true, guildId, name: toggleName, enabled })
         }),
     )
 }

--- a/packages/backend/tests/integration/routes/toggles.test.ts
+++ b/packages/backend/tests/integration/routes/toggles.test.ts
@@ -14,11 +14,15 @@ jest.mock('../../../src/services/SessionService', () => ({
     },
 }))
 
+const mockSetGuildFeatureToggle = jest.fn<any>().mockResolvedValue(undefined)
+
 jest.mock('@lucky/shared/services', () => ({
     featureToggleService: {
         getAllToggles: jest.fn(),
         isEnabledGlobal: jest.fn(),
         isEnabledForGuild: jest.fn(),
+        setGuildFeatureToggle: (...args: any[]) =>
+            mockSetGuildFeatureToggle(...args),
     },
 }))
 
@@ -322,7 +326,7 @@ describe('Toggles Routes Integration', () => {
     })
 
     describe('POST /api/guilds/:id/features/:name', () => {
-        test('should return success message', async () => {
+        test('saves toggle to db and returns updated state', async () => {
             const mockSessionService = sessionService as jest.Mocked<
                 typeof sessionService
             >
@@ -342,7 +346,17 @@ describe('Toggles Routes Integration', () => {
                 .send({ enabled: true })
                 .expect(200)
 
-            expect(response.body).toHaveProperty('success', true)
+            expect(response.body).toEqual({
+                success: true,
+                guildId: '111111111111111111',
+                name: 'DOWNLOAD_VIDEO',
+                enabled: true,
+            })
+            expect(mockSetGuildFeatureToggle).toHaveBeenCalledWith(
+                '111111111111111111',
+                'DOWNLOAD_VIDEO',
+                true,
+            )
         })
 
         test('should return 400 when enabled is missing', async () => {

--- a/packages/frontend/src/hooks/useFeatures.test.ts
+++ b/packages/frontend/src/hooks/useFeatures.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor, act } from '@testing-library/react'
 import { useFeatures } from './useFeatures'
 import { useAuthStore } from '@/stores/authStore'
 import { useGuildStore } from '@/stores/guildStore'
@@ -8,6 +8,7 @@ import { useFeaturesStore } from '@/stores/featuresStore'
 vi.mock('@/stores/authStore')
 vi.mock('@/stores/guildStore')
 vi.mock('@/stores/featuresStore')
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
 
 type AuthState = {
     isDeveloper: boolean
@@ -46,8 +47,8 @@ describe('useFeatures', () => {
     const fetchFeatures = vi.fn<() => Promise<void>>()
     const fetchGlobalToggles = vi.fn<() => Promise<void>>()
     const fetchServerToggles = vi.fn<(guildId: string) => Promise<void>>()
-    const updateGlobalToggle = vi.fn()
-    const updateServerToggle = vi.fn()
+    const updateGlobalToggle = vi.fn<() => Promise<void>>()
+    const updateServerToggle = vi.fn<() => Promise<void>>()
     const getServerToggles = vi.fn()
     const clearLoadError = vi.fn()
 
@@ -60,6 +61,8 @@ describe('useFeatures', () => {
         fetchFeatures.mockResolvedValue()
         fetchGlobalToggles.mockResolvedValue()
         fetchServerToggles.mockResolvedValue()
+        updateGlobalToggle.mockResolvedValue()
+        updateServerToggle.mockResolvedValue()
         getServerToggles.mockReturnValue({ DOWNLOAD_VIDEO: true })
 
         authState = {
@@ -84,18 +87,15 @@ describe('useFeatures', () => {
             getServerToggles,
         }
 
-        vi.mocked(useAuthStore).mockImplementation(
-            ((selector: (state: AuthState) => unknown) => selector(authState)) as
-                typeof useAuthStore,
-        )
-        vi.mocked(useGuildStore).mockImplementation(
-            ((selector: (state: GuildState) => unknown) =>
-                selector(guildState)) as typeof useGuildStore,
-        )
-        vi.mocked(useFeaturesStore).mockImplementation(
-            ((selector: (state: FeaturesState) => unknown) =>
-                selector(featuresState)) as typeof useFeaturesStore,
-        )
+        vi.mocked(useAuthStore).mockImplementation(((
+            selector: (state: AuthState) => unknown,
+        ) => selector(authState)) as typeof useAuthStore)
+        vi.mocked(useGuildStore).mockImplementation(((
+            selector: (state: GuildState) => unknown,
+        ) => selector(guildState)) as typeof useGuildStore)
+        vi.mocked(useFeaturesStore).mockImplementation(((
+            selector: (state: FeaturesState) => unknown,
+        ) => selector(featuresState)) as typeof useFeaturesStore)
     })
 
     test('does not fetch global toggles for non-developer users', async () => {
@@ -168,7 +168,9 @@ describe('useFeatures', () => {
     test('returns global toggles when guild is not selected', () => {
         const { result } = renderHook(() => useFeatures())
 
-        expect(result.current.serverToggles).toEqual(featuresState.globalToggles)
+        expect(result.current.serverToggles).toEqual(
+            featuresState.globalToggles,
+        )
         expect(getServerToggles).not.toHaveBeenCalled()
     })
 
@@ -212,6 +214,39 @@ describe('useFeatures', () => {
         rerender()
         result.current.handleServerToggle('AUTOPLAY', true)
         expect(updateServerToggle).toHaveBeenCalledTimes(1)
+    })
+
+    test('shows error toast when global toggle update fails', async () => {
+        const { toast } = await import('sonner')
+        updateGlobalToggle.mockRejectedValue(new Error('API failure'))
+
+        const { result } = renderHook(() => useFeatures())
+
+        await act(async () => {
+            result.current.handleGlobalToggle('AUTOPLAY', false)
+            await new Promise((r) => setTimeout(r, 10))
+        })
+
+        expect(toast.error).toHaveBeenCalledWith(
+            'Failed to update global toggle',
+        )
+    })
+
+    test('shows error toast when server toggle update fails', async () => {
+        const { toast } = await import('sonner')
+        guildState.selectedGuild = { id: 'guild-5' }
+        updateServerToggle.mockRejectedValue(new Error('API failure'))
+
+        const { result } = renderHook(() => useFeatures())
+
+        await act(async () => {
+            result.current.handleServerToggle('AUTOPLAY', false)
+            await new Promise((r) => setTimeout(r, 10))
+        })
+
+        expect(toast.error).toHaveBeenCalledWith(
+            'Failed to update server toggle',
+        )
     })
 
     test('retries load with current auth and guild context', async () => {

--- a/packages/frontend/src/hooks/useFeatures.ts
+++ b/packages/frontend/src/hooks/useFeatures.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { toast } from 'sonner'
 import { useFeaturesStore } from '@/stores/featuresStore'
 import { useAuthStore } from '@/stores/authStore'
 import { useGuildStore } from '@/stores/guildStore'
@@ -57,12 +58,16 @@ export function useFeatures() {
     }, [selectedGuild, fetchServerToggles, isAuthenticated, isAuthLoading])
 
     const handleGlobalToggle = (name: FeatureToggleName, enabled: boolean) => {
-        updateGlobalToggle(name, enabled)
+        updateGlobalToggle(name, enabled).catch(() => {
+            toast.error('Failed to update global toggle')
+        })
     }
 
     const handleServerToggle = (name: FeatureToggleName, enabled: boolean) => {
         if (selectedGuild) {
-            updateServerToggle(selectedGuild.id, name, enabled)
+            updateServerToggle(selectedGuild.id, name, enabled).catch(() => {
+                toast.error('Failed to update server toggle')
+            })
         }
     }
 

--- a/packages/frontend/src/stores/featuresStore.ts
+++ b/packages/frontend/src/stores/featuresStore.ts
@@ -183,27 +183,23 @@ export const useFeaturesStore = create<FeaturesState>((set, get) => ({
     },
 
     updateGlobalToggle: async (name, enabled) => {
-        try {
-            await api.features.updateGlobalToggle(name, enabled)
-            set((state) => ({
-                globalToggles: { ...state.globalToggles, [name]: enabled },
-            }))
-        } catch {}
+        await api.features.updateGlobalToggle(name, enabled)
+        set((state) => ({
+            globalToggles: { ...state.globalToggles, [name]: enabled },
+        }))
     },
 
     updateServerToggle: async (guildId, name, enabled) => {
-        try {
-            await api.features.updateServerToggle(guildId, name, enabled)
-            set((state) => ({
-                serverToggles: {
-                    ...state.serverToggles,
-                    [guildId]: {
-                        ...(state.serverToggles[guildId] || defaultToggles),
-                        [name]: enabled,
-                    },
+        await api.features.updateServerToggle(guildId, name, enabled)
+        set((state) => ({
+            serverToggles: {
+                ...state.serverToggles,
+                [guildId]: {
+                    ...(state.serverToggles[guildId] || defaultToggles),
+                    [name]: enabled,
                 },
-            }))
-        } catch {}
+            },
+        }))
     },
 
     getServerToggles: (guildId) =>

--- a/packages/shared/src/services/FeatureToggleService.spec.ts
+++ b/packages/shared/src/services/FeatureToggleService.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+
+const mockFindUnique = jest.fn()
+const mockUpsert = jest.fn()
+const mockPrismaClient = {
+    guildFeatureToggle: {
+        findUnique: (...args: unknown[]) => mockFindUnique(...args),
+        upsert: (...args: unknown[]) => mockUpsert(...args),
+    },
+}
+
+jest.mock('../utils/database/prismaClient', () => ({
+    getPrismaClient: () => mockPrismaClient,
+}))
+
+jest.mock('../config/unleash', () => ({
+    unleash: null,
+    isUnleashEnabled: () => false,
+}))
+
+jest.mock('../config/featureToggles', () => ({
+    getFeatureToggleConfig: () => ({
+        DOWNLOAD_VIDEO: {
+            name: 'DOWNLOAD_VIDEO',
+            description: 'test',
+            enabled: true,
+        },
+        DOWNLOAD_AUDIO: {
+            name: 'DOWNLOAD_AUDIO',
+            description: 'test',
+            enabled: false,
+        },
+    }),
+}))
+
+jest.mock('../utils/general/log', () => ({
+    debugLog: jest.fn(),
+}))
+
+describe('FeatureToggleService', () => {
+    let service: InstanceType<
+        (typeof import('./FeatureToggleService'))['featureToggleService'] extends infer S
+            ? S extends object
+                ? { new (): S }
+                : never
+            : never
+    >
+
+    beforeEach(async () => {
+        jest.resetModules()
+        mockFindUnique.mockReset()
+        mockUpsert.mockReset()
+
+        const mod = await import('./FeatureToggleService')
+        service = mod.featureToggleService as unknown as typeof service
+    })
+
+    describe('getDbOverride (via isEnabledForGuild)', () => {
+        it('returns db value when row exists (enabled=true)', async () => {
+            mockFindUnique.mockResolvedValue({ enabled: true })
+            const result = await (
+                service as unknown as {
+                    getDbOverride(
+                        guildId: string,
+                        name: string,
+                    ): Promise<boolean | null>
+                }
+            ).getDbOverride('guild-1', 'DOWNLOAD_AUDIO')
+            expect(result).toBe(true)
+        })
+
+        it('returns db value when row exists (enabled=false)', async () => {
+            mockFindUnique.mockResolvedValue({ enabled: false })
+            const result = await (
+                service as unknown as {
+                    getDbOverride(
+                        guildId: string,
+                        name: string,
+                    ): Promise<boolean | null>
+                }
+            ).getDbOverride('guild-1', 'DOWNLOAD_AUDIO')
+            expect(result).toBe(false)
+        })
+
+        it('returns null when no row found', async () => {
+            mockFindUnique.mockResolvedValue(null)
+            const result = await (
+                service as unknown as {
+                    getDbOverride(
+                        guildId: string,
+                        name: string,
+                    ): Promise<boolean | null>
+                }
+            ).getDbOverride('guild-1', 'DOWNLOAD_AUDIO')
+            expect(result).toBeNull()
+        })
+
+        it('returns null when db throws', async () => {
+            mockFindUnique.mockRejectedValue(new Error('DB connection failed'))
+            const result = await (
+                service as unknown as {
+                    getDbOverride(
+                        guildId: string,
+                        name: string,
+                    ): Promise<boolean | null>
+                }
+            ).getDbOverride('guild-1', 'DOWNLOAD_AUDIO')
+            expect(result).toBeNull()
+        })
+    })
+
+    describe('setGuildFeatureToggle', () => {
+        it('upserts the toggle with correct args', async () => {
+            mockUpsert.mockResolvedValue({})
+            await service.setGuildFeatureToggle(
+                'guild-1',
+                'DOWNLOAD_VIDEO',
+                true,
+            )
+            expect(mockUpsert).toHaveBeenCalledWith({
+                where: {
+                    guildId_name: {
+                        guildId: 'guild-1',
+                        name: 'DOWNLOAD_VIDEO',
+                    },
+                },
+                update: { enabled: true },
+                create: {
+                    guildId: 'guild-1',
+                    name: 'DOWNLOAD_VIDEO',
+                    enabled: true,
+                },
+            })
+        })
+
+        it('upserts with enabled=false', async () => {
+            mockUpsert.mockResolvedValue({})
+            await service.setGuildFeatureToggle(
+                'guild-1',
+                'DOWNLOAD_AUDIO',
+                false,
+            )
+            expect(mockUpsert).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    update: { enabled: false },
+                    create: expect.objectContaining({ enabled: false }),
+                }),
+            )
+        })
+
+        it('propagates db errors', async () => {
+            mockUpsert.mockRejectedValue(new Error('DB write failed'))
+            await expect(
+                service.setGuildFeatureToggle(
+                    'guild-1',
+                    'DOWNLOAD_VIDEO',
+                    true,
+                ),
+            ).rejects.toThrow('DB write failed')
+        })
+    })
+
+    describe('isEnabledForGuild with DB override', () => {
+        it('returns db override (true) without checking unleash', async () => {
+            mockFindUnique.mockResolvedValue({ enabled: true })
+            const result = await service.isEnabledForGuild(
+                'DOWNLOAD_AUDIO',
+                'guild-1',
+            )
+            expect(result).toBe(true)
+        })
+
+        it('returns db override (false) without checking unleash', async () => {
+            mockFindUnique.mockResolvedValue({ enabled: false })
+            const result = await service.isEnabledForGuild(
+                'DOWNLOAD_VIDEO',
+                'guild-1',
+            )
+            expect(result).toBe(false)
+        })
+
+        it('falls back to fallback toggle when no db override', async () => {
+            mockFindUnique.mockResolvedValue(null)
+            const result = await service.isEnabledForGuild(
+                'DOWNLOAD_VIDEO',
+                'guild-1',
+            )
+            expect(result).toBe(true)
+        })
+
+        it('falls back to fallback toggle when db throws', async () => {
+            mockFindUnique.mockRejectedValue(new Error('DB error'))
+            const result = await service.isEnabledForGuild(
+                'DOWNLOAD_VIDEO',
+                'guild-1',
+            )
+            expect(result).toBe(true)
+        })
+    })
+})

--- a/packages/shared/src/services/FeatureToggleService.ts
+++ b/packages/shared/src/services/FeatureToggleService.ts
@@ -2,6 +2,7 @@ import { unleash, isUnleashEnabled } from '../config/unleash'
 import type { FeatureToggleName } from '../types/featureToggle'
 import { getFeatureToggleConfig } from '../config/featureToggles'
 import { debugLog } from '../utils/general/log'
+import { getPrismaClient } from '../utils/database/prismaClient'
 
 const DEVELOPER_USER_IDS = (process.env.DEVELOPER_USER_IDS ?? '')
     .split(',')
@@ -49,6 +50,37 @@ class FeatureToggleService {
         return DEVELOPER_USER_IDS.includes(userId)
     }
 
+    private get db() {
+        return getPrismaClient()
+    }
+
+    private async getDbOverride(
+        guildId: string,
+        name: string,
+    ): Promise<boolean | null> {
+        try {
+            const row = await this.db.guildFeatureToggle.findUnique({
+                where: { guildId_name: { guildId, name } },
+                select: { enabled: true },
+            })
+            return row?.enabled ?? null
+        } catch {
+            return null
+        }
+    }
+
+    async setGuildFeatureToggle(
+        guildId: string,
+        name: FeatureToggleName,
+        enabled: boolean,
+    ): Promise<void> {
+        await this.db.guildFeatureToggle.upsert({
+            where: { guildId_name: { guildId, name } },
+            update: { enabled },
+            create: { guildId, name, enabled },
+        })
+    }
+
     async isEnabledGlobal(
         name: FeatureToggleName,
         userId?: string,
@@ -81,6 +113,11 @@ class FeatureToggleService {
         guildId: string,
         userId?: string,
     ): Promise<boolean> {
+        const dbOverride = await this.getDbOverride(guildId, name)
+        if (dbOverride !== null) {
+            return dbOverride
+        }
+
         if (!isUnleashEnabled() || !this.unleashReady || unleash === null) {
             return this.getFallbackValue(name)
         }

--- a/prisma/migrations/20260414000000_add_guild_feature_toggles/migration.sql
+++ b/prisma/migrations/20260414000000_add_guild_feature_toggles/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "guild_feature_toggles" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL,
+
+    CONSTRAINT "guild_feature_toggles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "guild_feature_toggles_guildId_idx" ON "guild_feature_toggles"("guildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "guild_feature_toggles_guildId_name_key" ON "guild_feature_toggles"("guildId", "name");
+
+-- AddForeignKey
+ALTER TABLE "guild_feature_toggles" ADD CONSTRAINT "guild_feature_toggles_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,8 +65,21 @@ model Guild {
   trackHistory        TrackHistory[]
   commandUsage        CommandUsage[]
   twitchNotifications TwitchNotification[]
+  featureToggles      GuildFeatureToggle[]
 
   @@map("guilds")
+}
+
+model GuildFeatureToggle {
+  id      String @id @default(cuid())
+  guildId String
+  guild   Guild  @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  name    String
+  enabled Boolean
+
+  @@unique([guildId, name])
+  @@index([guildId])
+  @@map("guild_feature_toggles")
 }
 
 model TwitchNotification {


### PR DESCRIPTION
## Summary

- Add `GuildFeatureToggle` Prisma model with `guildId + name` unique constraint
- Wire `POST /api/guilds/:id/features/:name` to upsert toggle state in DB
- `FeatureToggleService.isEnabledForGuild` checks DB override before Unleash/fallback
- Remove silent catches from `featuresStore` update actions — errors now surface to UI
- Add toast error feedback in `useFeatures` for failed toggle updates

## Test plan

- [ ] Backend toggle route tests updated: `setGuildFeatureToggle` mock added, POST response asserts new format `{success, guildId, name, enabled}`
- [ ] DB migration SQL verified: creates `guild_feature_toggles` table with FK to `guilds`
- [ ] CI passes (SonarCloud coverage + Quality Gates)
- [ ] After merge, run migration on prod: `npx prisma migrate deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)