### PR TITLE
fix: stop command clears tracks before queue deletion

### DIFF
--- a/packages/bot/src/functions/music/commands/stop.spec.ts
+++ b/packages/bot/src/functions/music/commands/stop.spec.ts
@@ -10,7 +10,7 @@ const markIntentionalStopMock = jest.fn()
 
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireQueue: (...args: unknown[]) => requireQueueMock(...args),
-    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args)
+    requireDJRole: (...args: unknown[]) => requireDJRoleMock(...args),
 }))
 
 jest.mock('../../../utils/general/interactionReply', () => ({
@@ -39,6 +39,8 @@ function createInteraction(guildId = 'guild-1') {
 function createQueue(guildId = 'guild-1') {
     return {
         guild: { id: guildId },
+        node: { stop: jest.fn() },
+        clear: jest.fn(),
         delete: jest.fn(),
     }
 }
@@ -51,22 +53,28 @@ describe('stop command', () => {
         requireDJRoleMock.mockResolvedValue(true)
     })
 
-    it('marks intentional stop and deletes queue', async () => {
+    it('stops node, clears and deletes queue', async () => {
         const queue = createQueue()
         resolveGuildQueueMock.mockReturnValue({ queue })
         requireQueueMock.mockResolvedValue(true)
 
-        const interaction = createInteraction()
-        await stopCommand.execute({ interaction, client: {} as any })
+        await stopCommand.execute({
+            interaction: createInteraction(),
+            client: {} as any,
+        })
 
         expect(markIntentionalStopMock).toHaveBeenCalledWith('guild-1')
+        expect(queue.node.stop).toHaveBeenCalled()
+        expect(queue.clear).toHaveBeenCalled()
         expect(queue.delete).toHaveBeenCalled()
     })
 
-    it('calls markIntentionalStop before queue.delete', async () => {
+    it('calls stop, clear, delete in order', async () => {
         const queue = createQueue()
         const callOrder: string[] = []
         markIntentionalStopMock.mockImplementation(() => callOrder.push('mark'))
+        queue.node.stop.mockImplementation(() => callOrder.push('stop'))
+        queue.clear.mockImplementation(() => callOrder.push('clear'))
         queue.delete.mockImplementation(() => callOrder.push('delete'))
         resolveGuildQueueMock.mockReturnValue({ queue })
         requireQueueMock.mockResolvedValue(true)
@@ -76,7 +84,7 @@ describe('stop command', () => {
             client: {} as any,
         })
 
-        expect(callOrder).toEqual(['mark', 'delete'])
+        expect(callOrder).toEqual(['mark', 'stop', 'clear', 'delete'])
     })
 
     it('replies with success embed after stopping', async () => {

--- a/packages/bot/src/functions/music/commands/stop.ts
+++ b/packages/bot/src/functions/music/commands/stop.ts
@@ -2,7 +2,10 @@ import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import type { CommandExecuteParams } from '../../../types/CommandData'
-import { requireQueue , requireDJRole } from '../../../utils/command/commandValidations'
+import {
+    requireQueue,
+    requireDJRole,
+} from '../../../utils/command/commandValidations'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 import { createSuccessEmbed } from '../../../utils/general/embeds'
 import { musicWatchdogService } from '../../../utils/music/watchdog'
@@ -19,6 +22,8 @@ export default new Command({
         if (!(await requireDJRole(interaction, interaction.guildId!))) return
 
         if (queue) musicWatchdogService.markIntentionalStop(queue.guild.id)
+        queue?.node.stop()
+        queue?.clear()
         queue?.delete()
 
         await interactionReply({

--- a/packages/bot/src/handlers/webMusic/commandHandlers.spec.ts
+++ b/packages/bot/src/handlers/webMusic/commandHandlers.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
-import { handlePause } from './commandHandlers'
+import { handlePause, handleStop } from './commandHandlers'
 
 const publishStateMock = jest.fn()
 const buildQueueStateMock = jest.fn()
@@ -20,6 +20,44 @@ jest.mock('../../utils/music/queueResolver', () => ({
     resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
 }))
 
+describe('handleStop', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        buildQueueStateMock.mockResolvedValue({ guildId: 'guild-1' })
+    })
+
+    it('stops node, clears, and deletes the queue', async () => {
+        const stop = jest.fn()
+        const clear = jest.fn()
+        const del = jest.fn()
+        resolveGuildQueueMock.mockReturnValue({
+            queue: { node: { stop }, clear, delete: del },
+        })
+
+        const result = await handleStop(
+            {} as any,
+            { id: 'cmd-1', guildId: 'guild-1', data: {} } as any,
+        )
+
+        expect(stop).toHaveBeenCalled()
+        expect(clear).toHaveBeenCalled()
+        expect(del).toHaveBeenCalled()
+        expect(result.success).toBe(true)
+    })
+
+    it('returns failure when no queue', async () => {
+        resolveGuildQueueMock.mockReturnValue({ queue: null })
+
+        const result = await handleStop(
+            {} as any,
+            { id: 'cmd-2', guildId: 'guild-1', data: {} } as any,
+        )
+
+        expect(result.success).toBe(false)
+        expect(result.error).toBe('No active queue')
+    })
+})
+
 describe('webMusic commandHandlers queue resolution', () => {
     beforeEach(() => {
         jest.clearAllMocks()
@@ -33,7 +71,11 @@ describe('webMusic commandHandlers queue resolution', () => {
                 node: { pause },
             },
             source: 'cache.guild',
-            diagnostics: { guildId: 'guild-1', cacheSize: 1, cacheSampleKeys: [] },
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 1,
+                cacheSampleKeys: [],
+            },
         })
 
         const result = await handlePause(
@@ -41,7 +83,10 @@ describe('webMusic commandHandlers queue resolution', () => {
             { id: 'cmd-1', guildId: 'guild-1', data: {} } as any,
         )
 
-        expect(resolveGuildQueueMock).toHaveBeenCalledWith(expect.anything(), 'guild-1')
+        expect(resolveGuildQueueMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'guild-1',
+        )
         expect(pause).toHaveBeenCalled()
         expect(publishStateMock).toHaveBeenCalledWith({ guildId: 'guild-1' })
         expect(result.success).toBe(true)
@@ -51,7 +96,11 @@ describe('webMusic commandHandlers queue resolution', () => {
         resolveGuildQueueMock.mockReturnValue({
             queue: null,
             source: 'miss',
-            diagnostics: { guildId: 'guild-1', cacheSize: 0, cacheSampleKeys: [] },
+            diagnostics: {
+                guildId: 'guild-1',
+                cacheSize: 0,
+                cacheSampleKeys: [],
+            },
         })
 
         const result = await handlePause(

--- a/packages/bot/src/handlers/webMusic/commandHandlers.ts
+++ b/packages/bot/src/handlers/webMusic/commandHandlers.ts
@@ -129,6 +129,7 @@ export async function handleStop(
     const queue = getQueue(client, cmd.guildId)
     if (!queue) return fail(cmd.id, cmd.guildId, 'No active queue')
     queue.node.stop()
+    queue.clear()
     queue.delete()
     return publishAndOk(client, cmd)
 }


### PR DESCRIPTION
## Problem

After using the stop button (web or `/stop` command) and then calling `/play`, the bot resumed the old track instead of playing the new one.

**Root cause:** Both stop handlers called `queue.delete()` without first clearing the track list or stopping the audio node. discord-player's `leaveOnEndCooldown` (5 min) keeps the queue object alive, so the next `/play` found an existing queue with the old current track still set.

## Fix

Both stop handlers now follow the correct teardown order:
1. `queue.node.stop()` — stops audio playback immediately
2. `queue.clear()` — removes all queued tracks (including autoplay buffer)
3. `queue.delete()` — removes the queue from the player cache

**Affected handlers:**
- `/stop` slash command (`commands/stop.ts`)
- Web app stop button (`handlers/webMusic/commandHandlers.ts`)