### PR TITLE
ci: make Deploy to Homelab manual-only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy to Homelab
 
 on:
-    push:
-        branches: [main]
     workflow_dispatch:
 
 jobs:
@@ -10,9 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             actions: read
-        if: >
-            github.event_name == 'workflow_dispatch' ||
-            github.event_name == 'push'
+        if: github.event_name == 'workflow_dispatch'
 
         steps:
             - name: Validate secrets


### PR DESCRIPTION
Deploy workflow has been silently failing on every push to main because no webhook listener is running on the homelab server — deploys happen manually via the lucky-deploy skill. Converting to workflow_dispatch only unblocks main CI while keeping the option to manually trigger.

## Test plan
- [x] Main CI runs show no Deploy to Homelab failure after merge
- [x] Manual trigger still works: gh workflow run deploy.yml