### PR TITLE
refactor(bot): type discord-player-youtubei dynamic import

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -1,5 +1,5 @@
 import { Player } from 'discord-player'
-import type { Track } from 'discord-player'
+import type { BaseExtractor, Track } from 'discord-player'
 import {
     SoundCloudExtractor,
     AppleMusicExtractor,
@@ -129,10 +129,16 @@ const initPlayDlSoundCloud = async (): Promise<void> => {
     }
 }
 
+type YoutubeExtractorModule = {
+    YoutubeExtractor?: typeof BaseExtractor<object>
+    YoutubeiExtractor?: typeof BaseExtractor<object>
+}
+
 const loadYoutubeExtractor = async (player: Player): Promise<void> => {
     try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const mod = (await import('discord-player-youtubei')) as any
+        const mod = (await import(
+            'discord-player-youtubei'
+        )) as YoutubeExtractorModule
 
         // v3 renamed YoutubeiExtractor → YoutubeExtractor
         const YoutubeExtractor = mod.YoutubeExtractor ?? mod.YoutubeiExtractor


### PR DESCRIPTION
## Summary
- Replace `(await import('discord-player-youtubei')) as any` + eslint-disable with a narrow `YoutubeExtractorModule` shape.
- Both `YoutubeExtractor` (v3) and legacy `YoutubeiExtractor` are typed against `discord-player`'s `BaseExtractor<object>` — the same base `player.extractors.register` expects.
- Closes backlog item **D.3** from `.claude/plans/backlog-2026-04-21.md` (`Replace \`any\` suppression around dynamic YouTube extractor integration`).

## Why
The loader was opaque to TypeScript: extractor-API changes in the underlying package would stay unchecked and fail at runtime. Typing the module shape restores that signal while keeping the runtime fallback for the v2 → v3 rename unchanged.

## Diff
9 insertions, 3 deletions — one file.

## Test plan
- [x] No behavior change — fallback from `YoutubeExtractor` to `YoutubeiExtractor` preserved.
- [x] Existing jest mocks in `packages/bot/tests/handlers/player/playerFactory.test.ts` continue to satisfy the loader (jest module-factory returns aren't typechecked against the real module).
- [ ] CI (Quality Gates + SonarCloud + Security) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)