### PR TITLE
chore: bump v2.6.132

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.6.131",
+    "version": "2.6.132",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [


### PR DESCRIPTION
Version bump: 2.6.131 → 2.6.132

Includes:
- Phase 3.6: replenisher extraction (#670)
- SSE heartbeat fix (#666 - pending merge)