### PR TITLE
feat(bot): birthdays schema + /birthday set|clear

### DIFF
--- a/packages/bot/src/functions/general/commands/birthday.spec.ts
+++ b/packages/bot/src/functions/general/commands/birthday.spec.ts
@@ -1,0 +1,174 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('@lucky/shared/utils', () => {
+    const upsert = jest.fn()
+    const deleteMany = jest.fn()
+    return {
+        infoLog: jest.fn(),
+        debugLog: jest.fn(),
+        errorLog: jest.fn(),
+        getPrismaClient: () => ({ memberBirthday: { upsert, deleteMany } }),
+        __mocks: { upsert, deleteMany },
+    }
+})
+
+jest.mock('../../../utils/general/interactionReply.js', () => {
+    const interactionReply = jest.fn()
+    return { interactionReply, __mocks: { interactionReply } }
+})
+
+const { __mocks: utilsMocks } = jest.requireMock('@lucky/shared/utils') as {
+    __mocks: {
+        upsert: jest.MockedFunction<(args: unknown) => Promise<unknown>>
+        deleteMany: jest.MockedFunction<
+            (args: unknown) => Promise<{ count: number }>
+        >
+    }
+}
+const { __mocks: replyMocks } = jest.requireMock(
+    '../../../utils/general/interactionReply.js',
+) as {
+    __mocks: {
+        interactionReply: jest.MockedFunction<
+            (args: { interaction: unknown; content: unknown }) => Promise<void>
+        >
+    }
+}
+const memberBirthdayUpsert = utilsMocks.upsert
+const memberBirthdayDeleteMany = utilsMocks.deleteMany
+const interactionReply = replyMocks.interactionReply
+
+import birthdayCommand from './birthday.js'
+
+function makeInteraction(
+    subcommand: string,
+    values: { month?: number; day?: number } = {},
+    withGuild = true,
+) {
+    return {
+        guild: withGuild ? { id: 'guild-1' } : null,
+        user: { id: 'u1', tag: 'alice#0' },
+        options: {
+            getSubcommand: () => subcommand,
+            getInteger: (name: string) => {
+                if (name === 'month') return values.month ?? null
+                if (name === 'day') return values.day ?? null
+                return null
+            },
+        },
+    }
+}
+
+beforeEach(() => {
+    memberBirthdayUpsert.mockReset().mockResolvedValue({})
+    memberBirthdayDeleteMany.mockReset().mockResolvedValue({ count: 1 })
+    interactionReply.mockClear().mockResolvedValue(undefined)
+})
+
+describe('/birthday', () => {
+    test('rejects when used in DMs', async () => {
+        await birthdayCommand.execute({
+            interaction: makeInteraction('set', { month: 3, day: 15 }, false) as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+        expect(args.content.content).toContain('server')
+        expect(memberBirthdayUpsert).not.toHaveBeenCalled()
+    })
+
+    test('rejects invalid month', async () => {
+        await birthdayCommand.execute({
+            interaction: makeInteraction('set', { month: 13, day: 1 }) as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+        expect(args.content.content).toContain('Month')
+        expect(memberBirthdayUpsert).not.toHaveBeenCalled()
+    })
+
+    test('rejects Feb 30', async () => {
+        await birthdayCommand.execute({
+            interaction: makeInteraction('set', { month: 2, day: 30 }) as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+        expect(args.content.content).toContain('February')
+        expect(memberBirthdayUpsert).not.toHaveBeenCalled()
+    })
+
+    test('accepts Feb 29 (leap-day tolerant)', async () => {
+        await birthdayCommand.execute({
+            interaction: makeInteraction('set', { month: 2, day: 29 }) as never,
+        })
+        expect(memberBirthdayUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                create: expect.objectContaining({ month: 2, day: 29 }),
+            }),
+        )
+    })
+
+    test('persists a valid birthday via upsert', async () => {
+        await birthdayCommand.execute({
+            interaction: makeInteraction('set', { month: 3, day: 15 }) as never,
+        })
+        expect(memberBirthdayUpsert).toHaveBeenCalledTimes(1)
+        const call = memberBirthdayUpsert.mock.calls[0][0] as {
+            where: { guildId_userId: { guildId: string; userId: string } }
+            create: { month: number; day: number }
+            update: { month: number; day: number }
+        }
+        expect(call.where.guildId_userId).toEqual({
+            guildId: 'guild-1',
+            userId: 'u1',
+        })
+        expect(call.create).toEqual({
+            guildId: 'guild-1',
+            userId: 'u1',
+            month: 3,
+            day: 15,
+        })
+        expect(call.update).toEqual({ month: 3, day: 15 })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { embeds: Array<{ description: string }> }
+        }
+        expect(args.content.embeds[0].description).toContain('March 15')
+    })
+
+    test('clear removes the birthday', async () => {
+        await birthdayCommand.execute({
+            interaction: makeInteraction('clear') as never,
+        })
+        expect(memberBirthdayDeleteMany).toHaveBeenCalledWith({
+            where: { guildId: 'guild-1', userId: 'u1' },
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+        expect(args.content.content).toContain('removed')
+    })
+
+    test('clear is idempotent when no birthday set', async () => {
+        memberBirthdayDeleteMany.mockResolvedValueOnce({ count: 0 })
+        await birthdayCommand.execute({
+            interaction: makeInteraction('clear') as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+        expect(args.content.content).toContain('No birthday')
+    })
+
+    test('handles upsert throwing gracefully', async () => {
+        memberBirthdayUpsert.mockRejectedValueOnce(new Error('db down'))
+        await birthdayCommand.execute({
+            interaction: makeInteraction('set', { month: 3, day: 15 }) as never,
+        })
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+        expect(args.content.content).toContain('Failed')
+    })
+})

--- a/packages/bot/src/functions/general/commands/birthday.ts
+++ b/packages/bot/src/functions/general/commands/birthday.ts
@@ -1,0 +1,176 @@
+import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders'
+import { COLOR } from '@lucky/shared/constants'
+import { getPrismaClient, infoLog, errorLog } from '@lucky/shared/utils'
+import Command from '../../../models/Command'
+import { interactionReply } from '../../../utils/general/interactionReply'
+
+const MONTHS = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+]
+
+const DAYS_PER_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+function formatBirthday(month: number, day: number): string {
+    return `${MONTHS[month - 1]} ${day}`
+}
+
+function validateDate(
+    month: number,
+    day: number,
+): { ok: true } | { ok: false; reason: string } {
+    if (!Number.isInteger(month) || month < 1 || month > 12) {
+        return { ok: false, reason: 'Month must be between 1 and 12.' }
+    }
+    if (!Number.isInteger(day) || day < 1 || day > 31) {
+        return { ok: false, reason: 'Day must be between 1 and 31.' }
+    }
+    const maxDay = DAYS_PER_MONTH[month - 1]
+    if (day > maxDay) {
+        return {
+            ok: false,
+            reason: `${MONTHS[month - 1]} only has ${maxDay} days.`,
+        }
+    }
+    return { ok: true }
+}
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('birthday')
+        .setDescription('🎂 Manage your birthday for this server.')
+        .addSubcommand((sub) =>
+            sub
+                .setName('set')
+                .setDescription('Set your birthday (month + day, no year).')
+                .addIntegerOption((opt) =>
+                    opt
+                        .setName('month')
+                        .setDescription('Month (1-12)')
+                        .setMinValue(1)
+                        .setMaxValue(12)
+                        .setRequired(true),
+                )
+                .addIntegerOption((opt) =>
+                    opt
+                        .setName('day')
+                        .setDescription('Day of month (1-31)')
+                        .setMinValue(1)
+                        .setMaxValue(31)
+                        .setRequired(true),
+                ),
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName('clear')
+                .setDescription('Remove your birthday from this server.'),
+        ),
+    category: 'general',
+    execute: async ({ interaction }) => {
+        const guild = interaction.guild
+        if (!guild) {
+            await interactionReply({
+                interaction,
+                content: {
+                    content: '❌ This command can only be used in a server.',
+                },
+            })
+            return
+        }
+
+        const subcommand = interaction.options.getSubcommand()
+        const prisma = getPrismaClient()
+
+        try {
+            if (subcommand === 'set') {
+                const month = interaction.options.getInteger('month', true)
+                const day = interaction.options.getInteger('day', true)
+                const check = validateDate(month, day)
+                if (!check.ok) {
+                    await interactionReply({
+                        interaction,
+                        content: { content: `❌ ${check.reason}` },
+                    })
+                    return
+                }
+
+                await prisma.memberBirthday.upsert({
+                    where: {
+                        guildId_userId: {
+                            guildId: guild.id,
+                            userId: interaction.user.id,
+                        },
+                    },
+                    create: {
+                        guildId: guild.id,
+                        userId: interaction.user.id,
+                        month,
+                        day,
+                    },
+                    update: { month, day },
+                })
+
+                infoLog({
+                    message: `birthday set by ${interaction.user.tag}: ${month}/${day}`,
+                    data: { guildId: guild.id },
+                })
+
+                const embed = new EmbedBuilder()
+                    .setTitle('🎂 Birthday saved')
+                    .setDescription(
+                        `Got it — I'll celebrate with you on **${formatBirthday(month, day)}** every year.`,
+                    )
+                    .setColor(COLOR.LUCKY_PURPLE)
+                    .setFooter({
+                        text: 'Only the date is stored. No year, no age.',
+                    })
+
+                await interactionReply({
+                    interaction,
+                    content: { embeds: [embed.toJSON()] },
+                })
+                return
+            }
+
+            if (subcommand === 'clear') {
+                const deleted = await prisma.memberBirthday.deleteMany({
+                    where: {
+                        guildId: guild.id,
+                        userId: interaction.user.id,
+                    },
+                })
+                await interactionReply({
+                    interaction,
+                    content: {
+                        content:
+                            deleted.count > 0
+                                ? '🧹 Birthday removed.'
+                                : 'No birthday was set for you in this server.',
+                    },
+                })
+                return
+            }
+
+            await interactionReply({
+                interaction,
+                content: { content: `❌ Unknown subcommand: ${subcommand}` },
+            })
+        } catch (error) {
+            errorLog({ message: 'birthday command failed', error: error as Error })
+            await interactionReply({
+                interaction,
+                content: { content: '❌ Failed to update birthday. Try again.' },
+            })
+        }
+    },
+})

--- a/prisma/migrations/20260420000000_add_member_birthdays/migration.sql
+++ b/prisma/migrations/20260420000000_add_member_birthdays/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "member_birthdays" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "month" INTEGER NOT NULL,
+    "day" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "member_birthdays_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "member_birthdays_guildId_month_day_idx" ON "member_birthdays"("guildId", "month", "day");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "member_birthdays_guildId_userId_key" ON "member_birthdays"("guildId", "userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -695,3 +695,20 @@ model AutoRole {
   @@index([guildId])
   @@map("auto_roles")
 }
+
+// Birthdays — month + day only (no year) to avoid storing age / DOB.
+// Used by a daily scheduler (follow-up PR) to post celebrations on the
+// configured guild channel.
+model MemberBirthday {
+  id        String   @id @default(cuid())
+  guildId   String
+  userId    String
+  month     Int // 1-12
+  day       Int // 1-31
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([guildId, userId])
+  @@index([guildId, month, day])
+  @@map("member_birthdays")
+}


### PR DESCRIPTION
## Summary
Phase 1 final gap from the competitive scan (Nekotina/Loritta pattern). Two tight subcommands now; scheduler/announcements deferred to a follow-up PR to keep scope S.

### Schema — new \`MemberBirthday\` model
- \`month\` (1-12) + \`day\` (1-31) **only** — no year, no DOB, no age tracking.
- \`@@unique([guildId, userId])\` — one row per guild-member.
- \`@@index([guildId, month, day])\` — indexed for the daily-lookup scheduler the follow-up PR will add.

Migration: \`prisma/migrations/20260420000000_add_member_birthdays/migration.sql\`.

### Commands
- \`/birthday set month day\` — upserts the record. Validates month bounds + per-month day cap (Feb 30 rejected; Feb 29 accepted as leap-day tolerant).
- \`/birthday clear\` — idempotent delete, friendly message when not set.

## Test plan
- [x] Prisma schema validates (client regenerated, types propagate to bot)
- [x] \`npx tsc --noEmit\` in \`packages/bot\` → clean
- [x] 8 unit tests: DM rejection, month/day validation, Feb 30 rejected, Feb 29 accepted, upsert round-trip, clear (both paths), error handling
- [ ] Deploy + run \`prisma migrate deploy\` on staging → table exists
- [ ] \`/birthday set\` in a test guild → row appears; \`/birthday clear\` → row removed

## Follow-up (separate PR)
Daily scheduler that queries \`(guildId, month, day)\` once per UTC day and posts to a guild-configured channel. Schema is already indexed for that lookup.