### PR TITLE
feat(backend): Stripe billing route scaffolding (503 when disabled)

### DIFF
--- a/packages/backend/src/routes/billing.ts
+++ b/packages/backend/src/routes/billing.ts
@@ -1,0 +1,46 @@
+import type { Express, Request, Response } from 'express'
+import { writeLimiter } from '../middleware/rateLimit'
+import { asyncHandler } from '../middleware/asyncHandler'
+import { AppError } from '../errors/AppError'
+import { requireStripeEnabled } from '../utils/billingConfig'
+
+// Route surface only — real handlers land in the next PR. Every handler
+// short-circuits via requireStripeEnabled() so production (with
+// STRIPE_ENABLED unset) sees 503 here.
+
+export function setupBillingRoutes(app: Express): void {
+    app.get(
+        '/api/billing/status',
+        asyncHandler(async (_req: Request, _res: Response) => {
+            requireStripeEnabled()
+            throw new AppError(501, 'Not implemented')
+        }),
+    )
+
+    app.post(
+        '/api/billing/checkout',
+        writeLimiter,
+        asyncHandler(async (_req: Request, _res: Response) => {
+            requireStripeEnabled()
+            throw new AppError(501, 'Not implemented')
+        }),
+    )
+
+    app.post(
+        '/api/billing/portal',
+        writeLimiter,
+        asyncHandler(async (_req: Request, _res: Response) => {
+            requireStripeEnabled()
+            throw new AppError(501, 'Not implemented')
+        }),
+    )
+
+    app.delete(
+        '/api/billing/subscription',
+        writeLimiter,
+        asyncHandler(async (_req: Request, _res: Response) => {
+            requireStripeEnabled()
+            throw new AppError(501, 'Not implemented')
+        }),
+    )
+}

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -18,6 +18,8 @@ import { setupStarboardRoutes } from './starboard'
 import { setupMusicRoutes } from './music'
 import { setupArtistsRoutes } from './artists'
 import { setupInternalNotifyRoutes } from './internalNotify'
+import { setupBillingRoutes } from './billing'
+import { setupStripeWebhookRoutes } from './stripeWebhook'
 import { apiLimiter } from '../middleware/rateLimit'
 import { requireAuth } from '../middleware/auth'
 import { requireGuildModuleAccess } from '../middleware/guildAccess'
@@ -75,6 +77,8 @@ const routeSetups = [
     setupStarboardRoutes,
     setupMusicRoutes,
     setupArtistsRoutes,
+    setupBillingRoutes,
+    setupStripeWebhookRoutes,
 ]
 
 export function setupRoutes(app: Express): void {

--- a/packages/backend/src/routes/stripeWebhook.ts
+++ b/packages/backend/src/routes/stripeWebhook.ts
@@ -1,0 +1,22 @@
+// When STRIPE_ENABLED=true lands, replace the global json parser for this
+// path with express.raw({ type: 'application/json' }) applied BEFORE the
+// setupMiddleware json step. Stripe's signature verification needs the
+// exact byte-for-byte request body; the global express.json() parser
+// mutates req.body into an object and the raw bytes are gone.
+
+import type { Express, Request, Response } from 'express'
+import { asyncHandler } from '../middleware/asyncHandler'
+import { AppError } from '../errors/AppError'
+import { isStripeEnabled } from '../utils/billingConfig'
+
+export function setupStripeWebhookRoutes(app: Express): void {
+    app.post(
+        '/webhooks/stripe',
+        asyncHandler(async (_req: Request, _res: Response) => {
+            if (!isStripeEnabled()) {
+                throw AppError.serviceUnavailable('Billing disabled')
+            }
+            throw new AppError(501, 'Not implemented')
+        }),
+    )
+}

--- a/packages/backend/src/utils/billingConfig.ts
+++ b/packages/backend/src/utils/billingConfig.ts
@@ -1,0 +1,25 @@
+import { AppError } from '../errors/AppError'
+
+export function isStripeEnabled(): boolean {
+    return (process.env.STRIPE_ENABLED ?? '').toLowerCase() === 'true'
+}
+
+export function getStripeConfig(): {
+    secretKey: string | undefined
+    publishableKey: string | undefined
+    priceId: string | undefined
+    webhookSecret: string | undefined
+} {
+    return {
+        secretKey: process.env.STRIPE_SECRET_KEY,
+        publishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
+        priceId: process.env.STRIPE_PRICE_ID,
+        webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+    }
+}
+
+export function requireStripeEnabled(): void {
+    if (!isStripeEnabled()) {
+        throw AppError.serviceUnavailable('Billing disabled')
+    }
+}

--- a/packages/backend/tests/unit/routes/billing.test.ts
+++ b/packages/backend/tests/unit/routes/billing.test.ts
@@ -1,0 +1,81 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from '@jest/globals'
+import express from 'express'
+import request from 'supertest'
+
+import { setupBillingRoutes } from '../../../src/routes/billing'
+
+function buildApp(): express.Express {
+    const app = express()
+    app.use(express.json())
+    setupBillingRoutes(app)
+    app.use(
+        (
+            err: { statusCode?: number; message?: string },
+            _req: express.Request,
+            res: express.Response,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            _next: express.NextFunction,
+        ) => {
+            res.status(err.statusCode ?? 500).json({
+                error: err.message ?? 'unknown',
+            })
+        },
+    )
+    return app
+}
+
+beforeEach(() => {
+    delete process.env.STRIPE_ENABLED
+})
+
+afterEach(() => {
+    delete process.env.STRIPE_ENABLED
+})
+
+describe('billing routes — disabled by default', () => {
+    it('GET /api/billing/status returns 503 when STRIPE_ENABLED unset', async () => {
+        const res = await request(buildApp()).get('/api/billing/status')
+        expect(res.status).toBe(503)
+    })
+
+    it('POST /api/billing/checkout returns 503 when STRIPE_ENABLED unset', async () => {
+        const res = await request(buildApp())
+            .post('/api/billing/checkout')
+            .send({})
+        expect(res.status).toBe(503)
+    })
+
+    it('POST /api/billing/portal returns 503 when STRIPE_ENABLED unset', async () => {
+        const res = await request(buildApp())
+            .post('/api/billing/portal')
+            .send({})
+        expect(res.status).toBe(503)
+    })
+
+    it('DELETE /api/billing/subscription returns 503 when STRIPE_ENABLED unset', async () => {
+        const res = await request(buildApp()).delete(
+            '/api/billing/subscription',
+        )
+        expect(res.status).toBe(503)
+    })
+
+    it('STRIPE_ENABLED=false (explicit) still returns 503', async () => {
+        process.env.STRIPE_ENABLED = 'false'
+        const res = await request(buildApp()).get('/api/billing/status')
+        expect(res.status).toBe(503)
+    })
+})
+
+describe('billing routes — proves flag is actually read', () => {
+    it('GET /api/billing/status returns 501 when STRIPE_ENABLED=true', async () => {
+        process.env.STRIPE_ENABLED = 'true'
+        const res = await request(buildApp()).get('/api/billing/status')
+        expect(res.status).toBe(501)
+    })
+})

--- a/packages/backend/tests/unit/routes/stripeWebhook.test.ts
+++ b/packages/backend/tests/unit/routes/stripeWebhook.test.ts
@@ -1,0 +1,56 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from '@jest/globals'
+import express from 'express'
+import request from 'supertest'
+
+import { setupStripeWebhookRoutes } from '../../../src/routes/stripeWebhook'
+
+function buildApp(): express.Express {
+    const app = express()
+    app.use(express.json())
+    setupStripeWebhookRoutes(app)
+    app.use(
+        (
+            err: { statusCode?: number; message?: string },
+            _req: express.Request,
+            res: express.Response,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            _next: express.NextFunction,
+        ) => {
+            res.status(err.statusCode ?? 500).json({
+                error: err.message ?? 'unknown',
+            })
+        },
+    )
+    return app
+}
+
+beforeEach(() => {
+    delete process.env.STRIPE_ENABLED
+})
+
+afterEach(() => {
+    delete process.env.STRIPE_ENABLED
+})
+
+describe('POST /webhooks/stripe', () => {
+    it('returns 503 when STRIPE_ENABLED unset', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/stripe')
+            .send({})
+        expect(res.status).toBe(503)
+    })
+
+    it('returns 501 when STRIPE_ENABLED=true', async () => {
+        process.env.STRIPE_ENABLED = 'true'
+        const res = await request(buildApp())
+            .post('/webhooks/stripe')
+            .send({})
+        expect(res.status).toBe(501)
+    })
+})


