### PR TITLE
fix(artists): prevent 304 Not Modified responses + test mock updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.126",
+    "version": "2.6.127",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lucky-bot",
-            "version": "2.6.126",
+            "version": "2.6.127",
             "license": "ISC",
             "workspaces": [
                 "packages/*"
@@ -24294,7 +24294,7 @@
         },
         "packages/backend": {
             "name": "@lucky/backend",
-            "version": "2.6.126",
+            "version": "2.6.127",
             "dependencies": {
                 "@lucky/shared": "file:../shared",
                 "connect-redis": "^9.0.0",
@@ -24355,7 +24355,7 @@
         },
         "packages/bot": {
             "name": "@lucky/bot",
-            "version": "2.6.126",
+            "version": "2.6.127",
             "dependencies": {
                 "@discord-player/extractor": "^7.2.0",
                 "@discordjs/builders": "^1.14.1",
@@ -24459,7 +24459,7 @@
         },
         "packages/frontend": {
             "name": "lucky-webapp",
-            "version": "2.6.126",
+            "version": "2.6.127",
             "dependencies": {
                 "@hookform/resolvers": "^5.0.0",
                 "@radix-ui/react-avatar": "^1.1.11",
@@ -25542,7 +25542,7 @@
         },
         "packages/shared": {
             "name": "@lucky/shared",
-            "version": "2.6.126",
+            "version": "2.6.127",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.3",
                 "@npmcli/agent": "^4.0.0",

--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -144,6 +144,7 @@ export function setupArtistsRoutes(app: Express): void {
                     }
                 }
 
+                res.set('Cache-Control', 'no-cache, no-store, must-revalidate')
                 res.json({
                     artists: Array.from(suggestions.values()),
                 })

--- a/packages/backend/tests/fixtures/test-helpers.ts
+++ b/packages/backend/tests/fixtures/test-helpers.ts
@@ -30,6 +30,7 @@ export function createMockResponse(): Response {
         sendFile: jest.fn().mockReturnThis(),
         cookie: jest.fn().mockReturnThis(),
         clearCookie: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
     } as unknown as Response
 
     return res


### PR DESCRIPTION
## Root Cause

The `/api/artists/suggestions` endpoint did not set explicit cache control headers. Express enables ETags by default, which caused browsers to cache responses. When the same request was made again, the server responded with HTTP 304 Not Modified and an empty body, causing the frontend to display 'No suggestions available'.

## Fixes Applied

1. **Backend (artists.ts)**: Added `res.set('Cache-Control', 'no-cache, no-store, must-revalidate')` to the suggestions endpoint to prevent browser caching.

2. **Test Fixtures**: Updated `createMockResponse()` in test-helpers.ts to include a mocked `res.set()` method so tests properly reflect the new behavior.

## Verification

- All 27 artist route tests pass
- Frontend build succeeds with no TS errors  
- Cache-Control header prevents 304 responses by forcing revalidation on every request