### PR TITLE
docs: refresh roadmap for v2.9.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,17 +1,16 @@
 # Roadmap — Lucky
 
-_Refreshed 2026-05-04. Version: v2.8.0._
+_Refreshed 2026-05-05. Version: v2.9.0._
 
 ## Now (active)
 
-- **Admin panel global toggles** — PR [#801](https://github.com/LucasSantana-Dev/Lucky/pull/801) in review. Self-serve guild feature flag management via web dashboard. Backend complete (`GlobalFeatureToggle` table, `requireAdmin` guard). Frontend form done.
+- **queueManipulation.ts modularisation** — Split 961-LOC hotspot into `candidateSelection.ts`, `queueOrchestration.ts`, `queueEditOps.ts`. Unblocks multiple downstream refactors.
+- **Autoplay tuning** — PR [#805](https://github.com/LucasSantana-Dev/Lucky/pull/805) in CI: artist exact-match routing, stop-clears-snapshot, Last.fm boost 0→0.20, deep-dive per-artist cap, mood cache.
 
 ## Next (proposed)
 
-- **queueManipulation.ts modularisation** — Split 953-LOC hotspot into `candidateSelection.ts`, `queueOrchestration.ts`, `queueEditOps.ts`. Unblocks multiple downstream refactors.
 - **autoplay.ts split** — 1,074-LOC command file → `autoplaySettings.ts`, `autoplayDiversity.ts`, `autoplaySeeding.ts`.
-- **Prisma homelab migration guide** — Document `GlobalFeatureToggle` table migration for homelab DB (Phase 3 prerequisite).
-- **2026-04-15-autoplay-diversity**  _(proposed)_  `autoplay,music,quality`
+- **Prisma homelab migration** — Apply `GlobalFeatureToggle` table migration to homelab DB. Run `npx prisma migrate deploy` on homelab after stop/start.
 - **2026-04-24-autoplay-genre-locale**  _(proposed)_  `autoplay,music,i18n`
 
 ## Deferred
@@ -22,8 +21,9 @@ _Refreshed 2026-05-04. Version: v2.8.0._
 
 ## Recently shipped
 
-- **v2.8.0: /artist and /album commands** — Last.fm-powered artist/album browsing with feature toggle gates. PR [#800](https://github.com/LucasSantana-Dev/Lucky/pull/800), [#799](https://github.com/LucasSantana-Dev/Lucky/pull/799).
+- **v2.9.0: Admin panel + feature gates** — Global feature toggle management via web dashboard (`GlobalFeatureToggle` table, `requireAdmin` guard). `/artist` and `/album` gated behind toggles. PR [#801](https://github.com/LucasSantana-Dev/Lucky/pull/801), [#800](https://github.com/LucasSantana-Dev/Lucky/pull/800).
+- **Test quality hardening** — Tightened false-positive assertions in music buttons and now-playing specs; all 2865 tests pass. PR [#804](https://github.com/LucasSantana-Dev/Lucky/pull/804).
+- **v2.8.0: /artist and /album commands** — Last.fm-powered artist/album browsing with feature toggle gates. PR [#799](https://github.com/LucasSantana-Dev/Lucky/pull/799).
 - **v2.7.0: Vercel feature flags migration** — Replaced Unleash with Vercel FeatureFlags. 19 flags live. PR [#796](https://github.com/LucasSantana-Dev/Lucky/pull/796).
 - **Autoplay Phase 1+2** — `/artist`, `/album`, diversity scaling, Last.fm tag scoring, autoplay seed/diversity subcommands.
 - **RBAC + guild access controls** — Role-based per-module permissions with `requireGuildModuleAccess` middleware.
-- **2026-04-15-internal-notify-endpoint**  _(shipped)_  `rag,backend,homelab`  →  PR: https://github.com/LucasSantana-Dev/Lucky/pull/625


### PR DESCRIPTION
## Summary

- Updates roadmap version to v2.9.0
- Moves admin panel from Now → Recently shipped (PR #801 merged)
- Adds test hardening PR #804 to Recently shipped
- Promotes queueManipulation.ts modularisation to Now (active work)
- Adds autoplay tuning PR #805 to Now

## Test plan
- [ ] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)