### PR TITLE
feat(bot): birthday role auto-grant + /birthday role

### DIFF
--- a/packages/bot/src/functions/general/commands/birthday.ts
+++ b/packages/bot/src/functions/general/commands/birthday.ts
@@ -90,6 +90,20 @@ export default new Command({
                         )
                         .addChannelTypes(ChannelType.GuildText),
                 ),
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName('role')
+                .setDescription(
+                    'Set a role granted to celebrators for the day (Manage Server only).',
+                )
+                .addRoleOption((opt) =>
+                    opt
+                        .setName('role')
+                        .setDescription(
+                            'Role to grant for the day. Leave empty to disable.',
+                        ),
+                ),
         ),
     category: 'general',
     execute: async ({ interaction }) => {
@@ -154,6 +168,45 @@ export default new Command({
                 await interactionReply({
                     interaction,
                     content: { embeds: [embed.toJSON()] },
+                })
+                return
+            }
+
+            if (subcommand === 'role') {
+                const member = interaction.member
+                const hasPerm =
+                    typeof member?.permissions === 'object' &&
+                    'has' in member.permissions &&
+                    (
+                        member.permissions as {
+                            has: (p: bigint) => boolean
+                        }
+                    ).has(PermissionFlagsBits.ManageGuild)
+                if (!hasPerm) {
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            content:
+                                '❌ You need the **Manage Server** permission to configure the birthday role.',
+                        },
+                    })
+                    return
+                }
+                const role = interaction.options.getRole('role')
+                const roleId = role?.id ?? null
+                await prisma.guildSettings.upsert({
+                    where: { guildId: guild.id },
+                    create: { guildId: guild.id, birthdayRoleId: roleId },
+                    update: { birthdayRoleId: roleId },
+                })
+                await interactionReply({
+                    interaction,
+                    content: {
+                        content: roleId
+                            ? `✅ Celebrators will be granted <@&${roleId}> for the day. Revocation is automatic when the date rolls over.`
+                            : '🔕 Birthday role disabled.',
+                        allowedMentions: { parse: [] },
+                    },
                 })
                 return
             }

--- a/packages/bot/src/utils/general/birthdayScheduler.spec.ts
+++ b/packages/bot/src/utils/general/birthdayScheduler.spec.ts
@@ -3,15 +3,19 @@ import { describe, test, expect, jest, beforeEach } from '@jest/globals'
 jest.mock('@lucky/shared/utils', () => {
     const findMany = jest.fn()
     const settingsFindUnique = jest.fn()
+    const settingsFindMany = jest.fn()
     return {
         infoLog: jest.fn(),
         debugLog: jest.fn(),
         errorLog: jest.fn(),
         getPrismaClient: () => ({
             memberBirthday: { findMany },
-            guildSettings: { findUnique: settingsFindUnique },
+            guildSettings: {
+                findUnique: settingsFindUnique,
+                findMany: settingsFindMany,
+            },
         }),
-        __mocks: { findMany, settingsFindUnique },
+        __mocks: { findMany, settingsFindUnique, settingsFindMany },
     }
 })
 
