### PR TITLE
feat(backend): top.gg vote webhook endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,3 +198,8 @@ SEARCH_RETRY_DELAY=5000
 # DEPENDENCY_CHECK_INTERVAL=86400000
 # DEPENDENCY_NOTIFY_ONLY_SECURITY=false
 LUCKY_NOTIFY_API_KEY=
+
+# top.gg vote webhook (optional — for the /webhooks/topgg-votes endpoint)
+# Get this from https://top.gg/bot/<BOT_ID>/webhooks after listing the bot.
+# The value you paste in top.gg's "Authorization" field must match this.
+# TOPGG_AUTH_TOKEN=your_topgg_webhook_auth_token

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -18,6 +18,7 @@ import { setupStarboardRoutes } from './starboard'
 import { setupMusicRoutes } from './music'
 import { setupArtistsRoutes } from './artists'
 import { setupInternalNotifyRoutes } from './internalNotify'
+import { setupWebhookRoutes } from './webhooks'
 import { apiLimiter } from '../middleware/rateLimit'
 import { requireAuth } from '../middleware/auth'
 import { requireGuildModuleAccess } from '../middleware/guildAccess'
@@ -81,6 +82,7 @@ export function setupRoutes(app: Express): void {
     setupHealthRoutes(app)
     setupStatsRoutes(app)
     setupInternalNotifyRoutes(app)
+    setupWebhookRoutes(app)
     app.use('/api/', apiLimiter)
 
     for (const config of guildGuardConfigs) {

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -18,7 +18,7 @@ import { setupStarboardRoutes } from './starboard'
 import { setupMusicRoutes } from './music'
 import { setupArtistsRoutes } from './artists'
 import { setupInternalNotifyRoutes } from './internalNotify'
-import { setupWebhookRoutes } from './webhooks'
+import { setupWebhookApiRoutes, setupWebhookPublicRoutes } from './webhooks'
 import { apiLimiter } from '../middleware/rateLimit'
 import { requireAuth } from '../middleware/auth'
 import { requireGuildModuleAccess } from '../middleware/guildAccess'
@@ -82,8 +82,9 @@ export function setupRoutes(app: Express): void {
     setupHealthRoutes(app)
     setupStatsRoutes(app)
     setupInternalNotifyRoutes(app)
-    setupWebhookRoutes(app)
+    setupWebhookPublicRoutes(app)
     app.use('/api/', apiLimiter)
+    setupWebhookApiRoutes(app)
 
     for (const config of guildGuardConfigs) {
         const middleware = config.mode

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -49,7 +49,51 @@ function verifyTopggAuth(req: Request): void {
     }
 }
 
+function verifyInternalKey(req: Request): void {
+    const expected = process.env.LUCKY_NOTIFY_API_KEY
+    const provided = req.header('x-notify-key')
+    if (!expected || !provided || provided !== expected) {
+        throw AppError.unauthorized('invalid internal key')
+    }
+}
+
+async function readVoteState(
+    redis: Redis,
+    userId: string,
+): Promise<{ hasVoted: boolean; streak: number; nextVoteInSeconds: number }> {
+    const voteKey = `votes:${userId}`
+    const streakKey = `votes:streak:${userId}`
+    const [[, voteTs], [, streakRaw], [, ttl]] = (await redis
+        .pipeline()
+        .get(voteKey)
+        .get(streakKey)
+        .ttl(voteKey)
+        .exec()) as [
+        [Error | null, string | null],
+        [Error | null, string | null],
+        [Error | null, number],
+    ]
+    return {
+        hasVoted: voteTs !== null,
+        streak: streakRaw ? Number(streakRaw) : 0,
+        nextVoteInSeconds: ttl > 0 ? ttl : 0,
+    }
+}
+
 export function setupWebhookRoutes(app: Express): void {
+    app.get(
+        '/api/internal/votes/:userId',
+        asyncHandler(async (req: Request, res: Response) => {
+            verifyInternalKey(req)
+            const { userId } = req.params
+            if (!userId || typeof userId !== 'string' || !/^\d+$/.test(userId)) {
+                throw AppError.badRequest('invalid userId')
+            }
+            const state = await readVoteState(getRedis(), userId)
+            res.status(200).json(state)
+        }),
+    )
+
     app.post(
         '/webhooks/topgg-votes',
         writeLimiter,

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -6,21 +6,11 @@ import { asyncHandler } from '../middleware/asyncHandler'
 import { AppError } from '../errors/AppError'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
 import { debugLog, errorLog } from '@lucky/shared/utils'
-
-// Vote tier thresholds — kept in sync with the bot's /voterewards command.
-const VOTE_TIERS = [
-    { threshold: 30, label: 'Lucky Legend' },
-    { threshold: 14, label: 'Lucky Regular' },
-    { threshold: 7, label: 'Lucky Fan' },
-    { threshold: 1, label: 'Lucky Supporter' },
-] as const
-
-function tierFor(streak: number): { label: string; threshold: number } | null {
-    for (const t of VOTE_TIERS) {
-        if (streak >= t.threshold) return t
-    }
-    return null
-}
+import {
+    TOP_GG_VOTE_TIERS,
+    TOP_GG_VOTE_URL,
+    tierForVoteStreak,
+} from '@lucky/shared/constants'
 
 // Vote window: top.gg allows one upvote every 12 hours.
 const VOTE_TTL_SECONDS = 60 * 60 * 12
@@ -48,7 +38,10 @@ function getRedis(): Redis {
     // while the connection is retrying. Log and swallow — calls will error
     // per-request via maxRetriesPerRequest, so we don't need to crash.
     redisClient.on('error', (err) => {
-        errorLog({ message: 'webhooks redis error', data: { error: String(err) } })
+        errorLog({
+            message: 'webhooks redis error',
+            data: { error: String(err) },
+        })
     })
     return redisClient
 }
@@ -110,13 +103,17 @@ async function readVoteState(
     }
 }
 
-export function setupWebhookRoutes(app: Express): void {
+export function setupWebhookApiRoutes(app: Express): void {
     app.get(
         '/api/internal/votes/:userId',
         asyncHandler(async (req: Request, res: Response) => {
             verifyInternalKey(req)
             const { userId } = req.params
-            if (!userId || typeof userId !== 'string' || !/^\d+$/.test(userId)) {
+            if (
+                !userId ||
+                typeof userId !== 'string' ||
+                !/^\d+$/.test(userId)
+            ) {
                 throw AppError.badRequest('invalid userId')
             }
             const state = await readVoteState(getRedis(), userId)
@@ -133,21 +130,25 @@ export function setupWebhookRoutes(app: Express): void {
                 throw AppError.unauthorized('not authenticated')
             }
             const state = await readVoteState(getRedis(), userId)
-            const tier = tierFor(state.streak)
-            const nextTier = [...VOTE_TIERS]
+            const tier = tierForVoteStreak(state.streak)
+            const nextTier = [...TOP_GG_VOTE_TIERS]
                 .reverse()
                 .find((t) => t.threshold > state.streak)
             res.status(200).json({
                 ...state,
-                tier: tier ? { label: tier.label, threshold: tier.threshold } : null,
+                tier: tier
+                    ? { label: tier.label, threshold: tier.threshold }
+                    : null,
                 nextTier: nextTier
                     ? { label: nextTier.label, threshold: nextTier.threshold }
                     : null,
-                voteUrl: 'https://top.gg/bot/962198089161134131/vote',
+                voteUrl: TOP_GG_VOTE_URL,
             })
         }),
     )
+}
 
+export function setupWebhookPublicRoutes(app: Express): void {
     app.post(
         '/webhooks/topgg-votes',
         writeLimiter,
@@ -193,7 +194,8 @@ export function setupWebhookRoutes(app: Express): void {
 
                 if (firstWrite !== 'OK') {
                     debugLog({
-                        message: 'top.gg vote already recorded — skipping streak increment',
+                        message:
+                            'top.gg vote already recorded — skipping streak increment',
                         data: { userId },
                     })
                     res.status(200).json({ ok: true, duplicate: true })
@@ -222,4 +224,9 @@ export function setupWebhookRoutes(app: Express): void {
             }
         }),
     )
+}
+
+export function setupWebhookRoutes(app: Express): void {
+    setupWebhookApiRoutes(app)
+    setupWebhookPublicRoutes(app)
 }

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -19,13 +19,23 @@ const VOTE_TTL_SECONDS = 60 * 60 * 12
 // doesn't lose their streak due to timezone or minor scheduling drift.
 const STREAK_TTL_SECONDS = 60 * 60 * 36
 
+const RECORD_VOTE_SCRIPT = `
+if redis.call('EXISTS', KEYS[1]) == 1 then
+  return 0
+end
+redis.call('INCR', KEYS[2])
+redis.call('EXPIRE', KEYS[2], tonumber(ARGV[3]))
+redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
+return 1
+`
+
 let redisClient: Redis | null = null
 
 function getRedis(): Redis {
     if (redisClient) return redisClient
     const host = process.env.REDIS_HOST
     if (!host) {
-        throw new AppError(500, 'REDIS_HOST is not configured')
+        throw AppError.serviceUnavailable('REDIS_HOST is not configured')
     }
     redisClient = new Redis({
         host,
@@ -61,6 +71,10 @@ type TopggVotePayload = {
     query?: string
 }
 
+function isDiscordSnowflake(value: string): boolean {
+    return /^\d{17,20}$/.test(value)
+}
+
 function verifyTopggAuth(req: Request): void {
     const expected = process.env.TOPGG_AUTH_TOKEN
     if (!expected) {
@@ -86,16 +100,37 @@ async function readVoteState(
 ): Promise<{ hasVoted: boolean; streak: number; nextVoteInSeconds: number }> {
     const voteKey = `votes:${userId}`
     const streakKey = `votes:streak:${userId}`
-    const [[, voteTs], [, streakRaw], [, ttl]] = (await redis
+    const replies = (await redis
         .pipeline()
         .get(voteKey)
         .get(streakKey)
         .ttl(voteKey)
-        .exec()) as [
-        [Error | null, string | null],
-        [Error | null, string | null],
-        [Error | null, number],
-    ]
+        .exec()) as
+        | [
+              [Error | null, string | null],
+              [Error | null, string | null],
+              [Error | null, number],
+          ]
+        | null
+
+    if (!replies) {
+        throw new AppError(500, 'failed to read vote state')
+    }
+
+    const [voteResult, streakResult, ttlResult] = replies
+    const commandError =
+        voteResult[0] ?? streakResult[0] ?? ttlResult[0] ?? null
+    if (commandError) {
+        errorLog({
+            message: 'vote state redis read failed',
+            data: { voteKey, streakKey, error: String(commandError) },
+        })
+        throw new AppError(500, 'failed to read vote state')
+    }
+
+    const voteTs = voteResult[1]
+    const streakRaw = streakResult[1]
+    const ttl = ttlResult[1]
     return {
         hasVoted: voteTs !== null,
         streak: streakRaw ? Number(streakRaw) : 0,
@@ -103,19 +138,45 @@ async function readVoteState(
     }
 }
 
+async function recordVote(
+    redis: Redis,
+    voteKey: string,
+    streakKey: string,
+): Promise<'recorded' | 'duplicate'> {
+    const result = await redis.eval(
+        RECORD_VOTE_SCRIPT,
+        2,
+        voteKey,
+        streakKey,
+        Date.now().toString(),
+        String(VOTE_TTL_SECONDS),
+        String(STREAK_TTL_SECONDS),
+    )
+    if (result === 1 || result === '1') return 'recorded'
+    if (result === 0 || result === '0') return 'duplicate'
+    throw new AppError(500, 'unexpected vote record result')
+}
+
+function validateVoteUserId(userId: unknown): string {
+    if (typeof userId !== 'string' || !isDiscordSnowflake(userId)) {
+        throw AppError.badRequest('user id missing or invalid')
+    }
+    return userId
+}
+
+function validateRouteUserId(userId: unknown): string {
+    if (typeof userId !== 'string' || !isDiscordSnowflake(userId)) {
+        throw AppError.badRequest('invalid userId')
+    }
+    return userId
+}
+
 export function setupWebhookApiRoutes(app: Express): void {
     app.get(
         '/api/internal/votes/:userId',
         asyncHandler(async (req: Request, res: Response) => {
             verifyInternalKey(req)
-            const { userId } = req.params
-            if (
-                !userId ||
-                typeof userId !== 'string' ||
-                !/^\d+$/.test(userId)
-            ) {
-                throw AppError.badRequest('invalid userId')
-            }
+            const userId = validateRouteUserId(req.params.userId)
             const state = await readVoteState(getRedis(), userId)
             res.status(200).json(state)
         }),
@@ -170,29 +231,16 @@ export function setupWebhookPublicRoutes(app: Express): void {
                 throw AppError.badRequest('unsupported vote type')
             }
 
-            const userId = payload.user
-            if (!userId || typeof userId !== 'string') {
-                throw AppError.badRequest('user id missing or invalid')
-            }
+            const userId = validateVoteUserId(payload.user)
 
             const redis = getRedis()
             const voteKey = `votes:${userId}`
             const streakKey = `votes:streak:${userId}`
 
             try {
-                // Idempotency gate: top.gg retries on handler failure/timeout.
-                // SET NX means only the first call within the 12h vote window
-                // lands a vote; subsequent retries return 200 without touching
-                // the streak counter.
-                const firstWrite = await redis.set(
-                    voteKey,
-                    Date.now().toString(),
-                    'EX',
-                    VOTE_TTL_SECONDS,
-                    'NX',
-                )
+                const recordResult = await recordVote(redis, voteKey, streakKey)
 
-                if (firstWrite !== 'OK') {
+                if (recordResult === 'duplicate') {
                     debugLog({
                         message:
                             'top.gg vote already recorded — skipping streak increment',
@@ -201,11 +249,6 @@ export function setupWebhookPublicRoutes(app: Express): void {
                     res.status(200).json({ ok: true, duplicate: true })
                     return
                 }
-
-                const pipeline = redis.pipeline()
-                pipeline.incr(streakKey)
-                pipeline.expire(streakKey, STREAK_TTL_SECONDS)
-                await pipeline.exec()
 
                 debugLog({
                     message: 'top.gg vote recorded',

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -1,4 +1,5 @@
 import type { Express, Request, Response } from 'express'
+import { timingSafeEqual } from 'node:crypto'
 import Redis from 'ioredis'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
@@ -43,7 +44,20 @@ function getRedis(): Redis {
         lazyConnect: true,
         maxRetriesPerRequest: 1,
     })
+    // ioredis raises uncaughtException if no 'error' listener is attached
+    // while the connection is retrying. Log and swallow — calls will error
+    // per-request via maxRetriesPerRequest, so we don't need to crash.
+    redisClient.on('error', (err) => {
+        errorLog({ message: 'webhooks redis error', data: { error: String(err) } })
+    })
     return redisClient
+}
+
+function safeEqualString(a: string, b: string): boolean {
+    const ab = Buffer.from(a)
+    const bb = Buffer.from(b)
+    if (ab.length !== bb.length) return false
+    return timingSafeEqual(ab, bb)
 }
 
 type TopggVotePayload = {
@@ -60,7 +74,7 @@ function verifyTopggAuth(req: Request): void {
         throw new AppError(503, 'TOPGG_AUTH_TOKEN not configured')
     }
     const provided = req.header('authorization')
-    if (!provided || provided !== expected) {
+    if (!provided || !safeEqualString(provided, expected)) {
         throw AppError.unauthorized('invalid top.gg webhook token')
     }
 }
@@ -68,7 +82,7 @@ function verifyTopggAuth(req: Request): void {
 function verifyInternalKey(req: Request): void {
     const expected = process.env.LUCKY_NOTIFY_API_KEY
     const provided = req.header('x-notify-key')
-    if (!expected || !provided || provided !== expected) {
+    if (!expected || !provided || !safeEqualString(provided, expected)) {
         throw AppError.unauthorized('invalid internal key')
     }
 }
@@ -148,6 +162,13 @@ export function setupWebhookRoutes(app: Express): void {
                 return
             }
 
+            // Only persist genuine upvotes. Unknown/future event types
+            // (e.g. downvotes, if top.gg ever adds them) must not bump the
+            // streak counter.
+            if (payload.type !== 'upvote') {
+                throw AppError.badRequest('unsupported vote type')
+            }
+
             const userId = payload.user
             if (!userId || typeof userId !== 'string') {
                 throw AppError.badRequest('user id missing or invalid')
@@ -158,8 +179,28 @@ export function setupWebhookRoutes(app: Express): void {
             const streakKey = `votes:streak:${userId}`
 
             try {
+                // Idempotency gate: top.gg retries on handler failure/timeout.
+                // SET NX means only the first call within the 12h vote window
+                // lands a vote; subsequent retries return 200 without touching
+                // the streak counter.
+                const firstWrite = await redis.set(
+                    voteKey,
+                    Date.now().toString(),
+                    'EX',
+                    VOTE_TTL_SECONDS,
+                    'NX',
+                )
+
+                if (firstWrite !== 'OK') {
+                    debugLog({
+                        message: 'top.gg vote already recorded — skipping streak increment',
+                        data: { userId },
+                    })
+                    res.status(200).json({ ok: true, duplicate: true })
+                    return
+                }
+
                 const pipeline = redis.pipeline()
-                pipeline.set(voteKey, Date.now().toString(), 'EX', VOTE_TTL_SECONDS)
                 pipeline.incr(streakKey)
                 pipeline.expire(streakKey, STREAK_TTL_SECONDS)
                 await pipeline.exec()

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -1,0 +1,100 @@
+import type { Express, Request, Response } from 'express'
+import Redis from 'ioredis'
+import { writeLimiter } from '../middleware/rateLimit'
+import { asyncHandler } from '../middleware/asyncHandler'
+import { AppError } from '../errors/AppError'
+import { debugLog, errorLog } from '@lucky/shared/utils'
+
+// Vote window: top.gg allows one upvote every 12 hours.
+const VOTE_TTL_SECONDS = 60 * 60 * 12
+
+// Streak window: 36h gives 12h grace around the 24h cycle so a daily voter
+// doesn't lose their streak due to timezone or minor scheduling drift.
+const STREAK_TTL_SECONDS = 60 * 60 * 36
+
+let redisClient: Redis | null = null
+
+function getRedis(): Redis {
+    if (redisClient) return redisClient
+    const host = process.env.REDIS_HOST
+    if (!host) {
+        throw new AppError(500, 'REDIS_HOST is not configured')
+    }
+    redisClient = new Redis({
+        host,
+        port: Number(process.env.REDIS_PORT ?? 6379),
+        password: process.env.REDIS_PASSWORD || undefined,
+        lazyConnect: true,
+        maxRetriesPerRequest: 1,
+    })
+    return redisClient
+}
+
+type TopggVotePayload = {
+    bot?: string
+    user?: string
+    type?: 'upvote' | 'test'
+    isWeekend?: boolean
+    query?: string
+}
+
+function verifyTopggAuth(req: Request): void {
+    const expected = process.env.TOPGG_AUTH_TOKEN
+    if (!expected) {
+        throw new AppError(503, 'TOPGG_AUTH_TOKEN not configured')
+    }
+    const provided = req.header('authorization')
+    if (!provided || provided !== expected) {
+        throw AppError.unauthorized('invalid top.gg webhook token')
+    }
+}
+
+export function setupWebhookRoutes(app: Express): void {
+    app.post(
+        '/webhooks/topgg-votes',
+        writeLimiter,
+        asyncHandler(async (req: Request, res: Response) => {
+            verifyTopggAuth(req)
+
+            const payload = (req.body ?? {}) as TopggVotePayload
+
+            if (payload.type === 'test') {
+                debugLog({ message: 'top.gg webhook test received' })
+                res.status(200).json({ ok: true, test: true })
+                return
+            }
+
+            const userId = payload.user
+            if (!userId || typeof userId !== 'string') {
+                throw AppError.badRequest('user id missing or invalid')
+            }
+
+            const redis = getRedis()
+            const voteKey = `votes:${userId}`
+            const streakKey = `votes:streak:${userId}`
+
+            try {
+                const pipeline = redis.pipeline()
+                pipeline.set(voteKey, Date.now().toString(), 'EX', VOTE_TTL_SECONDS)
+                pipeline.incr(streakKey)
+                pipeline.expire(streakKey, STREAK_TTL_SECONDS)
+                await pipeline.exec()
+
+                debugLog({
+                    message: 'top.gg vote recorded',
+                    data: {
+                        userId,
+                        isWeekend: payload.isWeekend === true,
+                    },
+                })
+                res.status(200).json({ ok: true })
+            } catch (error) {
+                errorLog({
+                    message: 'top.gg vote persist failed',
+                    data: { userId, error: String(error) },
+                })
+                throw new AppError(500, 'failed to record vote')
+            }
+        }),
+    )
+}

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -3,7 +3,23 @@ import Redis from 'ioredis'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { AppError } from '../errors/AppError'
+import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
 import { debugLog, errorLog } from '@lucky/shared/utils'
+
+// Vote tier thresholds — kept in sync with the bot's /voterewards command.
+const VOTE_TIERS = [
+    { threshold: 30, label: 'Lucky Legend' },
+    { threshold: 14, label: 'Lucky Regular' },
+    { threshold: 7, label: 'Lucky Fan' },
+    { threshold: 1, label: 'Lucky Supporter' },
+] as const
+
+function tierFor(streak: number): { label: string; threshold: number } | null {
+    for (const t of VOTE_TIERS) {
+        if (streak >= t.threshold) return t
+    }
+    return null
+}
 
 // Vote window: top.gg allows one upvote every 12 hours.
 const VOTE_TTL_SECONDS = 60 * 60 * 12
@@ -91,6 +107,30 @@ export function setupWebhookRoutes(app: Express): void {
             }
             const state = await readVoteState(getRedis(), userId)
             res.status(200).json(state)
+        }),
+    )
+
+    app.get(
+        '/api/me/vote-status',
+        requireAuth,
+        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+            const userId = req.user?.id
+            if (!userId) {
+                throw AppError.unauthorized('not authenticated')
+            }
+            const state = await readVoteState(getRedis(), userId)
+            const tier = tierFor(state.streak)
+            const nextTier = [...VOTE_TIERS]
+                .reverse()
+                .find((t) => t.threshold > state.streak)
+            res.status(200).json({
+                ...state,
+                tier: tier ? { label: tier.label, threshold: tier.threshold } : null,
+                nextTier: nextTier
+                    ? { label: nextTier.label, threshold: nextTier.threshold }
+                    : null,
+                voteUrl: 'https://top.gg/bot/962198089161134131/vote',
+            })
         }),
     )
 

--- a/packages/backend/tests/unit/routes/index.test.ts
+++ b/packages/backend/tests/unit/routes/index.test.ts
@@ -22,6 +22,8 @@ const setupMusicRoutes = jest.fn()
 const setupSpotifyRoutes = jest.fn()
 const setupArtistsRoutes = jest.fn()
 const setupInternalNotifyRoutes = jest.fn()
+const setupWebhookApiRoutes = jest.fn()
+const setupWebhookPublicRoutes = jest.fn()
 
 const requireGuildModuleAccess = jest.fn()
 const apiLimiter = jest.fn()
@@ -108,8 +110,13 @@ jest.mock('../../../src/routes/artists', () => ({
     setupArtistsRoutes,
 }))
 
-jest.mock("../../../src/routes/internalNotify", () => ({
+jest.mock('../../../src/routes/internalNotify', () => ({
     setupInternalNotifyRoutes,
+}))
+
+jest.mock('../../../src/routes/webhooks', () => ({
+    setupWebhookApiRoutes,
+    setupWebhookPublicRoutes,
 }))
 
 jest.mock('../../../src/middleware/rateLimit', () => ({
@@ -151,7 +158,9 @@ describe('setupRoutes', () => {
         expect(setupHealthRoutes).toHaveBeenCalledWith(app)
         expect(setupStatsRoutes).toHaveBeenCalledWith(app)
         expect(setupInternalNotifyRoutes).toHaveBeenCalledWith(app)
+        expect(setupWebhookPublicRoutes).toHaveBeenCalledWith(app)
         expect(app.use).toHaveBeenCalledWith('/api/', apiLimiter)
+        expect(setupWebhookApiRoutes).toHaveBeenCalledWith(app)
 
         expect(requireGuildModuleAccess).toHaveBeenCalledWith('moderation')
         expect(requireGuildModuleAccess).toHaveBeenCalledWith('automation')
@@ -195,6 +204,14 @@ describe('setupRoutes', () => {
         expect(app.use).toHaveBeenCalledWith(errorHandler)
         expect(useCalls[0]).toEqual(['/api/', apiLimiter])
         expect(useCalls[useCalls.length - 1]).toEqual([errorHandler])
+
+        const apiLimiterOrder = app.use.mock.invocationCallOrder[0]
+        expect(
+            setupWebhookPublicRoutes.mock.invocationCallOrder[0],
+        ).toBeLessThan(apiLimiterOrder)
+        expect(
+            setupWebhookApiRoutes.mock.invocationCallOrder[0],
+        ).toBeGreaterThan(apiLimiterOrder)
 
         const rbacGuardIndex = useCalls.findIndex(
             (call) => call[0] === '/api/guilds/:guildId/rbac',

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -8,6 +8,8 @@ const pipelineMock = {
     set: jest.fn().mockReturnThis(),
     incr: jest.fn().mockReturnThis(),
     expire: jest.fn().mockReturnThis(),
+    get: jest.fn().mockReturnThis(),
+    ttl: jest.fn().mockReturnThis(),
     exec: pipelineExec,
 }
 
@@ -41,16 +43,20 @@ function buildApp(): express.Express {
 
 beforeEach(() => {
     process.env.TOPGG_AUTH_TOKEN = 'valid-token'
+    process.env.LUCKY_NOTIFY_API_KEY = 'internal-key'
     process.env.REDIS_HOST = 'localhost'
     process.env.REDIS_PORT = '6379'
-    pipelineExec.mockClear()
+    pipelineExec.mockClear().mockResolvedValue([])
     pipelineMock.set.mockClear()
     pipelineMock.incr.mockClear()
     pipelineMock.expire.mockClear()
+    pipelineMock.get.mockClear()
+    pipelineMock.ttl.mockClear()
 })
 
 afterEach(() => {
     delete process.env.TOPGG_AUTH_TOKEN
+    delete process.env.LUCKY_NOTIFY_API_KEY
     delete process.env.REDIS_HOST
     delete process.env.REDIS_PORT
 })
@@ -95,6 +101,37 @@ describe('POST /webhooks/topgg-votes', () => {
             .post('/webhooks/topgg-votes')
             .set('authorization', 'valid-token')
             .send({ type: 'upvote' })
+        expect(res.status).toBe(400)
+    })
+
+    it('responds to GET /api/internal/votes/:userId with current state', async () => {
+        pipelineExec.mockResolvedValueOnce([
+            [null, '1700000000000'],
+            [null, '7'],
+            [null, 3600],
+        ])
+        const res = await request(buildApp())
+            .get('/api/internal/votes/123')
+            .set('x-notify-key', 'internal-key')
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({
+            hasVoted: true,
+            streak: 7,
+            nextVoteInSeconds: 3600,
+        })
+    })
+
+    it('rejects GET with wrong internal key', async () => {
+        const res = await request(buildApp())
+            .get('/api/internal/votes/123')
+            .set('x-notify-key', 'wrong')
+        expect(res.status).toBe(401)
+    })
+
+    it('rejects GET with non-numeric userId', async () => {
+        const res = await request(buildApp())
+            .get('/api/internal/votes/abc')
+            .set('x-notify-key', 'internal-key')
         expect(res.status).toBe(400)
     })
 

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals'
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    jest,
+} from '@jest/globals'
 import express from 'express'
 import request from 'supertest'
 
@@ -12,13 +19,13 @@ const pipelineMock = {
     ttl: jest.fn().mockReturnThis(),
     exec: pipelineExec,
 }
-const redisSet = jest.fn<() => Promise<string | null>>().mockResolvedValue('OK')
+const redisEval = jest.fn<() => Promise<unknown>>().mockResolvedValue(1)
 const redisOn = jest.fn()
 
 jest.mock('ioredis', () => {
     return jest.fn().mockImplementation(() => ({
         pipeline: () => pipelineMock,
-        set: redisSet,
+        eval: redisEval,
         on: redisOn,
     }))
 })
@@ -73,7 +80,7 @@ beforeEach(() => {
     pipelineMock.expire.mockClear()
     pipelineMock.get.mockClear()
     pipelineMock.ttl.mockClear()
-    redisSet.mockClear().mockResolvedValue('OK')
+    redisEval.mockClear().mockResolvedValue(1)
     redisOn.mockClear()
 })
 
@@ -133,9 +140,11 @@ describe('POST /webhooks/topgg-votes', () => {
             .set('authorization', 'valid-token')
             .send({ user: '1', type: 'downvote' })
         expect(res.status).toBe(400)
-        expect(redisSet).not.toHaveBeenCalled()
+        expect(redisEval).not.toHaveBeenCalled()
     })
+})
 
+describe('GET /api/internal/votes/:userId', () => {
     it('responds to GET /api/internal/votes/:userId with current state', async () => {
         pipelineExec.mockResolvedValueOnce([
             [null, '1700000000000'],
@@ -143,7 +152,7 @@ describe('POST /webhooks/topgg-votes', () => {
             [null, 3600],
         ])
         const res = await request(buildApp())
-            .get('/api/internal/votes/123')
+            .get('/api/internal/votes/123456789012345678')
             .set('x-notify-key', 'internal-key')
         expect(res.status).toBe(200)
         expect(res.body).toEqual({
@@ -155,7 +164,7 @@ describe('POST /webhooks/topgg-votes', () => {
 
     it('rejects GET with wrong internal key', async () => {
         const res = await request(buildApp())
-            .get('/api/internal/votes/123')
+            .get('/api/internal/votes/123456789012345678')
             .set('x-notify-key', 'wrong')
         expect(res.status).toBe(401)
     })
@@ -167,99 +176,139 @@ describe('POST /webhooks/topgg-votes', () => {
         expect(res.status).toBe(400)
     })
 
-    describe('GET /api/me/vote-status', () => {
-        it('returns 401 when not authenticated', async () => {
-            const res = await request(buildApp()).get('/api/me/vote-status')
-            expect(res.status).toBe(401)
-        })
+    it('rejects GET with numeric non-snowflake userId', async () => {
+        const res = await request(buildApp())
+            .get('/api/internal/votes/123')
+            .set('x-notify-key', 'internal-key')
+        expect(res.status).toBe(400)
+    })
 
-        it('returns state + tier + nextTier + voteUrl for a streak-14 voter', async () => {
-            pipelineExec.mockResolvedValueOnce([
-                [null, '1700000000000'],
-                [null, '14'],
-                [null, 7200],
-            ])
-            const res = await request(buildApp())
-                .get('/api/me/vote-status')
-                .set('x-test-user', '555')
-            expect(res.status).toBe(200)
-            expect(res.body).toEqual({
-                hasVoted: true,
-                streak: 14,
-                nextVoteInSeconds: 7200,
-                tier: { label: 'Lucky Regular', threshold: 14 },
-                nextTier: { label: 'Lucky Legend', threshold: 30 },
-                voteUrl: 'https://top.gg/bot/962198089161134131/vote',
-            })
-        })
+    it('returns 500 when a Redis read command fails', async () => {
+        pipelineExec.mockResolvedValueOnce([
+            [new Error('get failed'), null],
+            [null, null],
+            [null, -2],
+        ])
+        const res = await request(buildApp())
+            .get('/api/internal/votes/123456789012345678')
+            .set('x-notify-key', 'internal-key')
+        expect(res.status).toBe(500)
+    })
+})
 
-        it('returns tier=null for a 0-streak user', async () => {
-            pipelineExec.mockResolvedValueOnce([
-                [null, null],
-                [null, null],
-                [null, -2],
-            ])
-            const res = await request(buildApp())
-                .get('/api/me/vote-status')
-                .set('x-test-user', '777')
-            expect(res.status).toBe(200)
-            expect(res.body.tier).toBeNull()
-            expect(res.body.nextTier).toEqual({
-                label: 'Lucky Supporter',
-                threshold: 1,
-            })
-            expect(res.body.streak).toBe(0)
-            expect(res.body.hasVoted).toBe(false)
-        })
+describe('GET /api/me/vote-status', () => {
+    it('returns 401 when not authenticated', async () => {
+        const res = await request(buildApp()).get('/api/me/vote-status')
+        expect(res.status).toBe(401)
+    })
 
-        it('returns nextTier=null when user is at max tier (30+)', async () => {
-            pipelineExec.mockResolvedValueOnce([
-                [null, '1700000000000'],
-                [null, '45'],
-                [null, 100],
-            ])
-            const res = await request(buildApp())
-                .get('/api/me/vote-status')
-                .set('x-test-user', '999')
-            expect(res.status).toBe(200)
-            expect(res.body.tier.label).toBe('Lucky Legend')
-            expect(res.body.nextTier).toBeNull()
+    it('returns state + tier + nextTier + voteUrl for a streak-14 voter', async () => {
+        pipelineExec.mockResolvedValueOnce([
+            [null, '1700000000000'],
+            [null, '14'],
+            [null, 7200],
+        ])
+        const res = await request(buildApp())
+            .get('/api/me/vote-status')
+            .set('x-test-user', '555')
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({
+            hasVoted: true,
+            streak: 14,
+            nextVoteInSeconds: 7200,
+            tier: { label: 'Lucky Regular', threshold: 14 },
+            nextTier: { label: 'Lucky Legend', threshold: 30 },
+            voteUrl: 'https://top.gg/bot/962198089161134131/vote',
         })
     })
 
-    it('records a valid upvote via SET NX + streak pipeline', async () => {
+    it('returns tier=null for a 0-streak user', async () => {
+        pipelineExec.mockResolvedValueOnce([
+            [null, null],
+            [null, null],
+            [null, -2],
+        ])
+        const res = await request(buildApp())
+            .get('/api/me/vote-status')
+            .set('x-test-user', '777')
+        expect(res.status).toBe(200)
+        expect(res.body.tier).toBeNull()
+        expect(res.body.nextTier).toEqual({
+            label: 'Lucky Supporter',
+            threshold: 1,
+        })
+        expect(res.body.streak).toBe(0)
+        expect(res.body.hasVoted).toBe(false)
+    })
+
+    it('returns nextTier=null when user is at max tier (30+)', async () => {
+        pipelineExec.mockResolvedValueOnce([
+            [null, '1700000000000'],
+            [null, '45'],
+            [null, 100],
+        ])
+        const res = await request(buildApp())
+            .get('/api/me/vote-status')
+            .set('x-test-user', '999')
+        expect(res.status).toBe(200)
+        expect(res.body.tier.label).toBe('Lucky Legend')
+        expect(res.body.nextTier).toBeNull()
+    })
+})
+
+describe('POST /webhooks/topgg-votes persistence', () => {
+    it('records a valid upvote with one atomic Redis script', async () => {
         const res = await request(buildApp())
             .post('/webhooks/topgg-votes')
             .set('authorization', 'valid-token')
-            .send({ user: '123', type: 'upvote', bot: '962198089161134131' })
+            .send({
+                user: '123456789012345678',
+                type: 'upvote',
+                bot: '962198089161134131',
+            })
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ ok: true })
-        expect(redisSet).toHaveBeenCalledWith(
-            'votes:123',
+        expect(redisEval).toHaveBeenCalledWith(
+            expect.stringContaining("redis.call('INCR', KEYS[2])"),
+            2,
+            'votes:123456789012345678',
+            'votes:streak:123456789012345678',
             expect.any(String),
-            'EX',
-            60 * 60 * 12,
-            'NX',
+            String(60 * 60 * 12),
+            String(60 * 60 * 36),
         )
-        expect(pipelineMock.incr).toHaveBeenCalledWith('votes:streak:123')
-        expect(pipelineMock.expire).toHaveBeenCalledWith(
-            'votes:streak:123',
-            60 * 60 * 36,
-        )
-        expect(pipelineExec).toHaveBeenCalledTimes(1)
-    })
-
-    it('is idempotent — duplicate vote within TTL skips streak increment', async () => {
-        redisSet.mockResolvedValueOnce(null) // SET NX returns null when key exists
-        const res = await request(buildApp())
-            .post('/webhooks/topgg-votes')
-            .set('authorization', 'valid-token')
-            .send({ user: '123', type: 'upvote' })
-        expect(res.status).toBe(200)
-        expect(res.body).toEqual({ ok: true, duplicate: true })
-        expect(redisSet).toHaveBeenCalledTimes(1)
         expect(pipelineMock.incr).not.toHaveBeenCalled()
         expect(pipelineMock.expire).not.toHaveBeenCalled()
     })
 
+    it('is idempotent — duplicate vote within TTL skips streak increment', async () => {
+        redisEval.mockResolvedValueOnce(0)
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({ user: '123456789012345678', type: 'upvote' })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true, duplicate: true })
+        expect(redisEval).toHaveBeenCalledTimes(1)
+        expect(pipelineMock.incr).not.toHaveBeenCalled()
+        expect(pipelineMock.expire).not.toHaveBeenCalled()
+    })
+
+    it('rejects unsafe non-snowflake user ids before writing to Redis', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({ user: 'streak:123', type: 'upvote' })
+        expect(res.status).toBe(400)
+        expect(redisEval).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 when the Redis script returns an unexpected value', async () => {
+        redisEval.mockResolvedValueOnce('unexpected')
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({ user: '123456789012345678', type: 'upvote' })
+        expect(res.status).toBe(500)
+    })
 })

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals'
+import express from 'express'
+import request from 'supertest'
+
+// Mock ioredis so the route never opens a real connection.
+const pipelineExec = jest.fn<() => Promise<unknown>>().mockResolvedValue([])
+const pipelineMock = {
+    set: jest.fn().mockReturnThis(),
+    incr: jest.fn().mockReturnThis(),
+    expire: jest.fn().mockReturnThis(),
+    exec: pipelineExec,
+}
+
+jest.mock('ioredis', () => {
+    return jest.fn().mockImplementation(() => ({
+        pipeline: () => pipelineMock,
+    }))
+})
+
+import { setupWebhookRoutes } from '../../../src/routes/webhooks'
+
+function buildApp(): express.Express {
+    const app = express()
+    app.use(express.json())
+    setupWebhookRoutes(app)
+    app.use(
+        (
+            err: { statusCode?: number; message?: string },
+            _req: express.Request,
+            res: express.Response,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            _next: express.NextFunction,
+        ) => {
+            res.status(err.statusCode ?? 500).json({
+                error: err.message ?? 'unknown',
+            })
+        },
+    )
+    return app
+}
+
+beforeEach(() => {
+    process.env.TOPGG_AUTH_TOKEN = 'valid-token'
+    process.env.REDIS_HOST = 'localhost'
+    process.env.REDIS_PORT = '6379'
+    pipelineExec.mockClear()
+    pipelineMock.set.mockClear()
+    pipelineMock.incr.mockClear()
+    pipelineMock.expire.mockClear()
+})
+
+afterEach(() => {
+    delete process.env.TOPGG_AUTH_TOKEN
+    delete process.env.REDIS_HOST
+    delete process.env.REDIS_PORT
+})
+
+describe('POST /webhooks/topgg-votes', () => {
+    it('returns 503 when TOPGG_AUTH_TOKEN is unset', async () => {
+        delete process.env.TOPGG_AUTH_TOKEN
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'anything')
+            .send({ user: '1', type: 'upvote' })
+        expect(res.status).toBe(503)
+    })
+
+    it('rejects on missing authorization header', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .send({ user: '1', type: 'upvote' })
+        expect(res.status).toBe(401)
+    })
+
+    it('rejects on wrong authorization header', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'wrong')
+            .send({ user: '1', type: 'upvote' })
+        expect(res.status).toBe(401)
+    })
+
+    it('accepts test-type payload and returns { ok, test }', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({ type: 'test' })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true, test: true })
+        expect(pipelineExec).not.toHaveBeenCalled()
+    })
+
+    it('rejects when user id is missing', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({ type: 'upvote' })
+        expect(res.status).toBe(400)
+    })
+
+    it('records a valid upvote in redis via pipeline', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({ user: '123', type: 'upvote', bot: '962198089161134131' })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true })
+        expect(pipelineMock.set).toHaveBeenCalledWith(
+            'votes:123',
+            expect.any(String),
+            'EX',
+            60 * 60 * 12,
+        )
+        expect(pipelineMock.incr).toHaveBeenCalledWith('votes:streak:123')
+        expect(pipelineMock.expire).toHaveBeenCalledWith(
+            'votes:streak:123',
+            60 * 60 * 36,
+        )
+        expect(pipelineExec).toHaveBeenCalledTimes(1)
+    })
+})

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -12,10 +12,14 @@ const pipelineMock = {
     ttl: jest.fn().mockReturnThis(),
     exec: pipelineExec,
 }
+const redisSet = jest.fn<() => Promise<string | null>>().mockResolvedValue('OK')
+const redisOn = jest.fn()
 
 jest.mock('ioredis', () => {
     return jest.fn().mockImplementation(() => ({
         pipeline: () => pipelineMock,
+        set: redisSet,
+        on: redisOn,
     }))
 })
 
@@ -69,6 +73,8 @@ beforeEach(() => {
     pipelineMock.expire.mockClear()
     pipelineMock.get.mockClear()
     pipelineMock.ttl.mockClear()
+    redisSet.mockClear().mockResolvedValue('OK')
+    redisOn.mockClear()
 })
 
 afterEach(() => {
@@ -119,6 +125,15 @@ describe('POST /webhooks/topgg-votes', () => {
             .set('authorization', 'valid-token')
             .send({ type: 'upvote' })
         expect(res.status).toBe(400)
+    })
+
+    it('rejects unsupported vote type (not upvote/test)', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({ user: '1', type: 'downvote' })
+        expect(res.status).toBe(400)
+        expect(redisSet).not.toHaveBeenCalled()
     })
 
     it('responds to GET /api/internal/votes/:userId with current state', async () => {
@@ -212,18 +227,19 @@ describe('POST /webhooks/topgg-votes', () => {
         })
     })
 
-    it('records a valid upvote in redis via pipeline', async () => {
+    it('records a valid upvote via SET NX + streak pipeline', async () => {
         const res = await request(buildApp())
             .post('/webhooks/topgg-votes')
             .set('authorization', 'valid-token')
             .send({ user: '123', type: 'upvote', bot: '962198089161134131' })
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ ok: true })
-        expect(pipelineMock.set).toHaveBeenCalledWith(
+        expect(redisSet).toHaveBeenCalledWith(
             'votes:123',
             expect.any(String),
             'EX',
             60 * 60 * 12,
+            'NX',
         )
         expect(pipelineMock.incr).toHaveBeenCalledWith('votes:streak:123')
         expect(pipelineMock.expire).toHaveBeenCalledWith(
@@ -232,4 +248,18 @@ describe('POST /webhooks/topgg-votes', () => {
         )
         expect(pipelineExec).toHaveBeenCalledTimes(1)
     })
+
+    it('is idempotent — duplicate vote within TTL skips streak increment', async () => {
+        redisSet.mockResolvedValueOnce(null) // SET NX returns null when key exists
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({ user: '123', type: 'upvote' })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true, duplicate: true })
+        expect(redisSet).toHaveBeenCalledTimes(1)
+        expect(pipelineMock.incr).not.toHaveBeenCalled()
+        expect(pipelineMock.expire).not.toHaveBeenCalled()
+    })
+
 })

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -19,6 +19,23 @@ jest.mock('ioredis', () => {
     }))
 })
 
+// Mock auth middleware to inject a configurable user. The actual middleware
+// reads from session; for unit tests we short-circuit with a header.
+jest.mock('../../../src/middleware/auth', () => ({
+    requireAuth: (
+        req: { header: (n: string) => string | undefined; user?: unknown },
+        res: { status: (n: number) => { json: (b: unknown) => void } },
+        next: () => void,
+    ) => {
+        const testUser = req.header('x-test-user')
+        if (!testUser) {
+            return res.status(401).json({ error: 'not authenticated' })
+        }
+        req.user = { id: testUser }
+        next()
+    },
+}))
+
 import { setupWebhookRoutes } from '../../../src/routes/webhooks'
 
 function buildApp(): express.Express {
@@ -133,6 +150,66 @@ describe('POST /webhooks/topgg-votes', () => {
             .get('/api/internal/votes/abc')
             .set('x-notify-key', 'internal-key')
         expect(res.status).toBe(400)
+    })
+
+    describe('GET /api/me/vote-status', () => {
+        it('returns 401 when not authenticated', async () => {
+            const res = await request(buildApp()).get('/api/me/vote-status')
+            expect(res.status).toBe(401)
+        })
+
+        it('returns state + tier + nextTier + voteUrl for a streak-14 voter', async () => {
+            pipelineExec.mockResolvedValueOnce([
+                [null, '1700000000000'],
+                [null, '14'],
+                [null, 7200],
+            ])
+            const res = await request(buildApp())
+                .get('/api/me/vote-status')
+                .set('x-test-user', '555')
+            expect(res.status).toBe(200)
+            expect(res.body).toEqual({
+                hasVoted: true,
+                streak: 14,
+                nextVoteInSeconds: 7200,
+                tier: { label: 'Lucky Regular', threshold: 14 },
+                nextTier: { label: 'Lucky Legend', threshold: 30 },
+                voteUrl: 'https://top.gg/bot/962198089161134131/vote',
+            })
+        })
+
+        it('returns tier=null for a 0-streak user', async () => {
+            pipelineExec.mockResolvedValueOnce([
+                [null, null],
+                [null, null],
+                [null, -2],
+            ])
+            const res = await request(buildApp())
+                .get('/api/me/vote-status')
+                .set('x-test-user', '777')
+            expect(res.status).toBe(200)
+            expect(res.body.tier).toBeNull()
+            expect(res.body.nextTier).toEqual({
+                label: 'Lucky Supporter',
+                threshold: 1,
+            })
+            expect(res.body.streak).toBe(0)
+            expect(res.body.hasVoted).toBe(false)
+        })
+
+        it('returns nextTier=null when user is at max tier (30+)', async () => {
+            pipelineExec.mockResolvedValueOnce([
+                [null, '1700000000000'],
+                [null, '45'],
+                [null, 100],
+            ])
+            const res = await request(buildApp())
+                .get('/api/me/vote-status')
+                .set('x-test-user', '999')
+            expect(res.status).toBe(200)
+            expect(res.body.tier.label).toBe('Lucky Legend')
+            expect(res.body.nextTier).toBeNull()
+        })
     })
 
     it('records a valid upvote in redis via pipeline', async () => {

--- a/packages/bot/src/functions/general/commands/voterewards.spec.ts
+++ b/packages/bot/src/functions/general/commands/voterewards.spec.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+const interactionReplyMock = jest.fn<() => Promise<void>>()
+const infoLogMock = jest.fn()
+const errorLogMock = jest.fn()
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: (...args: unknown[]) => infoLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+}))
+
+import voterewardsCommand from './voterewards'
+
+const fetchMock = jest.fn<typeof fetch>()
+
+function makeInteraction() {
+    return {
+        user: {
+            id: '1234567890',
+            tag: 'lucky-user#0001',
+        },
+    } as unknown as Parameters<
+        typeof voterewardsCommand.execute
+    >[0]['interaction']
+}
+
+function latestReply() {
+    const call = interactionReplyMock.mock.calls.at(-1)
+    if (!call) throw new Error('interactionReply was not called')
+    return call[0] as {
+        content: {
+            embeds: Array<{
+                title?: string
+                description?: string
+                url?: string
+                fields?: Array<{
+                    name: string
+                    value: string
+                    inline?: boolean
+                }>
+                footer?: { text: string }
+            }>
+        }
+    }
+}
+
+describe('voterewards command', () => {
+    const originalFetch = global.fetch
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        process.env.WEBAPP_BACKEND_URL = 'https://api.lucky.test/base'
+        process.env.LUCKY_NOTIFY_API_KEY = 'notify-key'
+        global.fetch = fetchMock
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                hasVoted: false,
+                streak: 0,
+                nextVoteInSeconds: 0,
+            }),
+        } as Response)
+    })
+
+    afterEach(() => {
+        global.fetch = originalFetch
+        delete process.env.WEBAPP_BACKEND_URL
+        delete process.env.LUCKY_NOTIFY_API_KEY
+    })
+
+    it('has the expected command metadata', () => {
+        expect(voterewardsCommand.data.name).toBe('voterewards')
+        expect(voterewardsCommand.category).toBe('general')
+    })
+
+    it('shows the offline vote CTA when backend configuration is missing', async () => {
+        delete process.env.WEBAPP_BACKEND_URL
+
+        await voterewardsCommand.execute({
+            interaction: makeInteraction(),
+        } as never)
+
+        expect(fetchMock).not.toHaveBeenCalled()
+        const embed = latestReply().content.embeds[0]
+        expect(embed.title).toBe('💛 Vote for Lucky on top.gg')
+        expect(embed.description).toContain(
+            'https://top.gg/bot/962198089161134131/vote',
+        )
+        expect(embed.footer?.text).toContain('Vote tracking is offline')
+    })
+
+    it('fetches vote state with the internal key and a request timeout', async () => {
+        await voterewardsCommand.execute({
+            interaction: makeInteraction(),
+        } as never)
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://api.lucky.test/api/internal/votes/1234567890',
+            {
+                headers: { 'x-notify-key': 'notify-key' },
+                signal: expect.any(AbortSignal),
+            },
+        )
+    })
+
+    it('renders the current tier and next tier for a 14-vote streak', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                hasVoted: true,
+                streak: 14,
+                nextVoteInSeconds: 7200,
+            }),
+        } as Response)
+
+        await voterewardsCommand.execute({
+            interaction: makeInteraction(),
+        } as never)
+
+        const embed = latestReply().content.embeds[0]
+        expect(embed.title).toBe('💛 Lucky Vote Rewards')
+        expect(embed.description).toContain('Lucky Regular')
+        expect(embed.description).toContain('next vote in 2h 0m')
+        expect(embed.fields).toContainEqual(
+            expect.objectContaining({
+                name: 'Next tier',
+                value: 'Lucky Legend at 30',
+            }),
+        )
+    })
+
+    it('falls back to the vote CTA when the backend request fails', async () => {
+        fetchMock.mockRejectedValueOnce(new Error('network down'))
+
+        await voterewardsCommand.execute({
+            interaction: makeInteraction(),
+        } as never)
+
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'voterewards: failed to fetch vote state',
+            }),
+        )
+        expect(latestReply().content.embeds[0].title).toBe(
+            '💛 Vote for Lucky on top.gg',
+        )
+    })
+})

--- a/packages/bot/src/functions/general/commands/voterewards.spec.ts
+++ b/packages/bot/src/functions/general/commands/voterewards.spec.ts
@@ -133,6 +133,25 @@ describe('voterewards command', () => {
         )
     })
 
+    it('rounds sub-minute vote countdowns up to one minute', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                hasVoted: true,
+                streak: 1,
+                nextVoteInSeconds: 59,
+            }),
+        } as Response)
+
+        await voterewardsCommand.execute({
+            interaction: makeInteraction(),
+        } as never)
+
+        expect(latestReply().content.embeds[0].description).toContain(
+            'next vote in 1m',
+        )
+    })
+
     it('falls back to the vote CTA when the backend request fails', async () => {
         fetchMock.mockRejectedValueOnce(new Error('network down'))
 

--- a/packages/bot/src/functions/general/commands/voterewards.ts
+++ b/packages/bot/src/functions/general/commands/voterewards.ts
@@ -1,0 +1,163 @@
+import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders'
+import { COLOR } from '@lucky/shared/constants'
+import { infoLog, errorLog } from '@lucky/shared/utils'
+import Command from '../../../models/Command'
+import { interactionReply } from '../../../utils/general/interactionReply'
+
+const TOP_GG_BOT_ID = '962198089161134131'
+const TOP_GG_VOTE_URL = `https://top.gg/bot/${TOP_GG_BOT_ID}/vote`
+
+type VoteState = {
+    hasVoted: boolean
+    streak: number
+    nextVoteInSeconds: number
+}
+
+type VoteTier = {
+    threshold: number
+    label: string
+    perk: string
+}
+
+const TIERS: VoteTier[] = [
+    {
+        threshold: 30,
+        label: 'Lucky Legend',
+        perk: 'Dashboard badge + custom autoplay weighting + priority support',
+    },
+    {
+        threshold: 14,
+        label: 'Lucky Regular',
+        perk: 'Custom autoplay weighting + early access to new commands',
+    },
+    {
+        threshold: 7,
+        label: 'Lucky Fan',
+        perk: 'Early access to new commands',
+    },
+    { threshold: 1, label: 'Lucky Supporter', perk: 'Our thanks 💛' },
+]
+
+function tierFor(streak: number): VoteTier | null {
+    for (const t of TIERS) {
+        if (streak >= t.threshold) return t
+    }
+    return null
+}
+
+function getBackendOrigin(): string | null {
+    const raw = process.env.WEBAPP_BACKEND_URL?.trim()
+    if (!raw) return null
+    try {
+        const parsed = new URL(raw)
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return null
+        }
+        return parsed.origin
+    } catch {
+        return null
+    }
+}
+
+async function fetchVoteState(userId: string): Promise<VoteState | null> {
+    const origin = getBackendOrigin()
+    const key = process.env.LUCKY_NOTIFY_API_KEY
+    if (!origin || !key) return null
+    try {
+        const resp = await fetch(
+            `${origin}/api/internal/votes/${encodeURIComponent(userId)}`,
+            { headers: { 'x-notify-key': key } },
+        )
+        if (!resp.ok) return null
+        return (await resp.json()) as VoteState
+    } catch (error) {
+        errorLog({
+            message: 'voterewards: failed to fetch vote state',
+            data: { userId, error: String(error) },
+        })
+        return null
+    }
+}
+
+function formatNextVoteIn(seconds: number): string {
+    if (seconds <= 0) return 'now'
+    const hours = Math.floor(seconds / 3600)
+    const minutes = Math.floor((seconds % 3600) / 60)
+    if (hours > 0) return `in ${hours}h ${minutes}m`
+    return `in ${minutes}m`
+}
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('voterewards')
+        .setDescription(
+            '💛 Check your Lucky vote streak and upcoming perks on top.gg.',
+        ),
+    category: 'general',
+    execute: async ({ interaction }) => {
+        infoLog({
+            message: `voterewards requested by ${interaction.user.tag}`,
+        })
+
+        const state = await fetchVoteState(interaction.user.id)
+
+        if (!state) {
+            const embed = new EmbedBuilder()
+                .setTitle('💛 Vote for Lucky on top.gg')
+                .setColor(COLOR.LUCKY_PURPLE)
+                .setDescription(
+                    [
+                        'Your vote streak unlocks perks — custom autoplay weighting, a dashboard badge, and more.',
+                        '',
+                        `[Vote on top.gg](${TOP_GG_VOTE_URL})`,
+                    ].join('\n'),
+                )
+                .setFooter({
+                    text: 'Vote tracking is offline right now — try again later.',
+                })
+            await interactionReply({
+                interaction,
+                content: { embeds: [embed.toJSON()] },
+            })
+            return
+        }
+
+        const tier = tierFor(state.streak)
+        const voteLine = state.hasVoted
+            ? `🗳️ You voted recently — next vote ${formatNextVoteIn(state.nextVoteInSeconds)}`
+            : `🗳️ You can [vote now](${TOP_GG_VOTE_URL}) to start or extend your streak`
+        const tierLine = tier
+            ? `🏅 **${tier.label}** (${state.streak}-vote streak) — ${tier.perk}`
+            : `Vote to unlock your first perk at streak **1**.`
+
+        const embed = new EmbedBuilder()
+            .setTitle('💛 Lucky Vote Rewards')
+            .setColor(COLOR.LUCKY_PURPLE)
+            .setDescription([voteLine, '', tierLine].join('\n'))
+            .addFields(
+                {
+                    name: 'Current streak',
+                    value: `${state.streak}`,
+                    inline: true,
+                },
+                {
+                    name: 'Next tier',
+                    value: (() => {
+                        const nextTier = [...TIERS]
+                            .reverse()
+                            .find((t) => t.threshold > state.streak)
+                        return nextTier
+                            ? `${nextTier.label} at ${nextTier.threshold}`
+                            : 'Max tier reached'
+                    })(),
+                    inline: true,
+                },
+            )
+            .setURL(TOP_GG_VOTE_URL)
+
+        await interactionReply({
+            interaction,
+            content: { embeds: [embed.toJSON()] },
+        })
+    },
+})

--- a/packages/bot/src/functions/general/commands/voterewards.ts
+++ b/packages/bot/src/functions/general/commands/voterewards.ts
@@ -73,8 +73,12 @@ async function fetchVoteState(userId: string): Promise<VoteState | null> {
 
 function formatNextVoteIn(seconds: number): string {
     if (seconds <= 0) return 'now'
-    const hours = Math.floor(seconds / 3600)
-    const minutes = Math.floor((seconds % 3600) / 60)
+    let hours = Math.floor(seconds / 3600)
+    let minutes = Math.ceil((seconds - hours * 3600) / 60)
+    if (minutes === 60) {
+        hours += 1
+        minutes = 0
+    }
     if (hours > 0) return `in ${hours}h ${minutes}m`
     return `in ${minutes}m`
 }

--- a/packages/bot/src/functions/general/commands/voterewards.ts
+++ b/packages/bot/src/functions/general/commands/voterewards.ts
@@ -1,11 +1,14 @@
 import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders'
-import { COLOR } from '@lucky/shared/constants'
+import {
+    COLOR,
+    TOP_GG_VOTE_TIERS,
+    TOP_GG_VOTE_URL,
+    tierForVoteStreak,
+    type TopggVoteTier,
+} from '@lucky/shared/constants'
 import { infoLog, errorLog } from '@lucky/shared/utils'
 import Command from '../../../models/Command'
 import { interactionReply } from '../../../utils/general/interactionReply'
-
-const TOP_GG_BOT_ID = '962198089161134131'
-const TOP_GG_VOTE_URL = `https://top.gg/bot/${TOP_GG_BOT_ID}/vote`
 
 type VoteState = {
     hasVoted: boolean
@@ -14,36 +17,22 @@ type VoteState = {
 }
 
 type VoteTier = {
-    threshold: number
-    label: string
+    threshold: TopggVoteTier['threshold']
+    label: TopggVoteTier['label']
     perk: string
 }
 
-const TIERS: VoteTier[] = [
-    {
-        threshold: 30,
-        label: 'Lucky Legend',
-        perk: 'Dashboard badge + custom autoplay weighting + priority support',
-    },
-    {
-        threshold: 14,
-        label: 'Lucky Regular',
-        perk: 'Custom autoplay weighting + early access to new commands',
-    },
-    {
-        threshold: 7,
-        label: 'Lucky Fan',
-        perk: 'Early access to new commands',
-    },
-    { threshold: 1, label: 'Lucky Supporter', perk: 'Our thanks 💛' },
-]
-
-function tierFor(streak: number): VoteTier | null {
-    for (const t of TIERS) {
-        if (streak >= t.threshold) return t
-    }
-    return null
+const PERKS_BY_THRESHOLD: Record<TopggVoteTier['threshold'], string> = {
+    30: 'Dashboard badge + custom autoplay weighting + priority support',
+    14: 'Custom autoplay weighting + early access to new commands',
+    7: 'Early access to new commands',
+    1: 'Our thanks 💛',
 }
+
+const TIERS: VoteTier[] = TOP_GG_VOTE_TIERS.map((tier) => ({
+    ...tier,
+    perk: PERKS_BY_THRESHOLD[tier.threshold],
+}))
 
 function getBackendOrigin(): string | null {
     const raw = process.env.WEBAPP_BACKEND_URL?.trim()
@@ -66,7 +55,10 @@ async function fetchVoteState(userId: string): Promise<VoteState | null> {
     try {
         const resp = await fetch(
             `${origin}/api/internal/votes/${encodeURIComponent(userId)}`,
-            { headers: { 'x-notify-key': key } },
+            {
+                headers: { 'x-notify-key': key },
+                signal: AbortSignal.timeout(2500),
+            },
         )
         if (!resp.ok) return null
         return (await resp.json()) as VoteState
@@ -122,7 +114,10 @@ export default new Command({
             return
         }
 
-        const tier = tierFor(state.streak)
+        const tierBase = tierForVoteStreak(state.streak)
+        const tier = tierBase
+            ? { ...tierBase, perk: PERKS_BY_THRESHOLD[tierBase.threshold] }
+            : null
         const voteLine = state.hasVoted
             ? `🗳️ You voted recently — next vote ${formatNextVoteIn(state.nextVoteInSeconds)}`
             : `🗳️ You can [vote now](${TOP_GG_VOTE_URL}) to start or extend your streak`

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,2 +1,9 @@
 export { COLOR, type ColorKey } from './colors'
 export { API_ROUTES } from './apiRoutes'
+export {
+    TOP_GG_BOT_ID,
+    TOP_GG_VOTE_TIERS,
+    TOP_GG_VOTE_URL,
+    tierForVoteStreak,
+    type TopggVoteTier,
+} from './topgg'

--- a/packages/shared/src/constants/topgg.ts
+++ b/packages/shared/src/constants/topgg.ts
@@ -1,0 +1,18 @@
+export const TOP_GG_BOT_ID = '962198089161134131'
+export const TOP_GG_VOTE_URL = `https://top.gg/bot/${TOP_GG_BOT_ID}/vote`
+
+export const TOP_GG_VOTE_TIERS = [
+    { threshold: 30, label: 'Lucky Legend' },
+    { threshold: 14, label: 'Lucky Regular' },
+    { threshold: 7, label: 'Lucky Fan' },
+    { threshold: 1, label: 'Lucky Supporter' },
+] as const
+
+export type TopggVoteTier = (typeof TOP_GG_VOTE_TIERS)[number]
+
+export function tierForVoteStreak(streak: number): TopggVoteTier | null {
+    for (const tier of TOP_GG_VOTE_TIERS) {
+        if (streak >= tier.threshold) return tier
+    }
+    return null
+}


### PR DESCRIPTION
## Summary
Adds \`POST /webhooks/topgg-votes\` to persist vote events for the upcoming top.gg listing (Phase 0 of the next-phases ultraplan).

Locked behind \`TOPGG_AUTH_TOKEN\` — returns 503 when unset, so the endpoint is inert until the listing actually goes live.

### Behaviour
- Verifies the \`authorization\` header against \`TOPGG_AUTH_TOKEN\` (top.gg's webhook auth scheme).
- For \`type: "test"\` payloads → returns \`{ ok: true, test: true }\` (lets top.gg's "Send test webhook" button pass).
- For \`type: "upvote"\`:
  - \`votes:<userId>\` — 12h TTL (matches top.gg's 12h vote window)
  - \`votes:streak:<userId>\` — incremented, 36h TTL (12h grace around the 24h cycle so a daily voter doesn't lose their streak to timezone drift)
  - Uses a single Redis pipeline so either all three ops succeed or we return 500.

### Wiring
- Registered in \`routes/index.ts\` alongside the other non-API endpoints (health, stats, internal notify).
- **No \`/api/\` prefix** — matches top.gg's expected webhook URL shape and bypasses the per-origin \`apiLimiter\`. Still rate-limited via \`writeLimiter\`.

### Env
- \`TOPGG_AUTH_TOKEN\` added to \`.env.example\` (commented out).

## Test plan
- [x] \`npm run type:check --workspace=packages/backend\` → clean
- [x] 6 unit tests cover: missing token (503), missing/wrong auth (401), test-type payload, missing user id (400), successful upvote (verifies all 3 pipeline ops + correct TTLs).
- [ ] After merge + deploy: run top.gg's "Send test webhook" button; expect 200 with \`{ ok: true, test: true }\`
- [ ] Real upvote writes two Redis keys with correct TTLs (manually verifiable via \`redis-cli\`)

## Follow-up
Next PR will add \`/voterewards\` slash command in \`packages/bot\` that reads \`votes:streak:<user>\` and grants tier benefits. See \`docs/TOP_GG_SUBMISSION.md\` §6 for the broader wiring plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added top.gg vote webhook and public/internal endpoints to record and report votes
  * Added `/voterewards` Discord command showing vote status, streak, current/next tier, and vote link
  * Exposed vote tiers and vote URL used by UI and commands

* **Tests**
  * Added unit tests covering webhook endpoints and the voterewards command

* **Chores**
  * Added optional TOPGG_AUTH_TOKEN entry and docs to environment example
<!-- end of auto-generated comment: release notes by coderabbit.ai -->