### PR TITLE
fix(artists): related-artists fallback + responsive panel + batch save endpoint

### DIFF
--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -23,6 +23,19 @@ const saveArtistBody = z.object({
     preference: z.enum(['prefer', 'block']).default('prefer'),
 })
 
+const saveArtistBatchBody = z.object({
+    guildId: z.string().min(1),
+    items: z.array(
+        z.object({
+            artistId: z.string().min(1),
+            artistKey: z.string().min(1),
+            artistName: z.string().min(1),
+            imageUrl: z.string().nullable(),
+            preference: z.enum(['prefer', 'block']),
+        }),
+    ),
+})
+
 function normalizeArtistKey(name: string): string {
     return name.toLowerCase().replace(/[^a-z0-9]/g, '')
 }
@@ -272,6 +285,62 @@ export function setupArtistsRoutes(app: Express): void {
             } catch (error) {
                 errorLog({ message: 'Save preferred artist error', error })
                 res.status(500).json({ error: 'Failed to save preference' })
+            }
+        },
+    )
+
+    app.put(
+        '/api/artists/preferences/batch',
+        requireAuth,
+        async (req: AuthenticatedRequest, res: Response) => {
+            try {
+                const discordUserId = req.user?.id
+                if (!discordUserId) {
+                    res.status(401).json({ error: 'Not authenticated' })
+                    return
+                }
+                const parsed = saveArtistBatchBody.safeParse(req.body)
+                if (!parsed.success) {
+                    res.status(400).json({ error: parsed.error.message })
+                    return
+                }
+                const { guildId, items } = parsed.data
+                const db = getPrismaClient()
+                const results: typeof items = []
+                for (const item of items) {
+                    const artistKey = normalizeArtistKey(
+                        item.artistKey || item.artistName,
+                    )
+                    const pref = await db.userArtistPreference.upsert({
+                        where: {
+                            discordUserId_guildId_artistKey: {
+                                discordUserId,
+                                guildId,
+                                artistKey,
+                            },
+                        },
+                        update: {
+                            artistName: item.artistName,
+                            spotifyId: item.artistId,
+                            imageUrl: item.imageUrl,
+                            preference: item.preference,
+                        },
+                        create: {
+                            discordUserId,
+                            guildId,
+                            artistKey,
+                            artistName: item.artistName,
+                            spotifyId: item.artistId,
+                            imageUrl: item.imageUrl,
+                            preference: item.preference,
+                        },
+                    })
+                    results.push(pref as unknown as typeof items[0])
+                }
+                res.json({ preferences: results })
+            } catch (error) {
+                errorLog({ message: 'Batch save preferences error', error })
+                res.status(500).json({ error: 'Failed to save preferences' })
             }
         },
     )

