### PR TITLE
fix(player): harden stream bridge + add 57 missing tests

### DIFF
--- a/packages/bot/src/functions/music/commands/autoplay/queueHandlers.ts
+++ b/packages/bot/src/functions/music/commands/autoplay/queueHandlers.ts
@@ -78,7 +78,7 @@ async function handleSkipAutoplayTrack(
                 embeds: [
                     createErrorEmbed(
                         'Replenish Failed',
-                        'Track skipped but queue could not be replenished.',
+                        'Track skipped but the queue could not be replenished. Try `/autoplay skip` again or use `/play` to add tracks manually.',
                     ),
                 ],
                 ephemeral: true,
@@ -149,7 +149,7 @@ async function handleClearAutoplayTracks(
                 embeds: [
                     createErrorEmbed(
                         'Replenish Failed',
-                        'Autoplay tracks cleared but queue could not be replenished.',
+                        'Autoplay tracks cleared but the queue could not be replenished. Use `/play` to add tracks manually.',
                     ),
                 ],
                 ephemeral: true,

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -34,8 +34,8 @@ export const createPlayer = ({ client }: CreatePlayerParams): Player => {
 }
 
 const registerExtractors = (player: Player): void => {
-    // Register all extractors asynchronously in priority order:
-    //   Spotify → YouTube → SoundCloud → Apple Music → Vimeo → Attachments
+    // Register all extractors asynchronously in initialization order:
+    //   Spotify → play-dl SoundCloud init (yt-dlp bridge) → YouTube → SoundCloud extractor → Apple Music → Vimeo → Attachments
     // Fire without awaiting so createPlayer() returns synchronously.
     registerExtractorsInOrder(player).catch((error) => {
         errorLog({

--- a/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
@@ -1,0 +1,228 @@
+import { jest } from '@jest/globals'
+import { PassThrough } from 'stream'
+
+// --- mocks ---
+const mockSearch = jest.fn()
+const mockStream = jest.fn()
+
+jest.mock('play-dl', () => ({
+    search: (...args: unknown[]) => mockSearch(...args),
+    stream: (...args: unknown[]) => mockStream(...args),
+}))
+
+import {
+    streamViaSoundCloud,
+    findMatchingSoundCloudResult,
+    parseDurationString,
+} from './soundcloudMatcher.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResult(
+    name: string,
+    durationInSec?: number,
+): { name: string; url: string; durationInSec?: number } {
+    return { name, url: `https://soundcloud.com/artist/${name}`, durationInSec }
+}
+
+const fakeReadable = new PassThrough()
+
+// ---------------------------------------------------------------------------
+// parseDurationString
+// ---------------------------------------------------------------------------
+
+describe('parseDurationString', () => {
+    it('returns null for undefined', () => {
+        expect(parseDurationString(undefined)).toBeNull()
+    })
+
+    it('returns null for empty string', () => {
+        expect(parseDurationString('')).toBeNull()
+    })
+
+    it('parses MM:SS format', () => {
+        expect(parseDurationString('3:30')).toBe(210)
+    })
+
+    it('parses HH:MM:SS format', () => {
+        expect(parseDurationString('1:02:03')).toBe(3723)
+    })
+
+    it('handles zero-padded values', () => {
+        expect(parseDurationString('0:05')).toBe(5)
+    })
+
+    it('returns null for non-numeric parts', () => {
+        expect(parseDurationString('3:xx')).toBeNull()
+    })
+
+    it('returns null for a single segment (no colons)', () => {
+        expect(parseDurationString('123')).toBeNull()
+    })
+
+    it('returns null for four-segment duration', () => {
+        expect(parseDurationString('1:2:3:4')).toBeNull()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// findMatchingSoundCloudResult — title matching
+// ---------------------------------------------------------------------------
+
+describe('findMatchingSoundCloudResult – title matching', () => {
+    it('matches when all query tokens are in the result name', () => {
+        const results = [makeResult('Song Name By Artist')]
+        expect(findMatchingSoundCloudResult('song name', undefined, results)).toBe(
+            results[0],
+        )
+    })
+
+    it('returns undefined when query normalizes to empty', () => {
+        const results = [makeResult('Song')]
+        expect(findMatchingSoundCloudResult('!!!', undefined, results)).toBeUndefined()
+    })
+
+    it('returns undefined when no result meets the 75% token threshold', () => {
+        // query has 4 tokens, result matches only 1 (25%)
+        const results = [makeResult('Song')]
+        expect(
+            findMatchingSoundCloudResult('song name by artist', undefined, results),
+        ).toBeUndefined()
+    })
+
+    it('matches when exactly 75% of tokens are present', () => {
+        // 4 tokens, 3 matched = 75%
+        const results = [makeResult('Song Name By')]
+        expect(
+            findMatchingSoundCloudResult('song name by artist', undefined, results),
+        ).toBe(results[0])
+    })
+
+    it('strips punctuation before comparing', () => {
+        const results = [makeResult('Song: The Remix')]
+        expect(
+            findMatchingSoundCloudResult('song the remix', undefined, results),
+        ).toBe(results[0])
+    })
+
+    it('is case-insensitive', () => {
+        const results = [makeResult('SONG NAME')]
+        expect(findMatchingSoundCloudResult('Song Name', undefined, results)).toBe(
+            results[0],
+        )
+    })
+
+    it('skips results whose normalized name is empty', () => {
+        const results = [makeResult('!!!')]
+        expect(
+            findMatchingSoundCloudResult('song name', undefined, results),
+        ).toBeUndefined()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// findMatchingSoundCloudResult — duration matching
+// ---------------------------------------------------------------------------
+
+describe('findMatchingSoundCloudResult – duration matching', () => {
+    it('accepts match within 30 seconds of track duration', () => {
+        const results = [makeResult('Song', 200)] // 3:20
+        expect(findMatchingSoundCloudResult('song', '3:30', results)).toBe(results[0])
+    })
+
+    it('rejects match more than 30 seconds from track duration', () => {
+        const results = [makeResult('Song', 169)] // 31s off
+        expect(
+            findMatchingSoundCloudResult('song', '3:30', results),
+        ).toBeUndefined()
+    })
+
+    it('accepts exact boundary (30 seconds off)', () => {
+        const results = [makeResult('Song', 180)] // exactly 30s off from 3:30 (210s)
+        expect(findMatchingSoundCloudResult('song', '3:30', results)).toBe(results[0])
+    })
+
+    it('skips duration check when trackDuration is missing', () => {
+        const results = [makeResult('Song', 60)]
+        expect(findMatchingSoundCloudResult('song', undefined, results)).toBe(results[0])
+    })
+
+    it('skips duration check when result has no durationInSec', () => {
+        const results = [makeResult('Song')]
+        expect(findMatchingSoundCloudResult('song', '3:30', results)).toBe(results[0])
+    })
+
+    it('skips duration check when trackDuration is unparseable', () => {
+        const results = [makeResult('Song', 60)]
+        expect(findMatchingSoundCloudResult('song', 'bad:duration', results)).toBe(
+            results[0],
+        )
+    })
+
+    it('returns first result that passes both title and duration checks', () => {
+        const results = [
+            makeResult('Song', 60),   // title match, duration fails (150s off 3:30)
+            makeResult('Song Name', 200), // title match, duration ok (10s off 3:30)
+        ]
+        const match = findMatchingSoundCloudResult('song name', '3:30', results)
+        expect(match?.name).toBe('Song Name')
+    })
+})
+
+// ---------------------------------------------------------------------------
+// streamViaSoundCloud
+// ---------------------------------------------------------------------------
+
+describe('streamViaSoundCloud', () => {
+    beforeEach(() => {
+        mockStream.mockResolvedValue({ stream: fakeReadable })
+    })
+
+    it('throws on empty query', async () => {
+        await expect(streamViaSoundCloud('')).rejects.toThrow('SoundCloud: empty query')
+    })
+
+    it('throws on whitespace-only query', async () => {
+        await expect(streamViaSoundCloud('   ')).rejects.toThrow('SoundCloud: empty query')
+    })
+
+    it('throws when search returns no results', async () => {
+        mockSearch.mockResolvedValue([])
+        await expect(streamViaSoundCloud('some song', '3:30')).rejects.toThrow(
+            'SoundCloud: no results for "some song"',
+        )
+    })
+
+    it('throws when no result passes title/duration validation', async () => {
+        // result name has no tokens in common with query
+        mockSearch.mockResolvedValue([makeResult('Completely Different', 300)])
+        await expect(streamViaSoundCloud('song name', '3:30')).rejects.toThrow(
+            'SoundCloud: no validated match',
+        )
+    })
+
+    it('returns the stream for a matching result', async () => {
+        mockSearch.mockResolvedValue([makeResult('Song Name By Artist', 210)])
+        const result = await streamViaSoundCloud('song name', '3:30')
+        expect(result).toBe(fakeReadable)
+    })
+
+    it('wraps playdl.stream errors with context', async () => {
+        mockSearch.mockResolvedValue([makeResult('Song Name', 210)])
+        mockStream.mockRejectedValue(new Error('401 Unauthorized'))
+        await expect(streamViaSoundCloud('song name', '3:30')).rejects.toThrow(
+            'SoundCloud: stream creation failed for "Song Name" — 401 Unauthorized',
+        )
+    })
+
+    it('passes query and limit 5 to playdl.search', async () => {
+        mockSearch.mockResolvedValue([makeResult('Song Name', 210)])
+        await streamViaSoundCloud('song name')
+        expect(mockSearch).toHaveBeenCalledWith('song name', {
+            source: { soundcloud: 'tracks' },
+            limit: 5,
+        })
+    })
+})

--- a/packages/bot/src/handlers/player/soundcloudMatcher.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.ts
@@ -33,7 +33,15 @@ export async function streamViaSoundCloud(
         )
     }
 
-    const scStream = await playdl.stream(match.url)
+    let scStream: Awaited<ReturnType<typeof playdl.stream>>
+    try {
+        scStream = await playdl.stream(match.url)
+    } catch (err) {
+        throw new Error(
+            `SoundCloud: stream creation failed for "${match.name}" — ${(err as Error).message}`,
+            { cause: err },
+        )
+    }
     return scStream.stream
 }
 

--- a/packages/bot/src/handlers/player/streamBridge.spec.ts
+++ b/packages/bot/src/handlers/player/streamBridge.spec.ts
@@ -1,0 +1,328 @@
+import { jest } from '@jest/globals'
+import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
+
+// --- mocks (declared before imports) ---
+const mockSpawn = jest.fn()
+const mockStreamViaSoundCloud = jest.fn()
+const mockCleanTitle = jest.fn()
+const mockCleanAuthor = jest.fn()
+const mockCleanSearchQuery = jest.fn()
+const mockIsAvailable = jest.fn()
+const mockDebugLog = jest.fn()
+const mockInfoLog = jest.fn()
+const mockWarnLog = jest.fn()
+const mockErrorLog = jest.fn()
+
+jest.mock('child_process', () => ({ spawn: (...args: unknown[]) => mockSpawn(...args) }))
+jest.mock('./soundcloudMatcher', () => ({
+    streamViaSoundCloud: (...args: unknown[]) => mockStreamViaSoundCloud(...args),
+}))
+jest.mock('../../utils/music/searchQueryCleaner', () => ({
+    cleanTitle: (...args: unknown[]) => mockCleanTitle(...args),
+    cleanAuthor: (...args: unknown[]) => mockCleanAuthor(...args),
+    cleanSearchQuery: (...args: unknown[]) => mockCleanSearchQuery(...args),
+}))
+jest.mock('../../utils/music/search/providerHealth', () => ({
+    providerHealthService: { isAvailable: (...args: unknown[]) => mockIsAvailable(...args) },
+}))
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: (...args: unknown[]) => mockDebugLog(...args),
+    infoLog: (...args: unknown[]) => mockInfoLog(...args),
+    warnLog: (...args: unknown[]) => mockWarnLog(...args),
+    errorLog: (...args: unknown[]) => mockErrorLog(...args),
+}))
+
+import {
+    streamViaYtDlp,
+    streamViaYtDlpSearch,
+    createResilientStream,
+} from './streamBridge.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type FakeProc = EventEmitter & {
+    stdout: PassThrough
+    stderr: PassThrough
+    kill: jest.Mock
+}
+
+function makeFakeProc(): FakeProc {
+    const proc = new EventEmitter() as FakeProc
+    proc.stdout = new PassThrough()
+    proc.stderr = new PassThrough()
+    proc.kill = jest.fn()
+    return proc
+}
+
+function makeTrack(overrides: {
+    title?: string
+    author?: string
+    duration?: string
+    url?: string
+} = {}) {
+    return {
+        title: overrides.title ?? 'Test Track',
+        author: overrides.author ?? 'Test Artist',
+        duration: overrides.duration ?? '3:30',
+        url: overrides.url ?? 'https://www.youtube.com/watch?v=abc123',
+    }
+}
+
+const fakeStream = new EventEmitter() as any
+
+// ---------------------------------------------------------------------------
+// streamViaYtDlp — URL validation
+// ---------------------------------------------------------------------------
+
+describe('streamViaYtDlp – URL validation', () => {
+    it('rejects on an invalid (unparseable) URL', async () => {
+        await expect(streamViaYtDlp('not-a-url')).rejects.toThrow('yt-dlp: invalid URL')
+    })
+
+    it('rejects on a non-https URL', async () => {
+        await expect(
+            streamViaYtDlp('http://www.youtube.com/watch?v=abc'),
+        ).rejects.toThrow('yt-dlp: only https URLs are allowed')
+    })
+
+    it('rejects on a domain not in the allowlist', async () => {
+        await expect(
+            streamViaYtDlp('https://evil.example.com/video'),
+        ).rejects.toThrow('yt-dlp: domain not in allowlist')
+    })
+
+    it('passes validation for a ytsearch prefix without spawning URL check', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        // Let the proc emit data immediately so the promise resolves
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        const stream = await streamViaYtDlp('ytsearch1:some query')
+        expect(stream).toBeDefined()
+    })
+
+    it.each([
+        'https://youtube.com/watch?v=x',
+        'https://www.youtube.com/watch?v=x',
+        'https://youtu.be/x',
+        'https://music.youtube.com/watch?v=x',
+        'https://soundcloud.com/artist/track',
+        'https://www.soundcloud.com/artist/track',
+    ])('accepts allowed domain: %s', async (url) => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        await expect(streamViaYtDlp(url)).resolves.toBeDefined()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// streamViaYtDlp — process lifecycle
+// ---------------------------------------------------------------------------
+
+describe('streamViaYtDlp – process lifecycle', () => {
+    const validUrl = 'https://www.youtube.com/watch?v=abc123'
+
+    it('resolves with a PassThrough stream when stdout emits first chunk', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        const data = Buffer.from('audio-bytes')
+        setImmediate(() => proc.stdout.emit('data', data))
+        const stream = await streamViaYtDlp(validUrl)
+        expect(stream).toBeDefined()
+    })
+
+    it('rejects and kills proc when process emits an error', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('error', new Error('ENOENT yt-dlp')))
+        await expect(streamViaYtDlp(validUrl)).rejects.toThrow('ENOENT yt-dlp')
+        expect(proc.kill).toHaveBeenCalled()
+    })
+
+    it('rejects with exit code and stderr when process closes with non-zero code', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => {
+            proc.stderr.emit('data', Buffer.from('Video unavailable'))
+            proc.emit('close', 1)
+        })
+        await expect(streamViaYtDlp(validUrl)).rejects.toThrow(
+            'yt-dlp exited with code 1 — Video unavailable',
+        )
+    })
+
+    it('rejects with just the exit code when stderr is empty', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('close', 2))
+        await expect(streamViaYtDlp(validUrl)).rejects.toThrow(
+            'yt-dlp exited with code 2',
+        )
+    })
+
+    it('does not reject after stdout resolves even if close fires later', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => {
+            proc.stdout.emit('data', Buffer.from('bytes'))
+            // close fires after stdout — should be ignored
+            proc.emit('close', 1)
+        })
+        await expect(streamViaYtDlp(validUrl)).resolves.toBeDefined()
+    })
+
+    it('kills proc and rejects on timeout', async () => {
+        jest.useFakeTimers()
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        // never emit stdout data — let the timeout fire
+        const promise = streamViaYtDlp(validUrl)
+        jest.advanceTimersByTime(15_000)
+        await expect(promise).rejects.toThrow('yt-dlp: timed out')
+        expect(proc.kill).toHaveBeenCalled()
+        jest.useRealTimers()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// streamViaYtDlpSearch
+// ---------------------------------------------------------------------------
+
+describe('streamViaYtDlpSearch', () => {
+    it('rejects on empty query', async () => {
+        await expect(streamViaYtDlpSearch('')).rejects.toThrow('yt-dlp search: empty query')
+    })
+
+    it('rejects on whitespace-only query', async () => {
+        await expect(streamViaYtDlpSearch('   ')).rejects.toThrow('yt-dlp search: empty query')
+    })
+
+    it('prepends ytsearch1: and delegates to streamViaYtDlp', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        await streamViaYtDlpSearch('some song')
+        const [, args] = mockSpawn.mock.calls[0] as [string, string[]]
+        expect(args).toContain('ytsearch1:some song')
+    })
+})
+
+// ---------------------------------------------------------------------------
+// createResilientStream — fallback chain
+// ---------------------------------------------------------------------------
+
+describe('createResilientStream', () => {
+    beforeEach(() => {
+        mockCleanTitle.mockReturnValue('Test Track')
+        mockCleanAuthor.mockReturnValue('Test Artist')
+        mockCleanSearchQuery.mockReturnValue('test track test artist')
+        mockIsAvailable.mockReturnValue(true)
+    })
+
+    it('streams via yt-dlp directly for a YouTube URL', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        const result = await createResilientStream(makeTrack())
+        expect(result).toBeDefined()
+        expect(mockStreamViaSoundCloud).not.toHaveBeenCalled()
+    })
+
+    it('falls back to SoundCloud when yt-dlp fails for a YouTube URL', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        mockStreamViaSoundCloud.mockResolvedValue(fakeStream)
+        setImmediate(() => proc.emit('close', 1))
+        const result = await createResilientStream(makeTrack())
+        expect(result).toBe(fakeStream)
+        expect(mockStreamViaSoundCloud).toHaveBeenCalled()
+    })
+
+    it('tries yt-dlp YouTube search for a Spotify URL', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        const track = makeTrack({ url: 'https://open.spotify.com/track/abc' })
+        await createResilientStream(track)
+        const [, args] = mockSpawn.mock.calls[0] as [string, string[]]
+        expect(args.some((a: string) => a.startsWith('ytsearch1:'))).toBe(true)
+    })
+
+    it('falls through to SoundCloud when Spotify yt-dlp search fails', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        mockStreamViaSoundCloud.mockResolvedValue(fakeStream)
+        setImmediate(() => proc.emit('close', 1))
+        const track = makeTrack({ url: 'https://open.spotify.com/track/abc' })
+        const result = await createResilientStream(track)
+        expect(result).toBe(fakeStream)
+        expect(mockStreamViaSoundCloud).toHaveBeenCalled()
+    })
+
+    it('throws immediately when circuit breaker is open', async () => {
+        mockIsAvailable.mockReturnValue(false)
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('close', 1))
+        await expect(createResilientStream(makeTrack())).rejects.toThrow(
+            'Bridge exhausted',
+        )
+        expect(mockStreamViaSoundCloud).not.toHaveBeenCalled()
+    })
+
+    it('retries SoundCloud with title-only when primary query fails', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('close', 1))
+        mockStreamViaSoundCloud
+            .mockRejectedValueOnce(new Error('no results'))
+            .mockResolvedValueOnce(fakeStream)
+        const result = await createResilientStream(makeTrack())
+        expect(mockStreamViaSoundCloud).toHaveBeenCalledTimes(2)
+        expect(result).toBe(fakeStream)
+    })
+
+    it('retries SoundCloud with core title (strips parentheticals) when title-only fails', async () => {
+        mockCleanTitle.mockReturnValue('Song Name (Official Audio)')
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('close', 1))
+        mockStreamViaSoundCloud
+            .mockRejectedValueOnce(new Error('no results'))
+            .mockRejectedValueOnce(new Error('no results'))
+            .mockResolvedValueOnce(fakeStream)
+        const result = await createResilientStream(
+            makeTrack({ title: 'Song Name (Official Audio)' }),
+        )
+        expect(mockStreamViaSoundCloud).toHaveBeenCalledTimes(3)
+        const thirdCallQuery = (mockStreamViaSoundCloud.mock.calls[2] as string[])[0]
+        expect(thirdCallQuery).toBe('Song Name')
+        expect(result).toBe(fakeStream)
+    })
+
+    it('throws Bridge exhausted when all stages fail', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('close', 1))
+        mockStreamViaSoundCloud.mockRejectedValue(new Error('no results'))
+        await expect(
+            createResilientStream(makeTrack({ title: 'Song Name (Remix)' })),
+        ).rejects.toThrow('Bridge exhausted: no stream for "Song Name (Remix)"')
+    })
+
+    it('skips core-title retry when core title equals cleaned title', async () => {
+        // no parentheticals → coreTitle === cleanedTitle → no 3rd SoundCloud call
+        mockCleanTitle.mockReturnValue('Song Name')
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('close', 1))
+        mockStreamViaSoundCloud.mockRejectedValue(new Error('no results'))
+        await expect(
+            createResilientStream(makeTrack({ title: 'Song Name' })),
+        ).rejects.toThrow('Bridge exhausted')
+        expect(mockStreamViaSoundCloud).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -85,6 +85,7 @@ export function streamViaYtDlp(url: string): Promise<Readable> {
             if (settled) return
             settled = true
             clearTimeout(timeout)
+            proc.kill()
             reject(err)
         })
 


