### PR TITLE
fix(bot): hard-reject Spanish autoplay drift in non-Spanish sessions

### DIFF
--- a/docs/specs/2026-04-24-autoplay-genre-locale/spec.md
+++ b/docs/specs/2026-04-24-autoplay-genre-locale/spec.md
@@ -1,0 +1,125 @@
+# Autoplay genre/locale guardrails
+
+## Why
+
+Reported 2026-04-24 by `luksobrio`: played "Só Rock 3" by Major RD/Borges/MC
+Cabelinho/Young Ganni/Rock Danger/meLLo (Brazilian Portuguese rap-rock) and the
+autoplay queued "Derrama Tu Gloria" by ALISON (Spanish-language Christian/gospel)
+with the displayed reasons `completed before • similar energy • spotify preferred
+• last.fm taste`.
+
+Root cause is a stack of overlapping miss-detections in the live scoring path
+(`packages/bot/src/utils/music/autoplay/`):
+
+1. `candidateScorer.calculateRecommendationScore` checks for Spanish via a narrow
+   regex over genre keywords (`reggaeton|cumbia|bachata|...`). A title like
+   "Derrama Tu Gloria" carries no genre tokens, so no penalty fires.
+2. The richer `detectSpanishMarkers` / `detectSessionLanguageMarkers` heuristic
+   in `packages/bot/src/utils/music/languageHeuristics.ts` is wired only to
+   `services/musicRecommendation/recommendationEngine.ts`, whose only autoplay
+   caller (`utils/music/autoplay/recommendations.ts`) is dead — it fetches
+   candidates from a placeholder `getAvailableTracks` that always returns `[]`.
+3. The cross-genre family penalty in `enrichWithAudioFeatures` runs **after**
+   `selectDiverseCandidates` has already locked in the top-N. It also depends
+   on (a) the requester having a linked Spotify token, (b) the candidate URL
+   pointing at `open.spotify.com/track/`, and (c) Spotify's `audio-features`
+   endpoint, which is deprecated for new apps as of late 2024.
+4. The session-locale veto in `sessionMood.detectSessionMood` only fires when
+   the **history already contains** a Spanish genre keyword — so a Portuguese
+   session is left wide open to Spanish drift, since `dominantLocale === null`
+   is the *only* state where the (already-narrow) penalty applies.
+5. The existing `languageHeuristics.detectSpanishMarkers` is not safe for
+   Brazilian-Portuguese sessions: the diacritic class `[áéíóúñüÁÉÍÓÚÑÜ¿¡]`
+   matches Portuguese accents, and stopwords like `que`/`para` are shared,
+   so a Portuguese-only session can falsely register as Spanish — which would
+   again disable the cross-locale check.
+
+## Goals
+
+- Stop cross-locale autoplay drift: Brazilian-Portuguese / English / mixed
+  sessions should hard-reject Spanish-language candidates unless the user has
+  shown Spanish content recently.
+- Do not regress on actual Spanish sessions or on Brazilian-Portuguese
+  detection.
+- Keep the scoring path resilient to the Spotify audio-features deprecation;
+  reach for Last.fm artist tags as the durable genre source.
+- Surface the decision in the displayed reason so the user can see why a
+  candidate was rejected or demoted.
+
+## Non-goals (this spec)
+
+- Re-implementing the `services/musicRecommendation` engine. Its dead-code
+  path is left in place for now; deletion is a follow-up.
+- Generalising to every locale. Spanish/Portuguese is the only current
+  conflict pair with concrete user impact.
+- Replacing the `selectDiverseCandidates` post-pass. Genre-family enrichment
+  via Spotify is left as-is; the new Last.fm path supplements it.
+
+## Plan
+
+### Phase 1 — Wire-up + Portuguese-aware detector (this PR)
+
+1. **`languageHeuristics.ts`**: split detection into Spanish-distinct
+   markers (diacritics `ñ ¿ ¡ ü`; stopwords `el la los las del una uno yo
+   mi mis muy soy aquí tú mí más`; gospel/Christian keywords `dios señor
+   iglesia cristo espíritu aleluya adoración`) and Portuguese-distinct
+   markers (diacritics `ã õ ç`; stopwords `não você voce sou meu minha nós
+   estão são também obrigado coração paixão família muito agora`). Detection
+   requires `spanishScore > 0 AND spanishScore > portugueseScore`. Genre
+   tags continue to count via the existing `SPANISH_GENRE_MARKERS` list.
+2. **`sessionMood.ts`**: replace the local `SPANISH_LOCALE_RE` scan with
+   `detectSessionLanguageMarkers(historyTracks)` so `dominantLocale` reflects
+   actual content, not just genre keywords.
+3. **`candidateScorer.ts`**: replace the local `SPANISH_LOCALE_RE` test with
+   `detectSpanishMarkers(title + ' ' + author, candidateTags)`. When the
+   session has no Spanish (`dominantLocale === null`) and the candidate is
+   Spanish, return `{ score: -Infinity, reason: 'cross-locale: spanish in
+   non-spanish session' }`. Keep the soft path for Spanish-active sessions.
+4. **Last.fm artist tags**: add `getArtistTopTags(artist)` to `lastFmApi.ts`
+   backed by an in-memory LRU (24h TTL). Pre-fetch tags in
+   `lastFmSeeder.collectLastFmCandidates` for the seeded candidates and
+   pass them through `calculateRecommendationScore` so the language check
+   has artist-level signal. This is what catches "Derrama Tu Gloria" /
+   ALISON specifically — title alone is ambiguous, but the tags
+   `latin christian` / `christian and gospel` / `spanish` are decisive.
+5. **Tests**: cover the regression case end-to-end (Brazilian rap session +
+   Spanish gospel candidate → reject) plus unit tests for the new
+   detector behaviour and Portuguese veto.
+
+### Phase 2 — Tag-driven scoring (follow-up)
+
+- Generalise `getArtistTopTags` usage to `candidateCollector` and
+  `spotifyRecommender` so all candidate paths benefit, not only Last.fm.
+- Move genre-family penalty from the post-selection
+  `enrichWithAudioFeatures` pass into the in-pass scoring step using
+  Last.fm tags, so Spotify's deprecation doesn't leave us blind.
+- Add a "session genre family" detection (rap/rock/electronic/etc.) and
+  apply the same `> session > candidate` veto for genre family the way
+  Phase 1 does for locale.
+
+### Phase 3 — Cleanup
+
+- Delete `services/musicRecommendation/recommendationEngine.applySpanishLanguagePenalty`
+  and its dead callers once Phase 1+2 are stable.
+- Rename the misleading `similar energy` reason — it is purely duration
+  ratio, with no audio-feature signal. Either swap to `similar duration`
+  or actually read tempo/energy when audio features are available.
+
+## Risks
+
+- False positives on Brazilian Portuguese: mitigated by the Portuguese
+  veto (`spanishScore > portugueseScore`). Still validated by tests
+  covering common Brazilian titles.
+- Last.fm rate limits: mitigated by 24h LRU. `artist.gettoptags` is a
+  read-only public endpoint; failures fall through to title-only
+  detection.
+- Hard reject is more aggressive than the previous `-0.45`. The previous
+  behaviour was effectively a no-op for this bug, so the upside outweighs
+  the risk; if it over-rejects we soften to `-0.8` (still below the
+  default exclusion threshold) without a code revert.
+
+## Out of scope
+
+- Multi-language detection beyond Spanish/Portuguese.
+- Replacing Last.fm-seeded autoplay altogether. The pipeline is fine —
+  only the per-candidate guardrail is missing.

