### PR TITLE
feat(shared): PremiumService + GuildSubscription schema (Phase 2 PR 1)

### DIFF
--- a/packages/shared/src/services/PremiumService.spec.ts
+++ b/packages/shared/src/services/PremiumService.spec.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+jest.mock('../utils/database/prismaClient', () => {
+    const findUnique = jest.fn()
+    return {
+        getPrismaClient: () => ({ guildSubscription: { findUnique } }),
+        __mocks: { findUnique },
+    }
+})
+
+jest.mock('../utils/general/log', () => ({
+    errorLog: jest.fn(),
+}))
+
+const { __mocks } = jest.requireMock('../utils/database/prismaClient') as {
+    __mocks: {
+        findUnique: jest.MockedFunction<(args: unknown) => Promise<unknown>>
+    }
+}
+
+import { PremiumService } from './PremiumService'
+
+beforeEach(() => {
+    __mocks.findUnique.mockReset()
+})
+
+describe('PremiumService.isPremium', () => {
+    const service = new PremiumService()
+
+    test('returns false when no subscription exists', async () => {
+        __mocks.findUnique.mockResolvedValue(null)
+        expect(await service.isPremium('g1')).toBe(false)
+    })
+
+    test('returns true for active status with future period end', async () => {
+        __mocks.findUnique.mockResolvedValue({
+            status: 'active',
+            currentPeriodEnd: new Date(Date.now() + 86400000),
+        })
+        expect(await service.isPremium('g1')).toBe(true)
+    })
+
+    test('returns true for trialing status', async () => {
+        __mocks.findUnique.mockResolvedValue({
+            status: 'trialing',
+            currentPeriodEnd: new Date(Date.now() + 86400000),
+        })
+        expect(await service.isPremium('g1')).toBe(true)
+    })
+
+    test('returns true when no period end is set (safety default)', async () => {
+        __mocks.findUnique.mockResolvedValue({
+            status: 'active',
+            currentPeriodEnd: null,
+        })
+        expect(await service.isPremium('g1')).toBe(true)
+    })
+
+    test('returns false for canceled status', async () => {
+        __mocks.findUnique.mockResolvedValue({
+            status: 'canceled',
+            currentPeriodEnd: new Date(Date.now() + 86400000),
+        })
+        expect(await service.isPremium('g1')).toBe(false)
+    })
+
+    test('returns false for past_due', async () => {
+        __mocks.findUnique.mockResolvedValue({
+            status: 'past_due',
+            currentPeriodEnd: new Date(Date.now() + 86400000),
+        })
+        expect(await service.isPremium('g1')).toBe(false)
+    })
+
+    test('returns false for incomplete', async () => {
+        __mocks.findUnique.mockResolvedValue({
+            status: 'incomplete',
+            currentPeriodEnd: null,
+        })
+        expect(await service.isPremium('g1')).toBe(false)
+    })
+
+    test('returns false when period end is in the past (webhook-drop safety net)', async () => {
+        __mocks.findUnique.mockResolvedValue({
+            status: 'active',
+            currentPeriodEnd: new Date(Date.now() - 60000),
+        })
+        expect(await service.isPremium('g1')).toBe(false)
+    })
+
+    test('returns false (fail-closed) when DB throws', async () => {
+        __mocks.findUnique.mockRejectedValue(new Error('db down'))
+        expect(await service.isPremium('g1')).toBe(false)
+    })
+})
+
+describe('PremiumService.getSubscription', () => {
+    const service = new PremiumService()
+
+    test('forwards the row from prisma when present', async () => {
+        const row = { id: 'sub-1', guildId: 'g1', status: 'active' }
+        __mocks.findUnique.mockResolvedValue(row)
+        expect(await service.getSubscription('g1')).toEqual(row)
+        expect(__mocks.findUnique).toHaveBeenCalledWith({ where: { guildId: 'g1' } })
+    })
+
+    test('returns null when no row exists', async () => {
+        __mocks.findUnique.mockResolvedValue(null)
+        expect(await service.getSubscription('g1')).toBeNull()
+    })
+
+    test('returns null on DB error (caller shouldn\'t crash)', async () => {
+        __mocks.findUnique.mockRejectedValue(new Error('db down'))
+        expect(await service.getSubscription('g1')).toBeNull()
+    })
+})

--- a/packages/shared/src/services/PremiumService.ts
+++ b/packages/shared/src/services/PremiumService.ts
@@ -1,0 +1,43 @@
+import type { GuildSubscriptionModel as GuildSubscription } from '../generated/prisma/models/GuildSubscription'
+import { getPrismaClient } from '../utils/database/prismaClient'
+import { errorLog } from '../utils/general/log'
+
+// Statuses Stripe reports that indicate a live subscription. canceled,
+// past_due, incomplete, and incomplete_expired all fail the gate.
+const ACTIVE_STATUSES: ReadonlySet<string> = new Set(['active', 'trialing'])
+
+export class PremiumService {
+    /**
+     * Returns true when the guild has an active Stripe subscription.
+     * - Trusts Stripe's status field (not currentPeriodEnd — clock skew resistant)
+     * - currentPeriodEnd is a safety net: if status is active but the period
+     *   end is in the past, treat as expired (protects against webhook drops)
+     */
+    async isPremium(guildId: string): Promise<boolean> {
+        const sub = await this.getSubscription(guildId)
+        if (!sub) return false
+        if (!ACTIVE_STATUSES.has(sub.status)) return false
+        if (sub.currentPeriodEnd && sub.currentPeriodEnd.getTime() <= Date.now()) {
+            return false
+        }
+        return true
+    }
+
+    async getSubscription(guildId: string): Promise<GuildSubscription | null> {
+        try {
+            const prisma = getPrismaClient()
+            return await prisma.guildSubscription.findUnique({
+                where: { guildId },
+            })
+        } catch (error) {
+            errorLog({
+                message: 'PremiumService.getSubscription failed',
+                data: { guildId },
+                error: error as Error,
+            })
+            return null
+        }
+    }
+}
+
+export const premiumService = new PremiumService()

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -1,4 +1,5 @@
 export * from './FeatureToggleService'
