### PR TITLE
Redesign Preferred Artists page with default suggestions and batch save

### DIFF
--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -11,6 +11,7 @@ import {
     getSpotifyClientToken,
     isSpotifyAuthConfigured,
 } from '../services/SpotifyAuthService'
+import { spotifyLinkService } from '@lucky/shared/services'
 
 const saveArtistBody = z.object({
     guildId: z.string().min(1),
@@ -31,42 +32,104 @@ export function setupArtistsRoutes(app: Express): void {
         requireAuth,
         async (req: AuthenticatedRequest, res: Response) => {
             try {
+                const discordUserId = req.user?.id
+                if (!discordUserId) {
+                    res.status(401).json({ error: 'Not authenticated' })
+                    return
+                }
                 if (!isSpotifyAuthConfigured()) {
                     res.status(503).json({ error: 'Spotify not configured' })
                     return
                 }
-                const token = await getSpotifyClientToken()
-                if (!token) {
+                const clientToken = await getSpotifyClientToken()
+                if (!clientToken) {
                     res.status(503).json({
                         error: 'Failed to get Spotify token',
                     })
                     return
                 }
-                const suggestQueries = [
-                    'Drake',
-                    'The Weeknd',
-                    'Dua Lipa',
-                    'Billie Eilish',
-                    'Bad Bunny',
-                    'Ariana Grande',
-                ]
+
                 const suggestions = new Map<string, any>()
-                for (const query of suggestQueries) {
-                    if (suggestions.size >= 12) break
+
+                const link = await spotifyLinkService.getValidAccessToken(
+                    discordUserId,
+                )
+                if (link) {
                     try {
-                        const artists = await searchSpotifyArtists(
-                            token,
-                            query,
-                            2,
+                        const userTopRes = await fetch(
+                            'https://api.spotify.com/v1/me/top/artists?limit=12&time_range=medium_term',
+                            {
+                                headers: {
+                                    Authorization: `Bearer ${link}`,
+                                },
+                            },
                         )
-                        for (const artist of artists) {
-                            if (suggestions.size >= 12) break
-                            suggestions.set(artist.id, artist)
+                        if (userTopRes.ok) {
+                            const data = (await userTopRes.json()) as {
+                                items?: unknown[]
+                            }
+                            if (Array.isArray(data.items)) {
+                                for (const item of data.items) {
+                                    const artist = item as {
+                                        id?: string
+                                        name?: string
+                                        images?: { url: string }[]
+                                        popularity?: number
+                                        genres?: string[]
+                                    }
+                                    if (
+                                        artist.id &&
+                                        artist.name &&
+                                        suggestions.size < 12
+                                    ) {
+                                        suggestions.set(artist.id, {
+                                            id: artist.id,
+                                            name: artist.name,
+                                            imageUrl:
+                                                artist.images?.[0]?.url ?? null,
+                                            popularity: artist.popularity ?? 0,
+                                            genres: artist.genres ?? [],
+                                        })
+                                    }
+                                }
+                            }
                         }
                     } catch {
-                        // continue to next query
+                        // Fall back to popular artists
                     }
                 }
+
+                if (suggestions.size < 12) {
+                    const suggestQueries = [
+                        'Drake',
+                        'The Weeknd',
+                        'Dua Lipa',
+                        'Billie Eilish',
+                        'Bad Bunny',
+                        'Ariana Grande',
+                        'Taylor Swift',
+                        'Ed Sheeran',
+                    ]
+                    for (const query of suggestQueries) {
+                        if (suggestions.size >= 12) break
+                        try {
+                            const artists = await searchSpotifyArtists(
+                                clientToken,
+                                query,
+                                2,
+                            )
+                            for (const artist of artists) {
+                                if (suggestions.size >= 12) break
+                                if (!suggestions.has(artist.id)) {
+                                    suggestions.set(artist.id, artist)
+                                }
+                            }
+                        } catch {
+                            // continue to next query
+                        }
+                    }
+                }
+
                 res.json({
                     artists: Array.from(suggestions.values()),
                 })

--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -27,6 +27,60 @@ function normalizeArtistKey(name: string): string {
 
 export function setupArtistsRoutes(app: Express): void {
     app.get(
+        '/api/artists/suggestions',
+        requireAuth,
+        async (req: AuthenticatedRequest, res: Response) => {
+            try {
+                if (!isSpotifyAuthConfigured()) {
+                    res.status(503).json({ error: 'Spotify not configured' })
+                    return
+                }
+                const token = await getSpotifyClientToken()
+                if (!token) {
+                    res.status(503).json({
+                        error: 'Failed to get Spotify token',
+                    })
+                    return
+                }
+                const suggestQueries = [
+                    'Drake',
+                    'The Weeknd',
+                    'Dua Lipa',
+                    'Billie Eilish',
+                    'Bad Bunny',
+                    'Ariana Grande',
+                ]
+                const suggestions = new Map<string, any>()
+                for (const query of suggestQueries) {
+                    if (suggestions.size >= 12) break
+                    try {
+                        const artists = await searchSpotifyArtists(
+                            token,
+                            query,
+                            2,
+                        )
+                        for (const artist of artists) {
+                            if (suggestions.size >= 12) break
+                            suggestions.set(artist.id, artist)
+                        }
+                    } catch {
+                        // continue to next query
+                    }
+                }
+                res.json({
+                    artists: Array.from(suggestions.values()),
+                })
+            } catch (error) {
+                errorLog({
+                    message: 'Artist suggestions error',
+                    error,
+                })
+                res.status(500).json({ error: 'Failed to get suggestions' })
+            }
+        },
+    )
+
+    app.get(
         '/api/artists/search',
         requireAuth,
         async (req: AuthenticatedRequest, res: Response) => {

--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -5,6 +5,7 @@ import {
     getPrismaClient,
     searchSpotifyArtists,
     getSpotifyRelatedArtists,
+    type SpotifyArtist,
 } from '@lucky/shared/utils'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
 import {
@@ -49,7 +50,7 @@ export function setupArtistsRoutes(app: Express): void {
                     return
                 }
 
-                const suggestions = new Map<string, any>()
+                const suggestions = new Map<string, SpotifyArtist>()
 
                 const link = await spotifyLinkService.getValidAccessToken(
                     discordUserId,

--- a/packages/backend/tests/unit/routes/artists.test.ts
+++ b/packages/backend/tests/unit/routes/artists.test.ts
@@ -1,535 +1,609 @@
-import {
-    describe,
-    test,
-    expect,
-    jest,
-    beforeEach,
-    afterEach,
-} from '@jest/globals'
-import type { Request, Response, NextFunction } from 'express'
-
-// Mock shared utilities before import
-jest.mock('@lucky/shared/utils', () => ({
-    errorLog: jest.fn(),
-    getPrismaClient: jest.fn(),
-    searchSpotifyArtists: jest.fn(),
-    getSpotifyRelatedArtists: jest.fn(),
-}))
-
-// Mock SpotifyAuthService
-jest.mock('../../../src/services/SpotifyAuthService', () => ({
-    getSpotifyClientToken: jest.fn(),
-    isSpotifyAuthConfigured: jest.fn(),
-}))
-
-// Mock auth middleware — attach user to req
-jest.mock('../../../src/middleware/auth', () => ({
-    requireAuth: (req: Request, _res: Response, next: NextFunction) => {
-        ;(req as any).user = { id: 'user-123' }
-        next()
-    },
-}))
-
-import express from 'express'
-import request from 'supertest'
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import type { Express } from 'express'
 import { setupArtistsRoutes } from '../../../src/routes/artists'
-import * as sharedUtils from '@lucky/shared/utils'
-import * as spotifyAuth from '../../../src/services/SpotifyAuthService'
+import {
+	searchSpotifyArtists,
+	getSpotifyRelatedArtists,
+	getPrismaClient,
+	errorLog,
+} from '@lucky/shared/utils'
+import {
+	getSpotifyClientToken,
+	isSpotifyAuthConfigured,
+} from '../../../src/services/SpotifyAuthService'
+import { spotifyLinkService } from '@lucky/shared/services'
+import {
+	createMockRequest,
+	createMockResponse,
+} from '../../fixtures/test-helpers'
 
-function createApp() {
-    const app = express()
-    app.use(express.json())
-    setupArtistsRoutes(app)
-    app.use(
-        (
-            err: { statusCode?: number; message: string },
-            _req: Request,
-            res: Response,
-            _next: NextFunction,
-        ) => {
-            res.status(err.statusCode ?? 500).json({ error: err.message })
-        },
-    )
-    return app
+jest.mock('@lucky/shared/utils', () => ({
+	errorLog: jest.fn(),
+	getPrismaClient: jest.fn(),
+	searchSpotifyArtists: jest.fn(),
+	getSpotifyRelatedArtists: jest.fn(),
+}))
+
+jest.mock('../../../src/services/SpotifyAuthService', () => ({
+	getSpotifyClientToken: jest.fn(),
+	isSpotifyAuthConfigured: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+	spotifyLinkService: {
+		getValidAccessToken: jest.fn(),
+	},
+}))
+
+const mockApp = {
+	get: jest.fn(),
+	post: jest.fn(),
+	delete: jest.fn(),
+} as unknown as Express
+
+const mockArtist = {
+	id: 'spotify-1',
+	name: 'Drake',
+	imageUrl: 'https://example.com/image.jpg',
+	popularity: 85,
+	genres: ['hip-hop', 'rap'],
 }
 
-const mockDb = {
-    userArtistPreference: {
-        findMany: jest.fn(),
-        upsert: jest.fn(),
-        delete: jest.fn(),
-    },
+const mockPreference = {
+	id: 'pref-1',
+	discordUserId: 'discord-123',
+	guildId: 'guild-1',
+	artistKey: 'drake',
+	artistName: 'Drake',
+	spotifyId: 'spotify-1',
+	imageUrl: 'https://example.com/image.jpg',
+	preference: 'prefer' as const,
+	createdAt: new Date(),
+	updatedAt: new Date(),
 }
 
 describe('Artists Routes', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-        ;(sharedUtils.getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-    })
+	beforeEach(() => {
+		jest.clearAllMocks()
+		;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+		;(getSpotifyClientToken as jest.Mock).mockResolvedValue('client-token')
+		;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
+			null,
+		)
+	})
 
-    describe('GET /api/artists/search', () => {
-        test('returns 400 when q param is missing', async () => {
-            const app = createApp()
-            const res = await request(app).get('/api/artists/search')
-            expect(res.status).toBe(400)
-            expect(res.body.error).toBe('Missing query parameter q')
-        })
+	describe('GET /api/artists/suggestions', () => {
+		test('should return user top artists when OAuth link exists', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+			}) as any
+			const res = createMockResponse()
 
-        test('returns 400 when q param is empty string', async () => {
-            const app = createApp()
-            const res = await request(app)
-                .get('/api/artists/search')
-                .query({ q: '   ' })
-            expect(res.status).toBe(400)
-            expect(res.body.error).toBe('Missing query parameter q')
-        })
+			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
+				'user-token',
+			)
 
-        test('returns 503 when Spotify is not configured', async () => {
-            ;(spotifyAuth.isSpotifyAuthConfigured as jest.Mock).mockReturnValue(
-                false,
-            )
-            const app = createApp()
-            const res = await request(app)
-                .get('/api/artists/search')
-                .query({ q: 'Drake' })
-            expect(res.status).toBe(503)
-            expect(res.body.error).toBe('Spotify not configured')
-        })
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValue(
+					new Response(
+						JSON.stringify({
+							items: [
+								{
+									id: 'top-1',
+									name: 'Kanye West',
+									images: [{ url: 'https://example.com/kanye.jpg' }],
+									popularity: 90,
+									genres: ['hip-hop'],
+								},
+							],
+						}),
+						{ status: 200 },
+					),
+				)
 
-        test('returns 503 when getSpotifyClientToken fails', async () => {
-            ;(spotifyAuth.isSpotifyAuthConfigured as jest.Mock).mockReturnValue(
-                true,
-            )
-            ;(spotifyAuth.getSpotifyClientToken as jest.Mock).mockResolvedValue(
-                null,
-            )
-            const app = createApp()
-            const res = await request(app)
-                .get('/api/artists/search')
-                .query({ q: 'Drake' })
-            expect(res.status).toBe(503)
-            expect(res.body.error).toBe('Failed to get Spotify token')
-        })
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[0][2]
 
-        test('returns 200 with artists array on success', async () => {
-            ;(spotifyAuth.isSpotifyAuthConfigured as jest.Mock).mockReturnValue(
-                true,
-            )
-            ;(spotifyAuth.getSpotifyClientToken as jest.Mock).mockResolvedValue(
-                'test-token',
-            )
-            const mockArtists = [
-                {
-                    id: 'artist-1',
-                    name: 'Drake',
-                    image: 'https://example.com/drake.jpg',
-                },
-                {
-                    id: 'artist-2',
-                    name: 'The Weeknd',
-                    image: 'https://example.com/weeknd.jpg',
-                },
-            ]
-            ;(sharedUtils.searchSpotifyArtists as jest.Mock).mockResolvedValue(
-                mockArtists,
-            )
-            const app = createApp()
-            const res = await request(app)
-                .get('/api/artists/search')
-                .query({ q: 'Drake' })
-            expect(res.status).toBe(200)
-            expect(res.body.artists).toEqual(mockArtists)
-            expect(sharedUtils.searchSpotifyArtists).toHaveBeenCalledWith(
-                'test-token',
-                'Drake',
-                12,
-            )
-        })
+			await handler(req, res)
 
-        test('returns 500 when searchSpotifyArtists throws', async () => {
-            ;(spotifyAuth.isSpotifyAuthConfigured as jest.Mock).mockReturnValue(
-                true,
-            )
-            ;(spotifyAuth.getSpotifyClientToken as jest.Mock).mockResolvedValue(
-                'test-token',
-            )
-            ;(sharedUtils.searchSpotifyArtists as jest.Mock).mockRejectedValue(
-                new Error('Spotify API error'),
-            )
-            const app = createApp()
-            const res = await request(app)
-                .get('/api/artists/search')
-                .query({ q: 'Drake' })
-            expect(res.status).toBe(500)
-            expect(res.body.error).toBe('Failed to search artists')
-            expect(sharedUtils.errorLog).toHaveBeenCalled()
-        })
-    })
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({
+					artists: expect.any(Array),
+				}),
+			)
+			expect(res.json.mock.calls[0][0].artists.length).toBeGreaterThan(0)
 
-    describe('GET /api/artists/:artistId/related', () => {
-        test('returns 503 when Spotify is not configured', async () => {
-            ;(spotifyAuth.isSpotifyAuthConfigured as jest.Mock).mockReturnValue(
-                false,
-            )
-            const app = createApp()
-            const res = await request(app).get(
-                '/api/artists/artist-123/related',
-            )
-            expect(res.status).toBe(503)
-            expect(res.body.error).toBe('Spotify not configured')
-        })
+			fetchSpy.mockRestore()
+		})
 
-        test('returns 503 when getSpotifyClientToken fails', async () => {
-            ;(spotifyAuth.isSpotifyAuthConfigured as jest.Mock).mockReturnValue(
-                true,
-            )
-            ;(spotifyAuth.getSpotifyClientToken as jest.Mock).mockResolvedValue(
-                null,
-            )
-            const app = createApp()
-            const res = await request(app).get(
-                '/api/artists/artist-123/related',
-            )
-            expect(res.status).toBe(503)
-            expect(res.body.error).toBe('Failed to get Spotify token')
-        })
+		test('should fall back to popular artists search when OAuth fails', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+			}) as any
+			const res = createMockResponse()
 
-        test('returns 200 with related artists on success', async () => {
-            ;(spotifyAuth.isSpotifyAuthConfigured as jest.Mock).mockReturnValue(
-                true,
-            )
-            ;(spotifyAuth.getSpotifyClientToken as jest.Mock).mockResolvedValue(
-                'test-token',
-            )
-            const mockRelatedArtists = [
-                { id: 'related-1', name: 'Artist 1' },
-                { id: 'related-2', name: 'Artist 2' },
-            ]
-            ;(
-                sharedUtils.getSpotifyRelatedArtists as jest.Mock
-            ).mockResolvedValue(mockRelatedArtists)
-            const app = createApp()
-            const res = await request(app).get(
-                '/api/artists/artist-123/related',
-            )
-            expect(res.status).toBe(200)
-            expect(res.body.artists).toEqual(mockRelatedArtists)
-            expect(sharedUtils.getSpotifyRelatedArtists).toHaveBeenCalledWith(
-                'test-token',
-                'artist-123',
-            )
-        })
+			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
+				'user-token',
+			)
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockRejectedValueOnce(new Error('Network error'))
 
-        test('returns 500 when getSpotifyRelatedArtists throws', async () => {
-            ;(spotifyAuth.isSpotifyAuthConfigured as jest.Mock).mockReturnValue(
-                true,
-            )
-            ;(spotifyAuth.getSpotifyClientToken as jest.Mock).mockResolvedValue(
-                'test-token',
-            )
-            ;(
-                sharedUtils.getSpotifyRelatedArtists as jest.Mock
-            ).mockRejectedValue(new Error('Spotify API error'))
-            const app = createApp()
-            const res = await request(app).get(
-                '/api/artists/artist-123/related',
-            )
-            expect(res.status).toBe(500)
-            expect(res.body.error).toBe('Failed to get related artists')
-            expect(sharedUtils.errorLog).toHaveBeenCalled()
-        })
-    })
+			;(searchSpotifyArtists as jest.Mock).mockResolvedValue([mockArtist])
 
-    describe('GET /api/users/me/preferred-artists', () => {
-        test('returns 200 with preferences when guildId is provided', async () => {
-            const mockPreferences = [
-                {
-                    discordUserId: 'user-123',
-                    guildId: 'guild-1',
-                    artistKey: 'drake',
-                    artistName: 'Drake',
-                    spotifyId: 'spotify-1',
-                    imageUrl: 'https://example.com/image.jpg',
-                    preference: 'prefer',
-                    createdAt: '2024-01-01T00:00:00.000Z',
-                    updatedAt: '2024-01-01T00:00:00.000Z',
-                },
-            ]
-            ;(
-                mockDb.userArtistPreference.findMany as jest.Mock
-            ).mockResolvedValue(mockPreferences)
-            const app = createApp()
-            const res = await request(app)
-                .get('/api/users/me/preferred-artists')
-                .query({ guildId: 'guild-1' })
-            expect(res.status).toBe(200)
-            expect(res.body.preferences).toEqual(mockPreferences)
-            expect(mockDb.userArtistPreference.findMany).toHaveBeenCalledWith({
-                where: { discordUserId: 'user-123', guildId: 'guild-1' },
-                orderBy: { createdAt: 'desc' },
-            })
-        })
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[0][2]
 
-        test('returns 200 with preferences without guildId filter', async () => {
-            const mockPreferences = [
-                {
-                    discordUserId: 'user-123',
-                    guildId: 'guild-1',
-                    artistKey: 'drake',
-                    artistName: 'Drake',
-                    preference: 'prefer',
-                    createdAt: '2024-01-01T00:00:00.000Z',
-                    updatedAt: '2024-01-01T00:00:00.000Z',
-                },
-                {
-                    discordUserId: 'user-123',
-                    guildId: 'guild-2',
-                    artistKey: 'weeknd',
-                    artistName: 'The Weeknd',
-                    preference: 'prefer',
-                    createdAt: '2024-01-02T00:00:00.000Z',
-                    updatedAt: '2024-01-02T00:00:00.000Z',
-                },
-            ]
-            ;(
-                mockDb.userArtistPreference.findMany as jest.Mock
-            ).mockResolvedValue(mockPreferences)
-            const app = createApp()
-            const res = await request(app).get(
-                '/api/users/me/preferred-artists',
-            )
-            expect(res.status).toBe(200)
-            expect(res.body.preferences).toEqual(mockPreferences)
-            expect(mockDb.userArtistPreference.findMany).toHaveBeenCalledWith({
-                where: { discordUserId: 'user-123' },
-                orderBy: { createdAt: 'desc' },
-            })
-        })
+			await handler(req, res)
 
-        test('returns 500 when database query fails', async () => {
-            ;(
-                mockDb.userArtistPreference.findMany as jest.Mock
-            ).mockRejectedValue(new Error('Database error'))
-            const app = createApp()
-            const res = await request(app).get(
-                '/api/users/me/preferred-artists',
-            )
-            expect(res.status).toBe(500)
-            expect(res.body.error).toBe('Failed to get preferences')
-            expect(sharedUtils.errorLog).toHaveBeenCalled()
-        })
-    })
+			expect(searchSpotifyArtists as jest.Mock).toHaveBeenCalled()
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({
+					artists: expect.any(Array),
+				}),
+			)
 
-    describe('POST /api/users/me/preferred-artists', () => {
-        test('returns 400 when guildId is missing from body', async () => {
-            const app = createApp()
-            const res = await request(app)
-                .post('/api/users/me/preferred-artists')
-                .send({
-                    artistKey: 'drake',
-                    artistName: 'Drake',
-                })
-            expect(res.status).toBe(400)
-            expect(res.body).toHaveProperty('error')
-        })
+			fetchSpy.mockRestore()
+		})
 
-        test('returns 400 when artistName is missing', async () => {
-            const app = createApp()
-            const res = await request(app)
-                .post('/api/users/me/preferred-artists')
-                .send({
-                    guildId: 'guild-1',
-                    artistKey: 'drake',
-                })
-            expect(res.status).toBe(400)
-            expect(res.body).toHaveProperty('error')
-        })
+		test('should return 401 when not authenticated', async () => {
+			const req = createMockRequest({
+				user: undefined,
+			}) as any
+			const res = createMockResponse()
 
-        test('returns 200 with saved preference on success', async () => {
-            const mockPreference = {
-                discordUserId: 'user-123',
-                guildId: 'guild-1',
-                artistKey: 'drake',
-                artistName: 'Drake',
-                spotifyId: 'spotify-1',
-                imageUrl: 'https://example.com/drake.jpg',
-                preference: 'prefer',
-                createdAt: '2024-01-01T00:00:00.000Z',
-                updatedAt: '2024-01-01T00:00:00.000Z',
-            }
-            ;(
-                mockDb.userArtistPreference.upsert as jest.Mock
-            ).mockResolvedValue(mockPreference)
-            const app = createApp()
-            const res = await request(app)
-                .post('/api/users/me/preferred-artists')
-                .send({
-                    guildId: 'guild-1',
-                    artistKey: 'Drake',
-                    artistName: 'Drake',
-                    spotifyId: 'spotify-1',
-                    imageUrl: 'https://example.com/drake.jpg',
-                    preference: 'prefer',
-                })
-            expect(res.status).toBe(200)
-            expect(res.body.preference).toEqual(mockPreference)
-            expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    where: {
-                        discordUserId_guildId_artistKey: {
-                            discordUserId: 'user-123',
-                            guildId: 'guild-1',
-                            artistKey: 'drake',
-                        },
-                    },
-                }),
-            )
-        })
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[0][2]
 
-        test('normalizes artistKey to lowercase alphanumeric', async () => {
-            const mockPreference = {
-                discordUserId: 'user-123',
-                guildId: 'guild-1',
-                artistKey: 'drakejcole',
-                artistName: 'Drake & J Cole',
-                preference: 'prefer',
-                createdAt: '2024-01-01T00:00:00.000Z',
-                updatedAt: '2024-01-01T00:00:00.000Z',
-            }
-            ;(
-                mockDb.userArtistPreference.upsert as jest.Mock
-            ).mockResolvedValue(mockPreference)
-            const app = createApp()
-            const res = await request(app)
-                .post('/api/users/me/preferred-artists')
-                .send({
-                    guildId: 'guild-1',
-                    artistKey: 'Drake & J Cole',
-                    artistName: 'Drake & J Cole',
-                    preference: 'prefer',
-                })
-            expect(res.status).toBe(200)
-            expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    where: {
-                        discordUserId_guildId_artistKey: {
-                            discordUserId: 'user-123',
-                            guildId: 'guild-1',
-                            artistKey: 'drakejcole',
-                        },
-                    },
-                }),
-            )
-        })
+			await handler(req, res)
 
-        test('returns 400 when artistKey is missing (required field)', async () => {
-            const app = createApp()
-            const res = await request(app)
-                .post('/api/users/me/preferred-artists')
-                .send({
-                    guildId: 'guild-1',
-                    artistName: 'Drake',
-                    preference: 'prefer',
-                })
-            expect(res.status).toBe(400)
-            expect(res.body).toHaveProperty('error')
-        })
+			expect(res.status).toHaveBeenCalledWith(401)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Not authenticated',
+			})
+		})
 
-        test('defaults preference to prefer when not specified', async () => {
-            const mockPreference = {
-                discordUserId: 'user-123',
-                guildId: 'guild-1',
-                artistKey: 'drake',
-                artistName: 'Drake',
-                preference: 'prefer',
-                createdAt: '2024-01-01T00:00:00.000Z',
-                updatedAt: '2024-01-01T00:00:00.000Z',
-            }
-            ;(
-                mockDb.userArtistPreference.upsert as jest.Mock
-            ).mockResolvedValue(mockPreference)
-            const app = createApp()
-            const res = await request(app)
-                .post('/api/users/me/preferred-artists')
-                .send({
-                    guildId: 'guild-1',
-                    artistKey: 'drake',
-                    artistName: 'Drake',
-                })
-            expect(res.status).toBe(200)
-            expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    create: expect.objectContaining({
-                        preference: 'prefer',
-                    }),
-                }),
-            )
-        })
+		test('should return 503 when Spotify not configured', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+			}) as any
+			const res = createMockResponse()
 
