### PR TITLE
chore: bump version to 2.6.135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.135] - 2026-04-17
+
+### Added
+- feat(spotify): `getUserTopArtistsAndTracks` API wrapper for user-top artists/tracks (#686)
+- feat(spotify): user-seeds — extract + cache top artists/tracks/genres for autoplay (#687)
+- feat(autoplay): spotify-taste-blend — candidate scoring with user taste boost (#688)
+
+### Fixed
+- fix(autoplay): replenish queue on exhaustion + suppress recovery on stale snapshot (30 min staleness guard) (#691)
+- chore(backend): eliminate lint errors in GuildAutomationExecutionService via typed Prisma model casts (#690)
+
 ## [2.6.134] - 2026-04-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.134",
+  "version": "2.6.135",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.134",
+    "version": "2.6.135",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.134",
+    "version": "2.6.135",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.134",
+    "version": "2.6.135",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.134",
+    "version": "2.6.135",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## v2.6.135 — Phase 6 Spotify taste-blend complete

- feat(spotify): user-top API + user-seeds + taste-blend (#686, #687, #688)
- fix(autoplay): replenish on exhaustion + stale snapshot guard (#691)
- chore(backend): GuildAutomationExecutionService lint cleanup (#690)