### PR TITLE
chore: bump version to 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-05-05
+
+### Added
+- feat(admin): admin panel with writable global feature toggles — per-toggle enable/disable via the web UI, backed by `GlobalFeatureToggle` DB table (#801)
+- feat(bot): `/artist` and `/album` commands are now gated behind feature toggles — admins can disable them without a redeploy (#800)
+
+### Changed
+- docs: refresh roadmap for v2.8.0 and add Prisma migration guide (#802)
+
+## [2.8.0] - 2026-04-20
+
+### Added
+- feat(music): `/artist` — browse artist info, top tracks, and related artists from Spotify
+- feat(music): `/album` — search and browse albums with track listings and playback integration
+
 ## [2.6.148] - 2026-04-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.8.0",
+    "version": "2.9.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps all `package.json` files from `2.8.0` → `2.9.0`
- Adds `[2.9.0]` and `[2.8.0]` CHANGELOG entries (both were missing)

## Changes since v2.8.0
- feat(admin): admin panel with writable global feature toggles (#801)
- feat(bot): /artist and /album gated behind feature toggles (#800)
- docs: roadmap refresh + Prisma migration guide (#802)

🤖 Generated with [Claude Code](https://claude.com/claude-code)