### PR TITLE
docs(spec): Phase 2 premium-tier foundation

### DIFF
--- a/docs/specs/2026-04-20-premium-tier-foundation/spec.md
+++ b/docs/specs/2026-04-20-premium-tier-foundation/spec.md
@@ -1,0 +1,134 @@
+---
+status: proposed
+created: 2026-04-20
+owner: lucassantana
+pr:
+tags: premium,monetization,stripe,dashboard,phase-2
+---
+
+# premium-tier-foundation
+
+## Goal
+Introduce paid tiers on Lucky so the engagement base from Phases 0–1 (autoplay depth, reliability, dashboard, leaderboard, birthdays, social, voterewards) has a revenue surface. Target: **$50/month MRR within 60 days of launch** from ~3–5 paying guilds at a single $2.99/mo tier, proving the pricing loop before scaling tiers.
+
+The upstream ultraplan (`~/.claude/plans/lucky-next-phases-ultraplan.md`) assumed backend premium guards already existed (per the deferred `/playlist collaborative` roadmap entry). **Audit 2026-04-19 showed they do not.** No `requirePremium`, no Stripe, no subscription schema. This spec replaces that assumption with a concrete greenfield plan.
+
+## Non-goals
+- **Not** a multi-tier ladder. Single $2.99/mo tier for MVP. Ladder comes later if MRR gate clears.
+- **Not** a trial/coupon engine. A manual admin-set flag + Stripe-managed trials are enough for the first 90 days.
+- **Not** usage-based billing. Flat monthly subscription only.
+- **Not** a team/enterprise SKU. Per-guild only.
+
+## Pricing anchor
+- **Rythm**: $4.99/mo
+- **MEE6**: $1.99–$42.49/mo
+- **Nekotina**: freemium
+- **Dyno**: $10–$30/mo
+
+**Lucky tier: $2.99/mo per guild.** Undercuts Rythm, premium-feeling vs. MEE6 entry. Single price keeps the checkout flow trivial.
+
+## Approach
+
+### 1. Schema
+New Prisma models:
+
+```prisma
+model GuildSubscription {
+  id                    String    @id @default(cuid())
+  guildId               String    @unique
+  stripeCustomerId      String?
+  stripeSubscriptionId  String?   @unique
+  status                String    // "active" | "trialing" | "past_due" | "canceled" | "incomplete"
+  currentPeriodEnd      DateTime?
+  priceId               String?
+  canceledAt            DateTime?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+
+  @@index([guildId])
+  @@index([status])
+  @@map("guild_subscriptions")
+}
+
+model StripeWebhookEvent {
+  id        String   @id @default(cuid())
+  eventId   String   @unique   // Stripe event.id — dedupe key
+  type      String
+  payload   Json
+  createdAt DateTime @default(now())
+
+  @@index([type, createdAt])
+  @@map("stripe_webhook_events")
+}
+```
+
+- `GuildSubscription.status` is authoritative (mirrors Stripe). `isPremium(guildId) := subscription.status IN ('active', 'trialing') AND currentPeriodEnd > now()`.
+- `StripeWebhookEvent` dedupes replayed webhooks (Stripe recommends idempotency keys).
+
+### 2. Backend
+- `services/PremiumService.ts` — single read API:
+  - `isPremium(guildId): Promise<boolean>`
+  - `getSubscription(guildId): Promise<GuildSubscription | null>`
+  - `requirePremium(guildId): throws AppError(402) if not premium`
+- `routes/billing.ts`:
+  - `POST /api/billing/checkout-session` — requireAuth + guild manage perm → creates Stripe Checkout Session → returns `{ url }`
+  - `POST /api/billing/portal-session` — requireAuth + guild manage perm → returns Stripe billing portal URL
+  - `GET /api/me/premium-guilds` — requireAuth → guilds where the user has Manage Server + active subscription
+- `routes/webhooks.ts` (extend existing vote webhook file):
+  - `POST /webhooks/stripe` — verifies `stripe-signature` against `STRIPE_WEBHOOK_SECRET`, dedupes via `StripeWebhookEvent`, updates `GuildSubscription` for `customer.subscription.{created,updated,deleted}` + `invoice.paid` + `invoice.payment_failed`.
+
+### 3. Feature gates (first 3)
+Start small. Three feature gates prove the loop without risky over-scoping:
+
+1. **Premium autoplay depth** — non-premium guilds capped at 20-song autoplay backfill; premium uncapped. Already configurable in `autoplay/replenisher.ts`; just wire the ceiling to `isPremium`.
+2. **Premium-only commands** — `/leaderboard` extended limit (50 instead of 10), `/birthday role` (keeps feature but promotes the perk). Implement as a thin `requirePremium()` check at command entry.
+3. **Custom embed color in dashboard** — `GuildSettings.embedColor` already exists. Non-premium: fixed `0x5865F2`. Premium: user-editable. Pure frontend gate + backend guard on the PATCH endpoint.
+
+### 4. Dashboard
+- New `/settings/billing` route in the React dashboard
+- "Upgrade to Lucky Premium" button → POST to `/api/billing/checkout-session` → `window.location = url`
+- Active subscription card → "Manage billing" → `/api/billing/portal-session` → redirect
+- Per-feature toggle screens show a lock badge for premium-gated features with CTA back to billing
+
+### 5. Bot UX
+- No command-level checkout (Discord OAuth flow too heavy for slash commands)
+- `/voterewards` + `/leaderboard --limit > 10` reply gracefully with a dashboard link for non-premium users: *"This is a Lucky Premium perk. Upgrade at <https://lucky.lucassantana.tech/settings/billing>."*
+
+## Sequencing (4 PRs)
+
+| # | Effort | Dependencies | Contents |
+|---|---|---|---|
+| 1 | S | — | Schema + migration + `PremiumService.isPremium()` + unit tests. No Stripe yet. Everything returns `false`. |
+| 2 | M | PR 1, Stripe account | `routes/billing.ts` (checkout + portal sessions) + `routes/webhooks.ts` Stripe handler + webhook dedupe. Behind `STRIPE_ENABLED=false` env flag so deploy is safe even without the secret. |
+| 3 | S | PR 2, staging Stripe test mode | First feature gate (premium autoplay depth — minimal blast radius). Wires `PremiumService.isPremium` into `autoplay/replenisher.ts`. |
+| 4 | M | PR 3 | Dashboard `/settings/billing` route + upgrade CTA + frontend-only feature gates (embed color, leaderboard limit). |
+
+Timeline: 1 PR per working day = **4 days to first paying customer**.
+
+## Verification
+- **Unit**: `PremiumService.isPremium` covers {no subscription, active, trialing, canceled, past_due, expired period end}.
+- **Integration**: Stripe Checkout session creation + webhook round-trip via Stripe CLI (`stripe listen --forward-to ...`). Confirm `GuildSubscription` row reflects every relevant event.
+- **E2E**: Playwright flow in the dashboard — unauthenticated → upgrade CTA → Checkout → back to dashboard shows "Premium active" → portal → cancel → status flips to `canceled`.
+- **Rollback**: all 4 PRs behind `STRIPE_ENABLED` env flag so any failure can be `false`-gated in seconds without reverts.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Webhook signature failure silently drops status updates | Log every event ID received + returned 200/4xx to Sentry. Dedupe by `event.id`. Set up a `stripe_webhook_events` dashboard on metrics. |
+| Clock skew → `currentPeriodEnd` treated as active past Stripe's expiry | Trust Stripe's `status` field, not the period end. Period end is informational. |
+| Bot processes drift from backend on subscription status | Bot reads via backend HTTP (internal-key auth, same pattern as `/api/internal/votes/:userId`) rather than hitting Postgres directly. Cache 60s in-memory to avoid per-command roundtrips. |
+| Discord ToS on paid features | Read Discord's monetization terms before launch. Self-hostable side stays free; premium only on the hosted instance. |
+| Stripe account review delays | Set up account early (week 1), get account into live mode before PR 2 lands. |
+
+## Out of scope (future specs)
+- Team/enterprise SKU with seat billing
+- Annual billing discount
+- Multi-tier ladder (Pro / Legend / Enterprise)
+- Discord Server Subscriptions native integration
+- Referral / affiliate program
+
+## References
+- `~/.claude/plans/lucky-next-phases-ultraplan.md` (Phase 2 in the broader roadmap)
+- `~/.claude/plans/lucky-competitive-analysis.md` (pricing anchor)
+- Stripe Billing docs — webhook signature verification, subscription lifecycle events

