### PR TITLE
test(bot): dedupe getArtistTopTagsMock.mockResolvedValue([]) blocks

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -178,9 +178,7 @@ describe('queueManipulation.replenishQueue', () => {
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
-        getArtistTopTagsMock.mockResolvedValue([])
     })
 
     async function replenishWithSingleCandidate(options: {
@@ -2083,9 +2081,7 @@ describe('queueManipulation.replenishQueue query variation', () => {
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
-        getArtistTopTagsMock.mockResolvedValue([])
     })
 
     it('applies query modifiers based on replenish counter', async () => {
@@ -2179,9 +2175,7 @@ describe('queueManipulation.collectBroadFallbackCandidates diversification', () 
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
-        getArtistTopTagsMock.mockResolvedValue([])
     })
 
     it('uses multiple fallback queries when primary candidates empty', async () => {
@@ -2226,9 +2220,7 @@ describe('queueManipulation.selectDiverseCandidates score jitter', () => {
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
-        getArtistTopTagsMock.mockResolvedValue([])
     })
 
     it('applies jitter to candidate scores and maintains top candidate', async () => {
@@ -2289,9 +2281,7 @@ describe('queueManipulation.addSelectedTracks async writes', () => {
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
-        getArtistTopTagsMock.mockResolvedValue([])
         addTrackToHistoryMock.mockResolvedValue(true)
     })
 
@@ -2488,7 +2478,6 @@ describe('queueManipulation — genre candidate collection', () => {
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({
             autoplayMode: 'similar',
             autoplayGenres: [],
@@ -2545,7 +2534,6 @@ describe('queueManipulation — genre candidate collection', () => {
 
     it('caps genre collection at 3 tags', async () => {
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({
             autoplayMode: 'similar',
             autoplayGenres: ['rock', 'pop', 'indie', 'jazz', 'metal'],
@@ -2573,7 +2561,6 @@ describe('queueManipulation — multi-user VC blend', () => {
             autoplayGenres: [],
         })
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         dislikedTrackWeightsMock.mockResolvedValue(new Map())
         likedTrackWeightsMock.mockResolvedValue(new Map())
         getPreferredArtistKeysMock.mockResolvedValue(new Set())
@@ -3732,9 +3719,7 @@ describe('queueManipulation — within-cycle dedup via extractSongCore', () => {
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
-        getArtistTopTagsMock.mockResolvedValue([])
     })
 
     it('deduplicates inverted-format same-song within a single replenish cycle', async () => {
@@ -3827,9 +3812,7 @@ describe('queueManipulation — Spotify priority', () => {
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
-        getArtistTopTagsMock.mockResolvedValue([])
     })
 
     it('uses song-core query for Spotify engine when seed has artist-song format', async () => {
@@ -4101,9 +4084,7 @@ describe('queueManipulation — diversity improvements', () => {
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
         getTagTopTracksMock.mockResolvedValue([])
-        getArtistTopTagsMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
-        getArtistTopTagsMock.mockResolvedValue([])
     })
 
     it('penalises acoustic/live candidates so studio versions score higher', async () => {


### PR DESCRIPTION
## Summary

Cosmetic cleanup of `packages/bot/src/utils/music/queueManipulation.spec.ts`. The Phase 1 + Phase 2 autoplay stack rebase left every `replenishQueue` beforeEach setting `getArtistTopTagsMock.mockResolvedValue([])` 2–3 times in a row:

- Phase 2 commit `a4d52860` added the line in two positions per block.
- My Phase 1 fix (commit `f3888d17` on PR #780) used `replace_all` after `getTagTopTracksMock.mockResolvedValue([])` and added a third copy.

Functionally idempotent (`mockResolvedValue` just overwrites), but the duplicates will get flagged on the next touch of this file by Sonar / CodeRabbit. This PR drops 19 redundant lines across 11 beforeEach blocks plus one inline test, leaving exactly one `getArtistTopTagsMock.mockResolvedValue([])` per block.

## Test plan

- [x] Test count and assertions are unchanged — only removed redundant identical mock-setup lines.
- [ ] CI: full Quality Gates run on the bot test suite (2,829 tests should still pass with no skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)