### PR TITLE
fix(docker): frontend image build — youtube-dl-exec skip vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ COPY --from=build /app/prisma ./prisma
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S backend -u 1001 -G nodejs && \
-    chown -R backend:nodejs /app/dist /app/prisma
+    chown -R backend:nodejs /app/packages/backend/dist /app/prisma
 
 USER backend
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -10,7 +10,8 @@ COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
 RUN --mount=type=cache,id=npm-frontend-builder,target=/root/.npm,sharing=locked \
-    YOUTUBE_DL_SKIP_DOWNLOAD=true \
+    YOUTUBE_DL_SKIP_DOWNLOAD=1 \
+    YOUTUBE_DL_SKIP_PYTHON_CHECK=1 \
     npm ci --legacy-peer-deps --no-audit --no-fund && \
     (npm cache verify 2>/dev/null || true)
 


### PR DESCRIPTION
Frontend build was failing on youtube-dl-exec preinstall because `=true` didn't satisfy the script's check, and YOUTUBE_DL_SKIP_PYTHON_CHECK was missing. Already applied on server, this is the upstream sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend Docker build configuration to optimize the npm installation process with refined environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->