### PR TITLE
docs(specs): bootstrap Agent-OS-style spec + roadmap flow

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap — Lucky
+
+_Auto-regenerated 2026-04-15 from `docs/specs/`._
+
+## Now (active)
+
+_(none)_
+
+## Next (proposed)
+
+- **2026-04-15-autoplay-diversity**  _(proposed)_  `autoplay,music,quality`
+
+## Recently shipped
+
+- **2026-04-15-internal-notify-endpoint**  _(shipped)_  `rag,backend,homelab`  →  PR: https://github.com/LucasSantana-Dev/Lucky/pull/625

--- a/docs/specs/2026-04-15-autoplay-diversity/spec.md
+++ b/docs/specs/2026-04-15-autoplay-diversity/spec.md
@@ -1,0 +1,20 @@
+---
+status: proposed
+created: 2026-04-15
+owner: lucassantana
+pr:
+tags: autoplay,music,quality
+---
+
+# autoplay-diversity
+
+## Goal
+When Lucky auto-queues songs after the user's queue empties, results must feel curated — no repeated artists and no single-cluster collapse.
+
+## Approach
+Multi-objective ranking with diversity regularization: similarity to seed, penalty for artist within window, penalty for same album, boost on audio-feature match.
+
+## Verification
+- Golden dataset: 20 seed tracks.
+- Offline eval harness.
+- Soak in production for one week before default flip.

--- a/docs/specs/2026-04-15-autoplay-diversity/tasks.md
+++ b/docs/specs/2026-04-15-autoplay-diversity/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [ ] Artist-dedup penalty
+- [ ] Album-dedup penalty
+- [ ] Golden dataset (20 seeds)
+- [ ] Offline eval harness
+- [ ] Prod flag + soak
+- [ ] Default flip after soak passes

--- a/docs/specs/archived/2026-04-15-internal-notify-endpoint/spec.md
+++ b/docs/specs/archived/2026-04-15-internal-notify-endpoint/spec.md
@@ -1,0 +1,23 @@
+---
+status: shipped
+created: 2026-04-15
+shipped: 2026-04-15
+owner: lucassantana
+pr: https://github.com/LucasSantana-Dev/Lucky/pull/625
+tags: rag,backend,homelab
+---
+
+# internal-notify-endpoint
+
+## Goal
+Replace brittle per-channel Discord webhooks with a bot-token-backed REST proxy so homelab alerts keep flowing even when a channel webhook is rotated or deleted.
+
+## Context
+Four homelab webhooks went 404 silently for weeks before detection. Lucky bot already holds a valid token; proxying through it lets the bot identity carry the messages.
+
+## Approach
+New `POST /api/internal/notify` on lucky-backend. Header auth via `X-Notify-Key` (shared secret in env). Body `{channelId, content|embeds}`. Calls Discord REST v10 directly with Bot token. 204 on success.
+
+## Verification
+- Supertest unit coverage: 7 cases.
+- Smoke via homelab-watchdog send_discord posting to this endpoint.

--- a/docs/specs/archived/2026-04-15-internal-notify-endpoint/tasks.md
+++ b/docs/specs/archived/2026-04-15-internal-notify-endpoint/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Draft route + frontmatter
+- [x] Wire setupInternalNotifyRoutes
+- [x] Supertest coverage
+- [x] docker-compose env pass-through
+- [x] Land PR + rebuild backend on homelab
+- [x] Swap homelab-watchdog to POST here


### PR DESCRIPTION
## Summary
Introduces a lightweight spec + roadmap flow:
- `docs/specs/<date>-<slug>/spec.md` + `tasks.md` per feature with YAML frontmatter (`status`, `created`, `owner`, `pr`, `tags`).
- `docs/roadmap.md` auto-generated by `~/.claude/rag-index/specs.py roadmap --repo .`.
- Shipped specs archive under `docs/specs/archived/` via `spec-ship`.

## Seeded
- **2026-04-15-internal-notify-endpoint** (shipped via #625, archived with PR link).
- **2026-04-15-autoplay-diversity** (proposed).

## Risk
None. Docs only. No runtime impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a public roadmap outlining upcoming features and recently shipped improvements, with detailed specifications and implementation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->