### PR TITLE
feat(backend): GET /api/me/vote-status for the dashboard

### DIFF
--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -3,7 +3,23 @@ import Redis from 'ioredis'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { AppError } from '../errors/AppError'
+import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
 import { debugLog, errorLog } from '@lucky/shared/utils'
+
+// Vote tier thresholds — kept in sync with the bot's /voterewards command.
+const VOTE_TIERS = [
+    { threshold: 30, label: 'Lucky Legend' },
+    { threshold: 14, label: 'Lucky Regular' },
+    { threshold: 7, label: 'Lucky Fan' },
+    { threshold: 1, label: 'Lucky Supporter' },
+] as const
+
+function tierFor(streak: number): { label: string; threshold: number } | null {
+    for (const t of VOTE_TIERS) {
+        if (streak >= t.threshold) return t
+    }
+    return null
+}
 
 // Vote window: top.gg allows one upvote every 12 hours.
 const VOTE_TTL_SECONDS = 60 * 60 * 12
@@ -91,6 +107,30 @@ export function setupWebhookRoutes(app: Express): void {
             }
             const state = await readVoteState(getRedis(), userId)
             res.status(200).json(state)
+        }),
+    )
+
+    app.get(
+        '/api/me/vote-status',
+        requireAuth,
+        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+            const userId = req.user?.id
+            if (!userId) {
+                throw AppError.unauthorized('not authenticated')
+            }
+            const state = await readVoteState(getRedis(), userId)
+            const tier = tierFor(state.streak)
+            const nextTier = [...VOTE_TIERS]
+                .reverse()
+                .find((t) => t.threshold > state.streak)
+            res.status(200).json({
+                ...state,
+                tier: tier ? { label: tier.label, threshold: tier.threshold } : null,
+                nextTier: nextTier
+                    ? { label: nextTier.label, threshold: nextTier.threshold }
+                    : null,
+                voteUrl: 'https://top.gg/bot/962198089161134131/vote',
+            })
         }),
     )
 

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -19,6 +19,23 @@ jest.mock('ioredis', () => {
     }))
 })
 
+// Mock auth middleware to inject a configurable user. The actual middleware
+// reads from session; for unit tests we short-circuit with a header.
+jest.mock('../../../src/middleware/auth', () => ({
+    requireAuth: (
+        req: { header: (n: string) => string | undefined; user?: unknown },
+        res: { status: (n: number) => { json: (b: unknown) => void } },
+        next: () => void,
+    ) => {
+        const testUser = req.header('x-test-user')
+        if (!testUser) {
+            return res.status(401).json({ error: 'not authenticated' })
+        }
+        req.user = { id: testUser }
+        next()
+    },
+}))
+
 import { setupWebhookRoutes } from '../../../src/routes/webhooks'
 
 function buildApp(): express.Express {
@@ -133,6 +150,66 @@ describe('POST /webhooks/topgg-votes', () => {
             .get('/api/internal/votes/abc')
             .set('x-notify-key', 'internal-key')
         expect(res.status).toBe(400)
+    })
+
+    describe('GET /api/me/vote-status', () => {
+        it('returns 401 when not authenticated', async () => {
+            const res = await request(buildApp()).get('/api/me/vote-status')
+            expect(res.status).toBe(401)
+        })
+
+        it('returns state + tier + nextTier + voteUrl for a streak-14 voter', async () => {
+            pipelineExec.mockResolvedValueOnce([
+                [null, '1700000000000'],
+                [null, '14'],
+                [null, 7200],
+            ])
+            const res = await request(buildApp())
+                .get('/api/me/vote-status')
+                .set('x-test-user', '555')
+            expect(res.status).toBe(200)
+            expect(res.body).toEqual({
+                hasVoted: true,
+                streak: 14,
+                nextVoteInSeconds: 7200,
+                tier: { label: 'Lucky Regular', threshold: 14 },
+                nextTier: { label: 'Lucky Legend', threshold: 30 },
+                voteUrl: 'https://top.gg/bot/962198089161134131/vote',
+            })
+        })
+
+        it('returns tier=null for a 0-streak user', async () => {
+            pipelineExec.mockResolvedValueOnce([
+                [null, null],
+                [null, null],
+                [null, -2],
+            ])
+            const res = await request(buildApp())
+                .get('/api/me/vote-status')
+                .set('x-test-user', '777')
+            expect(res.status).toBe(200)
+            expect(res.body.tier).toBeNull()
+            expect(res.body.nextTier).toEqual({
+                label: 'Lucky Supporter',
+                threshold: 1,
+            })
+            expect(res.body.streak).toBe(0)
+            expect(res.body.hasVoted).toBe(false)
+        })
+
+        it('returns nextTier=null when user is at max tier (30+)', async () => {
+            pipelineExec.mockResolvedValueOnce([
+                [null, '1700000000000'],
+                [null, '45'],
+                [null, 100],
+            ])
+            const res = await request(buildApp())
+                .get('/api/me/vote-status')
+                .set('x-test-user', '999')
+            expect(res.status).toBe(200)
+            expect(res.body.tier.label).toBe('Lucky Legend')
+            expect(res.body.nextTier).toBeNull()
+        })
     })
 
     it('records a valid upvote in redis via pipeline', async () => {


### PR DESCRIPTION
## Summary
Extends the top.gg flywheel to the authenticated dashboard. Currently voters can only see their streak via the \`/voterewards\` Discord slash command. With this endpoint the React dashboard can show the same tier/streak info — closing the Phase 0 flywheel gap.

### Endpoint
\`\`\`
GET /api/me/vote-status  (requireAuth)
→ {
    hasVoted, streak, nextVoteInSeconds,
    tier: { label, threshold } | null,
    nextTier: { label, threshold } | null,
    voteUrl: "https://top.gg/bot/962198089161134131/vote"
  }
\`\`\`

### Tier thresholds (match \`/voterewards\` exactly)
| Streak | Tier |
|---|---|
| 1+ | Lucky Supporter |
| 7+ | Lucky Fan |
| 14+ | Lucky Regular |
| 30+ | Lucky Legend |

Reuses \`readVoteState()\` so the POST webhook / internal GET / me GET all read the same Redis keys. Zero drift between surfaces.

### Stacking
Base branch: \`feature/topgg-vote-webhook\` (builds on #729 + #730). Will auto-retarget to main once those land.

## Test plan
- [x] \`npm run type:check --workspace=packages/backend\` → clean
- [x] 13 unit tests pass (10 existing + 3 new for the me-vote-status endpoint)
- [ ] After deploy, call \`curl -H "cookie: \$SESSION" https://api.../api/me/vote-status\` — expect JSON with correct tier