+export * from './PremiumService'
 export * from './database/DatabaseService.js'
 export {
     MusicControlService,

--- a/prisma/migrations/20260420030000_add_premium_tier_schema/migration.sql
+++ b/prisma/migrations/20260420030000_add_premium_tier_schema/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "guild_subscriptions" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "stripeCustomerId" TEXT,
+    "stripeSubscriptionId" TEXT,
+    "status" TEXT NOT NULL,
+    "currentPeriodEnd" TIMESTAMP(3),
+    "priceId" TEXT,
+    "canceledAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "guild_subscriptions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "stripe_webhook_events" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "stripe_webhook_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "guild_subscriptions_guildId_key" ON "guild_subscriptions"("guildId");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "guild_subscriptions_stripeSubscriptionId_key" ON "guild_subscriptions"("stripeSubscriptionId");
+
+-- CreateIndex
+CREATE INDEX "guild_subscriptions_guildId_idx" ON "guild_subscriptions"("guildId");
+
+-- CreateIndex
+CREATE INDEX "guild_subscriptions_status_idx" ON "guild_subscriptions"("status");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "stripe_webhook_events_eventId_key" ON "stripe_webhook_events"("eventId");
+
+-- CreateIndex
+CREATE INDEX "stripe_webhook_events_type_createdAt_idx" ON "stripe_webhook_events"("type", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -712,3 +712,36 @@ model MemberBirthday {
   @@index([guildId, month, day])
   @@map("member_birthdays")
 }
+
+// Premium subscription — mirrors Stripe lifecycle. One row per guild.
+// status is authoritative (active|trialing|past_due|canceled|incomplete).
+// currentPeriodEnd is informational only.
+model GuildSubscription {
+  id                   String    @id @default(cuid())
+  guildId              String    @unique
+  stripeCustomerId     String?
+  stripeSubscriptionId String?   @unique
+  status               String
+  currentPeriodEnd     DateTime?
+  priceId              String?
+  canceledAt           DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  @@index([guildId])
+  @@index([status])
+  @@map("guild_subscriptions")
+}
+
+// Stripe webhook dedupe — events are idempotent by Stripe event.id.
+// Prevents double-processing on Stripe's automatic retries.
+model StripeWebhookEvent {
+  id        String   @id @default(cuid())
+  eventId   String   @unique
+  type      String
+  payload   Json
+  createdAt DateTime @default(now())
+
+  @@index([type, createdAt])
+  @@map("stripe_webhook_events")
+}


### PR DESCRIPTION
## Summary
First concrete step from the Phase 2 spec (#745). Stubs return \`false\` cleanly; no Stripe dependency yet. Sets the foundation for PR 2 (Stripe billing + webhooks).

### Schema — new migration \`20260420030000_add_premium_tier_schema\`
- **\`GuildSubscription\`**: one row per guild mirroring Stripe lifecycle. Indexed on \`guildId\` (unique) + \`stripeSubscriptionId\` (unique) + \`status\`.
- **\`StripeWebhookEvent\`**: idempotency log keyed by Stripe \`event.id\`. Indexed by \`(type, createdAt)\` for ops visibility.

### Service — \`@lucky/shared/services\`
- **\`PremiumService.isPremium(guildId)\`** — authoritative boolean gate. Only \`active\` or \`trialing\` count. \`currentPeriodEnd\` acts as a safety net so a dropped webhook can't leave a stale active flag indefinitely.
- **\`PremiumService.getSubscription(guildId)\`** — raw row for surfaces that need dates (e.g. billing UI in PR 4).
- **Fails closed**: DB error → \`false\`/\`null\` rather than throw. Prevents a DB outage from accidentally granting premium features.

## Test plan
- [x] Prisma schema validates, client regenerated
- [x] \`packages/shared\` builds clean
- [x] 12 unit tests covering all Stripe status values, null subscription, null period end, expired period-end safety net, DB-error fail-closed paths
- [ ] Deploy + \`prisma migrate deploy\` creates the tables. \`PremiumService.isPremium('any-id')\` returns false. No behaviour change anywhere in the app.

## Sequencing
Next: PR 2 from the spec — Stripe SDK integration + \`/api/billing/{checkout,portal}-session\` + \`/webhooks/stripe\` with idempotency. Behind \`STRIPE_ENABLED\` env flag.