### PR DESCRIPTION
## Summary
Introduces the \`/api/billing/*\` and \`/webhooks/stripe\` route surface gated behind \`STRIPE_ENABLED\`. **Zero runtime change** — \`STRIPE_ENABLED\` defaults to unset so production hits the 503 path everywhere.

Sets the shape for the real billing PR without touching the \`stripe\` npm dep, Prisma, or the frontend.

### Added
- **\`utils/billingConfig.ts\`** — \`isStripeEnabled()\`, \`getStripeConfig()\`, \`requireStripeEnabled()\`. Tiny env-reading helpers, no caching. Pattern mirrors \`utils/developerAccess.ts\`.
- **\`routes/billing.ts\`** — 4 endpoints (status GET, checkout POST, portal POST, subscription DELETE). Each short-circuits via \`requireStripeEnabled()\` then throws \`AppError(501, 'Not implemented')\` so enabling the flag later produces predictable "to be implemented" responses.
- **\`routes/stripeWebhook.ts\`** — \`POST /webhooks/stripe\`. Top-of-file comment flags the \`express.json()\` body-parsing issue that will matter once real signature verification lands (not solved here because the 503 returns before body access).
- **\`routes/index.ts\`** — imports + \`routeSetups\` entries for both new modules.

### Wiring notes
- \`/api/billing/*\` inherits \`apiLimiter\` via the existing \`/api/\` prefix middleware.
- Billing mutations use \`writeLimiter\`.
- \`/webhooks/stripe\` is deliberately non-\`/api/\` so it skips \`apiLimiter\` (Stripe retries on its own cadence; client-IP rate limiting would be counterproductive).
- No \`requireAuth\`, no \`guildGuardConfigs\` — those are future-PR concerns and the 503 returns before they'd apply.

### Follow-ups (explicitly NOT in this PR)
- \`stripe\` npm dep
- Prisma subscription reads via \`PremiumService\` (#746)
- Real checkout/portal session creation
- Webhook signature verification + body-parsing fix

## Test plan
- [x] \`npm run type:check --workspace=packages/backend\` → clean
- [x] 8 unit tests pass: 4 \"disabled → 503\" (one per billing endpoint) + \`STRIPE_ENABLED=false\` case + \`STRIPE_ENABLED=true → 501\` spot-check + 2 matching cases on the webhook
- [ ] Optional smoke: \`curl -i localhost:5000/api/billing/status\` → 503, then with \`STRIPE_ENABLED=true\` → 501

## Sequencing
Builds on #747 (env placeholders), #746 (\`PremiumService\` + schema), #745 (spec).