### PR TITLE
chore: bump version to 2.6.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.140] - 2026-04-18
+
+### Added
+- feat(artists): YouTube Music-style Preferred Artists experience — 150-artist seed with multi-time-range Spotify top-artists merge (short/medium/long term), flat-feed inline expansion with recursive splice/collapse, new Preferred Artists section in the UI (click-to-delete), already-preferred artists filtered from related expansions (#709)
+
 ## [2.6.139] - 2026-04-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.139",
+  "version": "2.6.140",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.139",
+    "version": "2.6.140",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.139",
+    "version": "2.6.140",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.139",
+    "version": "2.6.140",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.139",
+    "version": "2.6.140",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 2.6.140 for PR #709 (YouTube Music-style Preferred Artists + 150-artist seed + flat-feed inline expansion).

## Test plan
- [x] CHANGELOG updated
- [x] package.json version bumped in all workspaces