### PR TITLE
ci(bundle-size): install pnpm shim for preactjs v3 pm detection

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -31,14 +31,23 @@ jobs:
                   node-version: '22'
                   cache: 'npm'
 
+            # preactjs/compressed-size-action@v3 auto-detects pnpm on the runner
+            # and runs `<pm> run <build-script>`. This repo is npm-managed
+            # (package-lock.json only), but pnpm is pre-installed on newer
+            # ubuntu-latest images. Install pnpm explicitly so it can actually
+            # run the npm script; pnpm executes `package.json#scripts.build`
+            # natively without needing a pnpm-lock.yaml.
+            - name: Setup pnpm (shim for compressed-size-action pm detection)
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 9
+                  run_install: false
+
             - name: Compressed Size Diff
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v3
               with:
-                  # v3 auto-detects pnpm even without pnpm-lock.yaml; force npm
-                  # both for install and build since this project is npm-managed.
-                  package-manager: 'npm'
                   install-script: 'npm ci'
-                  build-script: 'npm run build'
+                  build-script: 'build'
                   pattern: 'packages/frontend/dist/**/*.{js,css}'
                   strip-hash: '\\b\\w{8}\\.'
                   minimum-change-threshold: 100


### PR DESCRIPTION
## Summary
PR #753 revealed a second layer: v3 of `preactjs/compressed-size-action` **ignores** the `package-manager` parameter and always auto-detects based on `$PATH`. On newer `ubuntu-latest` runners pnpm is present → detection locks onto pnpm, but we have no `pnpm-lock.yaml`.

Setting `build-script: 'npm run build'` (in #753) made it worse — the action ran `pnpm run "npm run build"`, which pnpm rejected.

## Fix
- Install pnpm explicitly via `pnpm/action-setup@v4` so it actually exists (as a shim for the action's detection)
- Revert `build-script` to `'build'` so the action runs `pnpm run build`
- Drop the no-op `package-manager: 'npm'` param
- Keep `install-script: 'npm ci'` — install is explicit, build is native

pnpm executes `package.json#scripts.build` natively without a pnpm-lock.yaml.

## Unblocks (for real this time)
- #727 production-deps group bump
- #737 vote-tier badge
- #751 chore(assets): compress PNG/SVG
- #752 dev-deps group bump

## Test plan
- [x] compressed-size completes on this PR without `Unable to locate executable file: pnpm`
- [ ] After merge, the 4 stuck PRs re-run green