### PR TITLE
chore: bump version to 2.6.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.137] - 2026-04-18
+
+### Added
+- feat(artists): YouTube Music-style Related Artists with horizontal carousel, larger circular avatars, scroll-snap, and 30-artist fetch limit (#699)
+
+### Fixed
+- fix(artists): filter already-preferred artists out of Related view to prevent re-adding (#699)
+- fix(frontend): drop double `/api` prefix on Save Preferences batch URL (was hitting `/api/api/...` → 404) (#698)
+
 ## [2.6.136] - 2026-04-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.136",
+  "version": "2.6.137",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.136",
+    "version": "2.6.137",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.136",
+    "version": "2.6.137",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.136",
+    "version": "2.6.137",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.136",
+    "version": "2.6.137",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Bundle: YT-Music carousel (#699) + batch URL fix (#698).