### PR TITLE
chore: bump version to 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.6.148",
+  "version": "2.7.0",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.6.148",
+    "version": "2.7.0",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.6.148",
+    "version": "2.7.0",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.6.148",
+    "version": "2.7.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.6.148",
+    "version": "2.7.0",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Version bump for v2.7.0 release.

## Highlights since v2.6.148

### Features
- feat(shared): migrate feature toggles from Unleash to Vercel Flags (#796)
- feat(bot): tag-driven autoplay scoring (phase 2) (#782)
- feat(frontend): land stale section-header-status-band stack into main (#781)
- feat(frontend): SectionHeader eyebrowIcon + statusBand (#765)
- feat(prisma): flatten migrations into single baseline (Supabase Phase 2) (#768)
- feat(prisma): migrate config to Prisma 7 defineConfig + DIRECT_URL fallback (#764)
- feat(bot): birthday scheduler + /birthday channel (#740)
- feat(frontend): vote-tier badge in the dashboard header (#737)
- feat(autoplay): premium guilds get 2× backfill buffer (8 → 16) (#750)
- feat(frontend): add redesign token aliases + commit brand decision (#763)
- feat(bot): /birthday list — next 5 upcoming birthdays (#742)
- feat(frontend): add i18n with EN + pt-BR language switcher (#760)
- feat(backend): top.gg vote webhook endpoint
- feat(visibility): Phase 0 — LICENSE + sharpened README + top.gg submission pack (#728)
- feat(artists): prioritize user's preferred artists in suggestions (#739)

### Bug Fixes
- fix(bot): hard-reject Spanish autoplay drift in non-Spanish sessions (#780)
- fix(frontend): harden runtime behavior and patch transitive deps (#779)
- fix(bot): bound player track state with LRU + 30min TTL (#773)
- fix(bot): strip Forge-Space references — org wound down (#759)

🤖 Generated with [Claude Code](https://claude.com/claude-code)