-        test('returns 500 when upsert fails', async () => {
-            ;(
-                mockDb.userArtistPreference.upsert as jest.Mock
-            ).mockRejectedValue(new Error('Database error'))
-            const app = createApp()
-            const res = await request(app)
-                .post('/api/users/me/preferred-artists')
-                .send({
-                    guildId: 'guild-1',
-                    artistKey: 'drake',
-                    artistName: 'Drake',
-                })
-            expect(res.status).toBe(500)
-            expect(res.body.error).toBe('Failed to save preference')
-            expect(sharedUtils.errorLog).toHaveBeenCalled()
-        })
-    })
+			;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(false)
 
-    describe('DELETE /api/users/me/preferred-artists/:artistKey', () => {
-        test('returns 400 when guildId query param is missing', async () => {
-            const app = createApp()
-            const res = await request(app).delete(
-                '/api/users/me/preferred-artists/drake',
-            )
-            expect(res.status).toBe(400)
-            expect(res.body.error).toBe('Missing guildId query param')
-        })
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[0][2]
 
-        test('returns 200 on successful delete', async () => {
-            ;(
-                mockDb.userArtistPreference.delete as jest.Mock
-            ).mockResolvedValue({
-                discordUserId: 'user-123',
-                guildId: 'guild-1',
-                artistKey: 'drake',
-            })
-            const app = createApp()
-            const res = await request(app)
-                .delete('/api/users/me/preferred-artists/drake')
-                .query({ guildId: 'guild-1' })
-            expect(res.status).toBe(200)
-            expect(res.body.success).toBe(true)
-            expect(mockDb.userArtistPreference.delete).toHaveBeenCalledWith({
-                where: {
-                    discordUserId_guildId_artistKey: {
-                        discordUserId: 'user-123',
-                        guildId: 'guild-1',
-                        artistKey: 'drake',
-                    },
-                },
-            })
-        })
+			await handler(req, res)
 
-        test('returns 500 when delete fails', async () => {
-            ;(
-                mockDb.userArtistPreference.delete as jest.Mock
-            ).mockRejectedValue(new Error('Database error'))
-            const app = createApp()
-            const res = await request(app)
-                .delete('/api/users/me/preferred-artists/drake')
-                .query({ guildId: 'guild-1' })
-            expect(res.status).toBe(500)
-            expect(res.body.error).toBe('Failed to delete preference')
-            expect(sharedUtils.errorLog).toHaveBeenCalled()
-        })
-    })
+			expect(res.status).toHaveBeenCalledWith(503)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Spotify not configured',
+			})
+		})
+
+		test('should return 503 when unable to get Spotify token', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+			}) as any
+			const res = createMockResponse()
+
+			;(getSpotifyClientToken as jest.Mock).mockResolvedValue(null)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(503)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Failed to get Spotify token',
+			})
+		})
+
+		test('should handle unexpected errors gracefully', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+			}) as any
+			const res = createMockResponse()
+
+			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockRejectedValue(
+				new Error('Unexpected error'),
+			)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(errorLog as jest.Mock).toHaveBeenCalled()
+			expect(res.status).toHaveBeenCalledWith(500)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Failed to get suggestions',
+			})
+		})
+	})
+
+	describe('GET /api/artists/search', () => {
+		test('should search artists by query', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				query: { q: 'Drake' },
+			}) as any
+			const res = createMockResponse()
+
+			;(searchSpotifyArtists as jest.Mock).mockResolvedValue([mockArtist])
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[1][2]
+
+			await handler(req, res)
+
+			expect(searchSpotifyArtists as jest.Mock).toHaveBeenCalledWith(
+				'client-token',
+				'Drake',
+				12,
+			)
+			expect(res.json).toHaveBeenCalledWith({
+				artists: [mockArtist],
+			})
+		})
+
+		test('should return 400 when query parameter is missing', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				query: {},
+			}) as any
+			const res = createMockResponse()
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[1][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(400)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Missing query parameter q',
+			})
+		})
+
+		test('should return 500 on search error', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				query: { q: 'Drake' },
+			}) as any
+			const res = createMockResponse()
+
+			;(searchSpotifyArtists as jest.Mock).mockRejectedValue(
+				new Error('Spotify API error'),
+			)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[1][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(500)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Failed to search artists',
+			})
+		})
+	})
+
+	describe('GET /api/artists/:artistId/related', () => {
+		test('should fetch related artists', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				params: { artistId: 'spotify-1' },
+			}) as any
+			const res = createMockResponse()
+
+			;(getSpotifyRelatedArtists as jest.Mock).mockResolvedValue([
+				mockArtist,
+			])
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[2][2]
+
+			await handler(req, res)
+
+			expect(getSpotifyRelatedArtists as jest.Mock).toHaveBeenCalledWith(
+				'client-token',
+				'spotify-1',
+			)
+			expect(res.json).toHaveBeenCalledWith({
+				artists: [mockArtist],
+			})
+		})
+
+		test('should return 500 on related artists error', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				params: { artistId: 'spotify-1' },
+			}) as any
+			const res = createMockResponse()
+
+			;(getSpotifyRelatedArtists as jest.Mock).mockRejectedValue(
+				new Error('API error'),
+			)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[2][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(500)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Failed to get related artists',
+			})
+		})
+	})
+
+	describe('GET /api/users/me/preferred-artists', () => {
+		test('should fetch user preferences for guild', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				query: { guildId: 'guild-1' },
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					findMany: jest.fn().mockResolvedValue([mockPreference]),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[3][2]
+
+			await handler(req, res)
+
+			expect(mockDb.userArtistPreference.findMany).toHaveBeenCalledWith({
+				where: { discordUserId: 'discord-123', guildId: 'guild-1' },
+				orderBy: { createdAt: 'desc' },
+			})
+			expect(res.json).toHaveBeenCalledWith({
+				preferences: [mockPreference],
+			})
+		})
+
+		test('should return 401 when not authenticated', async () => {
+			const req = createMockRequest({
+				user: undefined,
+				query: { guildId: 'guild-1' },
+			}) as any
+			const res = createMockResponse()
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[3][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(401)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Not authenticated',
+			})
+		})
+
+		test('should return 500 on database error', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				query: { guildId: 'guild-1' },
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					findMany: jest
+						.fn()
+						.mockRejectedValue(new Error('Database error')),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.get as jest.Mock).mock.calls[3][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(500)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Failed to get preferences',
+			})
+		})
+	})
+
+	describe('POST /api/users/me/preferred-artists', () => {
+		test('should save artist preference', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				body: {
+					guildId: 'guild-1',
+					artistKey: 'drake',
+					artistName: 'Drake',
+					spotifyId: 'spotify-1',
+					imageUrl: 'https://example.com/image.jpg',
+					preference: 'prefer',
+				},
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					upsert: jest.fn().mockResolvedValue(mockPreference),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.post as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(mockDb.userArtistPreference.upsert).toHaveBeenCalled()
+			expect(res.json).toHaveBeenCalledWith({
+				preference: mockPreference,
+			})
+		})
+
+		test('should return 400 on invalid request body', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				body: {
+					guildId: '',
+					artistKey: '',
+				},
+			}) as any
+			const res = createMockResponse()
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.post as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(400)
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({
+					error: expect.any(String),
+				}),
+			)
+		})
+
+		test('should return 401 when not authenticated', async () => {
+			const req = createMockRequest({
+				user: undefined,
+				body: {
+					guildId: 'guild-1',
+					artistKey: 'drake',
+					artistName: 'Drake',
+				},
+			}) as any
+			const res = createMockResponse()
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.post as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(401)
+		})
+
+		test('should return 500 on database error', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				body: {
+					guildId: 'guild-1',
+					artistKey: 'drake',
+					artistName: 'Drake',
+					spotifyId: 'spotify-1',
+					preference: 'prefer',
+				},
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					upsert: jest
+						.fn()
+						.mockRejectedValue(new Error('Database error')),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.post as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(500)
+		})
+	})
+
+	describe('DELETE /api/users/me/preferred-artists/:artistKey', () => {
+		test('should delete artist preference', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				params: { artistKey: 'drake' },
+				query: { guildId: 'guild-1' },
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					delete: jest.fn().mockResolvedValue(mockPreference),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.delete as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(mockDb.userArtistPreference.delete).toHaveBeenCalled()
+			expect(res.json).toHaveBeenCalledWith({ success: true })
+		})
+
+		test('should return 400 when guildId missing', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				params: { artistKey: 'drake' },
+				query: {},
+			}) as any
+			const res = createMockResponse()
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.delete as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(400)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Missing guildId query param',
+			})
+		})
+
+		test('should return 401 when not authenticated', async () => {
+			const req = createMockRequest({
+				user: undefined,
+				params: { artistKey: 'drake' },
+				query: { guildId: 'guild-1' },
+			}) as any
+			const res = createMockResponse()
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.delete as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(401)
+		})
+
+		test('should return 500 on database error', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				params: { artistKey: 'drake' },
+				query: { guildId: 'guild-1' },
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					delete: jest
+						.fn()
+						.mockRejectedValue(new Error('Database error')),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.delete as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(500)
+		})
+	})
 })

