### PR TITLE
fix(shared): expose utils/* subpath — HOTFIX bot crash loop

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,6 +26,10 @@
             "types": "./dist/utils/index.d.ts",
             "default": "./dist/utils/index.js"
         },
+        "./utils/*": {
+            "types": "./dist/utils/*.d.ts",
+            "default": "./dist/utils/*.js"
+        },
         "./types": {
             "types": "./dist/types/index.d.ts",
             "default": "./dist/types/index.js"


### PR DESCRIPTION
v2.6.123 crash-looping with `ERR_PACKAGE_PATH_NOT_EXPORTED` for `@lucky/shared/utils/general/errorSanitizer`. Adds wildcard utils/* subpath to package exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured package exports for utility modules, enabling direct imports via subpath patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->