### PR TITLE
fix(music): controls — skip/stop compounding fixes verified

### DIFF
--- a/packages/bot/src/utils/music/replenishSuppressionStore.spec.ts
+++ b/packages/bot/src/utils/music/replenishSuppressionStore.spec.ts
@@ -57,5 +57,18 @@ describe('replenishSuppressionStore', () => {
             setReplenishSuppressed(guildId, 30_000)
             expect(isReplenishSuppressed(guildId)).toBe(true)
         })
+
+        it('should suppress multiple guilds independently', () => {
+            const guildId2 = 'test-guild-456'
+            setReplenishSuppressed(guildId, 5000)
+            setReplenishSuppressed(guildId2, 5000)
+
+            expect(isReplenishSuppressed(guildId)).toBe(true)
+            expect(isReplenishSuppressed(guildId2)).toBe(true)
+
+            setReplenishSuppressed(guildId, 0)
+            expect(isReplenishSuppressed(guildId)).toBe(false)
+            expect(isReplenishSuppressed(guildId2)).toBe(true)
+        })
     })
 })


### PR DESCRIPTION
## Summary

Verified all 5 compounding music-control bugs are fixed:
- **Bug A**: Stop suppresses autoplay (replenishSuppressionStore) ✅
- **Bug B**: Skip awaits history before replenish ✅
- **Bug C**: Defensive exclusion in replenish ✅
- **Bug D**: Same-URL guard in stream error recovery ✅
- **Bug E**: Web skip awaits completion ✅

## Verification

- 2661 tests pass (music|player|skip|stop patterns)
- All affected test files verified:
  - `errorHandlers.spec.ts` — 13 tests ✅ (includes same-URL guard test)
  - `commandHandlers.spec.ts` — 7 tests ✅ (includes stop suppression & skip await tests)
  - `trackHandlers.spec.ts` — 20 tests ✅
  - `replenishSuppressionStore.spec.ts` — 9 tests ✅ (added multi-guild test)

## Changes Made

- `packages/bot/src/utils/music/replenishSuppressionStore.spec.ts` — Added regression test for Bug A fix verifying independent per-guild suppression control

## Root Cause Summary

All fixes were already implemented in codebase:
1. `setReplenishSuppressed()` called in `handleStop()` (30s window)
2. `addTrackToHistory()` awaited before `replenishIfAutoplay()` in skip handler
3. `buildExcludedUrls()` includes currentTrack.url + most-recent history
4. `isSameTrack()` guards against reinserting same YouTube URL
5. `handleSkip()` awaits `queue.node.skip()` before state publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)