### PR TITLE
docs(backlog): mark completed 2026-04-21 backlog items with PR evidence

### DIFF
--- a/docs/specs/2026-04-21-backlog-map/tasks.md
+++ b/docs/specs/2026-04-21-backlog-map/tasks.md
@@ -3,7 +3,7 @@
 ## Open
 
 - [ ] Security: refresh npm lock state for `follow-redirects >=1.15.12` and `hono >=4.12.14`.
-- [ ] Release process: restore GitHub release/tag flow for package version `2.6.148` (latest tag stuck at `v2.6.132`). **Production-visible — needs user confirmation before tagging.**
+- [ ] Release process: restore GitHub release/tag flow for package version `v2.6.148` (latest tag stuck at `v2.6.132`). **Production-visible — needs user confirmation before tagging.**
 - [ ] Autoplay diversity: start artist/album dedup in the existing `docs/specs/2026-04-15-autoplay-diversity/` spec (do not open a new spec).
 - [ ] Music debt: extract a pure scoring/enrichment slice from `queueManipulation.ts` (1,193 LOC, high-churn).
 - [ ] Redesign B-R4: collapse `/twitch` + `/lastfm` + `/spotify` into one `/integrations` page with legacy redirects.

--- a/docs/specs/2026-04-21-backlog-map/tasks.md
+++ b/docs/specs/2026-04-21-backlog-map/tasks.md
@@ -1,18 +1,24 @@
 # Tasks
 
-- [ ] PR #729: add webhook new-code coverage until Sonar reports >=80%.
-- [ ] Security: merge or replace #755 so open high `tar` Dependabot alerts close.
-- [ ] PR queue: update all open PRs from `origin/main` and re-read failing checks.
-- [ ] Shared constants: move Top.gg vote tiers and bot ID into `@lucky/shared`.
+## Open
+
 - [ ] Security: refresh npm lock state for `follow-redirects >=1.15.12` and `hono >=4.12.14`.
-- [ ] Backend validation: fix `validateBody` behavior and unskip two management invalid-body tests.
-- [ ] Release process: restore GitHub release/tag flow for package version `2.6.148`.
-- [ ] Autoplay diversity: start artist/album dedup in the existing 2026-04-15 spec.
-- [ ] Frontend tokens: choose one dashboard accent/font direction and apply in `packages/frontend/src/index.css`.
-- [ ] Music debt: extract a pure scoring/enrichment slice from `queueManipulation.ts`.
-- [ ] Sonar PRs: fix new-code coverage failures on PRs #737 and #740.
-- [x] Redesign A-R1: ADR — port-target decision. **Accepted 2026-04-21: Vite-port + dual accent + Sora/Manrope.** See `docs/decisions/2026-04-21-redesign-port-target.md`.
-- [ ] Redesign A-R2: add `--color-canvas/sidebar/panel/elevated/highlight/brand-discord/brand-accent/text-strong/body/muted/subtle` aliases to `packages/frontend/src/index.css`.
-- [ ] Redesign A-R3 + B-R1: extend `<SectionHeader>` with `eyebrowIcon` + `statusBand`; port `pages/DashboardOverview.tsx` to "Guild Summary" layout.
+- [ ] Release process: restore GitHub release/tag flow for package version `2.6.148` (latest tag stuck at `v2.6.132`). **Production-visible — needs user confirmation before tagging.**
+- [ ] Autoplay diversity: start artist/album dedup in the existing `docs/specs/2026-04-15-autoplay-diversity/` spec (do not open a new spec).
+- [ ] Music debt: extract a pure scoring/enrichment slice from `queueManipulation.ts` (1,193 LOC, high-churn).
 - [ ] Redesign B-R4: collapse `/twitch` + `/lastfm` + `/spotify` into one `/integrations` page with legacy redirects.
 - [ ] Redesign D-R2: update `branding/BRANDING_GUIDE.md` to match the redesign decision (dual accent: Discord blurple + neon pink; Sora display + Manrope body).
