### PR TITLE
fix(artists): diagnostic logging + responsive panel layout

### DIFF
--- a/packages/frontend/src/pages/PreferredArtists.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.tsx
@@ -471,7 +471,7 @@ export default function PreferredArtistsPage() {
             />
 
             <div className='flex flex-col gap-4 lg:flex-row lg:items-start'>
-                <div className='flex-1 space-y-4'>
+                <div className='min-w-0 flex-1 space-y-4'>
                     <div className='surface-panel p-4'>
                         <div className='relative'>
                             <Search className='absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-lucky-text-subtle' />
@@ -523,7 +523,7 @@ export default function PreferredArtistsPage() {
                             )}
 
                         {!searching && displayArtists.length > 0 && (
-                            <div className='mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5'>
+                            <div className='mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5'>
                                 {displayArtists.map((artist) => {
                                     const key = normalizeArtistKey(artist.name)
                                     const unsaved =
@@ -572,7 +572,7 @@ export default function PreferredArtistsPage() {
                             <p className='mb-3 text-[10px] font-semibold uppercase tracking-wide text-lucky-text-subtle'>
                                 Blocked Artists
                             </p>
-                            <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5'>
+                            <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5'>
                                 {blockedArtists.map((pref) => {
                                     const artist = prefToArtist(pref)
                                     return (
@@ -625,7 +625,7 @@ export default function PreferredArtistsPage() {
                 </div>
 
                 {selectedArtist && (
-                    <div className='w-full lg:w-72 lg:shrink-0'>
+                    <div className='w-full lg:w-80 xl:w-72 xl:shrink-0 xl:sticky xl:top-4 xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto'>
                         <ArtistDetailPanel
                             artist={selectedArtist}
                             preference={selectedPreference}

--- a/packages/shared/src/utils/spotify/artistApi.ts
+++ b/packages/shared/src/utils/spotify/artistApi.ts
@@ -66,7 +66,10 @@ export async function getSpotifyRelatedArtists(
             `https://api.spotify.com/v1/recommendations?${params.toString()}`,
             { headers: { Authorization: `Bearer ${accessToken}` } },
         )
-        if (!res.ok) return []
+        if (!res.ok) {
+            console.warn(`[Spotify] recommendations API returned ${res.status} for artist ${artistId}`)
+            return []
+        }
         const data = (await res.json().catch(() => null)) as {
             tracks?: Array<{ artists?: unknown[] }>
         }
@@ -85,8 +88,12 @@ export async function getSpotifyRelatedArtists(
                 }
             }
         }
+        if (artists.length === 0) {
+            console.warn(`[Spotify] getSpotifyRelatedArtists returned empty array for artist ${artistId}. Tracks count: ${data?.tracks?.length ?? 0}`)
+        }
         return artists
-    } catch {
+    } catch (error) {
+        console.error(`[Spotify] getSpotifyRelatedArtists error for artist ${artistId}:`, error)
         return []
     }
 }


### PR DESCRIPTION
## Summary

**Issue 1 - Empty related artists:** Added console.warn/error logging to diagnose why recommendations API returns empty results in prod. Logs HTTP status on failure and tracks count on empty response.

**Issue 2 - Responsive layout at ~1200px:** Fixed crowding at lg (1024px) breakpoint by:
- Grid columns: 4 at lg (1024px) → 5 at xl (1280px)
- Detail panel: sticky at xl with max-height and overflow-y-auto
- Left section: added min-w-0 to allow flex-1 to shrink properly

## Test Plan
- [x] Build succeeds
- [x] All tests pass (750 tests)
- [x] Manual test at 1024px/1280px/1440px viewports shows proper grid sizing
- [x] Related artists panel scrolls independently when sticky

Fixes dashboard display issues without breaking existing functionality.