### PR TITLE
chore: bump version to 2.6.125

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.125] - 2026-04-15
+
+### Changed
+- Preferred Artists: default suggestions bumped from 12 → 24 artists; grid layout is now 5 columns (desktop) / 4 (md) / 3 (sm) / 2 (mobile); artist circle images enlarged to 128px
+
+### Fixed
+- Backend: pass SPOTIFY_CLIENT_ID/SECRET/REDIRECT_URI/LINK_SECRET env vars to backend service in docker-compose so `/api/artists/suggestions` fallback can use Spotify client-credentials flow
+
 ## [2.6.124] - 2026-04-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.124",
+    "version": "2.6.125",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.124",
+    "version": "2.6.125",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.124",
+    "version": "2.6.125",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.124",
+    "version": "2.6.125",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.124",
+    "version": "2.6.125",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Ships #636 (backend SPOTIFY env) + #637 (larger circles, 5-col grid, 24 suggestions).