### PR TITLE
fix(docker): frontend image needs shared build first

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -17,7 +17,11 @@ RUN --mount=type=cache,id=npm-frontend-builder,target=/root/.npm,sharing=locked 
 
 COPY packages/frontend ./packages/frontend
 COPY packages/shared ./packages/shared
+COPY prisma ./prisma
 
+RUN npx prisma generate
+
+RUN npm run build --workspace=packages/shared
 RUN npm run build --workspace=packages/frontend
 
 # NOSONAR: nginx requires root to bind port 80


### PR DESCRIPTION
## Problem
Frontend Dockerfile build fails because `@lucky/shared/constants` cannot be resolved—shared package was never built before frontend.

## Solution
Add `RUN npm run build --workspace=packages/shared` before the frontend build step in `Dockerfile.frontend`.

This ensures the shared package exports are available when frontend imports from it during its build.

## Changes
- Dockerfile.frontend: Added shared build step before frontend build

## Testing
Local docker build verification pending. Server-side rebuild in progress.

## Type
- fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to ensure proper generation of dependencies before building the application, improving build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->