### PR TITLE
feat(bot): /leaderboard tracks|artists

### DIFF
--- a/packages/bot/src/functions/general/commands/leaderboard.spec.ts
+++ b/packages/bot/src/functions/general/commands/leaderboard.spec.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: jest.fn(),
+    debugLog: jest.fn(),
+    errorLog: jest.fn(),
+}))
+
+const getTopTracks = jest.fn() as jest.MockedFunction<
+    (guildId: string, limit: number) => Promise<unknown>
+>
+const getTopArtists = jest.fn() as jest.MockedFunction<
+    (guildId: string, limit: number) => Promise<unknown>
+>
+jest.mock('@lucky/shared/services', () => ({
+    trackHistoryService: {
+        getTopTracks,
+        getTopArtists,
+    },
+}))
+
+const interactionReply = jest.fn() as jest.MockedFunction<
+    (args: { interaction: unknown; content: unknown }) => Promise<void>
+>
+jest.mock('../../../utils/general/interactionReply.js', () => ({
+    interactionReply,
+}))
+
+import leaderboardCommand from './leaderboard.js'
+
+function makeInteraction(
+    subcommand: string,
+    limit?: number,
+    withGuild = true,
+) {
+    return {
+        guild: withGuild ? { id: 'guild-1', name: 'TestGuild' } : null,
+        user: { id: 'u1', tag: 'alice#0' },
+        options: {
+            getSubcommand: () => subcommand,
+            getInteger: () => limit ?? null,
+        },
+    }
+}
+
+beforeEach(() => {
+    getTopTracks.mockReset()
+    getTopArtists.mockReset()
+    interactionReply.mockClear().mockResolvedValue(undefined)
+})
+
+describe('/leaderboard', () => {
+    test('rejects when not in a guild', async () => {
+        await leaderboardCommand.execute({
+            interaction: makeInteraction('tracks', undefined, false) as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+        expect(args.content.content).toContain('server')
+    })
+
+    test('shows empty-state message when tracks list is empty', async () => {
+        getTopTracks.mockResolvedValue([])
+        await leaderboardCommand.execute({
+            interaction: makeInteraction('tracks') as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content?: string; embeds?: unknown[] }
+        }
+        expect(args.content.content).toContain('No track history')
+        expect(args.content.embeds).toBeUndefined()
+    })
+
+    test('shows top tracks embed with medals for top 3', async () => {
+        getTopTracks.mockResolvedValue([
+            { trackId: 't1', title: 'Song One', plays: 12 },
+            { trackId: 't2', title: 'Song Two', plays: 8 },
+            { trackId: 't3', title: 'Song Three', plays: 3 },
+        ])
+        await leaderboardCommand.execute({
+            interaction: makeInteraction('tracks') as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { embeds: Array<{ title: string; description: string }> }
+        }
+        const embed = args.content.embeds[0]
+        expect(embed.title).toContain('Top Tracks')
+        expect(embed.description).toContain('🥇')
+        expect(embed.description).toContain('🥈')
+        expect(embed.description).toContain('🥉')
+        expect(embed.description).toContain('Song One')
+        expect(embed.description).toContain('12 plays')
+        expect(embed.description).toContain('Song Two')
+    })
+
+    test('shows top artists embed', async () => {
+        getTopArtists.mockResolvedValue([
+            { artist: 'Artist One', plays: 20 },
+        ])
+        await leaderboardCommand.execute({
+            interaction: makeInteraction('artists') as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { embeds: Array<{ title: string; description: string }> }
+        }
+        expect(args.content.embeds[0].title).toContain('Top Artists')
+        expect(args.content.embeds[0].description).toContain('Artist One')
+        expect(args.content.embeds[0].description).toContain('20 plays')
+    })
+
+    test('clamps limit to MAX_LIMIT=10', async () => {
+        getTopTracks.mockResolvedValue([])
+        await leaderboardCommand.execute({
+            interaction: makeInteraction('tracks', 999) as never,
+        })
+        expect(getTopTracks).toHaveBeenCalledWith('guild-1', 10)
+    })
+
+    test('handles getTopTracks throwing gracefully', async () => {
+        getTopTracks.mockRejectedValueOnce(new Error('db down'))
+        await leaderboardCommand.execute({
+            interaction: makeInteraction('tracks') as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+        expect(args.content.content).toContain('Failed')
+    })
+
+    test('handles singular play count correctly', async () => {
+        getTopTracks.mockResolvedValue([
+            { trackId: 't1', title: 'Single', plays: 1 },
+        ])
+        await leaderboardCommand.execute({
+            interaction: makeInteraction('tracks') as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { embeds: Array<{ description: string }> }
+        }
+        expect(args.content.embeds[0].description).toContain('1 play')
+        expect(args.content.embeds[0].description).not.toContain('1 plays')
+    })
+})

--- a/packages/bot/src/functions/general/commands/leaderboard.ts
+++ b/packages/bot/src/functions/general/commands/leaderboard.ts
@@ -1,0 +1,156 @@
+import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders'
+import { COLOR } from '@lucky/shared/constants'
+import { infoLog, errorLog } from '@lucky/shared/utils'
+import { trackHistoryService } from '@lucky/shared/services'
+import Command from '../../../models/Command'
+import { interactionReply } from '../../../utils/general/interactionReply'
+
+const MAX_LIMIT = 10
+const DEFAULT_LIMIT = 10
+
+function ordinal(n: number): string {
+    if (n === 1) return '🥇'
+    if (n === 2) return '🥈'
+    if (n === 3) return '🥉'
+    return `\`${String(n).padStart(2, ' ')}\``
+}
+
+function truncate(s: string, max: number): string {
+    if (s.length <= max) return s
+    return s.slice(0, max - 1) + '…'
+}
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('leaderboard')
+        .setDescription(
+            '🏆 Show this server’s top tracks or top artists by plays.',
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName('tracks')
+                .setDescription('Top tracks by play count')
+                .addIntegerOption((opt) =>
+                    opt
+                        .setName('limit')
+                        .setDescription(`How many to show (1-${MAX_LIMIT})`)
+                        .setMinValue(1)
+                        .setMaxValue(MAX_LIMIT),
+                ),
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName('artists')
+                .setDescription('Top artists by play count')
+                .addIntegerOption((opt) =>
+                    opt
+                        .setName('limit')
+                        .setDescription(`How many to show (1-${MAX_LIMIT})`)
+                        .setMinValue(1)
+                        .setMaxValue(MAX_LIMIT),
+                ),
+        ),
+    category: 'general',
+    execute: async ({ interaction }) => {
+        const guild = interaction.guild
+        if (!guild) {
+            await interactionReply({
+                interaction,
+                content: {
+                    content: '❌ This command can only be used in a server.',
+                },
+            })
+            return
+        }
+
+        const subcommand = interaction.options.getSubcommand()
+        const limit = Math.max(
+            1,
+            Math.min(
+                MAX_LIMIT,
+                interaction.options.getInteger('limit') ?? DEFAULT_LIMIT,
+            ),
+        )
+
+        infoLog({
+            message: `leaderboard.${subcommand} (limit=${limit}) in guild ${guild.id}`,
+        })
+
+        try {
+            if (subcommand === 'tracks') {
+                const rows = await trackHistoryService.getTopTracks(
+                    guild.id,
+                    limit,
+                )
+                if (!rows.length) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            content:
+                                'No track history yet. Play some music and this leaderboard will populate.',
+                        },
+                    })
+                    return
+                }
+                const lines = rows.map(
+                    (row, i) =>
+                        `${ordinal(i + 1)} **${truncate(row.title, 64)}** — ${row.plays} play${row.plays === 1 ? '' : 's'}`,
+                )
+                const embed = new EmbedBuilder()
+                    .setTitle('🏆 Top Tracks')
+                    .setDescription(lines.join('\n'))
+                    .setColor(COLOR.LUCKY_PURPLE)
+                    .setFooter({ text: `Top ${rows.length} · ${guild.name}` })
+                await interactionReply({
+                    interaction,
+                    content: { embeds: [embed.toJSON()] },
+                })
+                return
+            }
+
+            if (subcommand === 'artists') {
+                const rows = await trackHistoryService.getTopArtists(
+                    guild.id,
+                    limit,
+                )
+                if (!rows.length) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            content:
+                                'No track history yet. Play some music and this leaderboard will populate.',
+                        },
+                    })
+                    return
+                }
+                const lines = rows.map(
+                    (row, i) =>
+                        `${ordinal(i + 1)} **${truncate(row.artist, 64)}** — ${row.plays} play${row.plays === 1 ? '' : 's'}`,
+                )
+                const embed = new EmbedBuilder()
+                    .setTitle('🎤 Top Artists')
+                    .setDescription(lines.join('\n'))
+                    .setColor(COLOR.LUCKY_PURPLE)
+                    .setFooter({ text: `Top ${rows.length} · ${guild.name}` })
+                await interactionReply({
+                    interaction,
+                    content: { embeds: [embed.toJSON()] },
+                })
+                return
+            }
+
+            await interactionReply({
+                interaction,
+                content: { content: `❌ Unknown subcommand: ${subcommand}` },
+            })
+        } catch (error) {
+            errorLog({ message: 'leaderboard failed', error: error as Error })
+            await interactionReply({
+                interaction,
+                content: {
+                    content: '❌ Failed to load the leaderboard. Try again.',
+                },
+            })
+        }
+    },
+})


