### PR TITLE
chore: bump version to 2.6.133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.133] - 2026-04-17
+
+### Added
+- feat(music): voice channel status updates on track start (#660)
+- feat(stats): public `/api/stats/public` endpoint + animated countup on landing page (#667)
+- feat(autoplay): refactor — queueManipulation split into 6 autoplay modules (candidateScorer, diversitySelector, spotifyRecommender, lastFmSeeder, candidateCollector, replenisher) (#658, #659, #662, #668, #669, #670)
+
+### Fixed
+- fix(backend): SSE heartbeat leak on client disconnect — AbortController guard prevents writes to dead sockets (#666)
+- fix(bot): LRU+TTL on audio-feature cache — prevents unbounded memory growth (#663)
+- fix(bot): LRU+TTL on duplicate-detection caches — 4 module-level Maps now bounded (#672)
+- fix(bot): LRU+TTL on trackNowPlaying state — class wrapper with cleanupGuild() hook (#675, #676)
+- fix(bot): cleanup Discord listeners and connections on SIGTERM/SIGINT (#676)
+- fix(music): skip/stop controls — compounding fixes verified (#677)
+- fix(security): require `guildModuleAccess` middleware on roles + moderation routes (#664)
+- fix(security): apiLimiter on 7 backend routes, writeLimiter on mutations (#673)
+- fix(security): follow-redirects CVE-2024-45590 bumped via pnpm.overrides (#673)
+- fix(security): TruffleHog action SHA-pinned to v3.94.3 (#673)
+- test(backend): fix Express 5 integration test breakage (#681)
+
+### Changed
+- chore(sonar): exclude bot entry point + event handler glue from coverage measurement
+
+## [2.6.132] - 2026-04-16
+
+### Added
+- Intermediate release bundling Phase 3 refactor completion and first wave of memory hygiene
+
 ## [2.6.131] - 2026-04-16
 
 - feat(landing): marketing landing page at `/` with hero, feature grid, stats strip, FAQ, footer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.132",
+  "version": "2.6.133",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.131",
+    "version": "2.6.133",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.131",
+    "version": "2.6.133",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.131",
+    "version": "2.6.133",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.131",
+    "version": "2.6.133",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

v2.6.133 bundles 7 PRs merged since v2.6.131:

### Features
- feat(music): voice channel status updates on track start (#660)
- feat(stats): public `/api/stats/public` + landing-page countup (#667)
- refactor: Phase 3 queueManipulation split into 6 autoplay modules (#658, #659, #662, #668, #669, #670)

### Fixes
- fix(backend): SSE heartbeat leak on client disconnect (#666)
- fix(bot): LRU+TTL on audio-feature / duplicate-detection / trackNowPlaying caches (#663, #672, #675, #676)
- fix(bot): SIGTERM/SIGINT listener + connection cleanup (#676)
- fix(music): skip/stop compounding fixes (#677)
- fix(security): guildModuleAccess middleware on roles + moderation routes (#664)
- fix(security): apiLimiter + CVE bump + TruffleHog SHA pin (#673)
- test(backend): Express 5 integration test breakage (#681)

### Deploy
After merge, redeploy via \`prod-rebuild\` or:
\`\`\`
ssh homelab "cd /home/luk-server/Lucky && git pull && docker compose build bot backend frontend && docker rm -f lucky-bot lucky-backend lucky-frontend && docker compose up -d bot backend frontend"
\`\`\`