--- a/docs/specs/2026-04-20-premium-tier-foundation/tasks.md
+++ b/docs/specs/2026-04-20-premium-tier-foundation/tasks.md
@@ -1,0 +1,79 @@
+---
+spec: 2026-04-20-premium-tier-foundation
+status: proposed
+---
+
+# tasks
+
+## PR 1 — Schema + PremiumService stub (S, ~2h)
+
+- [ ] Add `GuildSubscription` model to `prisma/schema.prisma`
+- [ ] Add `StripeWebhookEvent` model to `prisma/schema.prisma`
+- [ ] Create migration `<timestamp>_add_premium_tier_schema`
+- [ ] `packages/shared/src/services/PremiumService.ts`:
+  - [ ] `isPremium(guildId): Promise<boolean>`
+  - [ ] `getSubscription(guildId): Promise<GuildSubscription | null>`
+  - [ ] Status check: `status IN ('active', 'trialing')` AND (no `currentPeriodEnd` OR `currentPeriodEnd > now()`)
+- [ ] Unit tests covering all status combinations + null case
+- [ ] Export from `packages/shared/src/services/index.ts`
+
+Acceptance: `PremiumService.isPremium('any-guild-id')` returns `false` cleanly (no subscription row exists yet). TypeScript clean. No Stripe dependencies added.
+
+## PR 2 — Stripe billing + webhooks (M, ~6h)
+
+- [ ] Install `stripe` SDK in `packages/backend`
+- [ ] Env vars added to `.env.example`:
+  - [ ] `STRIPE_ENABLED` (default `false`)
+  - [ ] `STRIPE_SECRET_KEY`
+  - [ ] `STRIPE_PUBLISHABLE_KEY`
+  - [ ] `STRIPE_PRICE_ID`
+  - [ ] `STRIPE_WEBHOOK_SECRET`
+- [ ] `packages/backend/src/services/StripeService.ts`:
+  - [ ] Lazy singleton (`new Stripe(...)` only when `STRIPE_ENABLED`)
+  - [ ] `createCheckoutSession(guildId, userDiscordId, returnUrl)`
+  - [ ] `createBillingPortalSession(guildId, returnUrl)`
+  - [ ] `verifyWebhookSignature(rawBody, signature)`
+- [ ] `packages/backend/src/routes/billing.ts`:
+  - [ ] `POST /api/billing/checkout-session` — requireAuth + guild ManageGuild perm
+  - [ ] `POST /api/billing/portal-session` — requireAuth + guild ManageGuild perm
+  - [ ] `GET /api/me/premium-guilds` — requireAuth
+- [ ] `packages/backend/src/routes/webhooks.ts`: extend with `POST /webhooks/stripe`
+  - [ ] Use `express.raw({ type: 'application/json' })` for the route (NOT the global JSON parser — Stripe needs raw body for signature verification)
+  - [ ] Dedupe on `event.id` via `StripeWebhookEvent`
+  - [ ] Handle `customer.subscription.created|updated|deleted` + `invoice.paid` + `invoice.payment_failed`
+- [ ] Tests: webhook round-trip with `stripe.webhooks.constructEvent` against a fixture signature
+- [ ] Documentation: `docs/STRIPE_SETUP.md` with Stripe CLI `stripe listen` dev-loop instructions
+
+Acceptance: With `STRIPE_ENABLED=false` everything is inert and returns 503 cleanly. With `STRIPE_ENABLED=true` + test-mode secrets, a Checkout Session can be created via curl, followed in Stripe Dashboard, and the resulting subscription row appears in the DB.
+
+## PR 3 — First feature gate: premium autoplay depth (S, ~2h)
+
+- [ ] Identify the cap in `autoplay/replenisher.ts` (hardcoded number around the replenish threshold)
+- [ ] Wire `PremiumService.isPremium(guildId)` into the replenisher path
+- [ ] Non-premium: cap backfill at 20 songs
+- [ ] Premium: uncapped (or 200-song ceiling for safety)
+- [ ] Unit tests: mock `PremiumService`, verify replenisher returns capped list for non-premium, uncapped for premium
+- [ ] Add to CHANGELOG `[Unreleased]` under **Added** with clear premium callout
+
+Acceptance: Integration test in a dev environment with `STRIPE_ENABLED=true` — a premium guild's autoplay queue replenishes past the 20-song threshold; a non-premium guild stops at 20.
+
+## PR 4 — Dashboard billing route + second/third gates (M, ~6h)
+
+- [ ] `packages/frontend/src/pages/BillingPage.tsx`:
+  - [ ] "Upgrade to Lucky Premium" CTA → `apiClient.post('/billing/checkout-session')` → `window.location = data.url`
+  - [ ] Active subscription card with "Manage billing" → portal session
+  - [ ] Pricing breakdown + 3 feature gate descriptions
+- [ ] Add route to `App.tsx` at `/settings/billing`
+- [ ] Sidebar entry under Settings
+- [ ] Feature gate 2: `GuildSettings.embedColor` editable only when premium (backend PATCH guard + frontend input disabled state)
+- [ ] Feature gate 3: `/leaderboard --limit > 10` returns gentle "Premium only" message with dashboard link for non-premium guilds
+- [ ] Add all 3 gates to CHANGELOG
+
+Acceptance: Playwright smoke test — unauthenticated user sees upgrade CTA, authenticated non-premium user sees upgrade CTA, authenticated premium user sees portal link.
+
+## Post-launch monitoring (first 30 days)
+
+- [ ] Weekly: check Stripe dashboard for subscription growth vs. target
+- [ ] Weekly: verify webhook delivery success rate > 99% in Stripe logs
+- [ ] Bi-weekly: review Sentry for `StripeService` / `/webhooks/stripe` errors
+- [ ] After 30 days: decide tier ladder vs. single-tier based on conversion signal