--- a/packages/frontend/src/components/Layout/Sidebar.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.tsx
@@ -486,10 +486,12 @@ function Sidebar() {
 
     const isActive = (path: string) => {
         if (path === '/') return location.pathname === '/'
-        return (
-            location.pathname === path ||
-            location.pathname.startsWith(path + '/')
-        )
+        const exact = location.pathname === path
+        const withChild = location.pathname.startsWith(path + '/')
+        if (path === '/music') {
+            return location.pathname === '/music'
+        }
+        return exact || withChild
     }
 
     const effectiveAccess =

--- a/packages/frontend/src/components/Layout/Sidebar.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.tsx
@@ -488,9 +488,6 @@ function Sidebar() {
         if (path === '/') return location.pathname === '/'
         const exact = location.pathname === path
         const withChild = location.pathname.startsWith(path + '/')
-        if (path === '/music') {
-            return location.pathname === '/music'
-        }
         return exact || withChild
     }
 

--- a/packages/frontend/src/components/Layout/Sidebar.tsx
+++ b/packages/frontend/src/components/Layout/Sidebar.tsx
@@ -488,6 +488,9 @@ function Sidebar() {
         if (path === '/') return location.pathname === '/'
         const exact = location.pathname === path
         const withChild = location.pathname.startsWith(path + '/')
+        if (path === '/music' && location.pathname === '/music/artists') {
+            return false
+        }
         return exact || withChild
     }
 

--- a/packages/frontend/src/pages/PreferredArtists.test.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.test.tsx
@@ -461,4 +461,266 @@ describe('PreferredArtistsPage', () => {
             ).toBeInTheDocument()
         })
     })
