### PR TITLE
chore: bump version to 2.6.143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.143] - 2026-04-18
+
+### Fixed
+- fix(artists): cache the per-user merged top-artists (3 time-ranges) in Redis under `artist:user:top:v1:<discordUserId>` for 15 min — the suggestions endpoint was taking 9.8–10s on every page load (Spotify multi-time-range fetch + popular fallback) and tripping the frontend's 10s axios timeout (#715)
+- fix(artists): bump axios timeout for `getSuggestions` to 30s as a cold-cache safety net (#715)
+
 ## [2.6.142] - 2026-04-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.142",
+  "version": "2.6.143",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.142",
+    "version": "2.6.143",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.142",
+    "version": "2.6.143",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.142",
+    "version": "2.6.143",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.142",
+    "version": "2.6.143",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Bump for #715 (per-user top-artists cache + 30s timeout).