### PR TITLE
feat(frontend): polish accessibility semantics and stabilize tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9645,7 +9645,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9662,7 +9661,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9679,7 +9677,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9696,7 +9693,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9713,7 +9709,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9730,7 +9725,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9747,7 +9741,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9764,7 +9757,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9781,7 +9773,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9798,7 +9789,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9815,7 +9805,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9832,7 +9821,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [

--- a/packages/frontend/src/components/Layout/Layout.test.tsx
+++ b/packages/frontend/src/components/Layout/Layout.test.tsx
@@ -43,6 +43,8 @@ describe('Layout', () => {
         renderLayout('/')
 
         expect(screen.getByTestId('sidebar')).toBeInTheDocument()
+        expect(screen.getByRole('link', { name: /skip to content/i })).toHaveAttribute('href', '#lucky-main-content')
+        expect(screen.getByRole('main')).toHaveAttribute('id', 'lucky-main-content')
         expect(screen.getByText('Dashboard')).toBeInTheDocument()
         expect(
             screen.getByText(

--- a/packages/frontend/src/components/Layout/Layout.tsx
+++ b/packages/frontend/src/components/Layout/Layout.tsx
@@ -112,10 +112,13 @@ function Layout({ children }: LayoutProps) {
 
     return (
         <div className='lucky-shell flex min-h-screen'>
+            <a className='lucky-skip-link' href='#lucky-main-content'>
+                Skip to content
+            </a>
             <Sidebar />
             <div className='flex min-w-0 flex-1 flex-col'>
-                <header className='sticky top-0 z-20 border-b border-lucky-border bg-lucky-bg-primary/95 backdrop-blur-md relative'>
-                    <div className='mx-auto flex w-full max-w-[1400px] items-center justify-between gap-4 px-4 py-3 md:px-6'>
+                <header className='sticky top-0 z-20 border-b border-lucky-border bg-lucky-bg-primary/90 backdrop-blur-xl relative'>
+                    <div className='mx-auto flex w-full max-w-[1400px] items-center justify-between gap-4 px-4 py-3.5 md:px-6 md:py-4'>
                         <div className='min-w-0'>
                             <h1 className='type-title text-lucky-text-primary leading-tight'>
                                 {routeCopy.title}
@@ -133,8 +136,8 @@ function Layout({ children }: LayoutProps) {
                     <div className='lucky-header-accent-line' aria-hidden='true' />
                 </header>
 
-                <main className='flex-1 min-w-0 overflow-y-auto'>
-                    <div className='mx-auto w-full max-w-[1400px] px-4 py-6 md:px-6 lg:px-8'>
+                <main id='lucky-main-content' className='flex-1 min-w-0 overflow-y-auto' tabIndex={-1}>
+                    <div className='mx-auto w-full max-w-[1400px] px-4 py-6 md:px-6 lg:px-8 lg:py-7'>
                         {children}
                     </div>
                 </main>

--- a/packages/frontend/src/components/ui/Card.tsx
+++ b/packages/frontend/src/components/ui/Card.tsx
@@ -13,17 +13,19 @@ const Card = forwardRef<HTMLDivElement, CardProps>(
             <div
                 ref={ref}
                 className={cn(
-                    'bg-lucky-bg-secondary border border-lucky-border rounded-lg',
-                    'shadow-[0_2px_12px_rgb(0_0_0/0.2)]',
-                    'transition-colors duration-150',
-                    hover && 'hover:border-lucky-border-strong',
+                    'surface-card relative transition-all duration-200',
+                    'focus-within:border-lucky-brand/35 focus-within:ring-2 focus-within:ring-lucky-brand/20',
+                    hover && 'hover:border-lucky-border-strong hover:bg-lucky-bg-active/60',
                     interactive && [
                         'cursor-pointer',
+                        'transform-gpu',
                         'hover:border-lucky-border-strong',
+                        'hover:bg-lucky-bg-active/70',
                         'hover:-translate-y-px',
+                        'active:border-lucky-brand/30',
                         'active:translate-y-0',
                     ],
-                    glow && 'border-lucky-brand/30',
+                    glow && 'border-lucky-brand/30 shadow-[0_0_0_1px_rgb(236_72_153/0.08)]',
                     className,
                 )}
                 {...props}

--- a/packages/frontend/src/components/ui/EmptyState.tsx
+++ b/packages/frontend/src/components/ui/EmptyState.tsx
@@ -19,20 +19,20 @@ export default function EmptyState({
     return (
         <section
             className={cn(
-                'surface-panel flex min-h-[240px] flex-col items-center justify-center px-6 py-10 text-center',
+                'surface-panel mx-auto flex w-full min-h-[240px] max-w-2xl flex-col items-center justify-center px-6 py-12 text-center md:px-10 md:py-14',
                 className,
             )}
         >
             {icon && (
-                <div className='mb-5 flex items-center justify-center'>
-                    <div className='rounded-xl border border-lucky-border bg-lucky-bg-tertiary p-4 text-lucky-text-tertiary'>
+                <div className='mb-6 flex items-center justify-center' aria-hidden='true'>
+                    <div className='rounded-xl border border-lucky-border bg-lucky-bg-tertiary p-4 text-lucky-text-tertiary shadow-[0_1px_0_rgb(255_255_255/0.03)_inset]'>
                         {icon}
                     </div>
                 </div>
             )}
             <h2 className='type-h2 text-lucky-text-primary'>{title}</h2>
-            <p className='mt-2 max-w-lg type-body text-lucky-text-secondary'>{description}</p>
-            {action && <div className='mt-6'>{action}</div>}
+            <p className='mt-3 max-w-lg type-body text-lucky-text-secondary'>{description}</p>
+            {action && <div className='mt-8 flex justify-center'>{action}</div>}
         </section>
     )
 }

--- a/packages/frontend/src/components/ui/SectionHeader.tsx
+++ b/packages/frontend/src/components/ui/SectionHeader.tsx
@@ -47,8 +47,8 @@ export default function SectionHeader({
 }: SectionHeaderProps) {
     return (
         <div className={cn('space-y-4', className)}>
-            <header className='flex items-start justify-between gap-4'>
-                <div className='space-y-1'>
+            <header className='flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4'>
+                <div className='min-w-0 space-y-1'>
                     {eyebrow && (
                         <p className='type-meta inline-flex items-center gap-2 text-lucky-text-subtle'>
                             {eyebrowIcon && (
@@ -64,17 +64,17 @@ export default function SectionHeader({
                     )}
                     <h1 className='type-h1 text-lucky-text-primary'>{title}</h1>
                     {description && (
-                        <p className='type-body text-lucky-text-secondary max-w-3xl'>
+                        <p className='type-body max-w-3xl text-lucky-text-secondary'>
                             {description}
                         </p>
                     )}
                 </div>
-                {actions && <div className='shrink-0'>{actions}</div>}
+                {actions && <div className='flex flex-wrap gap-2 md:justify-end'>{actions}</div>}
             </header>
 
             {statusBand && statusBand.length > 0 && (
                 <div
-                    className='grid grid-cols-2 gap-2 rounded-2xl border border-panel bg-sidebar p-1 md:grid-cols-4'
+                    className='grid grid-cols-2 gap-2 rounded-2xl border border-panel bg-sidebar p-2 md:grid-cols-4 md:p-1.5'
                     role='list'
                     aria-label='Module status'
                 >
@@ -84,12 +84,12 @@ export default function SectionHeader({
                             <div
                                 key={tile.id ?? `${tile.label}:${tile.status}:${index}`}
                                 role='listitem'
-                                className='group flex items-center gap-3 rounded-xl border border-transparent bg-canvas/30 p-3 transition-colors hover:border-panel'
+                                className='group flex min-h-[84px] items-center gap-3 rounded-xl border border-transparent bg-canvas/40 p-3.5 transition-colors hover:border-panel'
                             >
                                 {tile.icon && (
                                     <span
                                         className={cn(
-                                            'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-panel bg-elevated transition-colors group-hover:bg-highlight',
+                                            'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-panel bg-elevated/90 transition-colors group-hover:bg-highlight',
                                             toneClass,
                                         )}
                                         aria-hidden='true'
@@ -98,12 +98,12 @@ export default function SectionHeader({
                                     </span>
                                 )}
                                 <div className='min-w-0'>
-                                    <p className='text-[10px] font-mono uppercase tracking-widest leading-none text-lucky-text-tertiary'>
+                                    <p className='type-meta text-lucky-text-tertiary'>
                                         {tile.label}
                                     </p>
                                     <p
                                         className={cn(
-                                            'mt-1 text-xs font-bold leading-none',
+                                            'mt-1.5 text-sm font-semibold leading-tight',
                                             toneClass,
                                         )}
                                     >

--- a/packages/frontend/src/components/ui/StatTile.tsx
+++ b/packages/frontend/src/components/ui/StatTile.tsx
@@ -32,16 +32,16 @@ export default function StatTile({
     return (
         <article
             className={cn(
-                'surface-panel space-y-3 p-4',
+                'surface-panel flex flex-col gap-4 p-5',
                 className,
             )}
         >
             <div className='flex items-center justify-between gap-2'>
-                <p className='type-body-sm text-lucky-text-tertiary'>{label}</p>
+                <p className='type-meta text-lucky-text-tertiary'>{label}</p>
                 {icon && (
                     <span
                         className={cn(
-                            'rounded-lg p-2',
+                            'rounded-lg p-2.5',
                             toneIconClass[tone],
                         )}
                     >
@@ -50,14 +50,14 @@ export default function StatTile({
                 )}
             </div>
             <p
-                className='type-h2 text-lucky-text-primary'
+                className='type-h2 leading-tight text-lucky-text-primary'
             >
                 {typeof value === 'number' ? value.toLocaleString() : value}
             </p>
             {delta !== undefined && (
                 <p
                     className={cn(
-                        'type-body-sm inline-flex items-center gap-1.5 rounded-full px-2 py-0.5',
+                        'type-body-sm inline-flex items-center gap-1.5 self-start rounded-full px-2.5 py-1 font-medium',
                         delta >= 0
                             ? 'bg-lucky-success/10 text-lucky-success'
                             : 'bg-lucky-error/10 text-lucky-error',

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -504,7 +504,44 @@
     position: relative;
     min-height: 100vh;
     color: var(--lucky-text-primary);
+    isolation: isolate;
+    overflow-x: clip;
     background-color: var(--lucky-surface-canvas);
+    background-image:
+      radial-gradient(circle at 20% 0%, rgb(236 72 153 / 0.08), transparent 34%),
+      radial-gradient(circle at 85% 10%, rgb(251 146 60 / 0.06), transparent 28%),
+      linear-gradient(180deg, rgb(255 255 255 / 0.025), transparent 18%),
+      linear-gradient(180deg, var(--lucky-surface-canvas), var(--lucky-surface-canvas));
+  }
+
+  .lucky-skip-link {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    z-index: 50;
+    border: 1px solid var(--lucky-border-strong);
+    border-radius: 9999px;
+    background: var(--lucky-bg-secondary);
+    padding: 0.75rem 1rem;
+    font-family: var(--font-lucky-body);
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--lucky-text-primary);
+    box-shadow: var(--lucky-shadow-panel);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-180%);
+    transition: transform 160ms ease, opacity 160ms ease, border-color 160ms ease,
+      background-color 160ms ease;
+
+    &:focus-visible {
+      opacity: 1;
+      pointer-events: auto;
+      outline: none;
+      transform: translateY(0);
+      border-color: rgb(88 101 242 / 0.55);
+      box-shadow: 0 0 0 3px rgb(88 101 242 / 0.25), var(--lucky-shadow-panel);
+    }
   }
 
   .lucky-focus-visible:focus-visible {

--- a/packages/frontend/src/pages/Config.test.tsx
+++ b/packages/frontend/src/pages/Config.test.tsx
@@ -67,10 +67,8 @@ describe('ConfigPage', () => {
             </MemoryRouter>,
         )
 
-        const musicCard = screen
-            .getByText('Music Module')
-            .closest('[role="button"]')
-        await user.click(musicCard!)
+        const musicCard = screen.getByRole('button', { name: /Music Module/i })
+        await user.click(musicCard)
 
         expect(screen.getByText('← Back')).toBeInTheDocument()
     })
@@ -86,10 +84,8 @@ describe('ConfigPage', () => {
             </MemoryRouter>,
         )
 
-        const musicCard = screen
-            .getByText('Music Module')
-            .closest('[role="button"]')
-        await user.click(musicCard!)
+        const musicCard = screen.getByRole('button', { name: /Music Module/i })
+        await user.click(musicCard)
 
         const backButton = screen.getByText('← Back')
         await user.click(backButton)

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -1,7 +1,6 @@
 import { useState, lazy, Suspense } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Music, MessageSquare, Shield } from 'lucide-react'
-import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
 import { useGuildSelection } from '@/hooks/useGuildSelection'
@@ -83,26 +82,18 @@ export default function ConfigPage() {
                     </h2>
                     <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
                         {modules.map((module) => (
-                            <Card
+                            <button
                                 key={module.id}
-                                className='p-6 hover:bg-lucky-bg-tertiary transition-colors cursor-pointer'
+                                type='button'
+                                className='surface-card group w-full p-6 text-left transition-all duration-200 hover:border-lucky-border-strong hover:bg-lucky-bg-active focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lucky-brand/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background'
                                 onClick={() => handleModuleClick(module.id)}
-                                role='button'
-                                tabIndex={0}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter' || e.key === ' ') {
-                                        e.preventDefault()
-                                        handleModuleClick(module.id)
-                                    }
-                                }}
-                                aria-label={`Configure ${module.name}`}
                             >
                                 <div className='flex items-start gap-4'>
                                     <div
-                                        className='p-3 bg-primary/20 rounded-lg'
+                                        className='rounded-lg bg-lucky-brand/15 p-3 text-lucky-brand transition-colors group-hover:bg-lucky-brand/20'
                                         aria-hidden='true'
                                     >
-                                        <module.icon className='w-6 h-6 text-primary' />
+                                        <module.icon className='h-6 w-6' />
                                     </div>
                                     <div className='flex-1'>
                                         <h3 className='type-h2 text-lucky-text-primary mb-1'>
@@ -113,7 +104,7 @@ export default function ConfigPage() {
                                         </p>
                                     </div>
                                 </div>
-                            </Card>
+                            </button>
                         ))}
                     </div>
                 </section>

--- a/packages/frontend/src/pages/Landing.test.tsx
+++ b/packages/frontend/src/pages/Landing.test.tsx
@@ -84,10 +84,10 @@ describe('Landing', () => {
         expect(subheadline).toBeInTheDocument()
 
         // Check for CTA buttons
-        const addToDiscordBtn = screen.getByRole('button', { name: /Add to Discord/i })
+        const addToDiscordLink = screen.getByRole('link', { name: /Add to Discord/i })
         const openDashboardBtn = screen.getByRole('button', { name: /Open Dashboard/i })
 
-        expect(addToDiscordBtn).toBeInTheDocument()
+        expect(addToDiscordLink).toBeInTheDocument()
         expect(openDashboardBtn).toBeInTheDocument()
     })
 
@@ -203,21 +203,14 @@ describe('Landing', () => {
         expect(githubLink).toHaveAttribute('rel', 'noreferrer')
     })
 
-    test('renders Add to Discord button with correct href when clicked', async () => {
-        const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    test('renders Add to Discord link with correct attributes', () => {
         render(<Landing />)
 
-        const addToDiscordBtn = screen.getByRole('button', { name: /Add to Discord/i })
-        expect(addToDiscordBtn).toBeInTheDocument()
+        const addToDiscordLink = screen.getByRole('link', { name: /Add to Discord/i })
 
-        fireEvent.click(addToDiscordBtn)
-
-        await waitFor(() => {
-            expect(openSpy).toHaveBeenCalledWith(
-                expect.stringContaining('discord.com/oauth2/authorize'),
-                '_blank'
-            )
-        })
+        expect(addToDiscordLink).toHaveAttribute('href', expect.stringContaining('discord.com/oauth2/authorize'))
+        expect(addToDiscordLink).toHaveAttribute('target', '_blank')
+        expect(addToDiscordLink).toHaveAttribute('rel', 'noopener noreferrer')
     })
 
     test('calls login when Open Dashboard button is clicked', async () => {

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -136,13 +136,14 @@ function HeroSection({ logoAnimation, onLogin }: { logoAnimation: any; onLogin: 
                     animate={{ opacity: 1 }}
                     transition={{ delay: 0.4, duration: 0.6 }}
                 >
-                    <Button
-                        onClick={() => window.open(BOT_INVITE_URL, '_blank')}
-                        variant='primary'
-                        className='px-8 py-3 h-12 rounded-lg bg-gradient-to-r from-pink-500 to-orange-400 text-white font-semibold hover:shadow-lg hover:shadow-pink-500/50 transition-all duration-300 border-0'
+                    <a
+                        href={BOT_INVITE_URL}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        className='inline-flex h-12 items-center justify-center rounded-lg border-0 bg-gradient-to-r from-pink-500 to-orange-400 px-8 py-3 font-semibold text-white transition-all duration-300 hover:shadow-lg hover:shadow-pink-500/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950'
                     >
                         {t('landing.hero.ctaPrimary')}
-                    </Button>
+                    </a>
                     <Button
                         onClick={onLogin}
                         variant='secondary'
@@ -158,7 +159,6 @@ function HeroSection({ logoAnimation, onLogin }: { logoAnimation: any; onLogin: 
 
 // Feature Grid with Neon Icon Orbs
 function FeatureSection() {
-    const prefersReducedMotion = useReducedMotion()
     const { t } = useTranslation()
 
     const features = [
@@ -220,30 +220,30 @@ function FeatureSection() {
                     <p className='text-gray-300 text-lg'>{t('landing.features.subheading')}</p>
                 </motion.div>
 
-                <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
+                <ul className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
                     {features.map((feature, idx) => {
                         const Icon = feature.icon
                         return (
-                            <motion.div
-                                key={feature.titleKey}
-                                initial={{ opacity: 0, y: 20 }}
-                                whileInView={{ opacity: 1, y: 0 }}
-                                transition={{ duration: 0.5, delay: idx * 0.1 }}
-                                viewport={{ once: true }}
-                                whileHover={prefersReducedMotion ? {} : { y: -4 }}
-                                className={`rounded-xl border border-white/10 bg-gradient-to-br ${feature.color} backdrop-blur-sm p-6 space-y-4 hover:border-white/20 transition-all duration-300 group cursor-pointer`}
-                            >
-                                <div className={`inline-flex p-3 rounded-lg bg-white/5 group-hover:bg-white/10 transition-colors ${feature.iconColor}`}>
-                                    <Icon size={24} />
-                                </div>
-                                <div>
-                                    <h3 className='text-xl font-semibold text-white mb-2'>{t(feature.titleKey)}</h3>
-                                    <p className='text-gray-300 text-sm'>{t(feature.descKey)}</p>
-                                </div>
-                            </motion.div>
+                            <li key={feature.titleKey} className='h-full'>
+                                <motion.article
+                                    initial={{ opacity: 0, y: 20 }}
+                                    whileInView={{ opacity: 1, y: 0 }}
+                                    transition={{ duration: 0.5, delay: idx * 0.1 }}
+                                    viewport={{ once: true }}
+                                    className={`h-full rounded-xl border border-white/10 bg-gradient-to-br ${feature.color} backdrop-blur-sm p-6 space-y-4 transition-colors duration-300`}
+                                >
+                                    <div className={`inline-flex rounded-lg bg-white/5 p-3 transition-colors ${feature.iconColor}`}>
+                                        <Icon size={24} />
+                                    </div>
+                                    <div>
+                                        <h3 className='mb-2 text-xl font-semibold text-white'>{t(feature.titleKey)}</h3>
+                                        <p className='text-sm text-gray-300'>{t(feature.descKey)}</p>
+                                    </div>
+                                </motion.article>
+                            </li>
                         )
                     })}
-                </div>
+                </ul>
             </div>
         </section>
     )

--- a/packages/frontend/src/pages/Music.test.tsx
+++ b/packages/frontend/src/pages/Music.test.tsx
@@ -19,6 +19,9 @@ vi.mock('@/components/Music/ImportPlaylist', () => ({
 vi.mock('@/components/Music/QueueList', () => ({
     default: () => <div data-testid='queue-list'>QueueList</div>,
 }))
+vi.mock('@/components/Music/AutoplayGenres', () => ({
+    default: () => <div data-testid='autoplay-genres'>AutoplayGenres</div>,
+}))
 
 const mockGuild = { id: '123', name: 'Test Guild' }
 
@@ -80,6 +83,7 @@ describe('MusicPage', () => {
         expect(screen.getByTestId('search-bar')).toBeInTheDocument()
         expect(screen.getByTestId('import-playlist')).toBeInTheDocument()
         expect(screen.getByTestId('queue-list')).toBeInTheDocument()
+        expect(screen.getByTestId('autoplay-genres')).toBeInTheDocument()
     })
 
     test('shows not connected message when no voice channel', () => {


### PR DESCRIPTION
## Summary
- improve shared frontend primitives and shell polish with token-consistent Card, SectionHeader, StatTile, and EmptyState updates
- add keyboard-first accessibility improvements with a global skip link, semantic module buttons in Config, and semantic external CTA/list markup on Landing
- update affected frontend tests and isolate Music page async side effects to eliminate Vitest teardown instability

## Validation
- npm run lint --workspace=packages/frontend
- npm run type:check --workspace=packages/frontend
- npm run build --workspace=packages/frontend
- npm run test --workspace=packages/frontend -- src/pages/Config.test.tsx src/pages/Landing.test.tsx src/components/Layout/Layout.test.tsx
- npm run test --workspace=packages/frontend