### PR TITLE
chore: bump version to 2.6.128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.128] - 2026-04-15
+
+### Fixed
+- Autoplay history race: `buildExcludedUrls` now also reads the most-recent URL from the freshly-fetched persistent (Redis) history, closing a race where `queue.history` (in-memory) lagged behind Redis and the just-played track could be re-selected
+- Bot leave-then-rejoin replaying the same song: watchdog orphan session recovery now passes `skipCurrentTrack: true` so the rejoin continues with the next queued track instead of restarting the last-playing one
+- Preferred Artists: related artists no longer empty — Spotify deprecated `/v1/artists/{id}/related-artists` (403 for new apps); replaced with `/v1/recommendations?seed_artists=<id>` fallback that dedupes recommended track artists
+- Preferred Artists detail panel now responsive: inline below grid on small viewports, sticky sidebar on `lg+`
+- Preferred Artists batch save: single `PUT /api/artists/preferences/batch` replaces the per-artist PUT fan-out when saving multiple preferences
+
 ## [2.6.127] - 2026-04-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.127",
+    "version": "2.6.128",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.127",
+    "version": "2.6.128",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.127",
+    "version": "2.6.128",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.127",
+    "version": "2.6.128",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.127",
+    "version": "2.6.128",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Ships #646 (autoplay history race), #647 (leave-rejoin same-song), #648 (related artists fallback + responsive panel + batch save).