### PR TITLE
feat(artists): prioritize preferred artists in Discover suggestions

### DIFF
--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -178,6 +178,31 @@ export function setupArtistsRoutes(app: Express): void {
 
                 const suggestions = new Map<string, SpotifyArtist>()
 
+                // PRIORITY 1: user's saved preferred artists (Musical Taste page).
+                // These come first in Discover so the user always sees what they
+                // explicitly favorited before any algorithmic suggestion.
+                try {
+                    const db = getPrismaClient()
+                    const preferred = await db.userArtistPreference.findMany({
+                        where: { discordUserId, preference: 'prefer' },
+                        orderBy: { createdAt: 'desc' },
+                    })
+                    for (const pref of preferred) {
+                        if (suggestions.size >= MAX_SUGGESTIONS) break
+                        const id = pref.spotifyId ?? `pref:${pref.artistKey}`
+                        if (suggestions.has(id)) continue
+                        suggestions.set(id, {
+                            id,
+                            name: pref.artistName,
+                            imageUrl: pref.imageUrl,
+                            popularity: 0,
+                            genres: [],
+                        })
+                    }
+                } catch (error) {
+                    errorLog({ message: 'Failed to load preferred artists for suggestions', error })
+                }
+
                 const link = await spotifyLinkService.getValidAccessToken(
                     discordUserId,
                 )


### PR DESCRIPTION
Reads user's saved preferred artists (Musical Taste) and prepends to /api/artists/suggestions response so Discover always surfaces what the user explicitly favorited, regardless of Spotify state. Non-fatal on DB error.