+- [ ] Page ports (per ADR execution plan): 13 pages, one PR each, in priority order. A-R3 + B-R1 shipped the `<SectionHeader>` primitive; the `DashboardOverview` → "Guild Summary" port is still pending.
+
+## Completed
+
+- [x] Redesign A-R1: ADR — port-target decision. **Accepted 2026-04-21: Vite-port + dual accent + Sora/Manrope.** See `docs/decisions/2026-04-21-redesign-port-target.md`.
+- [x] Redesign A-R2: short-form color token aliases added to `packages/frontend/src/index.css`. Landed in **#763** `feat(frontend): redesign token aliases + brand decision`.
+- [x] Redesign A-R3: `<SectionHeader>` extended with `eyebrowIcon` + `statusBand`. Landed in **#765** `feat(frontend): SectionHeader eyebrowIcon + statusBand`. `DashboardOverview` "Guild Summary" port (B-R1) still open — see "Page ports" above.
+- [x] PR #729: webhook new-code coverage merged 2026-04-22 (`ef069044`).
+- [x] Security: `tar` Dependabot alerts closed by **#766** `chore(security): delete orphaned per-package pnpm-lock.yaml files` (not the original #755 path — lockfiles were orphaned, so the tar chain was dead code). #755 closed.
+- [x] PR queue rebase sweep: ship-queue drained 2026-04-22 (#737, #740, #750, #751, #764, #768, #770, #771, #772, #773, #774, #766, #767, #769).
+- [x] Shared constants: Top.gg vote tiers + bot ID live in `packages/shared/src/constants/topgg.ts`. Both `packages/backend/src/routes/webhooks.ts` and `packages/bot/src/functions/general/commands/voterewards.ts` import `TOP_GG_VOTE_TIERS` / `TOP_GG_BOT_ID` / `TOP_GG_VOTE_URL` from shared.
+- [x] Backend validation: `validateBody` fixed and 400-on-invalid-body tests unskipped in **#769** `test(backend): unskip validateBody 400-on-invalid-body tests`.
+- [x] Frontend tokens: dashboard accent/font direction settled on dual-accent (Discord blurple + neon pink) with Sora/Manrope/JetBrains Mono. Landed in **#763**.
+- [x] Sonar PRs: new-code coverage failures on #737 and #740 cleared — both merged 2026-04-22 (#737 `a5808352`, #740 `e04d90e0`).


### PR DESCRIPTION
## Summary

Updates `docs/specs/2026-04-21-backlog-map/tasks.md` to reflect reality — **10 of 16 items already shipped**. The unchecked state was sending future agents down dead ends.

Splits the list into **Open** / **Completed** sections, cites the landing PR for each done item, and promotes the truly-remaining work to the top.

## Verified obsolete (now `[x]` with evidence)

- A-R2 token aliases — `--color-canvas`, `--color-sidebar`, `--color-panel`, etc. already in `packages/frontend/src/index.css` via **#763**.
- A-R3 `<SectionHeader>` `eyebrowIcon` + `statusBand` — **#765**.
- PR #729 webhook coverage — merged `ef069044`.
- `tar` Dependabot alerts — closed by **#766** (orphaned lockfile deletion; #755 was closed as superseded).
- PR queue rebase sweep — 14 PRs landed 2026-04-22.
- Shared Top.gg constants — already in `packages/shared/src/constants/topgg.ts`, both `packages/backend/src/routes/webhooks.ts` and `packages/bot/src/functions/general/commands/voterewards.ts` consume it.
- `validateBody` + unskipped invalid-body tests — **#769**.
- Frontend dashboard accent/font — **#763** settled dual-accent Blurple + Neon pink + Sora/Manrope.
- Sonar new-code coverage on #737 / #740 — both merged.

## Truly open (remaining work)

- Security: `follow-redirects >=1.15.12` + `hono >=4.12.14` lock refresh.
- Release/tag drift (`v2.6.132` vs `2.6.148`) — flagged as production-visible, needs user confirmation.
- Autoplay diversity dedup — continue in existing `docs/specs/2026-04-15-autoplay-diversity/`.
- `queueManipulation.ts` 1,193 LOC extraction.
- Redesign B-R4: `/twitch` + `/lastfm` + `/spotify` → `/integrations` collapse.
- Redesign D-R2: `branding/BRANDING_GUIDE.md` update.
- Per-page ports (13 pages per ADR execution plan; `DashboardOverview` → "Guild Summary" is the first B-R1 port still open).

## Test plan

- [x] Single-file diff, `docs/specs/2026-04-21-backlog-map/tasks.md` only
- [x] All `[x]` claims verified against `gh pr view`, `git log origin/main`, or direct grep on the relevant file
- [x] File structure matches repo's spec-doc convention (sibling `spec.md` already existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal project task tracking and organization with status updates on various development initiatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->