@@ -19,6 +23,9 @@ const { __mocks: dbMocks } = jest.requireMock('@lucky/shared/utils') as {
     __mocks: {
         findMany: jest.MockedFunction<(args?: unknown) => Promise<unknown>>
         settingsFindUnique: jest.MockedFunction<
+            (args?: unknown) => Promise<unknown>
+        >
+        settingsFindMany: jest.MockedFunction<
             (args?: unknown) => Promise<unknown>
         >
     }
@@ -48,7 +55,42 @@ function makeClient(sentCapture: Array<{ channelId: string; payload: unknown }>)
 beforeEach(() => {
     dbMocks.findMany.mockReset()
     dbMocks.settingsFindUnique.mockReset()
+    dbMocks.settingsFindMany.mockReset().mockResolvedValue([])
 })
+
+function makeGuildWithRole(
+    roleId: string,
+    currentMembers: Map<string, { rolesCacheHas: (id: string) => boolean; rolesAdd: jest.Mock; rolesRemove: jest.Mock }>,
+    roleMembers: Map<string, { rolesAdd: jest.Mock; rolesRemove: jest.Mock }>,
+) {
+    return {
+        members: {
+            fetch: jest.fn((id: string) => {
+                const m = currentMembers.get(id)
+                return Promise.resolve(
+                    m
+                        ? {
+                              roles: {
+                                  cache: { has: m.rolesCacheHas },
+                                  add: m.rolesAdd,
+                                  remove: m.rolesRemove,
+                              },
+                          }
+                        : null,
+                )
+            }),
+        },
+        roles: {
+            fetch: jest.fn((id: string) => {
+                if (id !== roleId) return Promise.resolve(null)
+                return Promise.resolve({
+                    id: roleId,
+                    members: roleMembers as unknown as Map<string, { roles: { remove: jest.Mock } }>,
+                })
+            }),
+        },
+    }
+}
 
 describe('BirthdayScheduler.tick', () => {
     test('no-ops when no birthdays match the date', async () => {
@@ -137,6 +179,100 @@ describe('BirthdayScheduler.tick', () => {
         currentDate = new Date('2026-04-21T00:30:00Z')
         await scheduler.tick()
         expect(sent).toHaveLength(2)
+    })
+
+    test('grants birthday role to today\'s celebrators', async () => {
+        dbMocks.findMany.mockResolvedValue([{ guildId: 'g1', userId: 'u1' }])
+        dbMocks.settingsFindUnique.mockResolvedValue({
+            birthdayChannelId: 'chan-1',
+            birthdayRoleId: 'role-1',
+        })
+        const sent: Array<{ channelId: string; payload: unknown }> = []
+        const rolesAdd = jest.fn(() => Promise.resolve())
+        const rolesRemove = jest.fn(() => Promise.resolve())
+        const member = {
+            rolesCacheHas: (_id: string) => false,
+            rolesAdd,
+            rolesRemove,
+        }
+        const currentMembers = new Map([['u1', member]])
+        const guildWithRole = makeGuildWithRole('role-1', currentMembers, new Map())
+        const client = {
+            ...makeClient(sent),
+            guilds: { fetch: jest.fn(() => Promise.resolve(guildWithRole)) },
+        } as unknown
+        const scheduler = new BirthdayScheduler({
+            clock: () => new Date('2026-04-20T00:00:00Z'),
+        })
+        scheduler['client'] = client as never
+        await scheduler.tick()
+        expect(rolesAdd).toHaveBeenCalledWith('role-1', expect.any(String))
+    })
+
+    test('revokes birthday role from stale holders whose birthday is not today', async () => {
+        // No birthdays today in guild g2, but someone still holds the role
+        dbMocks.findMany.mockResolvedValue([])
+        dbMocks.settingsFindMany.mockResolvedValueOnce([
+            { guildId: 'g2', birthdayRoleId: 'role-2' },
+        ])
+        dbMocks.settingsFindUnique.mockResolvedValue({
+            birthdayChannelId: null,
+            birthdayRoleId: 'role-2',
+        })
+        const revokeSpy = jest.fn(() => Promise.resolve())
+        const staleHolder = {
+            roles: { remove: revokeSpy },
+        }
+        const roleMembers = new Map([['stale-user', staleHolder]])
+        const guildWithRole = makeGuildWithRole(
+            'role-2',
+            new Map(),
+            roleMembers as never,
+        )
+        const client = {
+            channels: { fetch: jest.fn() },
+            guilds: { fetch: jest.fn(() => Promise.resolve(guildWithRole)) },
+        } as unknown
+        const scheduler = new BirthdayScheduler({
+            clock: () => new Date('2026-04-20T00:00:00Z'),
+        })
+        scheduler['client'] = client as never
+        await scheduler.tick()
+        expect(revokeSpy).toHaveBeenCalledWith('role-2', expect.any(String))
+    })
+
+    test('does not re-grant a role a member already has', async () => {
+        dbMocks.findMany.mockResolvedValue([{ guildId: 'g1', userId: 'u1' }])
+        dbMocks.settingsFindUnique.mockResolvedValue({
+            birthdayChannelId: 'chan-1',
+            birthdayRoleId: 'role-1',
+        })
+        const sent: Array<{ channelId: string; payload: unknown }> = []
+        const rolesAdd = jest.fn(() => Promise.resolve())
+        const member = {
+            rolesCacheHas: (id: string) => id === 'role-1', // already has it
+            rolesAdd,
+            rolesRemove: jest.fn(),
+        }
+        const currentMembers = new Map([['u1', member]])
+        const u1AsRoleMember = { roles: { remove: jest.fn() } }
+        const roleMembers = new Map([['u1', u1AsRoleMember]])
+        const guildWithRole = makeGuildWithRole(
+            'role-1',
+            currentMembers,
+            roleMembers as never,
+        )
+        const client = {
+            ...makeClient(sent),
+            guilds: { fetch: jest.fn(() => Promise.resolve(guildWithRole)) },
+        } as unknown
+        const scheduler = new BirthdayScheduler({
+            clock: () => new Date('2026-04-20T00:00:00Z'),
+        })
+        scheduler['client'] = client as never
+        await scheduler.tick()
+        expect(rolesAdd).not.toHaveBeenCalled()
+        expect(u1AsRoleMember.roles.remove).not.toHaveBeenCalled()
     })
 
     test('continues after a db error', async () => {

--- a/packages/bot/src/utils/general/birthdayScheduler.ts
+++ b/packages/bot/src/utils/general/birthdayScheduler.ts
@@ -91,23 +91,27 @@ export class BirthdayScheduler {
                 select: { userId: true, guildId: true },
             })) as BirthdayRow[]
 
+            const byGuild = new Map<string, Set<string>>()
+            for (const row of rows) {
+                const set = byGuild.get(row.guildId) ?? new Set<string>()
+                set.add(row.userId)
+                byGuild.set(row.guildId, set)
+            }
+
+            // Announce + grant for guilds with matches today
+            for (const [guildId, userIds] of byGuild) {
+                const userIdArr = [...userIds]
+                if (this.lastAnnouncedPerGuild.get(guildId) !== todayKey) {
+                    await this.announceForGuild(guildId, userIdArr, todayKey)
+                }
+                await this.reconcileBirthdayRole(guildId, userIds)
+            }
+
+            // Reconcile role for guilds with no matches today (revocation only)
+            await this.reconcileGuildsWithoutMatches(byGuild)
+
             if (rows.length === 0) {
                 debugLog({ message: `birthday tick: no matches for ${todayKey}` })
-                return
-            }
-
-            const byGuild = new Map<string, string[]>()
-            for (const row of rows) {
-                const list = byGuild.get(row.guildId) ?? []
-                list.push(row.userId)
-                byGuild.set(row.guildId, list)
-            }
-
-            for (const [guildId, userIds] of byGuild) {
-                if (this.lastAnnouncedPerGuild.get(guildId) === todayKey) {
-                    continue
-                }
-                await this.announceForGuild(guildId, userIds, todayKey)
             }
         } catch (error) {
             errorLog({
@@ -116,6 +120,93 @@ export class BirthdayScheduler {
             })
         } finally {
             this.tickInProgress = false
+        }
+    }
+
+    private async reconcileGuildsWithoutMatches(
+        byGuild: Map<string, Set<string>>,
+    ): Promise<void> {
+        if (!this.client) return
+        // Find guilds that have a role configured but aren't in today's match
+        // set — those need role revocation from any stale holders.
+        const prisma = getPrismaClient()
+        const guildsWithRole = (await prisma.guildSettings.findMany({
+            where: { birthdayRoleId: { not: null } },
+            select: { guildId: true, birthdayRoleId: true },
+        })) as Array<{ guildId: string; birthdayRoleId: string | null }>
+
+        for (const row of guildsWithRole) {
+            if (byGuild.has(row.guildId)) continue // handled above
+            if (!row.birthdayRoleId) continue
+            await this.reconcileBirthdayRole(row.guildId, new Set())
+        }
+    }
+
+    private async reconcileBirthdayRole(
+        guildId: string,
+        todaysUserIds: Set<string>,
+    ): Promise<void> {
+        if (!this.client) return
+        try {
+            const prisma = getPrismaClient()
+            const settings = await prisma.guildSettings.findUnique({
+                where: { guildId },
+                select: { birthdayRoleId: true },
+            })
+            const roleId = settings?.birthdayRoleId
+            if (!roleId) return
+
+            const guild = await this.client.guilds
+                .fetch(guildId)
+                .catch(() => null)
+            if (!guild) return
+            const role = await guild.roles.fetch(roleId).catch(() => null)
+            if (!role) {
+                errorLog({
+                    message: 'birthday role missing — admin must reconfigure',
+                    data: { guildId, roleId },
+                })
+                return
+            }
+
+            // Grant to today's celebrators who don't already have it
+            for (const userId of todaysUserIds) {
+                const member = await guild.members
+                    .fetch(userId)
+                    .catch(() => null)
+                if (!member) continue
+                if (!member.roles.cache.has(roleId)) {
+                    await member.roles
+                        .add(roleId, 'Birthday auto-grant')
+                        .catch((err) =>
+                            errorLog({
+                                message: 'birthday role grant failed',
+                                data: { guildId, userId, roleId },
+                                error: err as Error,
+                            }),
+                        )
+                }
+            }
+
+            // Revoke from any member holding the role who isn't on today's list
+            for (const [memberId, member] of role.members) {
+                if (todaysUserIds.has(memberId)) continue
+                await member.roles
+                    .remove(roleId, 'Birthday role expired')
+                    .catch((err) =>
+                        errorLog({
+                            message: 'birthday role revoke failed',
+                            data: { guildId, memberId, roleId },
+                            error: err as Error,
+                        }),
+                    )
+            }
+        } catch (error) {
+            errorLog({
+                message: 'birthday role reconcile failed',
+                data: { guildId },
+                error: error as Error,
+            })
         }
     }
 

--- a/prisma/migrations/20260420020000_add_birthday_role_to_guild_settings/migration.sql
+++ b/prisma/migrations/20260420020000_add_birthday_role_to_guild_settings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "guild_settings" ADD COLUMN "birthdayRoleId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,6 +134,10 @@ model GuildSettings {
 
   // Birthday announcement channel — if null, the scheduler skips the guild.
   birthdayChannelId String?
+  // Optional role granted for the day. Scheduler reconciles membership each
+  // tick against today's birthday set, so revocation is automatic when the
+  // clock rolls over.
+  birthdayRoleId String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Summary
Completes the birthday feature with the remaining Nekotina-style perk. Stacked on #740.

### Schema
- \`GuildSettings.birthdayRoleId\` (\`String?\`) — new migration \`20260420020000_add_birthday_role_to_guild_settings\`. Null by default (no side-effects for existing guilds).

### Command
- \`/birthday role <role>\` — Manage-Guild gated. Upserts \`GuildSettings\`. Empty role disables the grant.

### Scheduler (auto-grant/revoke)
- On each tick, for every guild with **matches today**: fetch role + grant to celebrators who don't already have it.
- For guilds with \`birthdayRoleId\` set but **no matches today**: iterate the role's current members and revoke. This gives **24-hour auto-expiry without a tracking table** — clean rollover when the UTC day changes.
- Scoped API calls — uses \`guild.roles.fetch(roleId).members\` rather than a full member sweep. No pagination, no rate-limit scaling risk.

### Failure modes
- Missing role → logged, skipped, no crash
- \`roles.add\`/\`roles.remove\` failures → logged per-member, loop continues
- DB errors in tick → swallowed at the top-level try/catch (consistent with announcement path)

## Test plan
- [x] Prisma schema validates + client regenerated
- [x] \`npx tsc --noEmit\` in \`packages/bot\` → clean
- [x] 9 unit tests pass on the scheduler (6 existing + 3 new: grant path, revoke stale holders, no-op on already-granted)
- [ ] Deploy + run \`prisma migrate deploy\` adds the column
- [ ] \`/birthday role @Birthday\` + set a birthday for today in a test guild → role appears within 1 tick
- [ ] Change the date to tomorrow → next tick revokes the role

## Stacking
Base: \`feature/birthday-scheduler\` (#740). Will auto-retarget to \`main\` when #740 lands.