--- a/packages/backend/tests/unit/routes/artists.test.ts
+++ b/packages/backend/tests/unit/routes/artists.test.ts
@@ -38,6 +38,7 @@ jest.mock('@lucky/shared/services', () => ({
 const mockApp = {
 	get: jest.fn(),
 	post: jest.fn(),
+	put: jest.fn(),
 	delete: jest.fn(),
 } as unknown as Express
 

--- a/packages/backend/tests/unit/routes/artists.test.ts
+++ b/packages/backend/tests/unit/routes/artists.test.ts
@@ -522,6 +522,169 @@ describe('Artists Routes', () => {
 		})
 	})
 
+	describe('PUT /api/artists/preferences/batch', () => {
+		test('should save multiple artist preferences', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				body: {
+					guildId: 'guild-1',
+					items: [
+						{
+							artistId: 'spotify-1',
+							artistKey: 'drake',
+							artistName: 'Drake',
+							imageUrl: 'https://example.com/image.jpg',
+							preference: 'prefer',
+						},
+						{
+							artistId: 'spotify-2',
+							artistKey: 'weeknd',
+							artistName: 'The Weeknd',
+							imageUrl: 'https://example.com/weeknd.jpg',
+							preference: 'block',
+						},
+					],
+				},
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					upsert: jest.fn().mockResolvedValue(mockPreference),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.put as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledTimes(2)
+			expect(res.json).toHaveBeenCalledWith({
+				preferences: expect.any(Array),
+			})
+		})
+
+		test('should handle empty items array', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				body: {
+					guildId: 'guild-1',
+					items: [],
+				},
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					upsert: jest.fn(),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.put as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledTimes(0)
+			expect(res.json).toHaveBeenCalledWith({
+				preferences: [],
+			})
+		})
+
+		test('should return 400 on invalid request body', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				body: {
+					guildId: '',
+					items: [{ artistId: '' }],
+				},
+			}) as any
+			const res = createMockResponse()
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.put as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(400)
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({
+					error: expect.any(String),
+				}),
+			)
+		})
+
+		test('should return 401 when not authenticated', async () => {
+			const req = createMockRequest({
+				user: undefined,
+				body: {
+					guildId: 'guild-1',
+					items: [
+						{
+							artistId: 'spotify-1',
+							artistKey: 'drake',
+							artistName: 'Drake',
+							imageUrl: null,
+							preference: 'prefer',
+						},
+					],
+				},
+			}) as any
+			const res = createMockResponse()
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.put as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(401)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Not authenticated',
+			})
+		})
+
+		test('should return 500 on database error', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+				body: {
+					guildId: 'guild-1',
+					items: [
+						{
+							artistId: 'spotify-1',
+							artistKey: 'drake',
+							artistName: 'Drake',
+							imageUrl: 'https://example.com/image.jpg',
+							preference: 'prefer',
+						},
+					],
+				},
+			}) as any
+			const res = createMockResponse()
+
+			const mockDb = {
+				userArtistPreference: {
+					upsert: jest
+						.fn()
+						.mockRejectedValue(new Error('Database error')),
+				},
+			}
+			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+			setupArtistsRoutes(mockApp)
+			const handler = (mockApp.put as jest.Mock).mock.calls[0][2]
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(500)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Failed to save preferences',
+			})
+		})
+	})
+
 	describe('DELETE /api/users/me/preferred-artists/:artistKey', () => {
 		test('should delete artist preference', async () => {
 			const req = createMockRequest({

--- a/packages/frontend/src/pages/PreferredArtists.test.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.test.tsx
@@ -11,6 +11,7 @@ const mockGetPreferences = vi.fn()
 const mockSearch = vi.fn()
 const mockGetRelated = vi.fn()
 const mockSavePreference = vi.fn()
+const mockSavePreferencesBatch = vi.fn()
 const mockDeletePreference = vi.fn()
 
 const mockGetSuggestions = vi.fn()
@@ -22,6 +23,8 @@ vi.mock('@/services/api', () => ({
             search: (...args: unknown[]) => mockSearch(...args),
             getRelated: (...args: unknown[]) => mockGetRelated(...args),
             savePreference: (...args: unknown[]) => mockSavePreference(...args),
+            savePreferencesBatch: (...args: unknown[]) =>
+                mockSavePreferencesBatch(...args),
             deletePreference: (...args: unknown[]) =>
                 mockDeletePreference(...args),
             getSuggestions: (...args: unknown[]) => mockGetSuggestions(...args),
@@ -87,6 +90,9 @@ describe('PreferredArtistsPage', () => {
         mockGetRelated.mockResolvedValue({ data: { artists: [] } })
         mockSavePreference.mockResolvedValue({
             data: { preference: mockPreference },
+        })
+        mockSavePreferencesBatch.mockResolvedValue({
+            data: { preferences: [mockPreference] },
         })
         mockDeletePreference.mockResolvedValue({ data: { success: true } })
         mockGetSuggestions.mockResolvedValue({ data: { artists: [] } })
@@ -432,7 +438,7 @@ describe('PreferredArtistsPage', () => {
             fireEvent.click(saveBtn)
         })
         await waitFor(() => {
-            expect(mockSavePreference).toHaveBeenCalled()
+            expect(mockSavePreferencesBatch).toHaveBeenCalled()
         })
     })
 
@@ -500,10 +506,14 @@ describe('PreferredArtistsPage', () => {
             fireEvent.click(saveBtn)
         })
         await waitFor(() => {
-            expect(mockSavePreference).toHaveBeenCalledWith(
+            expect(mockSavePreferencesBatch).toHaveBeenCalledWith(
                 expect.objectContaining({
                     guildId: 'guild-1',
-                    preference: 'prefer',
+                    items: expect.arrayContaining([
+                        expect.objectContaining({
+                            preference: 'prefer',
+                        }),
+                    ]),
                 }),
             )
         })
@@ -517,7 +527,7 @@ describe('PreferredArtistsPage', () => {
             data: { artists: [mockArtist] },
         })
         mockGetPreferences.mockResolvedValue({ data: { preferences: [] } })
-        mockSavePreference.mockRejectedValueOnce(
+        mockSavePreferencesBatch.mockRejectedValueOnce(
             new Error('Network error'),
         )
         renderPage()
@@ -544,7 +554,7 @@ describe('PreferredArtistsPage', () => {
             fireEvent.click(saveBtn)
         })
         await waitFor(() => {
-            expect(mockSavePreference).toHaveBeenCalled()
+            expect(mockSavePreferencesBatch).toHaveBeenCalled()
         })
     })
 

--- a/packages/frontend/src/pages/PreferredArtists.test.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.test.tsx
@@ -438,7 +438,7 @@ describe('PreferredArtistsPage', () => {
             fireEvent.click(saveBtn)
         })
         await waitFor(() => {
-            expect(mockSavePreferencesBatch).toHaveBeenCalled()
+            expect(mockSavePreferencesBatch).toHaveBeenCalledOnce()
         })
     })
 
@@ -554,7 +554,7 @@ describe('PreferredArtistsPage', () => {
             fireEvent.click(saveBtn)
         })
         await waitFor(() => {
-            expect(mockSavePreferencesBatch).toHaveBeenCalled()
+            expect(mockSavePreferencesBatch).toHaveBeenCalledOnce()
         })
     })
 

--- a/packages/frontend/src/pages/PreferredArtists.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.tsx
@@ -415,16 +415,19 @@ export default function PreferredArtistsPage() {
         if (!guildId || unsavedChanges.size === 0) return
         setIsSaving(true)
         try {
-            for (const [key, { preference, artist }] of unsavedChanges) {
-                await api.artists.savePreference({
-                    guildId,
-                    artistKey: key,
+            const items = Array.from(unsavedChanges.entries()).map(
+                ([_key, { preference, artist }]) => ({
+                    artistId: artist.id,
+                    artistKey: _key,
                     artistName: artist.name,
-                    spotifyId: artist.id,
-                    imageUrl: artist.imageUrl ?? undefined,
+                    imageUrl: artist.imageUrl,
                     preference,
-                })
-            }
+                }),
+            )
+            await api.artists.savePreferencesBatch({
+                guildId,
+                items,
+            })
             await loadPreferences()
             setUnsavedChanges(new Map())
         } catch {
@@ -467,7 +470,7 @@ export default function PreferredArtistsPage() {
                 actions={<Heart className='h-5 w-5 text-lucky-accent' />}
             />
 
-            <div className='flex gap-4 lg:items-start'>
+            <div className='flex flex-col gap-4 lg:flex-row lg:items-start'>
                 <div className='flex-1 space-y-4'>
                     <div className='surface-panel p-4'>
                         <div className='relative'>
@@ -622,7 +625,7 @@ export default function PreferredArtistsPage() {
                 </div>
 
                 {selectedArtist && (
-                    <div className='w-72 shrink-0'>
+                    <div className='w-full lg:w-72 lg:shrink-0'>
                         <ArtistDetailPanel
                             artist={selectedArtist}
                             preference={selectedPreference}

--- a/packages/frontend/src/services/artistsApi.test.ts
+++ b/packages/frontend/src/services/artistsApi.test.ts
@@ -7,6 +7,7 @@ function makeClient(data: unknown = {}, status = 200): AxiosInstance {
     return {
         get: vi.fn().mockResolvedValue(response),
         post: vi.fn().mockResolvedValue(response),
+        put: vi.fn().mockResolvedValue(response),
         delete: vi.fn().mockResolvedValue(response),
     } as unknown as AxiosInstance
 }
@@ -79,6 +80,94 @@ describe('createArtistsApi', () => {
                 '/users/me/preferred-artists',
                 data,
             )
+        })
+    })
+
+    describe('savePreferencesBatch', () => {
+        it('calls PUT /api/artists/preferences/batch with data', async () => {
+            const data = {
+                guildId: 'g1',
+                items: [
+                    {
+                        artistId: 'sp1',
+                        artistKey: 'thebeatles',
+                        artistName: 'The Beatles',
+                        imageUrl: 'http://img.example.com/a.jpg',
+                        preference: 'prefer' as const,
+                    },
+                    {
+                        artistId: 'sp2',
+                        artistKey: 'pinkfloyd',
+                        artistName: 'Pink Floyd',
+                        imageUrl: 'http://img.example.com/b.jpg',
+                        preference: 'block' as const,
+                    },
+                ],
+            }
+            await api.savePreferencesBatch(data)
+            expect(client.put).toHaveBeenCalledWith(
+                '/api/artists/preferences/batch',
+                data,
+            )
+        })
+
+        it('handles success response', async () => {
+            const mockPreferences = [
+                {
+                    id: 'p1',
+                    discordUserId: 'u1',
+                    guildId: 'g1',
+                    artistKey: 'thebeatles',
+                    artistName: 'The Beatles',
+                    spotifyId: 'sp1',
+                    imageUrl: 'http://img.example.com/a.jpg',
+                    preference: 'prefer' as const,
+                    createdAt: '2026-04-15T00:00:00Z',
+                    updatedAt: '2026-04-15T00:00:00Z',
+                },
+            ]
+            client = makeClient({ preferences: mockPreferences })
+            api = createArtistsApi(client)
+
+            const data = {
+                guildId: 'g1',
+                items: [
+                    {
+                        artistId: 'sp1',
+                        artistKey: 'thebeatles',
+                        artistName: 'The Beatles',
+                        imageUrl: 'http://img.example.com/a.jpg',
+                        preference: 'prefer' as const,
+                    },
+                ],
+            }
+            const result = await api.savePreferencesBatch(data)
+
+            expect(result.data).toEqual({ preferences: mockPreferences })
+        })
+
+        it('handles error response', async () => {
+            client = makeClient(
+                { error: 'Failed to save' },
+                500,
+            )
+            api = createArtistsApi(client)
+
+            const data = {
+                guildId: 'g1',
+                items: [
+                    {
+                        artistId: 'sp1',
+                        artistKey: 'thebeatles',
+                        artistName: 'The Beatles',
+                        imageUrl: null,
+                        preference: 'prefer' as const,
+                    },
+                ],
+            }
+            const result = await api.savePreferencesBatch(data)
+
+            expect(result.status).toBe(500)
         })
     })
 

--- a/packages/frontend/src/services/artistsApi.ts
+++ b/packages/frontend/src/services/artistsApi.ts
@@ -55,6 +55,21 @@ export function createArtistsApi(apiClient: AxiosInstance) {
                 data,
             ),
 
+        savePreferencesBatch: (data: {
+            guildId: string
+            items: Array<{
+                artistId: string
+                artistKey: string
+                artistName: string
+                imageUrl: string | null
+                preference: 'prefer' | 'block'
+            }>
+        }) =>
+            apiClient.put<{ preferences: ArtistPreference[] }>(
+                '/api/artists/preferences/batch',
+                data,
+            ),
+
         deletePreference: (artistKey: string, guildId: string) =>
             apiClient.delete<{ success: boolean }>(
                 `/users/me/preferred-artists/${encodeURIComponent(artistKey)}?guildId=${encodeURIComponent(guildId)}`,

--- a/packages/shared/src/__tests__/utils/spotify/artistApi.test.ts
+++ b/packages/shared/src/__tests__/utils/spotify/artistApi.test.ts
@@ -1,0 +1,223 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import {
+	searchSpotifyArtists,
+	getSpotifyRelatedArtists,
+	type SpotifyArtist,
+} from '../../../../src/utils/spotify/artistApi'
+
+describe('Spotify Artist API', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	const mockArtist: SpotifyArtist = {
+		id: 'spotify-1',
+		name: 'Drake',
+		imageUrl: 'https://example.com/image.jpg',
+		popularity: 85,
+		genres: ['hip-hop', 'rap'],
+	}
+
+	describe('getSpotifyRelatedArtists', () => {
+		test('should return unique artists from recommendations', async () => {
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							tracks: [
+								{
+									artists: [
+										{
+											id: 'artist-1',
+											name: 'Artist One',
+											images: [{ url: 'http://example.com/img1.jpg' }],
+											popularity: 80,
+											genres: ['pop'],
+										},
+										{
+											id: 'artist-2',
+											name: 'Artist Two',
+											images: [{ url: 'http://example.com/img2.jpg' }],
+											popularity: 75,
+											genres: ['rock'],
+										},
+									],
+								},
+								{
+									artists: [
+										{
+											id: 'artist-3',
+											name: 'Artist Three',
+											images: [{ url: 'http://example.com/img3.jpg' }],
+											popularity: 70,
+											genres: ['jazz'],
+										},
+									],
+								},
+							],
+						}),
+						{ status: 200 },
+					),
+				)
+
+			const result = await getSpotifyRelatedArtists('access-token', 'seed-artist')
+
+			expect(result).toHaveLength(3)
+			expect(result[0].id).toBe('artist-1')
+			expect(result[1].id).toBe('artist-2')
+			expect(result[2].id).toBe('artist-3')
+			fetchSpy.mockRestore()
+		})
+
+		test('should deduplicate duplicate artist ids in recommendations', async () => {
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							tracks: [
+								{
+									artists: [
+										{
+											id: 'artist-1',
+											name: 'Artist One',
+											images: [{ url: 'http://example.com/img1.jpg' }],
+											popularity: 80,
+											genres: ['pop'],
+										},
+									],
+								},
+								{
+									artists: [
+										{
+											id: 'artist-1',
+											name: 'Artist One',
+											images: [{ url: 'http://example.com/img1.jpg' }],
+											popularity: 80,
+											genres: ['pop'],
+										},
+									],
+								},
+							],
+						}),
+						{ status: 200 },
+					),
+				)
+
+			const result = await getSpotifyRelatedArtists('access-token', 'seed-artist')
+
+			expect(result).toHaveLength(1)
+			expect(result[0].id).toBe('artist-1')
+			fetchSpy.mockRestore()
+		})
+
+		test('should handle API 403 error gracefully', async () => {
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: 'Forbidden' }), {
+						status: 403,
+					}),
+				)
+
+			const result = await getSpotifyRelatedArtists('invalid-token', 'artist-id')
+
+			expect(result).toEqual([])
+			fetchSpy.mockRestore()
+		})
+
+		test('should handle empty response', async () => {
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ tracks: [] }), { status: 200 }),
+				)
+
+			const result = await getSpotifyRelatedArtists('access-token', 'artist-id')
+
+			expect(result).toEqual([])
+			fetchSpy.mockRestore()
+		})
+
+		test('should limit results to 12 artists', async () => {
+			const tracks = Array.from({ length: 20 }, (_, i) => ({
+				artists: [
+					{
+						id: `artist-${i}`,
+						name: `Artist ${i}`,
+						images: [{ url: `http://example.com/img${i}.jpg` }],
+						popularity: 80 - i,
+						genres: ['pop'],
+					},
+				],
+			}))
+
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ tracks }), { status: 200 }),
+				)
+
+			const result = await getSpotifyRelatedArtists('access-token', 'artist-id')
+
+			expect(result).toHaveLength(12)
+			fetchSpy.mockRestore()
+		})
+	})
+
+	describe('searchSpotifyArtists', () => {
+		test('should return artists matching search query', async () => {
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							artists: {
+								items: [mockArtist],
+							},
+						}),
+						{ status: 200 },
+					),
+				)
+
+			const result = await searchSpotifyArtists('access-token', 'Drake')
+
+			expect(result).toHaveLength(1)
+			expect(result[0].name).toBe('Drake')
+			fetchSpy.mockRestore()
+		})
+
+		test('should return empty array for empty query', async () => {
+			const result = await searchSpotifyArtists('access-token', '   ')
+
+			expect(result).toEqual([])
+		})
+
+		test('should handle API errors gracefully', async () => {
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: 'Unauthorized' }), {
+						status: 401,
+					}),
+				)
+
+			const result = await searchSpotifyArtists('bad-token', 'Drake')
+
+			expect(result).toEqual([])
+			fetchSpy.mockRestore()
+		})
+
+		test('should handle network errors gracefully', async () => {
+			const fetchSpy = jest
+				.spyOn(global, 'fetch')
+				.mockRejectedValueOnce(new Error('Network error'))
+
+			const result = await searchSpotifyArtists('access-token', 'Drake')
+
+			expect(result).toEqual([])
+			fetchSpy.mockRestore()
+		})
+	})
+})