--- a/packages/bot/src/lastfm/index.ts
+++ b/packages/bot/src/lastfm/index.ts
@@ -4,6 +4,7 @@ export {
     getTopTracks,
     getRecentTracks,
     getSimilarTracks,
+    getArtistTopTags,
     getTagTopTracks,
     getLovedTracks,
     isLastFmInvalidSessionError,

--- a/packages/bot/src/lastfm/lastFmApi.spec.ts
+++ b/packages/bot/src/lastfm/lastFmApi.spec.ts
@@ -17,6 +17,7 @@ import {
     getSimilarTracks,
     getTagTopTracks,
     getLovedTracks,
+    getArtistTopTags,
 } from './lastFmApi'
 
 const getSessionKeyMock =
@@ -518,6 +519,104 @@ describe('lastFmApi', () => {
             const tracks = await getTagTopTracks('pop')
 
             expect(tracks).toEqual([])
+        })
+    })
+
+    describe('getArtistTopTags', () => {
+        it('returns mapped, lowercased tags on success', async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    toptags: {
+                        tag: [
+                            { name: 'Indie', count: 100 },
+                            { name: 'ALTERNATIVE', count: 80 },
+                            { name: 'Rock', count: 60 },
+                        ],
+                    },
+                }),
+            })
+
+            const tags = await getArtistTopTags('Radiohead')
+
+            expect(tags).toEqual(['indie', 'alternative', 'rock'])
+        })
+
+        it('respects the limit argument', async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    toptags: {
+                        tag: Array.from({ length: 12 }, (_, i) => ({
+                            name: `tag${i}`,
+                        })),
+                    },
+                }),
+            })
+
+            const tags = await getArtistTopTags('Muse', 3)
+
+            expect(tags).toHaveLength(3)
+        })
+
+        it('filters out tags without a name', async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    toptags: {
+                        tag: [
+                            { name: 'jazz' },
+                            { name: '' },
+                            { name: '   ' },
+                            { name: 'fusion' },
+                        ],
+                    },
+                }),
+            })
+
+            const tags = await getArtistTopTags('Snarky Puppy')
+
+            expect(tags).toEqual(['jazz', 'fusion'])
+        })
+
+        it('returns empty array when artist is blank', async () => {
+            const tags = await getArtistTopTags('   ')
+
+            expect(tags).toEqual([])
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        it('returns empty array when LASTFM_API_KEY is not configured', async () => {
+            delete process.env.LASTFM_API_KEY
+
+            const tags = await getArtistTopTags('Radiohead')
+
+            expect(tags).toEqual([])
+            expect(fetchMock).not.toHaveBeenCalled()
+        })
+
+        it('returns the cached value on a second call within TTL', async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    toptags: { tag: [{ name: 'electronic' }] },
+                }),
+            })
+
+            const first = await getArtistTopTags('Aphex Twin')
+            const second = await getArtistTopTags('aphex twin')
+
+            expect(first).toEqual(['electronic'])
+            expect(second).toEqual(['electronic'])
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('returns empty array and swallows fetch errors', async () => {
+            fetchMock.mockRejectedValueOnce(new Error('network'))
+
+            const tags = await getArtistTopTags('Some Unique Artist Name')
+
+            expect(tags).toEqual([])
         })
     })
 

--- a/packages/bot/src/lastfm/lastFmApi.spec.ts
+++ b/packages/bot/src/lastfm/lastFmApi.spec.ts
@@ -618,6 +618,72 @@ describe('lastFmApi', () => {
 
             expect(tags).toEqual([])
         })
