### PR TITLE
chore: bump version to 2.6.127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.127] - 2026-04-15
+
+### Changed
+- Phase 4 code hygiene: consolidated duplicate Zod schemas (`guildIdParam`, `userIdParam`) into `packages/backend/src/schemas/common.ts`; extracted 17 Discord color constants + grouped API route builders into `@lucky/shared/constants` (subpath-only, no barrel pollution); added `logAndRethrow`/`logAndSwallow` error helpers and replaced 8 empty catch blocks across `lastFmApi` and `spotifyApi` with structured logging
+
 ## [2.6.126] - 2026-04-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.126",
+    "version": "2.6.127",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.126",
+    "version": "2.6.127",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.126",
+    "version": "2.6.127",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.126",
+    "version": "2.6.127",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.126",
+    "version": "2.6.127",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Ships #641 (zod schemas) + #642 (colors/API routes) + #644 (error helpers).