### PR TITLE
fix(artists): cache popular-artists fallback in Redis (suggestions empty bug)

### DIFF
--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -13,7 +13,10 @@ import {
     getSpotifyClientToken,
     isSpotifyAuthConfigured,
 } from '../services/SpotifyAuthService'
-import { spotifyLinkService } from '@lucky/shared/services'
+import { spotifyLinkService, redisClient } from '@lucky/shared/services'
+
+const FALLBACK_SUGGESTIONS_CACHE_KEY = 'artist:suggestions:fallback:v1'
+const FALLBACK_SUGGESTIONS_TTL_SECONDS = 60 * 60 // 1 hour
 
 const saveArtistBody = z.object({
     guildId: z.string().min(1),
@@ -116,32 +119,73 @@ export function setupArtistsRoutes(app: Express): void {
                 }
 
                 if (suggestions.size < 24) {
-                    const suggestQueries = [
-                        'Drake',
-                        'The Weeknd',
-                        'Dua Lipa',
-                        'Billie Eilish',
-                        'Bad Bunny',
-                        'Ariana Grande',
-                        'Taylor Swift',
-                        'Ed Sheeran',
-                    ]
-                    for (const query of suggestQueries) {
-                        if (suggestions.size >= 24) break
-                        try {
-                            const artists = await searchSpotifyArtists(
-                                clientToken,
-                                query,
-                                2,
-                            )
-                            for (const artist of artists) {
-                                if (suggestions.size >= 24) break
-                                if (!suggestions.has(artist.id)) {
-                                    suggestions.set(artist.id, artist)
+                    // Cached fallback: avoid hammering Spotify search (429s on
+                    // every page load otherwise). Cache the popular-artists
+                    // bundle in Redis for 1h.
+                    let fallback: SpotifyArtist[] = []
+                    try {
+                        const cached = await redisClient.get(
+                            FALLBACK_SUGGESTIONS_CACHE_KEY,
+                        )
+                        if (cached) {
+                            fallback = JSON.parse(cached) as SpotifyArtist[]
+                        }
+                    } catch {
+                        // Redis miss/error — fall through to live fetch
+                    }
+
+                    if (fallback.length === 0) {
+                        const suggestQueries = [
+                            'Drake',
+                            'The Weeknd',
+                            'Dua Lipa',
+                            'Billie Eilish',
+                            'Bad Bunny',
+                            'Ariana Grande',
+                            'Taylor Swift',
+                            'Ed Sheeran',
+                            'Bruno Mars',
+                            'Olivia Rodrigo',
+                            'Sabrina Carpenter',
+                            'Kendrick Lamar',
+                        ]
+                        const seen = new Set<string>()
+                        for (const query of suggestQueries) {
+                            if (fallback.length >= 24) break
+                            try {
+                                const artists = await searchSpotifyArtists(
+                                    clientToken,
+                                    query,
+                                    2,
+                                )
+                                for (const artist of artists) {
+                                    if (fallback.length >= 24) break
+                                    if (!seen.has(artist.id)) {
+                                        seen.add(artist.id)
+                                        fallback.push(artist)
+                                    }
                                 }
+                            } catch {
+                                // continue to next query
                             }
-                        } catch {
-                            // continue to next query
+                        }
+                        if (fallback.length > 0) {
+                            try {
+                                await redisClient.setex(
+                                    FALLBACK_SUGGESTIONS_CACHE_KEY,
+                                    FALLBACK_SUGGESTIONS_TTL_SECONDS,
+                                    JSON.stringify(fallback),
+                                )
+                            } catch {
+                                // Cache write failure is non-fatal
+                            }
+                        }
+                    }
+
+                    for (const artist of fallback) {
+                        if (suggestions.size >= 24) break
+                        if (!suggestions.has(artist.id)) {
+                            suggestions.set(artist.id, artist)
                         }
                     }
                 }

--- a/packages/backend/tests/unit/routes/artists.test.ts
+++ b/packages/backend/tests/unit/routes/artists.test.ts
@@ -33,6 +33,10 @@ jest.mock('@lucky/shared/services', () => ({
 	spotifyLinkService: {
 		getValidAccessToken: jest.fn(),
 	},
+	redisClient: {
+		get: jest.fn().mockResolvedValue(null),
+		setex: jest.fn().mockResolvedValue('OK'),
+	},
 })
 
 jest.mock('../../../src/middleware/rateLimit', () => ({


### PR DESCRIPTION
## Bug
`/api/artists/suggestions` returns `{"artists":[]}` on production. Page shows 'No suggestions available'.

## Root cause
Spotify search API returns 429 (rate-limited). Each page load fans out 8+ search calls (Drake, The Weeknd, Dua Lipa, etc.). Without caching, this saturates Spotify quota fast and starts returning empty.

## Fix
Cache the popular-artists fallback bundle in Redis (key `artist:suggestions:fallback:v1`, TTL 1h). First request populates, subsequent reads bypass Spotify. Also bumped the query list from 8 → 12 artists for variety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced artist suggestions endpoint with improved fallback logic and caching, providing faster load times and more reliable results when fetching popular artists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->