### PR TITLE
docs(env): STRIPE_* placeholders for Phase 2 PR 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,3 +198,19 @@ SEARCH_RETRY_DELAY=5000
 # DEPENDENCY_CHECK_INTERVAL=86400000
 # DEPENDENCY_NOTIFY_ONLY_SECURITY=false
 LUCKY_NOTIFY_API_KEY=
+
+# Stripe Billing (Optional — enables Lucky Premium subscriptions)
+# Master switch. When false, all /api/billing/* routes return 503 and
+# the /webhooks/stripe endpoint rejects inbound events. Safe to deploy
+# without any other Stripe env vars set.
+# STRIPE_ENABLED=false
+# Secret API key — dashboard → Developers → API keys. Use sk_test_... for staging.
+# STRIPE_SECRET_KEY=
+# Publishable key — exposed to the frontend to mount Stripe.js (if we ever need Elements).
+# STRIPE_PUBLISHABLE_KEY=
+# Price ID for the single $2.99/mo subscription tier — dashboard → Products.
+# STRIPE_PRICE_ID=
+# Webhook signing secret — dashboard → Developers → Webhooks → endpoint → signing secret.
+# For local development with `stripe listen --forward-to localhost:3001/webhooks/stripe`,
+# use the whsec_... secret that command prints.
+# STRIPE_WEBHOOK_SECRET=


### PR DESCRIPTION
## Summary
Drops the 5 env vars Phase 2 PR 2 will consume into \`.env.example\` now, commented out. **Zero runtime change** — the billing routes don't exist yet; when PR 2 lands they default to disabled via \`STRIPE_ENABLED=false\`.

### Placeholders
| Env var | Purpose |
|---|---|
| \`STRIPE_ENABLED\` | Master switch. 503s all billing routes when false. |
| \`STRIPE_SECRET_KEY\` | Server-side Stripe API key (use sk_test_... for staging). |
| \`STRIPE_PUBLISHABLE_KEY\` | Frontend Stripe.js mount, if we ever need Elements. |
| \`STRIPE_PRICE_ID\` | Single \$2.99/mo tier price ID. |
| \`STRIPE_WEBHOOK_SECRET\` | \`whsec_...\` for signature verification. \`stripe listen\` prints this locally. |

### Why land this separately
- Lets PR 2 start from a known env surface
- Keeps PR 2's diff focused on the Stripe integration itself
- Makes the env surface reviewable in isolation

## Test plan
- [x] \`.env.example\` still parses (no uncommented blanks, valid shell)
- [x] Zero code touched