### PR TITLE
refactor(bot): centralize cross-locale -Infinity guard in upsertScoredCandidate

### DIFF
--- a/packages/bot/src/utils/music/autoplay/candidateCollector.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.spec.ts
@@ -171,6 +171,52 @@ describe('candidateCollector', () => {
             expect(entry.reason).toBe('high')
         })
 
+        it('drops -Infinity recommendations without inserting', () => {
+            const candidates = new Map<string, ScoredTrack>()
+            const track = createTrack({
+                title: 'Hard Reject',
+                author: 'Artist',
+            })
+
+            upsertScoredCandidate(candidates, track, {
+                score: -Infinity,
+                reason: 'cross-locale: spanish in non-spanish session',
+            })
+
+            expect(candidates.size).toBe(0)
+        })
+
+        it('drops -Infinity even when an existing entry could be displaced', () => {
+            const candidates = new Map<string, ScoredTrack>()
+            const track = createTrack({ title: 'Same Song', author: 'Same Artist' })
+
+            upsertScoredCandidate(candidates, track, {
+                score: 0.5,
+                reason: 'first',
+            })
+            upsertScoredCandidate(candidates, track, {
+                score: -Infinity,
+                reason: 'reject',
+            })
+
+            expect(candidates.size).toBe(1)
+            const entry = Array.from(candidates.values())[0]
+            expect(entry.score).toBe(0.5)
+            expect(entry.reason).toBe('first')
+        })
+
+        it('drops NaN recommendations defensively', () => {
+            const candidates = new Map<string, ScoredTrack>()
+            const track = createTrack({ title: 'NaN Score', author: 'Artist' })
+
+            upsertScoredCandidate(candidates, track, {
+                score: Number.NaN,
+                reason: 'bug',
+            })
+
+            expect(candidates.size).toBe(0)
+        })
+
         it('should use track URL as fallback key when normalized key is empty', () => {
             const candidates = new Map<string, ScoredTrack>()
             const track = createTrack({

--- a/packages/bot/src/utils/music/autoplay/candidateCollector.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.ts
@@ -35,12 +35,21 @@ export function shouldIncludeCandidate(
 /**
  * Add or update a candidate in the scored pool.
  * Keeps the higher-scored version if a duplicate key exists.
+ *
+ * Non-finite scores (e.g. the cross-locale `-Infinity` hard-reject from
+ * `calculateRecommendationScore`) are dropped here so callers don't need to
+ * remember the in-place guard before every call. Any per-source boost
+ * (`+ LASTFM_SCORE_BOOST`, `* match`, `+ GENRE_SCORE_BOOST`) that runs on a
+ * `-Infinity` base stays non-finite, so this gate covers the boosted-score
+ * caller patterns too.
  */
 export function upsertScoredCandidate(
     candidates: Map<string, ScoredTrack>,
     candidate: Track,
     recommendation: { score: number; reason: string },
 ): void {
+    if (!Number.isFinite(recommendation.score)) return
+
     const normalizedKey = normalizeTrackKey(candidate.title, candidate.author)
     const candidateKey =
         normalizedKey !== '::' ? normalizedKey : (candidate.id || candidate.url || normalizeTrackKey(candidate.title, candidate.author))
@@ -160,9 +169,7 @@ export async function collectRecommendationCandidates(
                     sessionGenreFamilies,
                 },
             )
-            if (rec.score !== -Infinity) {
-                upsertScoredCandidate(candidates, candidate, rec)
-            }
+            upsertScoredCandidate(candidates, candidate, rec)
         }
     }
 

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
@@ -130,7 +130,6 @@ export async function collectLastFmCandidates(
                     sessionGenreFamilies,
                 },
             )
-            if (rec.score === -Infinity) continue
             upsertScoredCandidate(candidates, track, {
                 score: rec.score + LASTFM_SCORE_BOOST,
                 reason: rec.reason
@@ -177,7 +176,6 @@ export async function collectLastFmCandidates(
                         sessionGenreFamilies,
                     },
                 )
-                if (rec.score === -Infinity) continue
                 upsertScoredCandidate(candidates, track, {
                     score: (rec.score + LASTFM_SCORE_BOOST) * (s.match / 100),
                     reason: rec.reason

--- a/packages/bot/src/utils/music/autoplay/spotifyRecommender.ts
+++ b/packages/bot/src/utils/music/autoplay/spotifyRecommender.ts
@@ -161,7 +161,6 @@ export async function collectSpotifyRecommendationCandidates(
                 sessionGenreFamilies,
             },
         )
-        if (rec.score === -Infinity) continue
         let score = rec.score + 0.3
         let reason = rec.reason ? `${rec.reason} • spotify rec` : 'spotify rec'
 

--- a/packages/bot/src/utils/music/queueManipulation.ts
+++ b/packages/bot/src/utils/music/queueManipulation.ts
@@ -384,7 +384,6 @@ export async function collectBroadFallbackCandidates(
                     dislikedWeights,
                     sessionMood,
                 )
-                if (rec.score === -Infinity) continue
                 upsertScoredCandidate(candidates, track, {
                     score: rec.score - 0.1,
                     reason: rec.reason
@@ -447,7 +446,6 @@ function addGenreTrackCandidate(
         ctx.dislikedTrackKeys,
         ctx.sessionMood,
     )
-    if (rec.score === -Infinity) return
     upsertScoredCandidate(ctx.candidates, track, {
         score: rec.score + GENRE_SCORE_BOOST,
         reason: rec.reason ? `${rec.reason} • ${tag} vibes` : `${tag} vibes`,


### PR DESCRIPTION
## Summary

Centralises the cross-locale `-Infinity` veto from `calculateRecommendationScore` inside `upsertScoredCandidate` via `Number.isFinite`, so callers can no longer accidentally insert a hard-rejected candidate by forgetting an in-place guard.

This is the deferred CodeRabbit recommendation from #780's review (`PRRT_kwDOHJ-HYs59l-w2` — "Make the new -Infinity veto impossible to bypass"). The 5 in-place `if (rec.score === -Infinity) continue/return` checks across `spotifyRecommender.ts`, `lastFmSeeder.ts` (×2), and `queueManipulation.ts` (×2) are now redundant because every boost expression at the call sites preserves `-Infinity`:

- `rec.score + LASTFM_SCORE_BOOST` → `-Infinity`
- `(rec.score + LASTFM_SCORE_BOOST) * (s.match / 100)` → `-Infinity`
- `rec.score + 0.3` (+`+ 0.08` taste boost) → `-Infinity`
- `rec.score - 0.1` (artist fallback) → `-Infinity`
- `rec.score + GENRE_SCORE_BOOST` → `-Infinity`

Also collapses the older `if (rec.score !== -Infinity)` branch in `collectRecommendationCandidates` into the now-unconditional `upsertScoredCandidate` call.

## Test plan

- [x] Added 3 new cases on `upsertScoredCandidate` covering: `-Infinity` drop, `-Infinity` with existing entry preserved (no displacement), and defensive NaN drop.
- [x] Existing `should skip candidates with -Infinity score` integration test in `candidateCollector.spec.ts:369` still asserts `result.size` so it continues to validate the centralised path.
- [ ] CI: Quality Gates + SonarCloud Scan + Security on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to verify that invalid score values (such as -Infinity and NaN) are properly rejected during candidate selection and cannot overwrite existing valid scores.

* **Refactor**
  * Consolidated score validation logic that was previously distributed across multiple recommendation collection functions into a centralized validation point, ensuring consistent and robust handling of invalid scores throughout the recommendation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->