### PR TITLE
fix(bot): Phase 2.4 SIGTERM listener + connection cleanup

### DIFF
--- a/packages/bot/src/bot/start/initializer.ts
+++ b/packages/bot/src/bot/start/initializer.ts
@@ -143,7 +143,12 @@ export class BotInitializer {
     async shutdown(): Promise<void> {
         if (this.client) {
             try {
+                infoLog({ message: 'Starting graceful bot shutdown...' })
+
+                this.client.removeAllListeners()
                 await this.client.destroy()
+                await redisClient.disconnect()
+
                 this.client = null
                 this.isInitialized = false
                 this.state = {

--- a/packages/bot/src/index.spec.ts
+++ b/packages/bot/src/index.spec.ts
@@ -13,7 +13,9 @@ const initializeSentryMock = jest.fn()
 const flushSentryMock = jest.fn<(timeout?: number) => Promise<boolean>>()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
+const infoLogMock = jest.fn()
 const initializeBotMock = jest.fn<() => Promise<void>>()
+const shutdownMock = jest.fn<() => Promise<void>>()
 const dependencyCheckStartMock = jest.fn()
 
 jest.mock('@lucky/shared/config', () => ({
@@ -26,10 +28,12 @@ jest.mock('@lucky/shared/utils', () => ({
     flushSentry: (...args: unknown[]) => flushSentryMock(...args),
     debugLog: (...args: unknown[]) => debugLogMock(...args),
     errorLog: (...args: unknown[]) => errorLogMock(...args),
+    infoLog: (...args: unknown[]) => infoLogMock(...args),
 }))
 
 jest.mock('./bot/start', () => ({
     initializeBot: (...args: unknown[]) => initializeBotMock(...args),
+    shutdown: (...args: unknown[]) => shutdownMock(...args),
 }))
 
 jest.mock('./services/DependencyCheckService', () => ({
@@ -56,6 +60,7 @@ describe('bot entrypoint', () => {
         flushSentryMock.mockResolvedValue(true)
         ensureEnvironmentMock.mockResolvedValue()
         initializeBotMock.mockResolvedValue()
+        shutdownMock.mockResolvedValue()
         process.exit = jest.fn() as unknown as typeof process.exit
     })
 
@@ -104,5 +109,80 @@ describe('bot entrypoint', () => {
         })
         expect(flushSentryMock).toHaveBeenCalledWith(3000)
         expect(process.exit).toHaveBeenCalledWith(1)
+    })
+
+    it('handles SIGTERM signal with graceful shutdown', async () => {
+        let signalHandlers: Record<string, Function> = {}
+        const originalOn = process.on.bind(process)
+        process.on = jest.fn((signal: string, handler: Function) => {
+            signalHandlers[signal] = handler
+            return process as any
+        }) as any
+
+        await import('./index')
+
+        expect(process.on).toHaveBeenCalledWith(
+            'SIGTERM',
+            expect.any(Function),
+        )
+        expect(process.on).toHaveBeenCalledWith(
+            'SIGINT',
+            expect.any(Function),
+        )
+
+        await signalHandlers['SIGTERM']()
+
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: 'Received SIGTERM, initiating graceful shutdown...',
+        })
+        expect(shutdownMock).toHaveBeenCalled()
+        expect(flushSentryMock).toHaveBeenCalledWith(3000)
+        expect(process.exit).toHaveBeenCalledWith(0)
+
+        process.on = originalOn
+    })
+
+    it('handles SIGINT signal with graceful shutdown', async () => {
+        let signalHandlers: Record<string, Function> = {}
+        const originalOn = process.on.bind(process)
+        process.on = jest.fn((signal: string, handler: Function) => {
+            signalHandlers[signal] = handler
+            return process as any
+        }) as any
+
+        await import('./index')
+
+        await signalHandlers['SIGINT']()
+
+        expect(infoLogMock).toHaveBeenCalledWith({
+            message: 'Received SIGINT, initiating graceful shutdown...',
+        })
+        expect(shutdownMock).toHaveBeenCalled()
+        expect(flushSentryMock).toHaveBeenCalledWith(3000)
+        expect(process.exit).toHaveBeenCalledWith(0)
+
+        process.on = originalOn
+    })
+
+    it('exits with error code if signal handler fails', async () => {
+        const shutdownError = new Error('shutdown failed')
+        shutdownMock.mockRejectedValue(shutdownError)
+        let signalHandlers: Record<string, Function> = {}
+        const originalOn = process.on.bind(process)
+        process.on = jest.fn((signal: string, handler: Function) => {
+            signalHandlers[signal] = handler
+            return process as any
+        }) as any
+
+        await import('./index')
+        await signalHandlers['SIGTERM']()
+
+        expect(errorLogMock).toHaveBeenCalledWith({
+            message: 'Error during SIGTERM shutdown:',
+            error: shutdownError,
+        })
+        expect(process.exit).toHaveBeenCalledWith(1)
+
+        process.on = originalOn
     })
 })

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -1,9 +1,26 @@
 import { ensureEnvironment } from '@lucky/shared/config'
 import { setupErrorHandlers } from '@lucky/shared/utils'
 import { flushSentry, initializeSentry } from '@lucky/shared/utils'
-import { initializeBot } from './bot/start'
-import { debugLog, errorLog } from '@lucky/shared/utils'
+import { initializeBot, shutdown } from './bot/start'
+import { debugLog, errorLog, infoLog } from '@lucky/shared/utils'
 import { dependencyCheckService } from './services/DependencyCheckService'
+
+function setupSignalHandlers(): void {
+    const signals = ['SIGTERM', 'SIGINT']
+    signals.forEach((signal) => {
+        process.on(signal, async () => {
+            infoLog({ message: `Received ${signal}, initiating graceful shutdown...` })
+            try {
+                await shutdown()
+                await flushSentry(3000)
+                process.exit(0)
+            } catch (error) {
+                errorLog({ message: `Error during ${signal} shutdown:`, error })
+                process.exit(1)
+            }
+        })
+    })
+}
 
 async function main(): Promise<void> {
     await ensureEnvironment()
@@ -27,6 +44,8 @@ async function main(): Promise<void> {
     debugLog({
         message: `Starting bot in environment: ${process.env.NODE_ENV ?? 'default'}`,
     })
+
+    setupSignalHandlers()
     await initializeBot()
 }
 


### PR DESCRIPTION
## Summary
- Add SIGTERM/SIGINT signal handler at bot bootstrap to enable graceful shutdown
- Enrich shutdown method to remove all Discord listeners and disconnect Redis
- Prevents listener accumulation on hot-reload and ensures clean exit on graceful deploy

## Files Changed
- `packages/bot/src/index.ts`: Add signal handler registration in main()
- `packages/bot/src/bot/start/initializer.ts`: Enhance shutdown() to call removeAllListeners() and disconnect Redis
- `packages/bot/src/index.spec.ts`: Add tests for SIGTERM/SIGINT signal handling

## Smoke Test
```bash
# Deploy bot
docker start lucky-bot

# Send graceful shutdown signal
docker stop lucky-bot  # Sends SIGTERM

# Verify no listener leak or hanging connections in logs
docker logs lucky-bot | grep -E "(SIGTERM|shutdown|listener|disconnect)"
```

All listeners are now properly cleaned up on process termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Graceful shutdown: Bot now properly handles system termination signals, ensuring all event listeners and external connections are cleanly disconnected before shutdown.

* **Tests**
  * Added comprehensive test coverage for signal-based shutdown and error handling during termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->