### PR TITLE
fix(frontend): drop double /api prefix on Save Preferences batch

### DIFF
--- a/packages/frontend/src/services/artistsApi.test.ts
+++ b/packages/frontend/src/services/artistsApi.test.ts
@@ -84,7 +84,7 @@ describe('createArtistsApi', () => {
     })
 
     describe('savePreferencesBatch', () => {
-        it('calls PUT /api/artists/preferences/batch with data', async () => {
+        it('calls PUT /artists/preferences/batch with data', async () => {
             const data = {
                 guildId: 'g1',
                 items: [
@@ -106,7 +106,7 @@ describe('createArtistsApi', () => {
             }
             await api.savePreferencesBatch(data)
             expect(client.put).toHaveBeenCalledWith(
-                '/api/artists/preferences/batch',
+                '/artists/preferences/batch',
                 data,
             )
         })

--- a/packages/frontend/src/services/artistsApi.ts
+++ b/packages/frontend/src/services/artistsApi.ts
@@ -66,7 +66,7 @@ export function createArtistsApi(apiClient: AxiosInstance) {
             }>
         }) =>
             apiClient.put<{ preferences: ArtistPreference[] }>(
-                '/api/artists/preferences/batch',
+                '/artists/preferences/batch',
                 data,
             ),
 


### PR DESCRIPTION
## Bug
Console: `PUT https://lucky.lucassantana.tech/api/api/artists/preferences/batch 404`. Save Preferences fails silently.

## Fix
`packages/frontend/src/services/artistsApi.ts:69` was passing `/api/artists/preferences/batch` to apiClient whose baseURL already includes `/api` → double-prefix. Match convention used by other endpoints (`/artists/...` bare paths).