### PR TITLE
fix(artists,settings): real Discover pictures + autoplay genre upsert

### DIFF
--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -21,20 +21,6 @@ const FALLBACK_SUGGESTIONS_TTL_SECONDS = 60 * 60 // 1 hour
 const USER_TOP_ARTISTS_CACHE_PREFIX = 'artist:user:top:v1:'
 const USER_TOP_ARTISTS_TTL_SECONDS = 15 * 60 // 15 minutes
 
-const STATIC_FALLBACK_ARTISTS = [
-    'Taylor Swift', 'Drake', 'The Weeknd', 'Bad Bunny', 'Billie Eilish',
-    'Dua Lipa', 'Ariana Grande', 'Kendrick Lamar', 'SZA', 'Sabrina Carpenter',
-    'Olivia Rodrigo', 'Travis Scott', 'Bruno Mars', 'Frank Ocean', 'Tyler The Creator',
-    'Karol G', 'Anitta', 'Rosalía', 'Peso Pluma', 'J Balvin',
-    'Arctic Monkeys', 'Tame Impala', 'The Strokes', 'Radiohead', 'Foo Fighters',
-    'Red Hot Chili Peppers', 'Daft Punk', 'Calvin Harris', 'ODESZA', 'Disclosure',
-    'BTS', 'BLACKPINK', 'NewJeans', 'Stray Kids',
-    'The Beatles', 'Queen', 'Pink Floyd', 'Led Zeppelin', 'Metallica',
-    'Miles Davis', 'Nina Simone', 'Phoebe Bridgers', 'Vampire Weekend', 'Mac DeMarco',
-    'Morgan Wallen', 'Luke Combs', 'Kacey Musgraves', 'Zach Bryan',
-    'Matuê', 'Tim Bernardes', 'Racionais', 'Djonga',
-] as const
-
 const saveArtistBody = z.object({
     guildId: z.string().min(1),
     artistKey: z.string().min(1),
@@ -312,22 +298,12 @@ export function setupArtistsRoutes(app: Express): void {
                     }
                 }
 
-                // Last-resort static fallback: when Spotify is rate-limiting
-                // every path (user-top-read 403, popular search 429) and
-                // the Redis cache is cold, the user would otherwise see an
-                // empty grid. Seed with name-only entries; the tile UI shows
-                // the artist's initial when imageUrl is null.
                 if (suggestions.size === 0) {
-                    for (const name of STATIC_FALLBACK_ARTISTS) {
-                        const id = `static:${name.toLowerCase().replace(/[^a-z0-9]/g, '')}`
-                        suggestions.set(id, {
-                            id,
-                            name,
-                            imageUrl: null,
-                            popularity: 0,
-                            genres: [],
-                        })
-                    }
+                    res.set('Cache-Control', 'no-store')
+                    res.status(503).json({
+                        error: 'Artist suggestions temporarily unavailable',
+                    })
+                    return
                 }
 
                 res.set('Cache-Control', 'no-cache, no-store, must-revalidate')

--- a/packages/backend/tests/unit/routes/artists.test.ts
+++ b/packages/backend/tests/unit/routes/artists.test.ts
@@ -354,6 +354,28 @@ describe('Artists Routes', () => {
 
 			fetchSpy.mockRestore()
 		})
+
+		test('should return 503 when every Spotify path produces zero artists', async () => {
+			const req = createMockRequest({
+				user: { id: 'discord-123' },
+			}) as any
+			const res = createMockResponse()
+
+			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
+				null,
+			)
+			;(searchSpotifyArtists as jest.Mock).mockResolvedValue([])
+
+			setupArtistsRoutes(mockApp)
+			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+			await handler(req, res)
+
+			expect(res.status).toHaveBeenCalledWith(503)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Artist suggestions temporarily unavailable',
+			})
+		})
 	})
 
 	describe('GET /api/artists/search', () => {

--- a/packages/shared/src/__tests__/services/GuildSettingsService.test.ts
+++ b/packages/shared/src/__tests__/services/GuildSettingsService.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { GuildSettingsService } from '../../services/GuildSettingsService'
+import { redisClient } from '../../services/redis'
+
+jest.mock('../../services/redis', () => ({
+    redisClient: {
+        get: jest.fn(),
+        setex: jest.fn(),
+        del: jest.fn(),
+    },
+}))
+
+const mockGet = redisClient.get as jest.MockedFunction<typeof redisClient.get>
+const mockSetex = redisClient.setex as unknown as jest.MockedFunction<
+    (key: string, ttl: number, value: string) => Promise<string>
+>
+
+describe('GuildSettingsService.updateGuildSettings (upsert)', () => {
+    let service: GuildSettingsService
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        service = new GuildSettingsService(60)
+    })
+
+    test('seeds defaults and persists when no existing settings', async () => {
+        mockGet.mockResolvedValue(null)
+        mockSetex.mockResolvedValue('OK')
+
+        const result = await service.updateGuildSettings('guild-1', {
+            autoplayGenres: ['rock', 'jazz'],
+        })
+
+        expect(result).toBe(true)
+        expect(mockSetex).toHaveBeenCalledTimes(1)
+        const call = mockSetex.mock.calls[0]
+        expect(call[0]).toBe('guild_settings:guild-1')
+        expect(call[1]).toBe(60)
+        const persisted = JSON.parse(call[2] as string)
+        expect(persisted.guildId).toBe('guild-1')
+        expect(persisted.autoplayGenres).toEqual(['rock', 'jazz'])
+        expect(persisted.defaultVolume).toBe(50) // from defaults
+    })
+
+    test('merges updates with existing settings', async () => {
+        mockGet.mockResolvedValue(
+            JSON.stringify({
+                guildId: 'guild-1',
+                defaultVolume: 80,
+                autoplayGenres: ['old'],
+                autoPlayEnabled: true,
+            }),
+        )
+        mockSetex.mockResolvedValue('OK')
+
+        const result = await service.updateGuildSettings('guild-1', {
+            autoplayGenres: ['rock'],
+        })
+
+        expect(result).toBe(true)
+        const persisted = JSON.parse(mockSetex.mock.calls[0][2] as string)
+        expect(persisted.defaultVolume).toBe(80) // preserved from existing
+        expect(persisted.autoplayGenres).toEqual(['rock']) // overwritten
+        expect(persisted.guildId).toBe('guild-1')
+    })
+
+    test('returns false when redis throws', async () => {
+        mockGet.mockResolvedValue(null)
+        mockSetex.mockRejectedValue(new Error('redis down'))
+
+        const result = await service.updateGuildSettings('guild-1', {
+            autoplayGenres: ['rock'],
+        })
+
+        expect(result).toBe(false)
+    })
+})

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -119,14 +119,16 @@ export class GuildSettingsService {
         updates: Partial<GuildSettings>,
     ): Promise<boolean> {
         try {
-            const currentSettings = await this.getGuildSettings(guildId)
-            if (!currentSettings) {
-                return false
-            }
+            const currentSettings =
+                (await this.getGuildSettings(guildId)) ?? {
+                    ...this.getDefaultSettings(),
+                    guildId,
+                }
 
             const updatedSettings = {
                 ...currentSettings,
                 ...updates,
+                guildId,
                 updatedAt: new Date(),
             }
 


### PR DESCRIPTION
## Summary

- **Discover pictures**: drop the image-less STATIC_FALLBACK_ARTISTS (PR #717) and return 503 when no Spotify path produces artists. The frontend's existing error+retry UI handles it cleanly.
- **Autoplay genre save**: \`updateGuildSettings\` now upserts (mirrors \`setGuildSettings\`) so fresh guilds with no Redis row don't 500. Fixes the silent failure for both the dashboard PUT and every bot /autoplay subcommand.

## Test plan
- [x] 30/30 backend artists.test.ts pass (1 new: 503-when-empty)
- [x] 7/7 backend autoplay.test.ts pass (existing)
- [x] 3/3 new shared GuildSettingsService.test.ts pass (upsert + merge + redis-error)