### PR DESCRIPTION
## Summary

Follow-up to #814 addressing issues surfaced by the post-merge review.

**Fixes:**
- `soundcloudMatcher`: wrap `playdl.stream()` in try/catch — auth failures and rate limits now surface with context instead of propagating as raw unhandled rejections
- `streamBridge`: call `proc.kill()` in the error handler so yt-dlp subprocesses are cleaned up on spawn errors, not only on timeout (prevents orphan accumulation)
- `playerFactory`: fix priority comment — play-dl SoundCloud init runs before YouTube extractor, not after

**Tests (57 new):**
- `streamBridge.spec.ts` — 28 tests covering URL allowlist validation, process lifecycle (timeout+kill, error+kill, exit code with stderr), `streamViaYtDlpSearch` empty-query guard, and the full 5-stage `createResilientStream` fallback chain including circuit breaker and parenthetical-stripping retry
- `soundcloudMatcher.spec.ts` — 29 tests covering `parseDurationString` edge cases, `findMatchingSoundCloudResult` title-token threshold (75%) and duration boundary (±30s), and `streamViaSoundCloud` error paths including the new `playdl.stream` error wrapping

**UX:**
- `queueHandlers`: replenish-failure error messages now include actionable recovery steps (`/autoplay skip` again or `/play`)

## Test plan
- [ ] `npx jest --config packages/bot/jest.config.cjs packages/bot/src/handlers/player/` — all 57 new tests pass
- [ ] Full bot suite: 3338+ tests pass (pre-existing `queueResolver.guard` failure unrelated to this PR)
- [ ] SonarCloud quality gate passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and recovery for streaming operations.
  * Improved error messages for autoplay queue management operations.

* **Tests**
  * Added comprehensive test coverage for music streaming and matching functionality.

* **Documentation**
  * Updated initialization sequence documentation for music platform handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->