### PR TITLE
fix(frontend): harden runtime behavior and patch transitive deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15477,9 +15477,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -16248,9 +16248,9 @@
       "license": "ISC"
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -115,11 +115,11 @@
     "@smithy/config-resolver": ">=4.4.10",
     "@aws-sdk/client-sso": ">=3.726.0",
     "@hono/node-server": ">=1.19.13",
-    "hono": ">=4.12.12",
+    "hono": ">=4.12.14",
     "lodash": ">=4.17.22",
     "file-type": ">=21.3.2",
     "yauzl": ">=3.2.1",
     "picomatch": ">=2.3.2",
-    "follow-redirects": "^1.15.12"
+    "follow-redirects": "1.16.0"
   }
 }

--- a/packages/frontend/src/components/Layout/Layout.test.tsx
+++ b/packages/frontend/src/components/Layout/Layout.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Layout from './Layout'
 import { useGuildSelection } from '@/hooks/useGuildSelection'
@@ -57,6 +57,14 @@ describe('Layout', () => {
             }),
         ).toBeInTheDocument()
         expect(screen.getByText('Test Server')).toBeInTheDocument()
+    })
+
+    test('skip link focuses the main content', () => {
+        renderLayout('/')
+
+        fireEvent.click(screen.getByRole('link', { name: /skip to content/i }))
+
+        expect(screen.getByRole('main')).toHaveFocus()
     })
 
     test('renders music history route copy', () => {

--- a/packages/frontend/src/components/Layout/Layout.tsx
+++ b/packages/frontend/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { type MouseEvent, type ReactNode, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import Sidebar from './Sidebar'
@@ -109,15 +109,21 @@ function GuildChip() {
 function Layout({ children }: LayoutProps) {
     const location = useLocation()
     const routeCopy = useRouteCopy(location.pathname)
+    const mainRef = useRef<HTMLElement>(null)
+
+    const handleSkipLinkClick = (event: MouseEvent<HTMLAnchorElement>) => {
+        event.preventDefault()
+        mainRef.current?.focus({ preventScroll: true })
+    }
 
     return (
-        <div className='lucky-shell flex min-h-screen'>
-            <a className='lucky-skip-link' href='#lucky-main-content'>
+        <div className='lucky-shell lucky-shell-authenticated flex min-h-screen'>
+            <a className='lucky-skip-link' href='#lucky-main-content' onClick={handleSkipLinkClick}>
                 Skip to content
             </a>
             <Sidebar />
             <div className='flex min-w-0 flex-1 flex-col'>
-                <header className='sticky top-0 z-20 border-b border-lucky-border bg-lucky-bg-primary/90 backdrop-blur-xl relative'>
+                <header className='lucky-shell-header sticky top-0 z-20 border-b border-lucky-border bg-lucky-bg-primary/92 relative'>
                     <div className='mx-auto flex w-full max-w-[1400px] items-center justify-between gap-4 px-4 py-3.5 md:px-6 md:py-4'>
                         <div className='min-w-0'>
                             <h1 className='type-title text-lucky-text-primary leading-tight'>
@@ -136,7 +142,7 @@ function Layout({ children }: LayoutProps) {
                     <div className='lucky-header-accent-line' aria-hidden='true' />
                 </header>
 
-                <main id='lucky-main-content' className='flex-1 min-w-0 overflow-y-auto' tabIndex={-1}>
+                <main ref={mainRef} id='lucky-main-content' className='flex-1 min-w-0 overflow-y-auto' tabIndex={-1}>
                     <div className='mx-auto w-full max-w-[1400px] px-4 py-6 md:px-6 lg:px-8 lg:py-7'>
                         {children}
                     </div>

--- a/packages/frontend/src/components/ui/Card.tsx
+++ b/packages/frontend/src/components/ui/Card.tsx
@@ -13,12 +13,11 @@ const Card = forwardRef<HTMLDivElement, CardProps>(
             <div
                 ref={ref}
                 className={cn(
-                    'surface-card relative transition-all duration-200',
+                    'surface-card relative transition-colors transition-shadow transition-transform duration-200',
                     'focus-within:border-lucky-brand/35 focus-within:ring-2 focus-within:ring-lucky-brand/20',
                     hover && 'hover:border-lucky-border-strong hover:bg-lucky-bg-active/60',
                     interactive && [
                         'cursor-pointer',
-                        'transform-gpu',
                         'hover:border-lucky-border-strong',
                         'hover:bg-lucky-bg-active/70',
                         'hover:-translate-y-px',

--- a/packages/frontend/src/hooks/useCountUp.test.ts
+++ b/packages/frontend/src/hooks/useCountUp.test.ts
@@ -1,8 +1,39 @@
-import { describe, test, expect } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
 import { useCountUp } from './useCountUp'
 
 describe('useCountUp', () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+
+        globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+            const timeoutId = setTimeout(() => callback(Date.now()), 16)
+
+            return timeoutId as unknown as number
+        }) as typeof requestAnimationFrame
+
+        globalThis.cancelAnimationFrame = ((animationFrameId: number) => {
+            clearTimeout(animationFrameId as unknown as ReturnType<typeof setTimeout>)
+        }) as typeof cancelAnimationFrame
+    })
+
+    afterEach(() => {
+        vi.clearAllTimers()
+        vi.useRealTimers()
+
+        globalThis.requestAnimationFrame = originalRequestAnimationFrame
+        globalThis.cancelAnimationFrame = originalCancelAnimationFrame
+    })
+
+    const advanceTimers = async (ms: number) => {
+        await act(async () => {
+            vi.advanceTimersByTime(ms)
+        })
+    }
+
     test('should initialize with value 0', () => {
         const { result } = renderHook(() => useCountUp(100))
 
@@ -10,26 +41,55 @@ describe('useCountUp', () => {
         expect(result.current.isComplete).toBe(false)
     })
 
-    test('should animate to target value', async () => {
-        const { result } = renderHook(() => useCountUp(100, { duration: 100 }))
-
-        await new Promise((resolve) => setTimeout(resolve, 150))
-
-        expect(result.current.value).toBeGreaterThan(0)
-    })
-
-    test('should handle small target values', () => {
-        const { result } = renderHook(() => useCountUp(1, { duration: 100 }))
+    test('should delay the animation start once', async () => {
+        const { result } = renderHook(() =>
+            useCountUp(100, { duration: 100, delay: 50 }),
+        )
 
         expect(result.current.value).toBe(0)
+        expect(result.current.isComplete).toBe(false)
+
+        await advanceTimers(50)
+        expect(result.current.value).toBe(0)
+
+        await advanceTimers(16)
+        expect(result.current.value).toBeGreaterThan(0)
+        expect(result.current.isComplete).toBe(false)
     })
 
-    test('should return value and isComplete properties', () => {
-        const { result } = renderHook(() => useCountUp(100))
+    test('should complete the animation and set isComplete', async () => {
+        const { result } = renderHook(() =>
+            useCountUp(100, { duration: 100 }),
+        )
 
-        expect(result.current).toHaveProperty('value')
-        expect(result.current).toHaveProperty('isComplete')
-        expect(typeof result.current.value).toBe('number')
-        expect(typeof result.current.isComplete).toBe('boolean')
+        await advanceTimers(200)
+
+        expect(result.current.value).toBe(100)
+        expect(result.current.isComplete).toBe(true)
+    })
+
+    test('should reset state when the target changes', async () => {
+        const { result, rerender } = renderHook(
+            ({ targetValue }) =>
+                useCountUp(targetValue, { duration: 100 }),
+            {
+                initialProps: { targetValue: 100 },
+            },
+        )
+
+        await advanceTimers(32)
+
+        expect(result.current.value).toBeGreaterThan(0)
+        expect(result.current.value).toBeLessThan(100)
+
+        rerender({ targetValue: 200 })
+
+        expect(result.current.value).toBe(0)
+        expect(result.current.isComplete).toBe(false)
+
+        await advanceTimers(200)
+
+        expect(result.current.value).toBe(200)
+        expect(result.current.isComplete).toBe(true)
     })
 })

--- a/packages/frontend/src/hooks/useCountUp.ts
+++ b/packages/frontend/src/hooks/useCountUp.ts
@@ -17,23 +17,28 @@ export function useCountUp(
     const [isComplete, setIsComplete] = useState(false)
 
     useEffect(() => {
-        let animationFrameId: number
+        let animationFrameId: number | undefined
         let timeoutId: ReturnType<typeof setTimeout> | undefined
+        let cancelled = false
+
+        setValue(0)
+        setIsComplete(false)
 
         const animate = () => {
+            if (cancelled) {
+                return
+            }
+
             const startTime = Date.now()
-            const delayedStartTime = startTime + delay
 
             const step = () => {
-                const now = Date.now()
-
-                if (now < delayedStartTime) {
-                    // Still in delay period
-                    animationFrameId = requestAnimationFrame(step)
+                if (cancelled) {
                     return
                 }
 
-                const elapsed = now - delayedStartTime
+                const now = Date.now()
+
+                const elapsed = now - startTime
                 const progress = Math.min(elapsed / duration, 1)
 
                 // Easing function: ease-out cubic
@@ -64,8 +69,12 @@ export function useCountUp(
         }
 
         return () => {
-            cancelAnimationFrame(animationFrameId)
-            if (timeoutId) {
+            cancelled = true
+
+            if (animationFrameId !== undefined) {
+                cancelAnimationFrame(animationFrameId)
+            }
+            if (timeoutId !== undefined) {
                 clearTimeout(timeoutId)
             }
         }

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -514,6 +514,18 @@
       linear-gradient(180deg, var(--lucky-surface-canvas), var(--lucky-surface-canvas));
   }
 
+  .lucky-shell-authenticated {
+    background-image:
+      linear-gradient(180deg, rgb(255 255 255 / 0.02), transparent 14%),
+      linear-gradient(135deg, rgb(236 72 153 / 0.05), rgb(251 146 60 / 0.02) 42%, transparent 72%),
+      linear-gradient(180deg, var(--lucky-surface-canvas), var(--lucky-surface-canvas));
+  }
+
+  .lucky-shell-authenticated .lucky-shell-header {
+    background-color: rgb(15 17 23 / 0.92);
+    backdrop-filter: none;
+  }
+
   .lucky-skip-link {
     position: absolute;
     top: 1rem;

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '@/stores/authStore'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
@@ -36,19 +36,38 @@ export default function Landing() {
         delay: 500,
     })
 
+    const displayGuildCount = prefersReducedMotion ? stats?.totalGuilds ?? 0 : guildCount
+    const displayUserCount = prefersReducedMotion ? stats?.totalUsers ?? 0 : userCount
+
     useEffect(() => {
+        let isActive = true
+
         const fetchStats = async () => {
             try {
                 const response = await api.stats.getPublic()
+                if (!isActive) {
+                    return
+                }
+
                 setStats(response.data)
             } catch (error) {
+                if (!isActive) {
+                    return
+                }
+
                 console.error('Failed to fetch stats:', error)
             } finally {
-                setStatsLoading(false)
+                if (isActive) {
+                    setStatsLoading(false)
+                }
             }
         }
 
         fetchStats()
+
+        return () => {
+            isActive = false
+        }
     }, [])
 
     usePageMetadata({
@@ -56,12 +75,16 @@ export default function Landing() {
         description: t('landing.meta.description'),
     })
 
-    const logoAnimation = prefersReducedMotion
-        ? {}
-        : {
-              animate: { scale: [1, 1.03, 1] },
-              transition: { duration: 3, repeat: Infinity, ease: 'easeInOut' },
-          }
+    const logoAnimation = useMemo(
+        () =>
+            prefersReducedMotion
+                ? {}
+                : {
+                      animate: { scale: [1, 1.03, 1] },
+                      transition: { duration: 3, repeat: Infinity, ease: 'easeInOut' },
+                  },
+        [prefersReducedMotion],
+    )
 
     return (
         <div className='lucky-shell min-h-screen dark text-white'>
@@ -72,7 +95,12 @@ export default function Landing() {
             <FeatureSection />
 
             {/* Stats Strip */}
-            <StatsSection statsLoading={statsLoading} guildCount={guildCount} userCount={userCount} serversOnline={stats?.serversOnline} />
+            <StatsSection
+                statsLoading={statsLoading}
+                guildCount={displayGuildCount}
+                userCount={displayUserCount}
+                serversOnline={stats?.serversOnline}
+            />
 
             {/* FAQ */}
             <FAQSection />
@@ -84,7 +112,12 @@ export default function Landing() {
 }
 
 // Hero Section with Animated Logo
-function HeroSection({ logoAnimation, onLogin }: { logoAnimation: any; onLogin: () => void }) {
+type HeroSectionProps = {
+    logoAnimation: Record<string, unknown>
+    onLogin: () => void
+}
+
+function HeroSection({ logoAnimation, onLogin }: HeroSectionProps) {
     const prefersReducedMotion = useReducedMotion()
     const { t } = useTranslation()
 
@@ -114,7 +147,11 @@ function HeroSection({ logoAnimation, onLogin }: { logoAnimation: any; onLogin: 
                         src='/lucky-logo.png'
                         alt='Lucky Bot'
                         className='h-32 w-32 mx-auto drop-shadow-2xl filter saturate-150'
-                        loading='lazy'
+                        width='128'
+                        height='128'
+                        loading='eager'
+                        fetchPriority='high'
+                        decoding='async'
                     />
                 </motion.div>
 
@@ -161,50 +198,53 @@ function HeroSection({ logoAnimation, onLogin }: { logoAnimation: any; onLogin: 
 function FeatureSection() {
     const { t } = useTranslation()
 
-    const features = [
-        {
-            icon: Music,
-            titleKey: 'landing.features.music.title',
-            descKey: 'landing.features.music.description',
-            color: 'from-pink-500/20 to-pink-600/10',
-            iconColor: 'text-pink-400',
-        },
-        {
-            icon: Shield,
-            titleKey: 'landing.features.autoMod.title',
-            descKey: 'landing.features.autoMod.description',
-            color: 'from-orange-500/20 to-orange-600/10',
-            iconColor: 'text-orange-400',
-        },
-        {
-            icon: Zap,
-            titleKey: 'landing.features.customCommands.title',
-            descKey: 'landing.features.customCommands.description',
-            color: 'from-purple-500/20 to-purple-600/10',
-            iconColor: 'text-purple-400',
-        },
-        {
-            icon: BarChart3,
-            titleKey: 'landing.features.webDashboard.title',
-            descKey: 'landing.features.webDashboard.description',
-            color: 'from-blue-500/20 to-blue-600/10',
-            iconColor: 'text-blue-400',
-        },
-        {
-            icon: Palette,
-            titleKey: 'landing.features.embedBuilder.title',
-            descKey: 'landing.features.embedBuilder.description',
-            color: 'from-cyan-500/20 to-cyan-600/10',
-            iconColor: 'text-cyan-400',
-        },
-        {
-            icon: Sparkles,
-            titleKey: 'landing.features.artistPreferences.title',
-            descKey: 'landing.features.artistPreferences.description',
-            color: 'from-amber-500/20 to-amber-600/10',
-            iconColor: 'text-amber-400',
-        },
-    ]
+    const features = useMemo(
+        () => [
+            {
+                icon: Music,
+                titleKey: 'landing.features.music.title',
+                descKey: 'landing.features.music.description',
+                color: 'from-pink-500/20 to-pink-600/10',
+                iconColor: 'text-pink-400',
+            },
+            {
+                icon: Shield,
+                titleKey: 'landing.features.autoMod.title',
+                descKey: 'landing.features.autoMod.description',
+                color: 'from-orange-500/20 to-orange-600/10',
+                iconColor: 'text-orange-400',
+            },
+            {
+                icon: Zap,
+                titleKey: 'landing.features.customCommands.title',
+                descKey: 'landing.features.customCommands.description',
+                color: 'from-purple-500/20 to-purple-600/10',
+                iconColor: 'text-purple-400',
+            },
+            {
+                icon: BarChart3,
+                titleKey: 'landing.features.webDashboard.title',
+                descKey: 'landing.features.webDashboard.description',
+                color: 'from-blue-500/20 to-blue-600/10',
+                iconColor: 'text-blue-400',
+            },
+            {
+                icon: Palette,
+                titleKey: 'landing.features.embedBuilder.title',
+                descKey: 'landing.features.embedBuilder.description',
+                color: 'from-cyan-500/20 to-cyan-600/10',
+                iconColor: 'text-cyan-400',
+            },
+            {
+                icon: Sparkles,
+                titleKey: 'landing.features.artistPreferences.title',
+                descKey: 'landing.features.artistPreferences.description',
+                color: 'from-amber-500/20 to-amber-600/10',
+                iconColor: 'text-amber-400',
+            },
+        ],
+        [],
+    )
 
     return (
         <section className='bg-gradient-to-b from-slate-900 to-slate-950 px-4 py-20 md:px-8 relative overflow-hidden'>
@@ -250,7 +290,14 @@ function FeatureSection() {
 }
 
 // Stats Strip with Neon Numbers
-function StatsSection({ statsLoading, guildCount, userCount, serversOnline }: any) {
+type StatsSectionProps = {
+    statsLoading: boolean
+    guildCount: number
+    userCount: number
+    serversOnline?: number
+}
+
+function StatsSection({ statsLoading, guildCount, userCount, serversOnline }: StatsSectionProps) {
     const { t, i18n } = useTranslation()
     const locale = i18n.resolvedLanguage ?? i18n.language
     const stats = [
@@ -314,11 +361,13 @@ function FAQSection() {
     const { t } = useTranslation()
     const [openIdx, setOpenIdx] = useState<number | null>(null)
 
-    const faqKeys = ['free', 'commands', 'autoplay', 'selfHost', 'spam', 'support'] as const
-    const faqs = faqKeys.map((key) => ({
-        q: t(`landing.faq.items.${key}.question`),
-        a: t(`landing.faq.items.${key}.answer`),
-    }))
+    const faqs = useMemo(() => {
+        const faqKeys = ['free', 'commands', 'autoplay', 'selfHost', 'spam', 'support'] as const
+        return faqKeys.map((key) => ({
+            q: t(`landing.faq.items.${key}.question`),
+            a: t(`landing.faq.items.${key}.answer`),
+        }))
+    }, [t])
 
     return (
         <section className='bg-gradient-to-b from-slate-950 to-slate-900 px-4 py-20 md:px-8'>


### PR DESCRIPTION
## Summary
- harden the landing page and count-up flows by cleaning up async state, reducing rerenders, and making reduced-motion behavior deterministic
- improve authenticated-shell runtime behavior with reliable skip-link focus, narrower card transitions, and lighter shell styling
- patch the remaining `follow-redirects` and `hono` transitive advisories so the branch ships with a clean audit report

## Verification
- npm audit --json
- npm run lint --workspace=packages/frontend
- npm run type:check --workspace=packages/frontend
- npm run test --workspace=packages/frontend
- npm run build --workspace=packages/frontend