### PR TITLE
fix(frontend): correct Discord client_id on landing page

### DIFF
--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -6,7 +6,7 @@ import Button from '@/components/ui/Button'
 import { useReducedMotion } from 'framer-motion'
 import { api } from '@/services/api'
 
-const CLIENT_ID = '999088926074396732'
+const CLIENT_ID = '962198089161134131'
 const BOT_INVITE_URL = `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot%20applications.commands&permissions=8`
 
 const HERO_GRADIENT = 'bg-gradient-to-br from-indigo-950 via-purple-950 to-slate-950'


### PR DESCRIPTION
## Bug
Clicking 'Add to Discord' on landing page → Discord shows 'Unknown Application' because client_id was a non-existent ID (`999088926074396732`).

## Fix
`packages/frontend/src/pages/Landing.tsx:9` — set CLIENT_ID to the real Lucky bot application ID `962198089161134131`.

## Verify
After deploy, click 'Add to Discord' on https://lucky.lucassantana.tech/ → Discord shows 'Lucky' bot authorize prompt.