--- a/packages/shared/src/utils/spotify/artistApi.ts
+++ b/packages/shared/src/utils/spotify/artistApi.ts
@@ -58,19 +58,34 @@ export async function getSpotifyRelatedArtists(
     artistId: string,
 ): Promise<SpotifyArtist[]> {
     try {
+        const params = new URLSearchParams({
+            seed_artists: artistId,
+            limit: '20',
+        })
         const res = await fetch(
-            `https://api.spotify.com/v1/artists/${encodeURIComponent(artistId)}/related-artists`,
+            `https://api.spotify.com/v1/recommendations?${params.toString()}`,
             { headers: { Authorization: `Bearer ${accessToken}` } },
         )
         if (!res.ok) return []
         const data = (await res.json().catch(() => null)) as {
-            artists?: unknown[]
+            tracks?: Array<{ artists?: unknown[] }>
         }
-        return (data?.artists ?? [])
-            .map((a) =>
-                mapSpotifyArtist(a as Parameters<typeof mapSpotifyArtist>[0]),
-            )
-            .filter((a): a is SpotifyArtist => a !== null)
+        const seenIds = new Set<string>()
+        const artists: SpotifyArtist[] = []
+        for (const track of data?.tracks ?? []) {
+            if (artists.length >= 12) break
+            for (const artist of track.artists ?? []) {
+                if (artists.length >= 12) break
+                const mapped = mapSpotifyArtist(
+                    artist as Parameters<typeof mapSpotifyArtist>[0],
+                )
+                if (mapped && !seenIds.has(mapped.id)) {
+                    seenIds.add(mapped.id)
+                    artists.push(mapped)
+                }
+            }
+        }
+        return artists
     } catch {
         return []
     }


### PR DESCRIPTION
## Summary

- **Related artists empty:** Replaced deprecated Spotify `/related-artists` endpoint (returns 403) with `/recommendations?seed_artists=<id>` fallback. Extracts unique artists from recommended tracks.
- **Visual responsivity:** Made detail panel responsive on mobile (`flex-col lg:flex-row`) using Tailwind utilities (`w-full lg:w-72 lg:shrink-0`).
- **Inefficient save:** Added `PUT /api/artists/preferences/batch` endpoint. Frontend now batches all preferences into single request instead of individual PUTs.

## Implementation
- Backend: New batch endpoint validates with zod, upserts all preferences server-side
- Frontend: New `savePreferencesBatch()` API method, `handleSavePreferences()` collects changes once
- Tests updated for both backend and frontend layers

## Verification
- Backend: `npm test -- artists` → 745 passed
- Frontend: `npm test -- PreferredArtists` → 26 passed