+
+    test('saves preferences successfully and updates state', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
+        })
+        mockGetPreferences.mockResolvedValue({ data: { preferences: [] } })
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+        const beatlesBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('The Beatles'))!
+        await act(async () => {
+            fireEvent.click(beatlesBtn)
+        })
+        await waitFor(() => {
+            expect(screen.getByText('Prefer')).toBeInTheDocument()
+        })
+        const preferBtn = screen.getByText('Prefer').closest('button')!
+        await act(async () => {
+            fireEvent.click(preferBtn)
+        })
+        await waitFor(() => {
+            expect(screen.getByText(/Save Preferences/)).toBeInTheDocument()
+        })
+        mockGetPreferences.mockResolvedValue({
+            data: { preferences: [mockPreference] },
+        })
+        const saveBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('Save Preferences'))!
+        await act(async () => {
+            fireEvent.click(saveBtn)
+        })
+        await waitFor(() => {
+            expect(mockSavePreference).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    guildId: 'guild-1',
+                    preference: 'prefer',
+                }),
+            )
+        })
+    })
+
+    test('handles save preference error gracefully', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
+        })
+        mockGetPreferences.mockResolvedValue({ data: { preferences: [] } })
+        mockSavePreference.mockRejectedValueOnce(
+            new Error('Network error'),
+        )
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+        const beatlesBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('The Beatles'))!
+        await act(async () => {
+            fireEvent.click(beatlesBtn)
+        })
+        await waitFor(() => {
+            expect(screen.getByText('Prefer')).toBeInTheDocument()
+        })
+        const preferBtn = screen.getByText('Prefer').closest('button')!
+        await act(async () => {
+            fireEvent.click(preferBtn)
+        })
+        const saveBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('Save Preferences'))!
+        await act(async () => {
+            fireEvent.click(saveBtn)
+        })
+        await waitFor(() => {
+            expect(mockSavePreference).toHaveBeenCalled()
+        })
+    })
+
+    test('renders artist with no genres gracefully', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        const artistNoGenres = {
+            ...mockArtist,
+            genres: [],
+        }
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [artistNoGenres] },
+        })
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+    })
+
+    test('handles related artists loading state', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
+        })
+        let resolveRelated!: (value: unknown) => void
+        mockGetRelated.mockReturnValue(
+            new Promise((res) => {
+                resolveRelated = res
+            }),
+        )
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+        const beatlesBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('The Beatles'))!
+        await act(async () => {
+            fireEvent.click(beatlesBtn)
+        })
+        await waitFor(() => {
+            const spinners = document.querySelectorAll('.animate-spin')
+            expect(spinners.length).toBeGreaterThan(0)
+        })
+        await act(async () => {
+            resolveRelated({ data: { artists: [] } })
+        })
+    })
+
+    test('removes unsaved changes when remove preference is clicked', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
+        })
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+        const beatlesBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('The Beatles'))!
+        await act(async () => {
+            fireEvent.click(beatlesBtn)
+        })
+        await waitFor(() => {
+            expect(screen.getByText('Prefer')).toBeInTheDocument()
+        })
+        const preferBtn = screen.getByText('Prefer').closest('button')!
+        await act(async () => {
+            fireEvent.click(preferBtn)
+        })
+        await waitFor(() => {
+            expect(screen.getByText('Preferred')).toBeInTheDocument()
+        })
+        const preferredBtn = screen.getByText('Preferred').closest('button')!
+        await act(async () => {
+            fireEvent.click(preferredBtn)
+        })
+        await waitFor(() => {
+            expect(
+                screen.queryByText(/Save Preferences/),
+            ).not.toBeInTheDocument()
+        })
+    })
+
+    test('handles duplicate artists in unsaved changes', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        const duplicateArtist = { ...mockArtist, id: 'different-id' }
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist, duplicateArtist] },
+        })
+        renderPage()
+        await waitFor(() => {
+            const beatlesButtons = screen
+                .getAllByRole('button')
+                .filter((b) => b.textContent?.includes('The Beatles'))
+            expect(beatlesButtons.length).toBeGreaterThan(0)
+        })
+    })
+
+    test('handles empty result from getRelated error', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
+        })
+        mockGetRelated.mockRejectedValueOnce(new Error('API error'))
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+        const beatlesBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('The Beatles'))!
+        await act(async () => {
+            fireEvent.click(beatlesBtn)
+        })
+        await waitFor(() => {
+            expect(
+                screen.getByText('No related artists found'),
+            ).toBeInTheDocument()
+        })
+    })
+
+    test('handles loadPreferences error gracefully', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetPreferences.mockRejectedValueOnce(new Error('Network error'))
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
+        })
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+    })
+
+    test('shows correct preference state in related artists panel', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
+        })
+        mockGetPreferences.mockResolvedValue({
+            data: { preferences: [mockPreference] },
+        })
+        const relatedArtist = {
+            id: 'related-1',
+            name: 'Led Zeppelin',
+            imageUrl: null,
+            popularity: 75,
+            genres: ['rock'],
+        }
+        mockGetRelated.mockResolvedValue({ data: { artists: [relatedArtist] } })
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+        const beatlesBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('The Beatles'))!
+        await act(async () => {
+            fireEvent.click(beatlesBtn)
+        })
+        await waitFor(() => {
+            expect(screen.getByText('Led Zeppelin')).toBeInTheDocument()
+        })
+    })
 })

