### PR TITLE
chore: bump version to 2.6.124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.124] - 2026-04-15
+
+### Added
+- Preferred Artists page: default suggestions grid (replaces empty search state), click-to-expand related artists (Spotify API), and batch "Save Preferences" button that commits multiple prefer/block selections at once
+- Backend `GET /api/artists/suggestions`: returns 12 suggested artists from user's Spotify top artists (if OAuth linked) with fallback to popular artists search
+
+### Fixed
+- Sidebar active-link: `/music` no longer activates when navigating to `/music/artists` or other music sub-routes — uses exact match for /music specifically
+- Preferred Artists batch save preserves artist metadata from search results so preferences aren't lost when search is cleared before saving
+- Docker production image now includes workspace-local `node_modules` for bot and backend workspaces — root cause of v2.6.123 lru-cache ERR_MODULE_NOT_FOUND crash loop
+
 ## [2.6.123] - 2026-04-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.123",
+    "version": "2.6.124",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.123",
+    "version": "2.6.124",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.123",
+    "version": "2.6.124",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.123",
+    "version": "2.6.124",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.123",
+    "version": "2.6.124",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Ships #630 (Preferred Artists UX) + #633 (Docker workspace node_modules fix) to production.