### PR TITLE
fix(ci): force npm in compressed-size action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -34,6 +34,10 @@ jobs:
             - name: Compressed Size Diff
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v3
               with:
+                  # Force npm — the action defaults to pnpm when both
+                  # package-lock.json and pnpm-lock.yaml exist, but this
+                  # project is npm-managed (see package.json scripts).
+                  install-script: 'npm ci'
                   build-script: 'build'
                   pattern: 'packages/frontend/dist/**/*.{js,css}'
                   strip-hash: '\\b\\w{8}\\.'


### PR DESCRIPTION
## Summary
- The bundle-size workflow's compressed-size step was failing on every PR with \`Unable to locate executable file: pnpm\`.
- Root cause: \`preactjs/compressed-size-action\` autodetects pnpm when both \`package-lock.json\` and \`pnpm-lock.yaml\` exist. This project is npm-managed (all \`package.json\` scripts use npm), but a stale \`pnpm-lock.yaml\` triggered the wrong path.
- Fix: pass \`install-script: 'npm ci'\` to force npm. Single-line change to \`.github/workflows/bundle-size.yml\`.

This unblocks dependency-bump PRs (#723 prod-deps, #705 dev-deps) that were red on this check despite having no functional regression.

## Test plan
- [x] Workflow YAML still parses (no syntax errors)
- [ ] CI re-runs with fix → \`compressed-size\` job succeeds
- [ ] After merge, retry-run on #723 and #705 — \`compressed-size\` should go green