### PR TITLE
test(backend): unskip validateBody 400-on-invalid-body tests

### DIFF
--- a/packages/backend/tests/integration/routes/management.test.ts
+++ b/packages/backend/tests/integration/routes/management.test.ts
@@ -246,7 +246,7 @@ describe('Management Routes Integration', () => {
             })
         })
 
-        test.skip('should return 400 on invalid body', async () => {
+        test('should return 400 on invalid body', async () => {
             const response = await request(app)
                 .patch('/api/guilds/111111111111111111/automod/settings')
                 .set('Cookie', ['sessionId=valid_session_id'])
@@ -441,9 +441,7 @@ describe('Management Routes Integration', () => {
             })
         })
 
-        test.skip('should return 400 on invalid body', async () => {
-            // This test is skipped due to an issue with validateBody not catching errors
-            // in certain scenarios. The main RBAC functionality is working correctly.
+        test('should return 400 on invalid body', async () => {
             const mockSessionService = sessionService as jest.Mocked<
                 typeof sessionService
             >


### PR DESCRIPTION
## Summary

Two integration tests in \`packages/backend/tests/integration/routes/management.test.ts\` were marked \`.skip\` with a note that \`validateBody\` wasn't catching errors in certain scenarios. Backlog item (\`.claude/plans/backlog-2026-04-21.md\`) flagged them.

## Evidence that unskipping is safe

Middleware chain for both endpoints:

\`\`\`
requireAuth
→ requireGuildModuleAccess('settings'|'commands', 'manage')
→ writeLimiter
→ validateParams(guildIdParam)
→ validateBody(...)      ← the check under test
→ asyncHandler
\`\`\`

\`beforeEach\` (file line 76) sets up:
- \`sessionService.getSession\` → \`MOCK_SESSION_DATA\` (authenticated, \`fixtures/mock-data.ts:46\`)
- \`guildAccessService.resolveGuildContext\` → \`MOCK_GUILD_CONTEXT\` with full \`manage\` access on every module (\`fixtures/mock-data.ts:65\`)
- \`guildAccessService.hasAccess\` → \`true\`
- \`jest.clearAllMocks()\` for isolation

Given this, a request to \`PATCH /api/guilds/:guildId/automod/settings\` with \`{ spamThreshold: 'not a number' }\` should reach \`validateBody\` with the body parsed (\`spamThreshold: z.number().int().min(1).max(100).optional()\` in \`schemas/management.ts:16\`), fail Zod's type check, and return 400. Same for \`POST /api/guilds/:guildId/commands\` with empty body — \`name\` is required per \`createCommandBody\`.

The skip comment was likely a carryover from an earlier middleware state. Unskipping in this PR to verify; if CI surfaces a real failure, we get actionable evidence instead of a silent skip.

## Test plan

- [ ] CI: \`Quality Gates\` must run \`npm run test --workspace=packages/backend\` and both tests pass.
- [ ] If they fail, the failure output tells us whether it's a mock-setup gap or a real middleware bug — either actionable.

## Risk

Zero. If the tests fail, CI catches it and this PR doesn't merge. If they pass, we eliminate 2 skipped negative-path tests from the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)