### PR TITLE
chore: gitignore .playwright-mcp/ diagnostic dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ coverage/
 # Playwright
 packages/frontend/playwright-report/
 packages/frontend/test-results/
+.playwright-mcp/
 
 # Secrets and keys
 *.pem


### PR DESCRIPTION
## Summary

Playwright MCP auto-generates page snapshots and console logs under `.playwright-mcp/` during browser automation runs (typically 100KB+ per run). These are session artifacts, not intended for version control.

Pattern sits next to the existing `packages/frontend/playwright-report/` and `packages/frontend/test-results/` ignores.

## Test plan

- [x] `git status` in a fresh checkout shows no untracked `.playwright-mcp/` files
- [x] No existing tracked files match the pattern (confirmed via `git ls-files .playwright-mcp/` returning nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)