### PR TITLE
test(bot): tighten false-positive assertions in music buttons and now-playing

### DIFF
--- a/packages/bot/src/handlers/musicButtonHandler.spec.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.spec.ts
@@ -13,6 +13,7 @@ const createErrorEmbedMock = jest.fn((title: string, desc: string) => ({
     desc,
 }))
 const createMusicControlButtonsMock = jest.fn(() => ({ type: 1 }))
+const createMusicActionButtonsMock = jest.fn(() => ({}))
 const createQueueEmbedMock = jest.fn()
 const shuffleQueueMock = jest.fn()
 const resolveGuildQueueMock = jest.fn()
@@ -31,7 +32,8 @@ const createLeaderboardPaginationButtonsMock = jest.fn()
 jest.mock('../utils/music/buttonComponents', () => ({
     createMusicControlButtons: (...args: unknown[]) =>
         createMusicControlButtonsMock(...args),
-    createMusicActionButtons: jest.fn().mockReturnValue({}),
+    createMusicActionButtons: (...args: unknown[]) =>
+        createMusicActionButtonsMock(...args),
     createLeaderboardPaginationButtons: (...args: unknown[]) =>
         createLeaderboardPaginationButtonsMock(...args),
 }))
@@ -122,6 +124,8 @@ describe('handleMusicButtonInteraction', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         createQueueEmbedMock.mockResolvedValue({ embed: {}, components: [] })
+        createMusicControlButtonsMock.mockReturnValue({ type: 1 })
+        createMusicActionButtonsMock.mockReturnValue({})
     })
 
     it('replies ephemeral error when member not in voice channel', async () => {
@@ -173,7 +177,7 @@ describe('handleMusicButtonInteraction', () => {
         expect(queue.node.pause).toHaveBeenCalled()
         expect(createMusicControlButtonsMock).toHaveBeenCalledWith(queue)
         expect(interaction.editReply).toHaveBeenCalledWith(
-            expect.objectContaining({ components: expect.any(Array) }),
+            expect.objectContaining({ components: [{ type: 1 }, {}] }),
         )
     })
 
@@ -188,7 +192,7 @@ describe('handleMusicButtonInteraction', () => {
         expect(queue.node.resume).toHaveBeenCalled()
         expect(createMusicControlButtonsMock).toHaveBeenCalledWith(queue)
         expect(interaction.editReply).toHaveBeenCalledWith(
-            expect.objectContaining({ components: expect.any(Array) }),
+            expect.objectContaining({ components: [{ type: 1 }, {}] }),
         )
     })
 

--- a/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
@@ -225,7 +225,13 @@ describe('trackNowPlaying handlers', () => {
 
             await sendNowPlayingEmbed(mockQueue, mockTrack, false)
 
-            expect(mockChannel.send).toHaveBeenCalled()
+            expect(createMusicControlButtonsMock).toHaveBeenCalledWith(mockQueue)
+            expect(mockChannel.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    embeds: [{ title: 'test embed' }],
+                    components: [[], []],
+                }),
+            )
         })
 
         it('includes embed colors in create embed call', async () => {
@@ -314,8 +320,8 @@ describe('trackNowPlaying handlers', () => {
             expect(fetchMock).toHaveBeenCalledWith(prevMessageId)
             expect(prevMessage.edit).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    embeds: expect.arrayContaining([{ title: 'test embed' }]),
-                    components: expect.anything(),
+                    embeds: [{ title: 'test embed' }],
+                    components: [[], []],
                 })
             )
         })


### PR DESCRIPTION
## Summary

- **musicButtonHandler**: extracted `createMusicActionButtonsMock` variable, reset it in `beforeEach`, and assert the exact `components` array `[{ type: 1 }, {}]` for both pause and resume paths — previously the resume test used `expect.any(Array)` which passed even if buttons were `undefined`
- **trackNowPlaying**: tightened `channel.send` assertion from bare `.toHaveBeenCalled()` to checking exact `{ embeds, components }` payload; also asserts `createMusicControlButtons` is called with the queue; tightened the edit-path from `components: expect.anything()` to `[[], []]`

These were the remaining false-positive tests from the audit: tests that passed regardless of whether the code was broken because they never asserted on what Discord actually received.

## Test plan

- [ ] `npx jest --no-coverage musicButtonHandler` — 19 tests pass
- [ ] `npx jest --no-coverage trackNowPlaying` — 34 tests pass
- [ ] `npx jest --no-coverage` (full suite) — 2865 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)