### PR TITLE
ci(bundle-size): force package-manager=npm for preactjs v3 action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -34,11 +34,11 @@ jobs:
             - name: Compressed Size Diff
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v3
               with:
-                  # Force npm — the action defaults to pnpm when both
-                  # package-lock.json and pnpm-lock.yaml exist, but this
-                  # project is npm-managed (see package.json scripts).
+                  # v3 auto-detects pnpm even without pnpm-lock.yaml; force npm
+                  # both for install and build since this project is npm-managed.
+                  package-manager: 'npm'
                   install-script: 'npm ci'
-                  build-script: 'build'
+                  build-script: 'npm run build'
                   pattern: 'packages/frontend/dist/**/*.{js,css}'
                   strip-hash: '\\b\\w{8}\\.'
                   minimum-change-threshold: 100


### PR DESCRIPTION
## Summary
The `compressed-size` check started failing on every PR that touches `packages/frontend/**` with:

```
##[error]Unable to locate executable file: pnpm
```

v3 of `preactjs/compressed-size-action` auto-detects the base branch's package manager and now defaults to pnpm on some runner images even without a `pnpm-lock.yaml`. When pnpm isn't pre-installed on `ubuntu-latest`, the build step blows up.

## Fix
Lock both install and build to npm explicitly (`package-manager: 'npm'`, `install-script: 'npm ci'`, `build-script: 'npm run build'`). This project is entirely npm-managed (package-lock.json only, no pnpm-lock.yaml), so the lock is safe.

## Unblocks
- #727 (production-deps group)
- #737 (vote-tier badge)
- #752 (dev-deps group)

## Test plan
- [x] `compressed-size` action re-runs green on this PR
- [ ] After merge, dependabot PRs re-run and `compressed-size` clears