### PR DESCRIPTION
## Summary
Phase 3 preview — server analytics taste at S effort. Surfaces the existing \`trackHistoryService.getTopTracks\` / \`getTopArtists\` aggregation (already used by the autoplay replenisher).

### Subcommands
- \`/leaderboard tracks [limit]\` — top N tracks by play count
- \`/leaderboard artists [limit]\` — top N artists by play count

Both default to 10, clamped at \`MAX_LIMIT=10\`.

### Presentation
- Medal emojis (🥇🥈🥉) for top 3, padded rank for 4-10
- Title truncation at 64 chars (avoids embed-description overflow)
- Singular/plural play count
- Empty-state message when history is empty

No new services, no schema changes, no env vars. Auto-discovered via \`getCommandsFromDirectory\`.

## Test plan
- [x] \`npx tsc --noEmit\` in \`packages/bot\` → clean
- [x] 7 unit tests pass: DM rejection, empty state, top 3 medals, artists branch, limit clamping, error handling, singular-count formatting
- [ ] Deploy + run each subcommand in a test guild → verify embed formats

## Why this path (not Phase 2)
Original Phase 2 plan was "premium tier surfacing" on the assumption that backend guards already existed. Audit found **no** \`requirePremium\` / Stripe / subscription code — Phase 2 is actually L-effort greenfield (Stripe + schema + guards + UI). Pivoted to this Phase 3 preview because the aggregation was already shipped in \`trackHistoryService\`, making it an actual S-effort win instead of a hypothetical one.