### PR DESCRIPTION
## Summary
Turns the vague \"L-effort greenfield\" in the next-phases ultraplan into a concrete 4-PR plan with schema, endpoints, sequencing, and rollback strategy. **Zero code, zero runtime impact** — pure planning artifact.

### Key decisions (see \`spec.md\` for full rationale)
- **Single \$2.99/mo tier for MVP** — undercuts Rythm (\$4.99), premium-feeling vs. MEE6 entry (\$1.99). Tier ladder deferred to post-gate ($50 MRR target).
- **New Prisma models**: \`GuildSubscription\` mirrors Stripe lifecycle; \`StripeWebhookEvent\` idempotency by \`event.id\`.
- **Status is authoritative from Stripe**; \`currentPeriodEnd\` informational only (avoids clock-skew bugs).
- **Three initial feature gates** chosen for minimum blast radius: premium autoplay depth (cap 20 → uncapped), custom embed color, \`/leaderboard --limit > 10\`. All fail gracefully with dashboard link.
- **Every PR behind \`STRIPE_ENABLED\` env flag** — rollback is a config flip.
- **Bot reads subscription via backend HTTP** (same internal-key pattern as vote-status) — no Postgres drift.

### 4-PR sequencing (~16h total)
| PR | Effort | Contents |
|---|---|---|
| 1 | S (~2h) | Schema + migration + \`PremiumService.isPremium()\` stub returning false |
| 2 | M (~6h) | Stripe SDK + billing routes + webhook handler with idempotency |
| 3 | S (~2h) | First gate: premium autoplay depth (20 → uncapped) |
| 4 | M (~6h) | Dashboard \`/settings/billing\` + 2 more gates (embed color, leaderboard limit) |

## Test plan
- [x] Spec validates (frontmatter parses, `status: proposed`)
- [x] Pricing anchor cross-referenced against competitive-analysis doc
- [x] All 4 PRs have acceptance criteria in tasks.md
- [ ] After merge: link this spec from next-phases-ultraplan as the Phase 2 implementation plan

## Next actions
- Review/tweak in discussion if needed
- When ready to execute: create the 4 PRs sequentially following tasks.md. Each has its own acceptance criteria.