### PR TITLE
fix(artists): readable active-tab badge + visible suggestions errors

### DIFF
--- a/packages/frontend/src/pages/PreferredArtists.test.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.test.tsx
@@ -749,4 +749,54 @@ describe('PreferredArtistsPage', () => {
         })
     })
 
+    test('active tab badge uses white text; inactive badges use brand text', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetSuggestions.mockResolvedValue({
+            data: { artists: [mockArtist] },
+        })
+        renderPage()
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+
+        const discoverBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.toLowerCase().includes('discover'))!
+        const preferredBtn = screen
+            .getAllByRole('button')
+            .find((b) => b.textContent?.toLowerCase().includes('preferred'))!
+
+        const activeBadge = discoverBtn.querySelector('span.rounded-full')
+        const inactiveBadge = preferredBtn.querySelector('span.rounded-full')
+        expect(activeBadge?.className).toContain('text-white')
+        expect(inactiveBadge?.className).toContain('text-lucky-brand')
+    })
+
+    test('shows error + Try again on suggestions failure; retry re-fetches', async () => {
+        vi.mocked(useGuildSelection).mockReturnValue({
+            selectedGuild: mockGuild,
+        } as any)
+        mockGetSuggestions
+            .mockRejectedValueOnce(new Error('Network error'))
+            .mockResolvedValueOnce({ data: { artists: [mockArtist] } })
+
+        renderPage()
+        await waitFor(() => {
+            expect(
+                screen.getByText('Failed to load suggestions'),
+            ).toBeInTheDocument()
+        })
+
+        const retryBtn = screen.getByRole('button', { name: /try again/i })
+        await act(async () => {
+            fireEvent.click(retryBtn)
+        })
+
+        await waitFor(() => {
+            expect(screen.getByText('The Beatles')).toBeInTheDocument()
+        })
+        expect(mockGetSuggestions).toHaveBeenCalledTimes(2)
+    })
 })

--- a/packages/frontend/src/pages/PreferredArtists.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.tsx
@@ -11,6 +11,7 @@ import {
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
 import { useGuildSelection } from '@/hooks/useGuildSelection'
 import { api } from '@/services/api'
+import { ApiError } from '@/services/ApiError'
 import type { SpotifyArtist, ArtistPreference } from '@/services/artistsApi'
 import SectionHeader from '@/components/ui/SectionHeader'
 import EmptyState from '@/components/ui/EmptyState'
@@ -177,6 +178,7 @@ export default function PreferredArtistsPage() {
     const [searchError, setSearchError] = useState<string | null>(null)
 
     const [suggestionsLoading, setSuggestionsLoading] = useState(true)
+    const [suggestionsError, setSuggestionsError] = useState<string | null>(null)
 
     const [savedPreferences, setSavedPreferences] = useState<
         Map<string, ArtistPreference>
@@ -211,11 +213,17 @@ export default function PreferredArtistsPage() {
 
     const loadSuggestions = useCallback(async () => {
         setSuggestionsLoading(true)
+        setSuggestionsError(null)
         try {
             const res = await api.artists.getSuggestions()
             setFeedArtists(res.data.artists)
-        } catch {
+        } catch (err) {
             setFeedArtists([])
+            setSuggestionsError(
+                err instanceof ApiError
+                    ? err.message
+                    : 'Failed to load suggestions',
+            )
         } finally {
             setSuggestionsLoading(false)
         }
@@ -436,7 +444,14 @@ export default function PreferredArtistsPage() {
                                     {tab === 'preferred' && 'Preferred'}
                                     {tab === 'blocked' && 'Blocked'}
                                 </span>
-                                <span className='inline-flex items-center justify-center h-5 px-1.5 rounded-full bg-lucky-brand/20 text-lucky-brand text-xs font-medium'>
+                                <span
+                                    className={cn(
+                                        'inline-flex items-center justify-center h-5 px-1.5 rounded-full text-xs font-medium',
+                                        currentTab === tab
+                                            ? 'bg-white/20 text-white'
+                                            : 'bg-lucky-brand/20 text-lucky-brand',
+                                    )}
+                                >
                                     {counts[tab]}
                                 </span>
                             </button>
@@ -542,9 +557,28 @@ export default function PreferredArtistsPage() {
                             </motion.div>
                         )}
 
+                        {!searching &&
+                            !query.trim() &&
+                            suggestionsError &&
+                            !suggestionsLoading && (
+                                <div className='py-6 text-center space-y-3'>
+                                    <p className='type-body-sm text-lucky-error'>
+                                        {suggestionsError}
+                                    </p>
+                                    <button
+                                        type='button'
+                                        onClick={loadSuggestions}
+                                        className='lucky-focus-visible rounded-lg bg-lucky-brand px-4 py-2 type-body-sm font-medium text-white hover:bg-lucky-brand/90'
+                                    >
+                                        Try again
+                                    </button>
+                                </div>
+                            )}
+
                         {!query.trim() &&
                             displayArtists.length === 0 &&
-                            !suggestionsLoading && (
+                            !suggestionsLoading &&
+                            !suggestionsError && (
                                 <div className='py-6 text-center'>
                                     <p className='type-body-sm text-lucky-text-tertiary'>
                                         No suggestions available. Try searching


### PR DESCRIPTION
## Summary
- Active tab's count badge now uses white background/text so the count is visible against the brand-colored button (was previously brand-on-brand → invisible).
- `loadSuggestions` now stores the error and surfaces it with a **Try again** button; failures (503, 500, network) used to be silently shown as the generic "No suggestions available" empty state, leaving users with no path forward and ops with no signal.

## Test plan
- [x] 24/24 frontend tests pass (2 new: badge contrast + error+retry flow)
- [x] Type check clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * When suggestion loading fails, users now see an error message with a "Try again" button to retry fetching
  * Improved tab badge styling for clearer visual distinction between active and inactive tabs

* **Bug Fixes**
  * Enhanced error handling for failed suggestion fetches with user-friendly messaging

* **Tests**
  * Added comprehensive test coverage for error scenarios and tab styling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->