### PR TITLE
fix: prevent same-song replay on orphan session recovery

### DIFF
--- a/packages/bot/src/utils/music/sessionSnapshots.spec.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.spec.ts
@@ -421,3 +421,62 @@ describe('MusicSessionSnapshotService', () => {
         expect(delMock).not.toHaveBeenCalled()
     })
 })
+
+    it('skips current track when skipCurrentTrack option is true', async () => {
+        const service = new MusicSessionSnapshotService(300)
+        const snapshot = {
+            sessionSnapshotId: 'snap-skip-current',
+            guildId: 'guild-skip',
+            savedAt: Date.now(),
+            currentTrack: {
+                title: 'Same Song',
+                author: 'Artist',
+                url: 'https://example.com/same',
+                duration: '3:00',
+                source: 'youtube',
+            },
+            upcomingTracks: [
+                {
+                    title: 'Next Song',
+                    author: 'Next Artist',
+                    url: 'https://example.com/next',
+                    duration: '3:00',
+                    source: 'youtube',
+                },
+            ],
+        }
+        getMock.mockResolvedValue(JSON.stringify(snapshot))
+        delMock.mockResolvedValue(1)
+
+        const addTrack = jest.fn()
+        const queue = {
+            guild: { id: 'guild-skip' },
+            currentTrack: null,
+            tracks: { size: 0 },
+            addTrack,
+            node: {
+                isPlaying: () => false,
+                play: jest.fn().mockResolvedValue(undefined),
+            },
+            player: {
+                search: jest.fn().mockResolvedValue({
+                    tracks: [
+                        {
+                            title: 'Next Song',
+                            author: 'Next Artist',
+                            url: 'https://example.com/next',
+                            metadata: null,
+                            setMetadata: jest.fn(),
+                        },
+                    ],
+                }),
+            },
+        } as unknown as GuildQueue
+
+        await service.restoreSnapshot(queue, undefined, { skipCurrentTrack: true })
+
+        expect(addTrack).toHaveBeenCalledTimes(1)
+        expect(addTrack.mock.calls[0]?.[0]).toMatchObject({
+            title: 'Next Song',
+        })
+    })

--- a/packages/bot/src/utils/music/sessionSnapshots.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.ts
@@ -171,7 +171,7 @@ export class MusicSessionSnapshotService {
     async restoreSnapshot(
         queue: GuildQueue,
         requestedBy?: User,
-        options: { maxAgeMs?: number } = {},
+        options: { maxAgeMs?: number; skipCurrentTrack?: boolean } = {},
     ): Promise<SnapshotRestoreResult> {
         try {
             if (queue.currentTrack || queue.tracks.size > 0) {
@@ -205,8 +205,11 @@ export class MusicSessionSnapshotService {
             }
 
             // Build ordered track list: currentTrack first so it replays from the top.
+            // Unless skipCurrentTrack is true (used during orphan session recovery to avoid replaying the same song).
             const tracksToRestore: SnapshotTrack[] = [
-                ...(snapshot.currentTrack ? [snapshot.currentTrack] : []),
+                ...(snapshot.currentTrack && !options.skipCurrentTrack
+                    ? [snapshot.currentTrack]
+                    : []),
                 ...snapshot.upcomingTracks,
             ]
 

--- a/packages/bot/src/utils/music/watchdog.spec.ts
+++ b/packages/bot/src/utils/music/watchdog.spec.ts
@@ -291,7 +291,7 @@ describe('MusicWatchdogService — orphan session monitor', () => {
 
         expect(nodes.create).toHaveBeenCalledWith(guild)
         expect(queue.connect).toHaveBeenCalledWith(voiceChannel)
-        expect(restoreSnapshotMock).toHaveBeenCalledWith(queue)
+        expect(restoreSnapshotMock).toHaveBeenCalledWith(queue, undefined, { skipCurrentTrack: true })
         expect(service.getGuildState('guild-recover')).toEqual(
             expect.objectContaining({ lastRecoveryAction: 'rejoin' }),
         )
@@ -334,7 +334,7 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         await service.scanOrphanSessions(player)
 
         expect(nodes.create).not.toHaveBeenCalled()
-        expect(restoreSnapshotMock).toHaveBeenCalledWith(existingQueue)
+        expect(restoreSnapshotMock).toHaveBeenCalledWith(existingQueue, undefined, { skipCurrentTrack: true })
     })
 
     it('clears snapshot and marks failed when restore yields no tracks', async () => {

--- a/packages/bot/src/utils/music/watchdog.ts
+++ b/packages/bot/src/utils/music/watchdog.ts
@@ -303,7 +303,7 @@ export class MusicWatchdogService {
         }
 
         const restoreResult =
-            await musicSessionSnapshotService.restoreSnapshot(queue)
+            await musicSessionSnapshotService.restoreSnapshot(queue, undefined, { skipCurrentTrack: true })
         if (!restoreResult || restoreResult.restoredCount <= 0) {
             await musicSessionSnapshotService.deleteSnapshot(guildId)
 


### PR DESCRIPTION
## Summary

Fixes the bug where the bot leaves and returns playing the same song.

When watchdog detects an orphan session (bot disconnected from VC), it rejoins and restores the music snapshot. The snapshot includes both currentTrack and upcomingTracks. Previously, restoring would replay the currentTrack first, causing users to hear the same song again.

## Changes

- Add `skipCurrentTrack` option to `restoreSnapshot()` method in sessionSnapshots.ts
- Pass `skipCurrentTrack: true` in orphan session recovery in watchdog.ts
- Update watchdog tests to expect the new parameter
- Add test case for skipCurrentTrack behavior

## Root Cause

Production logs showed watchdog orphan recovery pattern (~every 3-5 minutes):
```
[19:42:58] Watchdog detected orphan session, attempting rejoin
[19:42:58] Watchdog orphan session recovered
[21:16:54] Started playing "Empty Pages" (same song that was playing before disconnect)
```

The bot was rejoining and replaying the last-saved snapshot's currentTrack instead of advancing to the next track in queue.

## Test Coverage

- sessionSnapshots.spec.ts: Added test for skipCurrentTrack option
- watchdog.spec.ts: Updated existing orphan recovery tests
- All tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to skip restoring the current track when recovering music session snapshots. When enabled, only upcoming tracks in the queue are restored, improving control over session recovery behavior.

* **Tests**
  * Added test coverage for the new skip-current-track restoration option.
  * Updated existing tests to verify the new session recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->