### PR TITLE
chore: bump version to 2.6.123

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.123] - 2026-04-14
+
+### Added
+- `POST /api/internal/notify`: homelab-only endpoint for sending Discord notifications from the server (content + embeds, auth via `INTERNAL_API_KEY`)
+
+### Changed
+- Phase 1 dedupe: deleted 368 LOC of 95%-duplicate files — `queueStateManager.ts`, `downloadHelpers.ts`, and `errorSanitizer.ts` now have a single canonical location; `errorSanitizer` moved to `@lucky/shared`
+- Phase 2 memory hygiene: replaced 4 unbounded module-level Maps with LRU caches — `artistPopularityCache` (max 5000, 24h TTL), `audioFeatureCache` (max 10000, 24h TTL), duplicate-detection caches (max 1000, 1h TTL), and now-playing caches (max 500, 4h TTL); prevents long-running-bot memory growth
+
+### Fixed
+- CI: `Deploy to Homelab` workflow converted to manual-dispatch-only (no webhook listener was running on server — was failing silently on every push)
+
 ## [2.6.122] - 2026-04-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.122",
+    "version": "2.6.123",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.122",
+    "version": "2.6.123",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.122",
+    "version": "2.6.123",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.122",
+    "version": "2.6.123",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.122",
+    "version": "2.6.123",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Bundles #625 (notify endpoint), #626 (phase 1 dedupe, -368 LOC), #627 (phase 2 memory hygiene, 4 LRU caches).