### PR TITLE
chore: bump version to 2.6.134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.134] - 2026-04-17
+
+### Added
+- feat(frontend): Lucky neon-brand landing page redesign — prominent glowing maneki-neko hero, Sora/Manrope typography, lucide icons in colored orbs, pink/orange/purple neon palette, framer-motion micro-interactions with reduced-motion support, monospace stats with pulsing online dot (#693)
+- feat(autoplay): genre preferences Wave A — per-guild genre seeds influence autoplay recommendations (#679)
+- test(backend): comprehensive validate middleware unit tests (#689)
+
+### Fixed
+- fix(frontend): correct Discord application `client_id` on Add-to-Discord button — invite now opens the real Lucky bot authorize flow instead of showing "Unknown Application" (#692)
+
 ## [2.6.133] - 2026-04-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.133",
+  "version": "2.6.134",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.133",
+    "version": "2.6.134",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.133",
+    "version": "2.6.134",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.133",
+    "version": "2.6.134",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.133",
+    "version": "2.6.134",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## v2.6.134 — Lucky neon brand landing

- feat(frontend): landing-page redesign — neon cat hero, Sora/Manrope typography, lucide icons, pink/orange palette (#693)
- feat(autoplay): genre preferences Wave A (#679)
- fix(frontend): correct Discord client_id on invite button (#692)
- test(backend): validate middleware unit tests (#689)

Post-merge: deploy via `prod-rebuild` to pick up the new landing on https://lucky.lucassantana.tech.