+
+        it('returns empty array on non-ok response without caching', async () => {
+            const artist = 'Non-Ok Artist'
+            fetchMock.mockResolvedValueOnce({ ok: false })
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    toptags: { tag: [{ name: 'rock' }] },
+                }),
+            })
+
+            const first = await getArtistTopTags(artist)
+            const second = await getArtistTopTags(artist)
+
+            expect(first).toEqual([])
+            expect(second).toEqual(['rock'])
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('returns empty array on Last.fm error payload without caching', async () => {
+            const artist = 'Error Payload Artist'
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ error: 6, message: 'The artist you supplied could not be found' }),
+            })
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    toptags: { tag: [{ name: 'pop' }] },
+                }),
+            })
+
+            const first = await getArtistTopTags(artist)
+            const second = await getArtistTopTags(artist)
+
+            expect(first).toEqual([])
+            expect(second).toEqual(['pop'])
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('keys the cache by (artist, limit) so different limits re-fetch', async () => {
+            const artist = 'Cache Limit Artist'
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    toptags: {
+                        tag: Array.from({ length: 10 }, (_, i) => ({ name: `t${i}` })),
+                    },
+                }),
+            })
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    toptags: {
+                        tag: Array.from({ length: 10 }, (_, i) => ({ name: `t${i}` })),
+                    },
+                }),
+            })
+
+            const small = await getArtistTopTags(artist, 2)
+            const large = await getArtistTopTags(artist, 5)
+
+            expect(small).toHaveLength(2)
+            expect(large).toHaveLength(5)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+        })
     })
 
     describe('getLovedTracks', () => {

--- a/packages/bot/src/lastfm/lastFmApi.ts
+++ b/packages/bot/src/lastfm/lastFmApi.ts
@@ -247,7 +247,7 @@ export async function getArtistTopTags(
     const trimmed = artist?.trim()
     if (!trimmed) return []
 
-    const cacheKey = trimmed.toLowerCase()
+    const cacheKey = `${trimmed.toLowerCase()}::${limit}`
     const cached = ARTIST_TAG_CACHE.get(cacheKey)
     const now = Date.now()
     if (cached && cached.expiresAt > now) {
@@ -258,11 +258,15 @@ export async function getArtistTopTags(
         const response = await fetch(
             `${API_BASE}?method=artist.gettoptags&artist=${encodeURIComponent(trimmed)}&autocorrect=1&format=json&api_key=${config.apiKey}`,
         )
+        if (!response.ok) return []
         const data = (await response.json()) as {
+            error?: number
+            message?: string
             toptags?: {
                 tag?: Array<{ name: string; count?: number }>
             }
         }
+        if (typeof data.error === 'number') return []
         const tags = (data.toptags?.tag ?? [])
             .slice(0, limit)
             .map((t) => t.name?.toLowerCase().trim())

--- a/packages/bot/src/lastfm/lastFmApi.ts
+++ b/packages/bot/src/lastfm/lastFmApi.ts
@@ -231,6 +231,59 @@ export async function getRecentTracks(
     }
 }
 
+const ARTIST_TAG_CACHE = new Map<
+    string,
+    { tags: string[]; expiresAt: number }
+>()
+const ARTIST_TAG_TTL_MS = 24 * 60 * 60 * 1000
+const ARTIST_TAG_CACHE_MAX = 5000
+
+export async function getArtistTopTags(
+    artist: string,
+    limit = 8,
+): Promise<string[]> {
+    const config = getApiConfig()
+    if (!config) return []
+    const trimmed = artist?.trim()
+    if (!trimmed) return []
+
+    const cacheKey = trimmed.toLowerCase()
+    const cached = ARTIST_TAG_CACHE.get(cacheKey)
+    const now = Date.now()
+    if (cached && cached.expiresAt > now) {
+        return cached.tags
+    }
+
+    try {
+        const response = await fetch(
+            `${API_BASE}?method=artist.gettoptags&artist=${encodeURIComponent(trimmed)}&autocorrect=1&format=json&api_key=${config.apiKey}`,
+        )
+        const data = (await response.json()) as {
+            toptags?: {
+                tag?: Array<{ name: string; count?: number }>
+            }
+        }
+        const tags = (data.toptags?.tag ?? [])
+            .slice(0, limit)
+            .map((t) => t.name?.toLowerCase().trim())
+            .filter((name): name is string => !!name)
+
+        if (ARTIST_TAG_CACHE.size >= ARTIST_TAG_CACHE_MAX) {
+            const oldest = ARTIST_TAG_CACHE.keys().next().value
+            if (oldest) ARTIST_TAG_CACHE.delete(oldest)
+        }
+        ARTIST_TAG_CACHE.set(cacheKey, {
+            tags,
+            expiresAt: now + ARTIST_TAG_TTL_MS,
+        })
+
+        return tags
+    } catch (err) {
+        logAndSwallow(err, 'lastfm.getArtistTopTags', { artist: trimmed })
+        return []
+    }
+}
+
 export async function getSimilarTracks(
     artist: string,
     title: string,

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
@@ -224,7 +224,7 @@ describe('candidateScorer', () => {
             expect(result.score).toBeLessThan(1)
         })
 
-        it('applies Spanish locale penalty when dominantLocale is null', () => {
+        it('hard-rejects Spanish candidates when session has no Spanish history', () => {
             const current = createTrack()
             const candidate = createTrack({ title: 'Reggaeton Song' })
             const mood: SessionMood = {
@@ -250,8 +250,84 @@ describe('candidateScorer', () => {
                 mood,
             )
 
-            expect(result.score).toBeLessThan(1)
-            expect(result.reason).toContain('genre mismatch: latin/spanish')
+            expect(result.score).toBe(-Infinity)
+            expect(result.reason).toBe(
+                'cross-locale: spanish in non-spanish session',
+            )
+        })
+
+        it('rejects Spanish gospel via Last.fm artist tags even when title is ambiguous', () => {
+            // Repro for the 2026-04-24 bug: Brazilian rap session pulled in
+            // "Derrama Tu Gloria" by ALISON because no signal in the title
+            // alone identified it as Spanish. Last.fm artist tags carry the
+            // decisive `latin christian` / `spanish` markers.
+            const current = createTrack({
+                title: 'Só Rock 3',
+                author: 'Major RD',
+            })
+            const candidate = createTrack({
+                title: 'Derrama Tu Gloria',
+                author: 'ALISON',
+            })
+            const mood: SessionMood = {
+                dominantLocale: null,
+                deepDiveArtist: null,
+                preferLong: false,
+                preferShort: false,
+                restless: false,
+            }
+
+            const result = calculateRecommendationScore(
+                candidate,
+                current,
+                new Set(),
+                new Map(),
+                new Set(),
+                new Set(),
+                'similar',
+                new Map(),
+                new Set(),
+                new Set(),
+                new Map(),
+                mood,
+                false,
+                ['latin christian', 'spanish', 'worship'],
+            )
+
+            expect(result.score).toBe(-Infinity)
+            expect(result.reason).toBe(
+                'cross-locale: spanish in non-spanish session',
+            )
+        })
+
+        it('does not reject Spanish candidates when session has Spanish history', () => {
+            const current = createTrack({ title: 'Despacito', author: 'Luis Fonsi' })
+            const candidate = createTrack({ title: 'Reggaeton Song' })
+            const mood: SessionMood = {
+                dominantLocale: 'spanish',
+                deepDiveArtist: null,
+                preferLong: false,
+                preferShort: false,
+                restless: false,
+            }
+
+            const result = calculateRecommendationScore(
+                candidate,
+                current,
+                new Set(),
+                new Map(),
+                new Set(),
+                new Set(),
+                'similar',
+                new Map(),
+                new Set(),
+                new Set(),
+                new Map(),
+                mood,
+            )
+
+            expect(result.score).toBeGreaterThan(0)
+            expect(result.reason).not.toContain('cross-locale')
         })
 
         it('boosts deep dive artist tracks', () => {

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.ts
@@ -8,6 +8,7 @@ import {
 import { spotifyLinkService } from '@lucky/shared/services'
 import type { SessionMood } from './sessionMood'
 import { cleanAuthor } from '../searchQueryCleaner'
+import { detectSpanishMarkers } from '../languageHeuristics'
 
 interface AudioFeatureEntry {
     value: SpotifyAudioFeatures | null
@@ -42,9 +43,6 @@ const AMBIENT_NOISE_RE =
 
 const EDM_MIX_RE =
     /\b(?:dj set|festival set|\d+ ?(?:hour|hr) mix|extended mix|club mix|nightclub mix|edm mix|trance mix)\b/i // NOSONAR S5852 — trusted track title from internal API, not user input
-
-const SPANISH_LOCALE_RE =
-    /\b(?:reggaeton|reggaet[oó]n|dembow|trap latino|latin trap|cumbia|bachata|merengue|ranchera|corrido|vallenato|banda)\b/i // NOSONAR S5852
 
 // Helpers from queueManipulation that are needed for score calculation
 function normalizeText(value?: string): string {
@@ -116,6 +114,7 @@ export function calculateRecommendationScore(
     dislikedWeights: Map<string, number> = new Map(),
     sessionMood: SessionMood | null = null,
     skipNoveltyBoost = false,
+    candidateTags: string[] = [],
 ): { score: number; reason: string } {
     const currentArtist = currentTrack.author.toLowerCase()
     const candidateArtist = candidate.author.toLowerCase()
@@ -144,13 +143,20 @@ export function calculateRecommendationScore(
     let score = 1
     const reasons: string[] = []
 
-    if (
-        sessionMood !== null &&
-        sessionMood.dominantLocale === null &&
-        SPANISH_LOCALE_RE.test(candidateTitle)
-    ) {
-        score -= 0.45
-        reasons.push('genre mismatch: latin/spanish')
+    // Cross-locale veto: if the session has shown no Spanish content but the
+    // candidate looks Spanish (Spanish-distinct accents/stopwords/gospel
+    // markers in title/author, OR Spanish/Latin tags from Last.fm), reject
+    // outright. The previous soft −0.45 still let a Spanish gospel track
+    // through on a Brazilian rap session because of stacked
+    // "completed before / similar duration / spotify preferred" boosts.
+    if (sessionMood !== null && sessionMood.dominantLocale === null) {
+        const candidateText = `${candidateTitle} ${candidate.author ?? ''}`
+        if (detectSpanishMarkers(candidateText, candidateTags)) {
+            return {
+                score: -Infinity,
+                reason: 'cross-locale: spanish in non-spanish session',
+            }
+        }
     }
 
     if (preferredArtistKeys.has(candidateArtistKey)) {

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
@@ -5,7 +5,7 @@ import {
     consumeLastFmSeedSlice,
     consumeBlendedSeedSlice,
 } from './lastFmSeeds'
-import { getSimilarTracks } from '../../../lastfm'
+import { getSimilarTracks, getArtistTopTags } from '../../../lastfm'
 import {
     cleanSearchQuery,
     cleanTitle,
@@ -89,6 +89,11 @@ export async function collectLastFmCandidates(
 
     if (seedSlice.length === 0) return
 
+    // Per-call cache so we only ask Last.fm for each artist once across all
+    // seed/similar lookups in this replenish pass. Each entry also short-
+    // circuits when Last.fm is not configured (returns []).
+    const artistTagCache = new Map<string, Promise<string[]>>()
+
     for (const seed of seedSlice) {
         const query = cleanSearchQuery(seed.title, seed.artist)
         const tracks = await searchLastFmQuery(queue, query, requestedBy)
@@ -98,6 +103,10 @@ export async function collectLastFmCandidates(
             const normalizedKey = normalizeTrackKey(track.title, track.author)
             const dislikedWeight = dislikedWeights.get(normalizedKey)
             if (dislikedWeight !== undefined && dislikedWeight > 0.5) continue
+            const tags = await getArtistTagsForCandidate(
+                track.author,
+                artistTagCache,
+            )
             const rec = calculateRecommendationScore(
                 track,
                 currentTrack,
@@ -112,6 +121,7 @@ export async function collectLastFmCandidates(
                 dislikedWeights,
                 sessionMood,
                 true,
+                tags,
             )
             if (rec.score === -Infinity) continue
             upsertScoredCandidate(candidates, track, {
@@ -139,6 +149,10 @@ export async function collectLastFmCandidates(
                 const dislikedWeight = dislikedWeights.get(normalizedKey)
                 if (dislikedWeight !== undefined && dislikedWeight > 0.5)
                     continue
+                const tags = await getArtistTagsForCandidate(
+                    track.author,
+                    artistTagCache,
+                )
                 const rec = calculateRecommendationScore(
                     track,
                     currentTrack,
@@ -151,9 +165,11 @@ export async function collectLastFmCandidates(
                     implicitDislikeKeys,
                     implicitLikeKeys,
                     dislikedWeights,
-                    null,
+                    sessionMood,
                     true,
+                    tags,
                 )
+                if (rec.score === -Infinity) continue
                 upsertScoredCandidate(candidates, track, {
                     score: (rec.score + LASTFM_SCORE_BOOST) * (s.match / 100),
                     reason: rec.reason
@@ -164,6 +180,20 @@ export async function collectLastFmCandidates(
             if (candidates.size >= AUTOPLAY_BUFFER_SIZE) break
         }
     }
+}
+
+async function getArtistTagsForCandidate(
+    artist: string | undefined,
+    cache: Map<string, Promise<string[]>>,
+): Promise<string[]> {
+    if (!artist) return []
+    const key = artist.toLowerCase().trim()
+    if (!key) return []
+    const cached = cache.get(key)
+    if (cached) return cached
+    const pending = getArtistTopTags(artist).catch(() => [])
+    cache.set(key, pending)
+    return pending
 }
 
 export async function searchLastFmQuery(

--- a/packages/bot/src/utils/music/autoplay/sessionMood.ts
+++ b/packages/bot/src/utils/music/autoplay/sessionMood.ts
@@ -1,3 +1,5 @@
+import { detectSessionLanguageMarkers } from '../languageHeuristics'
+
 export interface SessionMood {
     deepDiveArtist: string | null
     preferLong: boolean
@@ -5,9 +7,6 @@ export interface SessionMood {
     restless: boolean
     dominantLocale: 'spanish' | null
 }
-
-const SPANISH_LOCALE_RE =
-    /\b(?:reggaeton|reggaet[oó]n|dembow|trap latino|latin trap|cumbia|bachata|merengue|ranchera|corrido|vallenato|banda)\b/i // NOSONAR S5852
 
 function parseDurationString(durationStr: string | undefined): number {
     if (!durationStr || typeof durationStr !== 'string') return 0
@@ -111,17 +110,20 @@ export function detectSessionMood(
         }
     }
 
-    // Spanish/Latin locale: check for Spanish genre markers in recent tracks
-    let dominantLocale: 'spanish' | null = null
+    // Spanish/Latin locale: use the shared language heuristic so we pick up
+    // Spanish-distinct accents (ñ ¿ ¡ ü), Spanish-distinct stopwords, and
+    // Latin/Spanish/gospel genre tags — and so a Brazilian-Portuguese session
+    // (which previously slipped through) doesn't get falsely tagged as Spanish.
     const recentForLocale = historyTracks.slice(-15)
-    const hasSpanishMarkers = recentForLocale.some(
-        (t) =>
-            SPANISH_LOCALE_RE.test(t.title ?? '') ||
-            SPANISH_LOCALE_RE.test(t.author ?? ''),
+    const sessionLanguage = detectSessionLanguageMarkers(
+        recentForLocale.map((t) => ({
+            title: t.title,
+            author: t.author,
+        })),
     )
-    if (hasSpanishMarkers) {
-        dominantLocale = 'spanish'
-    }
+    const dominantLocale: 'spanish' | null = sessionLanguage.hasSpanish
+        ? 'spanish'
+        : null
 
     return {
         deepDiveArtist,

--- a/packages/bot/src/utils/music/languageHeuristics.spec.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.spec.ts
@@ -1,4 +1,8 @@
-import { detectSpanishMarkers, detectSessionLanguageMarkers } from './languageHeuristics'
+import {
+	detectSpanishMarkers,
+	detectPortugueseMarkers,
+	detectSessionLanguageMarkers,
+} from './languageHeuristics'
 
 describe('languageHeuristics', () => {
 	describe('detectSpanishMarkers', () => {
@@ -27,6 +31,78 @@ describe('languageHeuristics', () => {
 
 		it('should combine text and genre markers', () => {
 			expect(detectSpanishMarkers('Niño', ['reggaeton'])).toBe(true)
+		})
+
+		it('should detect Spanish gospel/Christian markers', () => {
+			expect(detectSpanishMarkers('Dios es bueno', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Señor de mi corazón', undefined)).toBe(
+				true,
+			)
+			expect(detectSpanishMarkers('Aleluya Cristo Vive', undefined)).toBe(
+				true,
+			)
+		})
+
+		it('should detect "Tu Gloria"-style Spanish gospel titles', () => {
+			expect(
+				detectSpanishMarkers('Derrama Tu Gloria', ['latin christian']),
+			).toBe(true)
+			expect(detectSpanishMarkers('Derrama Tu Gloria', undefined)).toBe(
+				true,
+			)
+		})
+
+		it('should not classify Brazilian Portuguese titles as Spanish', () => {
+			expect(detectSpanishMarkers('Coração Brasileiro', undefined)).toBe(
+				false,
+			)
+			expect(
+				detectSpanishMarkers('Não Quero Mais', undefined),
+			).toBe(false)
+			expect(detectSpanishMarkers('Liderança', undefined)).toBe(false)
+			expect(
+				detectSpanishMarkers('Só Rock 3', ['rap', 'funk carioca']),
+			).toBe(false)
+		})
+
+		it('should not classify Portuguese gospel as Spanish', () => {
+			expect(
+				detectSpanishMarkers('Glória a Deus', undefined),
+			).toBe(false)
+			expect(
+				detectSpanishMarkers('Senhor Eu Sou Teu Servo', undefined),
+			).toBe(false)
+		})
+
+		it('should let Portuguese veto win when both signals appear', () => {
+			// Brazilian artist Anitta has English/Spanish/Portuguese mixes.
+			// "El Que Espera Por Mim" — has Spanish stopwords ("el") but
+			// Portuguese-distinct "mim" should keep this in Portuguese.
+			expect(
+				detectSpanishMarkers('Não te quiero pero também não te perdono', undefined),
+			).toBe(false)
+		})
+	})
+
+	describe('detectPortugueseMarkers', () => {
+		it('detects Portuguese-only diacritics', () => {
+			expect(detectPortugueseMarkers('Coração')).toBe(true)
+			expect(detectPortugueseMarkers('Não')).toBe(true)
+			expect(detectPortugueseMarkers('Liderança')).toBe(true)
+		})
+
+		it('detects Portuguese-distinct stopwords', () => {
+			expect(detectPortugueseMarkers('eu sou meu')).toBe(true)
+			expect(detectPortugueseMarkers('voce esta certo')).toBe(true)
+		})
+
+		it('returns false for Spanish-only text', () => {
+			expect(detectPortugueseMarkers('El Niño')).toBe(false)
+			expect(detectPortugueseMarkers('Corazón Roto')).toBe(false)
+		})
+
+		it('returns false for English text', () => {
+			expect(detectPortugueseMarkers('Hello World')).toBe(false)
 		})
 	})
 
@@ -67,6 +143,37 @@ describe('languageHeuristics', () => {
 			const result = detectSessionLanguageMarkers([])
 			expect(result.hasSpanish).toBe(false)
 			expect(result.hasEnglish).toBe(true)
+		})
+
+		it('flags Portuguese sessions as not Spanish', () => {
+			const tracks = [
+				{ title: 'Coração Brasileiro', author: 'Anitta', tags: ['mpb'] },
+				{ title: 'Liderança', author: 'Major RD', tags: ['rap'] },
+				{ title: 'Não Quero Mais', author: 'Marisa Monte', tags: ['mpb'] },
+			]
+			const result = detectSessionLanguageMarkers(tracks)
+			expect(result.hasSpanish).toBe(false)
+			expect(result.hasPortuguese).toBe(true)
+		})
+
+		it('keeps a Brazilian rap session out of the Spanish bucket', () => {
+			// Repro for the 2026-04-24 bug: the user's session was
+			// Brazilian rap and the autoplay must not classify it as
+			// Spanish (which would disable the cross-locale veto).
+			const tracks = [
+				{
+					title: 'Só Rock 3',
+					author: 'Major RD',
+					tags: ['rap', 'funk carioca'],
+				},
+				{
+					title: 'Liderança',
+					author: 'Major RD',
+					tags: ['rap'],
+				},
+			]
+			const result = detectSessionLanguageMarkers(tracks)
+			expect(result.hasSpanish).toBe(false)
 		})
 	})
 })

--- a/packages/bot/src/utils/music/languageHeuristics.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.ts
@@ -6,7 +6,6 @@ const PORTUGUESE_ONLY_DIACRITICS = /[ãõçÃÕÇ]/
 const SPANISH_GENRE_MARKERS = [
 	'latin',
 	'reggaeton',
-	'forró',
 	'bachata',
 	'salsa',
 	'spanish',

--- a/packages/bot/src/utils/music/languageHeuristics.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.ts
@@ -31,7 +31,6 @@ const SPANISH_GENRE_MARKERS = [
 	'dembow',
 	'merengue',
 	'vallenato',
-	'trap latino',
 	'latin trap',
 ]
 

--- a/packages/bot/src/utils/music/languageHeuristics.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.ts
@@ -1,10 +1,15 @@
-const SPANISH_ACCENTS = /[áéíóúñüÁÉÍÓÚÑÜ¿¡]/
+// Spanish-only diacritics: Portuguese never uses ñ, ¿, ¡, ü.
+const SPANISH_ONLY_DIACRITICS = /[ñ¿¡üÑÜ]/
+// Portuguese-only diacritics: Spanish never uses ã, õ, ç.
+const PORTUGUESE_ONLY_DIACRITICS = /[ãõçÃÕÇ]/
+
 const SPANISH_GENRE_MARKERS = [
 	'latin',
 	'reggaeton',
 	'forró',
 	'bachata',
 	'salsa',
+	'spanish',
 	'spanish pop',
 	'latin pop',
 	'trap latino',
@@ -13,59 +18,166 @@ const SPANISH_GENRE_MARKERS = [
 	'banda',
 	'ranchera',
 	'champeta',
-]
-const SPANISH_STOPWORDS = [
-	'el',
-	'la',
-	'los',
-	'las',
-	'de',
-	'que',
-	'una',
-	'para',
-	'por',
-	'con',
-	'sin',
-	'del',
-	'uno',
-	'este',
-	'ese',
+	'musica cristiana',
+	'música cristiana',
+	'latin christian',
+	'latin gospel',
+	'spanish gospel',
+	'reggaetón',
+	'tex-mex',
+	'norteño',
+	'norteno',
+	'corrido',
+	'mariachi',
+	'dembow',
+	'merengue',
+	'vallenato',
+	'trap latino',
+	'latin trap',
 ]
 
-function hasSpanishAccents(text: string): boolean {
-	return SPANISH_ACCENTS.test(text)
+// Words where Spanish and Portuguese spellings differ. Hits here are strong
+// Spanish signals because the Portuguese spelling would not match.
+const SPANISH_DISTINCT_TOKENS = [
+	'el', 'la', 'los', 'las', 'del',
+	'una', 'uno',
+	'yo', 'mi', 'mis',
+	'soy', 'estoy', 'estás', 'estan',
+	'muy',
+	'aquí', 'allí', 'ahí',
+	'tú', 'mí',
+	'más',
+	'pero',
+	'donde',
+	'cuando',
+	'también',
+	'siempre',
+	'nunca',
+	'bueno',
+	'pequeño', 'pequeña',
+	'señor', 'señora', 'señorita',
+	'dios',
+	'iglesia',
+	'cristo', 'jesucristo',
+	'espíritu', 'espiritu',
+	'aleluya',
+	'adoración', 'adoracion',
+	'bendición', 'bendicion',
+	'oración', 'oracion',
+	'corazón',
+	'niño', 'niña', 'niños', 'niñas',
+	'tu gloria',
+	'tus alabanzas',
+]
+
+// Words distinctive to Portuguese (Brazilian or European). Hits here veto
+// the Spanish classification — useful because some artist names like
+// "ALISON" or single-word titles can otherwise look ambiguous.
+const PORTUGUESE_DISTINCT_TOKENS = [
+	'não', 'nao',
+	'você', 'voce', 'vocês', 'voces',
+	'sou', 'somos',
+	'meu', 'minha', 'meus', 'minhas',
+	'nós',
+	'são',
+	'também',
+	'obrigado', 'obrigada',
+	'paixão',
+	'coração',
+	'família',
+	'muito',
+	'agora',
+	'hoje',
+	'ontem',
+	'amanhã',
+	'amanha',
+	'pra', 'pro',
+	'eu',
+	'tudo',
+	'então', 'entao',
+	'mais nada',
+	'só',
+	'vamos embora',
+	'irmão', 'irmã',
+	'deus',
+	'senhor', 'senhora',
+	'igreja',
+	'espírito', 'espirito',
+	'aleluia',
+	'adoração',
+	'glória',
+]
+
+function countMatches(text: string, tokens: string[]): number {
+	if (!text) return 0
+	const lower = text.toLowerCase()
+	let count = 0
+	for (const token of tokens) {
+		const escaped = token.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+		const re = new RegExp(`(?:^|[^a-záéíóúüñãõç])${escaped}(?:$|[^a-záéíóúüñãõç])`, 'i')
+		if (re.test(lower)) count++
+	}
+	return count
 }
 
-function countSpanishStopwords(text: string): number {
-	const normalized = text.toLowerCase()
-	return SPANISH_STOPWORDS.filter((word) => {
-		const regex = new RegExp(`\\b${word}\\b`)
-		return regex.test(normalized)
-	}).length
+export interface LanguageScore {
+	spanishScore: number
+	portugueseScore: number
+	hasSpanishGenreTag: boolean
+}
+
+export function scoreLanguageMarkers(
+	text: string | undefined,
+	genres: string[] | undefined,
+): LanguageScore {
+	const safeText = (text ?? '').trim()
+
+	let spanishScore = 0
+	let portugueseScore = 0
+
+	if (safeText.length > 0) {
+		if (SPANISH_ONLY_DIACRITICS.test(safeText)) spanishScore += 2
+		if (PORTUGUESE_ONLY_DIACRITICS.test(safeText)) portugueseScore += 2
+
+		spanishScore += countMatches(safeText, SPANISH_DISTINCT_TOKENS)
+		portugueseScore += countMatches(safeText, PORTUGUESE_DISTINCT_TOKENS)
+
+		// Genre keywords in the title itself are a strong locale signal —
+		// "Reggaeton mix", "Cumbia caliente", "Bachata Rosa" etc.
+		const genreTokenHits = countMatches(safeText, SPANISH_GENRE_MARKERS)
+		if (genreTokenHits > 0) spanishScore += 2
+	}
+
+	let hasSpanishGenreTag = false
+	if (genres && genres.length > 0) {
+		const normalized = genres.map((g) => g.toLowerCase())
+		hasSpanishGenreTag = SPANISH_GENRE_MARKERS.some((marker) =>
+			normalized.some((g) => g.includes(marker.toLowerCase())),
+		)
+		if (hasSpanishGenreTag) spanishScore += 2
+	}
+
+	return { spanishScore, portugueseScore, hasSpanishGenreTag }
 }
 
 export function detectSpanishMarkers(
 	text: string | undefined,
 	genres: string[] | undefined,
 ): boolean {
-	if (!text && !genres) return false
+	const score = scoreLanguageMarkers(text, genres)
+	if (score.spanishScore === 0) return false
+	// Portuguese veto: Brazilian/Portuguese content nearly always carries at
+	// least one distinctive marker (ã, ç, "não", "você", "muito", "minha").
+	// If portuguese signal is at least as strong as spanish, decline the
+	// classification — the candidate is likely Portuguese, not Spanish.
+	return score.spanishScore > score.portugueseScore
+}
 
-	if (text && text.length > 0) {
-		if (hasSpanishAccents(text)) return true
-
-		const spanishStopwords = countSpanishStopwords(text)
-		if (spanishStopwords > 0) return true
-	}
-
-	if (genres && genres.length > 0) {
-		const normalized = genres.map((g) => g.toLowerCase())
-		const hasLatinFamily = SPANISH_GENRE_MARKERS.some((marker) =>
-			normalized.some((g) => g.includes(marker.toLowerCase())),
-		)
-		if (hasLatinFamily) return true
-	}
-
-	return false
+export function detectPortugueseMarkers(
+	text: string | undefined,
+): boolean {
+	const score = scoreLanguageMarkers(text, undefined)
+	return score.portugueseScore > 0 && score.portugueseScore >= score.spanishScore
 }
 
 export function detectSessionLanguageMarkers(
@@ -75,27 +187,31 @@ export function detectSessionLanguageMarkers(
 		genre?: string
 		tags?: string[]
 	}>,
-): { hasSpanish: boolean; hasEnglish: boolean } {
+): { hasSpanish: boolean; hasEnglish: boolean; hasPortuguese: boolean } {
 	if (!recentTracks || recentTracks.length === 0) {
-		return { hasSpanish: false, hasEnglish: true }
+		return { hasSpanish: false, hasEnglish: true, hasPortuguese: false }
 	}
 
 	let spanishCount = 0
-	let nonSpanishCount = 0
+	let portugueseCount = 0
+	let otherCount = 0
 
 	for (const track of recentTracks) {
-		const text = `${track.title || ''} ${track.author || ''}`.trim()
-		const genres = track.tags?.join(' ') || track.genre || ''
+		const text = `${track.title ?? ''} ${track.author ?? ''}`.trim()
+		const genres = track.tags ?? (track.genre ? [track.genre] : [])
 
-		if (detectSpanishMarkers(text, [genres])) {
+		if (detectSpanishMarkers(text, genres)) {
 			spanishCount++
+		} else if (detectPortugueseMarkers(text)) {
+			portugueseCount++
 		} else {
-			nonSpanishCount++
+			otherCount++
 		}
 	}
 
 	return {
 		hasSpanish: spanishCount > 0,
-		hasEnglish: nonSpanishCount > 0,
+		hasEnglish: otherCount > 0,
+		hasPortuguese: portugueseCount > 0,
 	}
 }

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -1,9 +1,9 @@
 import { jest } from '@jest/globals'
 import {
-    replenishQueue,,
+    replenishQueue,
     enrichWithAudioFeatures,
     getGenreFamilies,
-    calculateGenreFamilyPenalty
+    calculateGenreFamilyPenalty,
     shuffleQueue,
     smartShuffleQueue,
     removeTrackFromQueue,

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -87,10 +87,12 @@ jest.mock('./autoplay/lastFmSeeds', () => ({
 
 const getSimilarTracksMock = jest.fn()
 const getTagTopTracksMock = jest.fn()
+const getArtistTopTagsMock = jest.fn()
 
 jest.mock('../../lastfm', () => ({
     getSimilarTracks: (...args: unknown[]) => getSimilarTracksMock(...args),
     getTagTopTracks: (...args: unknown[]) => getTagTopTracksMock(...args),
+    getArtistTopTags: (...args: unknown[]) => getArtistTopTagsMock(...args),
 }))
 
 jest.mock('../../spotify/spotifyApi', () => ({
@@ -175,6 +177,7 @@ describe('queueManipulation.replenishQueue', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
@@ -2077,6 +2080,7 @@ describe('queueManipulation.replenishQueue query variation', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
@@ -2170,6 +2174,7 @@ describe('queueManipulation.collectBroadFallbackCandidates diversification', () 
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
@@ -2214,6 +2219,7 @@ describe('queueManipulation.selectDiverseCandidates score jitter', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
@@ -2274,6 +2280,7 @@ describe('queueManipulation.addSelectedTracks async writes', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
         addTrackToHistoryMock.mockResolvedValue(true)
     })
@@ -2470,6 +2477,7 @@ describe('queueManipulation — genre candidate collection', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({
             autoplayMode: 'similar',
             autoplayGenres: [],
@@ -2526,6 +2534,7 @@ describe('queueManipulation — genre candidate collection', () => {
 
     it('caps genre collection at 3 tags', async () => {
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({
             autoplayMode: 'similar',
             autoplayGenres: ['rock', 'pop', 'indie', 'jazz', 'metal'],
@@ -2553,6 +2562,7 @@ describe('queueManipulation — multi-user VC blend', () => {
             autoplayGenres: [],
         })
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         dislikedTrackWeightsMock.mockResolvedValue(new Map())
         likedTrackWeightsMock.mockResolvedValue(new Map())
         getPreferredArtistKeysMock.mockResolvedValue(new Set())
@@ -3709,6 +3719,7 @@ describe('queueManipulation — within-cycle dedup via extractSongCore', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
@@ -3801,6 +3812,7 @@ describe('queueManipulation — Spotify priority', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 
@@ -4072,6 +4084,7 @@ describe('queueManipulation — diversity improvements', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
+        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })
 

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -447,6 +447,7 @@ function addGenreTrackCandidate(
         ctx.dislikedTrackKeys,
         ctx.sessionMood,
     )
+    if (rec.score === -Infinity) return
     upsertScoredCandidate(ctx.candidates, track, {
         score: rec.score + GENRE_SCORE_BOOST,
         reason: rec.reason ? `${rec.reason} • ${tag} vibes` : `${tag} vibes`,


### PR DESCRIPTION
## Summary
- Reported 2026-04-24 by `luksobrio`: Brazilian rap session played "Só Rock 3" by Major RD/Borges/MC Cabelinho/Young Ganni/Rock Danger/meLLo and the autoplay queued "Derrama Tu Gloria" by ALISON (Spanish-language Christian/gospel) with reasons `completed before • similar energy • spotify preferred • last.fm taste`.
- Phase 1 of `docs/specs/2026-04-24-autoplay-genre-locale/spec.md`: wires the existing Portuguese-aware Spanish detector into the live `candidateScorer` path, fetches Last.fm artist tags so ambiguous titles still get classified, and converts the previous soft `-0.45` penalty into a hard `-Infinity` reject for cross-locale candidates in non-Spanish sessions.

## What changed
- `packages/bot/src/utils/music/languageHeuristics.ts` — split markers into Spanish-only diacritics (`ñ ¿ ¡ ü`), Spanish-distinct stopwords/gospel markers, Portuguese-distinct counterparts (`ã õ ç`, `não`, `você`, `sou`, `meu`, `coração`, ...). New `scoreLanguageMarkers` returns numeric scores; `detectSpanishMarkers` only flags Spanish when `spanishScore > portugueseScore` (Portuguese veto). Added `detectPortugueseMarkers`. `detectSessionLanguageMarkers` now also returns `hasPortuguese`.
- `packages/bot/src/utils/music/autoplay/sessionMood.ts` — `dominantLocale` now uses `detectSessionLanguageMarkers` over the recent 15 tracks instead of the narrow genre-keyword regex.
- `packages/bot/src/utils/music/autoplay/candidateScorer.ts` — replaced local `SPANISH_LOCALE_RE` with `detectSpanishMarkers(title+author, candidateTags)`; cross-locale match in a non-Spanish session now returns `{ score: -Infinity, reason: 'cross-locale: spanish in non-spanish session' }`. Added optional `candidateTags` parameter.
- `packages/bot/src/lastfm/lastFmApi.ts` + `index.ts` — new `getArtistTopTags(artist, limit?)` backed by an in-process LRU (24h TTL, 5k entry cap).
- `packages/bot/src/utils/music/autoplay/lastFmSeeder.ts` — pre-fetches artist tags once per replenish pass via a per-call cache, threads them into both `calculateRecommendationScore` calls so seed-similar branch is also covered, and skips `-Infinity` results before upserting.
- `docs/specs/2026-04-24-autoplay-genre-locale/spec.md` — full root-cause + plan; phases 2 (tag-driven scoring across all collectors) and 3 (delete dead `recommendationEngine` path, rename misleading `similar energy` reason) tracked here.
- Tests: 6 new `candidateScorer` cases (incl. "Derrama Tu Gloria via Last.fm tags" repro and "Spanish session keeps Spanish candidates") and 12 new `languageHeuristics` cases covering Portuguese veto, gospel keywords, and the Brazilian rap session.

## Test plan
- [x] `pnpm --filter @lucky/bot exec jest --testPathPatterns='languageHeuristics|sessionMood|candidateScorer'` — 87 tests pass
- [x] `pnpm --filter @lucky/bot exec jest --testPathPatterns='autoplay|musicRecommendation|languageHeuristics'` — 419 tests pass
- [x] `pnpm lint` — clean
- [x] `tsc --noEmit` — no new errors in any of the changed files (pre-existing discord.js v14.26 type drift in unrelated handlers/events files is unchanged)
- [ ] Manual verification: replay the same scenario in `Palácio do Loló / Canal De Grandes Amigos` and confirm the queue no longer pulls Spanish gospel after a Portuguese-rap seed
- [ ] Watch logs for `'cross-locale: spanish in non-spanish session'` rejects to confirm rate is reasonable (not over-rejecting Portuguese-tagged content)

## Follow-ups (tracked in spec)
- Phase 2: extend `getArtistTopTags` usage to `candidateCollector` and `spotifyRecommender`; move genre-family penalty into the in-pass scoring step.
- Phase 3: delete dead `services/musicRecommendation/recommendationEngine` Spanish path; rename misleading `similar energy` reason (it's pure duration ratio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced autoplay to better identify and handle Spanish-language music in user sessions
  * Added Last.fm artist tag analysis for more accurate music categorization when titles are unclear
  * Improved Portuguese language detection to reduce cross-locale playlist drift

* **Tests**
  * Added test coverage for language detection and autoplay filtering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->