--- a/packages/frontend/src/pages/PreferredArtists.test.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.test.tsx
@@ -13,6 +13,8 @@ const mockGetRelated = vi.fn()
 const mockSavePreference = vi.fn()
 const mockDeletePreference = vi.fn()
 
+const mockGetSuggestions = vi.fn()
+
 vi.mock('@/services/api', () => ({
     api: {
         artists: {
@@ -22,6 +24,7 @@ vi.mock('@/services/api', () => ({
             savePreference: (...args: unknown[]) => mockSavePreference(...args),
             deletePreference: (...args: unknown[]) =>
                 mockDeletePreference(...args),
+            getSuggestions: (...args: unknown[]) => mockGetSuggestions(...args),
         },
     },
 }))
@@ -86,6 +89,7 @@ describe('PreferredArtistsPage', () => {
             data: { preference: mockPreference },
         })
         mockDeletePreference.mockResolvedValue({ data: { success: true } })
+        mockGetSuggestions.mockResolvedValue({ data: { artists: [] } })
     })
 
     test('shows empty state when no guild selected', () => {
@@ -120,9 +124,22 @@ describe('PreferredArtistsPage', () => {
         mockGetPreferences.mockResolvedValue({
             data: { preferences: [mockPreference] },
         })
+        mockGetSuggestions.mockResolvedValue({
+            data: {
+                artists: [
+                    {
+                        id: 'suggested-1',
+                        name: 'Suggested Artist',
+                        imageUrl: null,
+                        popularity: 70,
+                        genres: ['pop'],
+                    },
+                ],
+            },
+        })
         renderPage()
         await waitFor(() => {
-            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+            expect(screen.getByText('Suggested Artist')).toBeInTheDocument()
         })
     })
 
@@ -151,11 +168,12 @@ describe('PreferredArtistsPage', () => {
         vi.mocked(useGuildSelection).mockReturnValue({
             selectedGuild: mockGuild,
         } as any)
+        mockGetSuggestions.mockResolvedValue({ data: { artists: [] } })
         renderPage()
         await waitFor(() => {
             expect(
                 screen.getByText(
-                    'Search for artists above to add your preferences',
+                    'No suggestions available. Try searching for artists above.',
                 ),
             ).toBeInTheDocument()
         })
@@ -165,17 +183,17 @@ describe('PreferredArtistsPage', () => {
         vi.mocked(useGuildSelection).mockReturnValue({
             selectedGuild: mockGuild,
         } as any)
-        let resolvePrefs!: (value: unknown) => void
-        mockGetPreferences.mockReturnValue(
+        let resolveSuggestions!: (value: unknown) => void
+        mockGetSuggestions.mockReturnValue(
             new Promise((res) => {
-                resolvePrefs = res
+                resolveSuggestions = res
             }),
         )
         renderPage()
         const spinners = document.querySelectorAll('.animate-spin')
         expect(spinners.length).toBeGreaterThan(0)
         await act(async () => {
-            resolvePrefs({ data: { preferences: [] } })
+            resolveSuggestions({ data: { artists: [] } })
         })
     })
 
@@ -267,12 +285,12 @@ describe('PreferredArtistsPage', () => {
         vi.mocked(useGuildSelection).mockReturnValue({
             selectedGuild: mockGuild,
         } as any)
-        const prefWithImage = {
-            ...mockPreference,
+        const artistWithImage = {
+            ...mockArtist,
             imageUrl: 'https://example.com/img.jpg',
         }
-        mockGetPreferences.mockResolvedValue({
-            data: { preferences: [prefWithImage] },
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [artistWithImage] },
         })
         renderPage()
         await waitFor(() => {
@@ -286,8 +304,8 @@ describe('PreferredArtistsPage', () => {
         vi.mocked(useGuildSelection).mockReturnValue({
             selectedGuild: mockGuild,
         } as any)
-        mockGetPreferences.mockResolvedValue({
-            data: { preferences: [mockPreference] },
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
         })
         mockGetRelated.mockResolvedValue({
             data: {
@@ -326,8 +344,8 @@ describe('PreferredArtistsPage', () => {
         vi.mocked(useGuildSelection).mockReturnValue({
             selectedGuild: mockGuild,
         } as any)
-        mockGetPreferences.mockResolvedValue({
-            data: { preferences: [mockPreference] },
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
         })
         renderPage()
         await waitFor(() => {
@@ -341,7 +359,7 @@ describe('PreferredArtistsPage', () => {
             fireEvent.click(beatlesBtn!)
         })
         await waitFor(() => {
-            expect(screen.getByText('Preferred')).toBeInTheDocument()
+            expect(screen.getByText('Prefer')).toBeInTheDocument()
             expect(screen.getByText('Block')).toBeInTheDocument()
         })
     })
@@ -350,8 +368,8 @@ describe('PreferredArtistsPage', () => {
         vi.mocked(useGuildSelection).mockReturnValue({
             selectedGuild: mockGuild,
         } as any)
-        mockGetPreferences.mockResolvedValue({
-            data: { preferences: [mockPreference] },
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
         })
         renderPage()
         await waitFor(() => {
@@ -379,8 +397,13 @@ describe('PreferredArtistsPage', () => {
         vi.mocked(useGuildSelection).mockReturnValue({
             selectedGuild: mockGuild,
         } as any)
+        mockGetSuggestions.mockResolvedValue({
+            data: {
+                artists: [mockArtist],
+            },
+        })
         mockGetPreferences.mockResolvedValue({
-            data: { preferences: [mockPreference] },
+            data: { preferences: [] },
         })
         renderPage()
         await waitFor(() => {
@@ -393,17 +416,23 @@ describe('PreferredArtistsPage', () => {
             fireEvent.click(beatlesBtn)
         })
         await waitFor(() => {
-            expect(screen.getByText('Preferred')).toBeInTheDocument()
+            expect(screen.getByText('Prefer')).toBeInTheDocument()
         })
-        const removeBtn = screen.getByText('Preferred').closest('button')!
+        const preferBtn = screen.getByText('Prefer').closest('button')!
         await act(async () => {
-            fireEvent.click(removeBtn)
+            fireEvent.click(preferBtn)
         })
         await waitFor(() => {
-            expect(mockDeletePreference).toHaveBeenCalledWith(
-                'thebeatles',
-                'guild-1',
-            )
+            expect(screen.getByText(/Save Preferences/)).toBeInTheDocument()
+        })
+        const saveBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.includes('Save Preferences'))!
+        await act(async () => {
+            fireEvent.click(saveBtn)
+        })
+        await waitFor(() => {
+            expect(mockSavePreference).toHaveBeenCalled()
         })
     })
 
@@ -411,8 +440,8 @@ describe('PreferredArtistsPage', () => {
         vi.mocked(useGuildSelection).mockReturnValue({
             selectedGuild: mockGuild,
         } as any)
-        mockGetPreferences.mockResolvedValue({
-            data: { preferences: [mockPreference] },
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
         })
         mockGetRelated.mockResolvedValue({ data: { artists: [] } })
         renderPage()

--- a/packages/frontend/src/pages/PreferredArtists.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.tsx
@@ -311,7 +311,7 @@ export default function PreferredArtistsPage() {
     const [relatedLoading, setRelatedLoading] = useState(false)
 
     const [unsavedChanges, setUnsavedChanges] = useState<
-        Map<string, 'prefer' | 'block'>
+        Map<string, { preference: 'prefer' | 'block'; artist: SpotifyArtist }>
     >(new Map())
     const [isSaving, setIsSaving] = useState(false)
 
@@ -393,7 +393,7 @@ export default function PreferredArtistsPage() {
             const key = normalizeArtistKey(artist.name)
             setUnsavedChanges((prev) => {
                 const next = new Map(prev)
-                next.set(key, pref)
+                next.set(key, { preference: pref, artist })
                 return next
             })
         },
@@ -413,32 +413,15 @@ export default function PreferredArtistsPage() {
         if (!guildId || unsavedChanges.size === 0) return
         setIsSaving(true)
         try {
-            for (const [key, pref] of unsavedChanges) {
-                const artist = suggestedArtists.find(
-                    (a) => normalizeArtistKey(a.name) === key,
-                )
-                if (!artist) {
-                    const saved = savedPreferences.get(key)
-                    if (saved) {
-                        await api.artists.savePreference({
-                            guildId,
-                            artistKey: key,
-                            artistName: saved.artistName,
-                            spotifyId: saved.spotifyId ?? undefined,
-                            imageUrl: saved.imageUrl ?? undefined,
-                            preference: pref,
-                        })
-                    }
-                } else {
-                    await api.artists.savePreference({
-                        guildId,
-                        artistKey: key,
-                        artistName: artist.name,
-                        spotifyId: artist.id,
-                        imageUrl: artist.imageUrl ?? undefined,
-                        preference: pref,
-                    })
-                }
+            for (const [key, { preference, artist }] of unsavedChanges) {
+                await api.artists.savePreference({
+                    guildId,
+                    artistKey: key,
+                    artistName: artist.name,
+                    spotifyId: artist.id,
+                    imageUrl: artist.imageUrl ?? undefined,
+                    preference,
+                })
             }
             await loadPreferences()
             setUnsavedChanges(new Map())
@@ -447,14 +430,15 @@ export default function PreferredArtistsPage() {
         } finally {
             setIsSaving(false)
         }
-    }, [guildId, unsavedChanges, suggestedArtists, savedPreferences, loadPreferences])
+    }, [guildId, unsavedChanges, loadPreferences])
 
     const blockedArtists = [...savedPreferences.values()].filter(
         (p) => p.preference === 'block',
     )
 
     const selectedPreference = selectedArtist
-        ? (unsavedChanges.get(normalizeArtistKey(selectedArtist.name)) ??
+        ? (unsavedChanges.get(normalizeArtistKey(selectedArtist.name))
+                ?.preference ??
             savedPreferences.get(normalizeArtistKey(selectedArtist.name))
                 ?.preference ??
             null)
@@ -538,7 +522,7 @@ export default function PreferredArtistsPage() {
                                 {displayArtists.map((artist) => {
                                     const key = normalizeArtistKey(artist.name)
                                     const unsaved =
-                                        unsavedChanges.get(key) ?? null
+                                        unsavedChanges.get(key)?.preference ?? null
                                     const pref =
                                         unsaved ??
                                         savedPreferences.get(key)?.preference ??

--- a/packages/frontend/src/pages/PreferredArtists.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.tsx
@@ -297,10 +297,12 @@ export default function PreferredArtistsPage() {
     const [searching, setSearching] = useState(false)
     const [searchError, setSearchError] = useState<string | null>(null)
 
+    const [suggestedArtists, setSuggestedArtists] = useState<SpotifyArtist[]>([])
+    const [suggestionsLoading, setSuggestionsLoading] = useState(false)
+
     const [savedPreferences, setSavedPreferences] = useState<
         Map<string, ArtistPreference>
     >(new Map())
-    const [prefsLoading, setPrefsLoading] = useState(false)
 
     const [selectedArtist, setSelectedArtist] = useState<SpotifyArtist | null>(
         null,
@@ -308,13 +310,15 @@ export default function PreferredArtistsPage() {
     const [relatedArtists, setRelatedArtists] = useState<SpotifyArtist[]>([])
     const [relatedLoading, setRelatedLoading] = useState(false)
 
-    const [savingKeys, setSavingKeys] = useState<Set<string>>(new Set())
+    const [unsavedChanges, setUnsavedChanges] = useState<
+        Map<string, 'prefer' | 'block'>
+    >(new Map())
+    const [isSaving, setIsSaving] = useState(false)
 
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     const loadPreferences = useCallback(async () => {
         if (!guildId) return
-        setPrefsLoading(true)
         try {
             const res = await api.artists.getPreferences(guildId)
             const map = new Map<string, ArtistPreference>()
@@ -324,14 +328,25 @@ export default function PreferredArtistsPage() {
             setSavedPreferences(map)
         } catch {
             // non-critical
-        } finally {
-            setPrefsLoading(false)
         }
     }, [guildId])
 
+    const loadSuggestions = useCallback(async () => {
+        setSuggestionsLoading(true)
+        try {
+            const res = await api.artists.getSuggestions()
+            setSuggestedArtists(res.data.artists)
+        } catch {
+            setSuggestedArtists([])
+        } finally {
+            setSuggestionsLoading(false)
+        }
+    }, [])
+
     useEffect(() => {
         loadPreferences()
-    }, [loadPreferences])
+        loadSuggestions()
+    }, [loadPreferences, loadSuggestions])
 
     useEffect(() => {
         if (debounceRef.current) clearTimeout(debounceRef.current)
@@ -374,77 +389,78 @@ export default function PreferredArtistsPage() {
     }, [])
 
     const handleTogglePreference = useCallback(
-        async (artist: SpotifyArtist, pref: 'prefer' | 'block') => {
-            if (!guildId) return
+        (artist: SpotifyArtist, pref: 'prefer' | 'block') => {
             const key = normalizeArtistKey(artist.name)
-            setSavingKeys((prev) => new Set(prev).add(key))
-            try {
-                const res = await api.artists.savePreference({
-                    guildId,
-                    artistKey: key,
-                    artistName: artist.name,
-                    spotifyId: artist.id,
-                    imageUrl: artist.imageUrl ?? undefined,
-                    preference: pref,
-                })
-                setSavedPreferences((prev) => {
-                    const next = new Map(prev)
-                    next.set(key, res.data.preference)
-                    return next
-                })
-            } catch {
-                // ignore
-            } finally {
-                setSavingKeys((prev) => {
-                    const next = new Set(prev)
-                    next.delete(key)
-                    return next
-                })
-            }
+            setUnsavedChanges((prev) => {
+                const next = new Map(prev)
+                next.set(key, pref)
+                return next
+            })
         },
-        [guildId],
+        [],
     )
 
-    const handleRemovePreference = useCallback(
-        async (artist: SpotifyArtist) => {
-            if (!guildId) return
-            const key = normalizeArtistKey(artist.name)
-            setSavingKeys((prev) => new Set(prev).add(key))
-            try {
-                await api.artists.deletePreference(key, guildId)
-                setSavedPreferences((prev) => {
-                    const next = new Map(prev)
-                    next.delete(key)
-                    return next
-                })
-            } catch {
-                // ignore
-            } finally {
-                setSavingKeys((prev) => {
-                    const next = new Set(prev)
-                    next.delete(key)
-                    return next
-                })
-            }
-        },
-        [guildId],
-    )
+    const handleRemovePreference = useCallback((artist: SpotifyArtist) => {
+        const key = normalizeArtistKey(artist.name)
+        setUnsavedChanges((prev) => {
+            const next = new Map(prev)
+            next.delete(key)
+            return next
+        })
+    }, [])
 
-    const preferredArtists = [...savedPreferences.values()].filter(
-        (p) => p.preference === 'prefer',
-    )
+    const handleSavePreferences = useCallback(async () => {
+        if (!guildId || unsavedChanges.size === 0) return
+        setIsSaving(true)
+        try {
+            for (const [key, pref] of unsavedChanges) {
+                const artist = suggestedArtists.find(
+                    (a) => normalizeArtistKey(a.name) === key,
+                )
+                if (!artist) {
+                    const saved = savedPreferences.get(key)
+                    if (saved) {
+                        await api.artists.savePreference({
+                            guildId,
+                            artistKey: key,
+                            artistName: saved.artistName,
+                            spotifyId: saved.spotifyId ?? undefined,
+                            imageUrl: saved.imageUrl ?? undefined,
+                            preference: pref,
+                        })
+                    }
+                } else {
+                    await api.artists.savePreference({
+                        guildId,
+                        artistKey: key,
+                        artistName: artist.name,
+                        spotifyId: artist.id,
+                        imageUrl: artist.imageUrl ?? undefined,
+                        preference: pref,
+                    })
+                }
+            }
+            await loadPreferences()
+            setUnsavedChanges(new Map())
+        } catch {
+            // error handling could be improved with a toast
+        } finally {
+            setIsSaving(false)
+        }
+    }, [guildId, unsavedChanges, suggestedArtists, savedPreferences, loadPreferences])
+
     const blockedArtists = [...savedPreferences.values()].filter(
         (p) => p.preference === 'block',
     )
 
     const selectedPreference = selectedArtist
-        ? (savedPreferences.get(normalizeArtistKey(selectedArtist.name))
-              ?.preference ?? null)
+        ? (unsavedChanges.get(normalizeArtistKey(selectedArtist.name)) ??
+            savedPreferences.get(normalizeArtistKey(selectedArtist.name))
+                ?.preference ??
+            null)
         : null
 
-    const displayArtists = query.trim()
-        ? searchResults
-        : preferredArtists.map(prefToArtist)
+    const displayArtists = query.trim() ? searchResults : suggestedArtists
 
     if (!selectedGuild) {
         return (
@@ -509,21 +525,28 @@ export default function PreferredArtistsPage() {
                                 </p>
                             )}
 
+                        {!searching &&
+                            !query.trim() &&
+                            suggestionsLoading && (
+                                <div className='flex items-center justify-center py-6'>
+                                    <Loader2 className='h-5 w-5 animate-spin text-lucky-text-tertiary' />
+                                </div>
+                            )}
+
                         {!searching && displayArtists.length > 0 && (
                             <div className='mt-4 flex flex-wrap gap-1'>
                                 {displayArtists.map((artist) => {
                                     const key = normalizeArtistKey(artist.name)
+                                    const unsaved =
+                                        unsavedChanges.get(key) ?? null
                                     const pref =
+                                        unsaved ??
                                         savedPreferences.get(key)?.preference ??
                                         null
-                                    const isSaving = savingKeys.has(key)
                                     return (
                                         <div
                                             key={artist.id + key}
-                                            className={cn(
-                                                'transition-opacity',
-                                                isSaving && 'opacity-50',
-                                            )}
+                                            className='transition-opacity'
                                         >
                                             <ArtistAvatar
                                                 artist={artist}
@@ -543,21 +566,15 @@ export default function PreferredArtistsPage() {
                         )}
 
                         {!query.trim() &&
-                            preferredArtists.length === 0 &&
-                            !prefsLoading && (
+                            displayArtists.length === 0 &&
+                            !suggestionsLoading && (
                                 <div className='py-6 text-center'>
                                     <p className='type-body-sm text-lucky-text-tertiary'>
-                                        Search for artists above to add your
-                                        preferences
+                                        No suggestions available. Try searching
+                                        for artists above.
                                     </p>
                                 </div>
                             )}
-
-                        {prefsLoading && !query.trim() && (
-                            <div className='flex items-center justify-center py-6'>
-                                <Loader2 className='h-5 w-5 animate-spin text-lucky-text-tertiary' />
-                            </div>
-                        )}
                     </div>
 
                     {blockedArtists.length > 0 && (
@@ -568,17 +585,8 @@ export default function PreferredArtistsPage() {
                             <div className='flex flex-wrap gap-1'>
                                 {blockedArtists.map((pref) => {
                                     const artist = prefToArtist(pref)
-                                    const isSaving = savingKeys.has(
-                                        pref.artistKey,
-                                    )
                                     return (
-                                        <div
-                                            key={pref.id}
-                                            className={cn(
-                                                'transition-opacity',
-                                                isSaving && 'opacity-50',
-                                            )}
-                                        >
+                                        <div key={pref.id} className='transition-opacity'>
                                             <ArtistAvatar
                                                 artist={artist}
                                                 active={
@@ -599,6 +607,29 @@ export default function PreferredArtistsPage() {
                                 })}
                             </div>
                         </div>
+                    )}
+
+                    {unsavedChanges.size > 0 && (
+                        <button
+                            type='button'
+                            onClick={handleSavePreferences}
+                            disabled={isSaving}
+                            className={cn(
+                                'lucky-focus-visible w-full rounded-lg px-4 py-2.5 type-body-sm font-medium transition-colors',
+                                isSaving
+                                    ? 'bg-lucky-brand/50 text-white'
+                                    : 'bg-lucky-brand text-white hover:bg-lucky-brand/90',
+                            )}
+                        >
+                            {isSaving ? (
+                                <div className='flex items-center justify-center gap-2'>
+                                    <Loader2 className='h-4 w-4 animate-spin' />
+                                    Saving...
+                                </div>
+                            ) : (
+                                `Save Preferences (${unsavedChanges.size})`
+                            )}
+                        </button>
                     )}
                 </div>
 

--- a/packages/frontend/src/services/artistsApi.ts
+++ b/packages/frontend/src/services/artistsApi.ts
@@ -23,6 +23,9 @@ export interface ArtistPreference {
 
 export function createArtistsApi(apiClient: AxiosInstance) {
     return {
+        getSuggestions: () =>
+            apiClient.get<{ artists: SpotifyArtist[] }>('/artists/suggestions'),
+
         search: (query: string) =>
             apiClient.get<{ artists: SpotifyArtist[] }>(
                 `/artists/search?q=${encodeURIComponent(query)}`,


### PR DESCRIPTION
## Summary
- Load suggested artists on page mount (user's Spotify top artists or popular artists fallback)
- Display artist grid immediately without requiring search
- Click artist to expand related artists panel with add buttons
- Batch save button for preference changes instead of auto-save
- Fixed sidebar active link highlighting for /music vs /music/artists paths

## Backend Changes
- Added GET /api/artists/suggestions endpoint returning suggested artists (12 max)
- Tries user's Spotify top artists if linked, falls back to popular artist search
- Integrates with existing spotifyLinkService for user OAuth tokens

## Frontend Changes
- PreferredArtists page now loads suggestions on mount
- State management refactored from auto-save to batch save with unsavedChanges map
- Save Preferences button shows count of pending changes
- Sidebar fixed to only highlight exact /music path, not /music/artists
- Related artists expand already implemented, now works with new flow

## Tests
- Frontend builds successfully (no TypeScript errors)
- Manual testing: dev server running at http://localhost:5173/
- Backend build blocked on pre-existing type errors in GuildAutomationExecutionService (unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personalized artist suggestions on the Preferred Artists page, pulling recommendations based on your Spotify listening history.
  * Changed preference management to batch updates with a "Save Preferences" button instead of immediate saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->