### PR TITLE
chore: bump version to 2.6.142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.142] - 2026-04-18
+
+### Fixed
+- fix(artists): active tab's count badge now uses bg-white/20 + text-white so the count stays readable on the brand-colored button (was previously brand-on-brand → invisible) (#713)
+- fix(artists): suggestions errors now show the actual error message + a "Try again" button; previously every failure (503, 500, network) was silently masked as the generic "No suggestions available" empty state (#713)
+
 ## [2.6.141] - 2026-04-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.141",
+  "version": "2.6.142",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.141",
+    "version": "2.6.142",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.141",
+    "version": "2.6.142",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.141",
+    "version": "2.6.142",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.141",
+    "version": "2.6.142",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 2.6.142 (badge contrast + error surfacing — PR #713)

## Test plan
- [x] CHANGELOG updated