### PR TITLE
fix(autoplay): prioritize user tracks, Spotify liked seeds, sertanejo filter, expand Last.fm limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15325,9 +15325,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "devOptional": true,
       "funding": [
         {
@@ -16385,9 +16385,9 @@
       "license": "ISC"
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/packages/bot/src/spotify/spotifyApi.spec.ts
+++ b/packages/bot/src/spotify/spotifyApi.spec.ts
@@ -14,6 +14,7 @@ import {
     getSpotifyRecommendations,
     getArtistGenres,
     getUserTopArtistsAndTracks,
+    getUserSavedTracks,
 } from './spotifyApi'
 
 type MockFetchResponse = {
@@ -834,6 +835,183 @@ describe('spotifyApi', () => {
             const result = await getUserTopArtistsAndTracks('token')
 
             expect(result).toBeNull()
+        })
+    })
+
+    describe('getUserSavedTracks', () => {
+        it('returns empty array when response is not ok', async () => {
+            fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toEqual([])
+        })
+
+        it('returns track ids from a single page', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    items: [
+                        { track: { id: 'track-1' } },
+                        { track: { id: 'track-2' } },
+                    ],
+                    total: 2,
+                }),
+            })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toEqual(['track-1', 'track-2'])
+        })
+
+        it('paginates until all tracks are fetched', async () => {
+            let callCount = 0
+            fetchMock.mockImplementation(async () => {
+                callCount++
+                if (callCount === 1) {
+                    return {
+                        ok: true,
+                        json: async () => ({
+                            items: Array.from({ length: 50 }, (_, i) => ({ track: { id: `track-${i}` } })),
+                            total: 60,
+                        }),
+                    }
+                }
+                return {
+                    ok: true,
+                    json: async () => ({
+                        items: Array.from({ length: 10 }, (_, i) => ({ track: { id: `track-${50 + i}` } })),
+                        total: 60,
+                    }),
+                }
+            })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toHaveLength(60)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('stops when maxTracks (200) is reached', async () => {
+            fetchMock.mockImplementation(async () => ({
+                ok: true,
+                json: async () => ({
+                    items: Array.from({ length: 50 }, (_, i) => ({ track: { id: `t${i}` } })),
+                    total: 1000,
+                }),
+            }))
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result.length).toBeLessThanOrEqual(200)
+            expect(fetchMock).toHaveBeenCalledTimes(4)
+        })
+
+        it('stops when items array is empty', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: async () => ({ items: [], total: 100 }),
+            })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toEqual([])
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('breaks on non-ok response mid-pagination', async () => {
+            let callCount = 0
+            fetchMock.mockImplementation(async () => {
+                callCount++
+                if (callCount === 1) {
+                    return {
+                        ok: true,
+                        json: async () => ({
+                            items: [{ track: { id: 'track-1' } }],
+                            total: 100,
+                        }),
+                    }
+                }
+                return { ok: false, json: async () => ({}) }
+            })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toEqual(['track-1'])
+        })
+
+        it('breaks on JSON parse error', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: async () => { throw new Error('JSON error') },
+            })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toEqual([])
+        })
+
+        it('returns empty array on network error', async () => {
+            fetchMock.mockRejectedValue(new Error('network error'))
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toEqual([])
+        })
+
+        it('skips items without a track id', async () => {
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        items: [
+                            { track: { id: 'valid-1' } },
+                            { track: {} },
+                            { track: null },
+                            {},
+                            { track: { id: 'valid-2' } },
+                        ],
+                        total: 5,
+                    }),
+                })
+                .mockResolvedValue({
+                    ok: true,
+                    json: async () => ({ items: [], total: 5 }),
+                })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toEqual(['valid-1', 'valid-2'])
+        })
+
+        it('breaks when data has no items field', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: async () => ({ total: 10 }),
+            })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toEqual([])
+        })
+
+        it('stops early when data.total matches accumulated count', async () => {
+            let callCount = 0
+            fetchMock.mockImplementation(async () => {
+                callCount++
+                return {
+                    ok: true,
+                    json: async () => ({
+                        items: [{ track: { id: `t${callCount}` } }],
+                        total: 1,
+                    }),
+                }
+            })
+
+            const result = await getUserSavedTracks('token')
+
+            expect(result).toHaveLength(1)
+            expect(fetchMock).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -464,3 +464,56 @@ export async function getUserTopArtistsAndTracks(
         return null
     }
 }
+
+export async function getUserSavedTracks(
+    accessToken: string,
+): Promise<string[]> {
+    const savedTrackIds: string[] = []
+    const limit = 50
+    const maxTracks = 200
+    let offset = 0
+
+    try {
+        while (offset < maxTracks) {
+            const res = await fetch(
+                `https://api.spotify.com/v1/me/tracks?limit=${limit}&offset=${offset}`,
+                {
+                    method: 'GET',
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                    },
+                },
+            )
+
+            if (!res.ok) {
+                break
+            }
+
+            const data = (await res.json().catch(() => null)) as {
+                items?: Array<{ track?: { id?: string } }>
+                total?: number
+            }
+
+            if (!data?.items) {
+                break
+            }
+
+            for (const item of data.items) {
+                if (item.track?.id) {
+                    savedTrackIds.push(item.track.id)
+                }
+            }
+
+            if (savedTrackIds.length >= maxTracks || !data.items.length) {
+                break
+            }
+
+            offset += limit
+        }
+
+        return savedTrackIds.slice(0, maxTracks)
+    } catch (err) {
+        logAndSwallow(err, 'spotify.getUserSavedTracks')
+        return []
+    }
+}

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -494,9 +494,10 @@ export async function getUserSavedTracks(
                 break
             }
 
-            let data: { items?: Array<{ track?: { id?: string } }>; total?: number } | null = null
+            type SavedTracksPage = { items: Array<{ track?: { id?: string } }>; total?: number }
+            let data: SavedTracksPage | null = null
             try {
-                data = (await res.json()) as typeof data
+                data = (await res.json()) as SavedTracksPage
             } catch (parseErr) {
                 logAndSwallow(parseErr, 'spotify.getUserSavedTracks.parse', { offset })
                 break
@@ -512,7 +513,8 @@ export async function getUserSavedTracks(
                 }
             }
 
-            if (savedTrackIds.length >= maxTracks || !data.items.length) {
+            const allFetched = data.total !== undefined && savedTrackIds.length >= data.total
+            if (savedTrackIds.length >= maxTracks || !data.items.length || allFetched) {
                 break
             }
 

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -467,7 +467,7 @@ export async function getUserTopArtistsAndTracks(
 
 export async function getUserSavedTracks(
     accessToken: string,
-    limit = 50,
+    limit = 200,
 ): Promise<string[]> {
     const savedTrackIds: string[] = []
     const pageLimit = 50

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -486,12 +486,20 @@ export async function getUserSavedTracks(
             )
 
             if (!res.ok) {
+                logAndSwallow(
+                    new Error(`HTTP ${res.status}`),
+                    'spotify.getUserSavedTracks.request',
+                    { status: res.status, offset },
+                )
                 break
             }
 
-            const data = (await res.json().catch(() => null)) as {
-                items?: Array<{ track?: { id?: string } }>
-                total?: number
+            let data: { items?: Array<{ track?: { id?: string } }>; total?: number } | null = null
+            try {
+                data = (await res.json()) as typeof data
+            } catch (parseErr) {
+                logAndSwallow(parseErr, 'spotify.getUserSavedTracks.parse', { offset })
+                break
             }
 
             if (!data?.items) {

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -496,6 +496,7 @@ export async function getUserSavedTracks(
                     'spotify.getUserSavedTracks.request',
                     { status: res.status, offset },
                 )
+                await res.body?.cancel().catch(() => undefined)
                 break
             }
 

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -475,8 +475,12 @@ export async function getUserSavedTracks(
 
     try {
         while (offset < maxTracks) {
+            const params = new URLSearchParams({
+                limit: String(limit),
+                offset: String(offset),
+            })
             const res = await fetch(
-                `https://api.spotify.com/v1/me/tracks?limit=${limit}&offset=${offset}`,
+                `https://api.spotify.com/v1/me/tracks?${params.toString()}`,
                 {
                     method: 'GET',
                     headers: {

--- a/packages/bot/src/spotify/spotifyUserSeeds.spec.ts
+++ b/packages/bot/src/spotify/spotifyUserSeeds.spec.ts
@@ -12,12 +12,14 @@ jest.mock('@lucky/shared/services', () => ({
 
 jest.mock('./spotifyApi', () => ({
     getUserTopArtistsAndTracks: jest.fn(),
+    getUserSavedTracks: jest.fn().mockResolvedValue([]),
 }))
 
 describe('spotifyUserSeeds', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         clearUserSeedsCache('test-user-id')
+        ;(spotifyApi.getUserSavedTracks as jest.Mock).mockResolvedValue([])
     })
 
     it('should fetch and cache user Spotify seeds', async () => {
@@ -56,6 +58,30 @@ describe('spotifyUserSeeds', () => {
         expect(result?.artistIds).toEqual(['artist-1', 'artist-2'])
         expect(result?.artistNames).toEqual(new Set(['artist one', 'artist two']))
         expect(result?.trackIds).toEqual(['track-1', 'track-2'])
+        expect(result?.likedTrackIds).toEqual([])
+    })
+
+    it('should populate likedTrackIds when getUserSavedTracks returns data', async () => {
+        const mockLink = {
+            spotifyId: 'spotify-123',
+            accessToken: 'token',
+            refreshToken: 'refresh',
+            tokenExpiresAt: new Date(Date.now() + 3600000),
+            spotifyUsername: 'testuser',
+        }
+        const mockSeeds = {
+            artists: [{ id: 'artist-1', name: 'Artist One', genres: ['rock'] }],
+            tracks: [],
+        }
+        ;(spotifyLinkService.getByDiscordId as jest.Mock).mockResolvedValue(mockLink)
+        ;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue('token')
+        ;(spotifyApi.getUserTopArtistsAndTracks as jest.Mock).mockResolvedValue(mockSeeds)
+        ;(spotifyApi.getUserSavedTracks as jest.Mock).mockResolvedValue(['liked-1', 'liked-2'])
+
+        clearUserSeedsCache('test-user-id')
+        const result = await getUserSpotifySeeds('test-user-id')
+
+        expect(result?.likedTrackIds).toEqual(['liked-1', 'liked-2'])
     })
 
     it('should return null if user has no Spotify link', async () => {

--- a/packages/bot/src/spotify/spotifyUserSeeds.spec.ts
+++ b/packages/bot/src/spotify/spotifyUserSeeds.spec.ts
@@ -139,7 +139,7 @@ describe('spotifyUserSeeds', () => {
         expect(result).toBeNull()
     })
 
-    it('should cache results for 5 minutes', async () => {
+    it('should cache results for 30 minutes', async () => {
         const mockLink = {
             spotifyId: 'spotify-123',
             accessToken: 'token',

--- a/packages/bot/src/spotify/spotifyUserSeeds.ts
+++ b/packages/bot/src/spotify/spotifyUserSeeds.ts
@@ -15,12 +15,12 @@ interface SeededUserEntry {
     fetched: number
 }
 
+const CACHE_TTL_MS = 30 * 60 * 1000
+
 const userSeedsCache = new LRUCache<string, SeededUserEntry>({
     max: 500,
-    ttl: 30 * 60 * 1000,
+    ttl: CACHE_TTL_MS,
 })
-
-const CACHE_TTL_MS = 30 * 60 * 1000
 
 export async function getUserSpotifySeeds(userId: string): Promise<UserSpotifySeeds | null> {
     const now = Date.now()

--- a/packages/bot/src/spotify/spotifyUserSeeds.ts
+++ b/packages/bot/src/spotify/spotifyUserSeeds.ts
@@ -1,12 +1,13 @@
 import { LRUCache } from 'lru-cache'
 import { spotifyLinkService } from '@lucky/shared/services'
-import { getUserTopArtistsAndTracks } from './spotifyApi'
+import { getUserTopArtistsAndTracks, getUserSavedTracks } from './spotifyApi'
 import { debugLog, errorLog } from '@lucky/shared/utils/general/log'
 
 export interface UserSpotifySeeds {
     artistIds: string[]
     artistNames: Set<string>
     trackIds: string[]
+    likedTrackIds: string[]
 }
 
 interface SeededUserEntry {
@@ -16,10 +17,10 @@ interface SeededUserEntry {
 
 const userSeedsCache = new LRUCache<string, SeededUserEntry>({
     max: 500,
-    ttl: 5 * 60 * 1000,
+    ttl: 30 * 60 * 1000,
 })
 
-const CACHE_TTL_MS = 5 * 60 * 1000
+const CACHE_TTL_MS = 30 * 60 * 1000
 
 export async function getUserSpotifySeeds(userId: string): Promise<UserSpotifySeeds | null> {
     const now = Date.now()
@@ -57,10 +58,13 @@ export async function getUserSpotifySeeds(userId: string): Promise<UserSpotifySe
             return null
         }
 
+        const likedTrackIds = await getUserSavedTracks(token)
+
         const seeds: UserSpotifySeeds = {
             artistIds: seedData.artists.map((a) => a.id),
             artistNames: new Set(seedData.artists.map((a) => a.name.toLowerCase())),
             trackIds: seedData.tracks.map((t) => t.id),
+            likedTrackIds,
         }
 
         userSeedsCache.set(userId, {
@@ -74,6 +78,7 @@ export async function getUserSpotifySeeds(userId: string): Promise<UserSpotifySe
                 userId,
                 artistCount: seeds.artistIds.length,
                 trackCount: seeds.trackIds.length,
+                likedTrackCount: likedTrackIds.length,
             },
         })
 

--- a/packages/bot/src/utils/music/autoplay/artistTagCache.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/artistTagCache.spec.ts
@@ -1,0 +1,76 @@
+import { jest } from '@jest/globals'
+import { hasGenreTag, createArtistTagFetcher } from './artistTagCache'
+
+jest.mock('../../../lastfm', () => ({
+    getArtistTopTags: jest.fn(),
+}))
+
+describe('hasGenreTag', () => {
+    it('returns false when tags array is empty', () => {
+        expect(hasGenreTag([], ['rock', 'pop'])).toBe(false)
+    })
+
+    it('returns true when a tag matches a genre variant', () => {
+        expect(hasGenreTag(['sertanejo', 'country'], ['sertanejo'])).toBe(true)
+    })
+
+    it('returns false when no tags match', () => {
+        expect(hasGenreTag(['rock', 'indie'], ['sertanejo', 'forró'])).toBe(false)
+    })
+
+    it('is case-insensitive', () => {
+        expect(hasGenreTag(['Sertanejo'], ['sertanejo'])).toBe(true)
+        expect(hasGenreTag(['sertanejo'], ['SERTANEJO'])).toBe(true)
+    })
+
+    it('trims whitespace from tags and variants', () => {
+        expect(hasGenreTag([' sertanejo '], ['sertanejo'])).toBe(true)
+    })
+
+    it('returns false when variants array is empty', () => {
+        expect(hasGenreTag(['rock'], [])).toBe(false)
+    })
+})
+
+describe('createArtistTagFetcher', () => {
+    it('returns an empty array for undefined artist', async () => {
+        const fetcher = createArtistTagFetcher()
+        const result = await fetcher(undefined)
+        expect(result).toEqual([])
+    })
+
+    it('returns an empty array for empty string artist', async () => {
+        const fetcher = createArtistTagFetcher()
+        const result = await fetcher('')
+        expect(result).toEqual([])
+    })
+
+    it('returns an empty array for whitespace-only artist', async () => {
+        const fetcher = createArtistTagFetcher()
+        const result = await fetcher('   ')
+        expect(result).toEqual([])
+    })
+
+    it('fetches and caches tags for a known artist', async () => {
+        const { getArtistTopTags } = require('../../../lastfm')
+        ;(getArtistTopTags as jest.Mock).mockResolvedValue(['rock', 'indie'])
+
+        const fetcher = createArtistTagFetcher()
+        const result1 = await fetcher('Radiohead')
+        const result2 = await fetcher('radiohead')
+
+        expect(result1).toEqual(['rock', 'indie'])
+        expect(result2).toEqual(['rock', 'indie'])
+        expect((getArtistTopTags as jest.Mock).mock.calls.length).toBe(1)
+    })
+
+    it('returns empty array when Last.fm fetch fails', async () => {
+        const { getArtistTopTags } = require('../../../lastfm')
+        ;(getArtistTopTags as jest.Mock).mockRejectedValue(new Error('API down'))
+
+        const fetcher = createArtistTagFetcher()
+        const result = await fetcher('Some Artist')
+
+        expect(result).toEqual([])
+    })
+})

--- a/packages/bot/src/utils/music/autoplay/artistTagCache.ts
+++ b/packages/bot/src/utils/music/autoplay/artistTagCache.ts
@@ -2,6 +2,12 @@ import { getArtistTopTags } from '../../../lastfm'
 
 export type ArtistTagFetcher = (artist: string | undefined) => Promise<string[]>
 
+export function hasGenreTag(tags: string[], genreVariants: string[]): boolean {
+    if (tags.length === 0) return false
+    const normalized = tags.map((t) => t.toLowerCase().trim())
+    return genreVariants.some((g) => normalized.includes(g.toLowerCase().trim()))
+}
+
 /**
  * Per-pass de-duplicating Last.fm artist-tag fetcher. The replenisher creates
  * one of these per autoplay pass and threads it through every candidate

--- a/packages/bot/src/utils/music/autoplay/candidateCollector.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.spec.ts
@@ -531,5 +531,104 @@ describe('candidateCollector', () => {
                 }),
             )
         })
+
+        it('blocks sertanejo candidates when blockSertanejo=true and tags match', async () => {
+            collectSpotifyRecommendationCandidatesMock.mockResolvedValue(undefined)
+            const serTanejoTrack = createTrack({ title: 'Saudade do Nordeste', author: 'Jorge e Mateus' })
+            searchSeedCandidatesMock.mockResolvedValue([serTanejoTrack])
+
+            const getArtistTags = jest.fn().mockResolvedValue(['sertanejo'])
+
+            const result = await collectRecommendationCandidates(
+                createGuildQueue(),
+                [createTrack()],
+                null,
+                new Set(),
+                new Set(),
+                new Map(),
+                new Map(),
+                new Set(),
+                new Set(),
+                createTrack(),
+                new Set(),
+                0,
+                'similar',
+                new Map(),
+                new Set(),
+                new Set(),
+                null,
+                null,
+                { getArtistTags },
+                true, // blockSertanejo
+            )
+
+            expect(result.size).toBe(0)
+        })
+
+        it('allows sertanejo candidates when blockSertanejo=false', async () => {
+            collectSpotifyRecommendationCandidatesMock.mockResolvedValue(undefined)
+            const serTanejoTrack = createTrack({ title: 'Saudade do Nordeste', author: 'Jorge e Mateus' })
+            searchSeedCandidatesMock.mockResolvedValue([serTanejoTrack])
+
+            const getArtistTags = jest.fn().mockResolvedValue(['sertanejo'])
+
+            const result = await collectRecommendationCandidates(
+                createGuildQueue(),
+                [createTrack()],
+                null,
+                new Set(),
+                new Set(),
+                new Map(),
+                new Map(),
+                new Set(),
+                new Set(),
+                createTrack(),
+                new Set(),
+                0,
+                'similar',
+                new Map(),
+                new Set(),
+                new Set(),
+                null,
+                null,
+                { getArtistTags },
+                false, // blockSertanejo
+            )
+
+            expect(result.size).toBeGreaterThan(0)
+        })
+
+        it('does not block sertanejo when tags are empty (fail-open when Last.fm unavailable)', async () => {
+            collectSpotifyRecommendationCandidatesMock.mockResolvedValue(undefined)
+            const serTanejoTrack = createTrack({ title: 'Saudade do Nordeste', author: 'Jorge e Mateus' })
+            searchSeedCandidatesMock.mockResolvedValue([serTanejoTrack])
+
+            const getArtistTags = jest.fn().mockResolvedValue([]) // no tags returned
+
+            const result = await collectRecommendationCandidates(
+                createGuildQueue(),
+                [createTrack()],
+                null,
+                new Set(),
+                new Set(),
+                new Map(),
+                new Map(),
+                new Set(),
+                new Set(),
+                createTrack(),
+                new Set(),
+                0,
+                'similar',
+                new Map(),
+                new Set(),
+                new Set(),
+                null,
+                null,
+                { getArtistTags },
+                true, // blockSertanejo is true but tags are empty — must not block
+            )
+
+            expect(result.size).toBeGreaterThan(0)
+        })
     })
 })

--- a/packages/bot/src/utils/music/autoplay/candidateCollector.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.spec.ts
@@ -630,5 +630,39 @@ describe('candidateCollector', () => {
 
             expect(result.size).toBeGreaterThan(0)
         })
+
+        it('falls back to empty tags when getArtistTags rejects', async () => {
+            collectSpotifyRecommendationCandidatesMock.mockResolvedValue(undefined)
+            const track = createTrack({ title: 'Some Song', author: 'Some Artist' })
+            searchSeedCandidatesMock.mockResolvedValue([track])
+
+            const getArtistTags = jest.fn().mockRejectedValue(new Error('Last.fm down'))
+
+            const result = await collectRecommendationCandidates(
+                createGuildQueue(),
+                [createTrack()],
+                null,
+                new Set(),
+                new Set(),
+                new Map(),
+                new Map(),
+                new Set(),
+                new Set(),
+                createTrack(),
+                new Set(),
+                0,
+                'similar',
+                new Map(),
+                new Set(),
+                new Set(),
+                null,
+                null,
+                { getArtistTags },
+                true,
+            )
+
+            // fail-open: track should not be blocked when tag fetch errors
+            expect(result.size).toBeGreaterThan(0)
+        })
     })
 })

--- a/packages/bot/src/utils/music/autoplay/candidateCollector.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.ts
@@ -165,7 +165,10 @@ export async function collectRecommendationCandidates(
             if (dislikedWeight !== undefined && dislikedWeight > 0.5) {
                 continue
             }
-            const tags = await getArtistTags(candidate.author).catch(() => [] as string[])
+            const tags = await getArtistTags(candidate.author).catch((err: unknown) => {
+                debugLog({ message: 'candidateCollector: getArtistTags failed', data: { author: candidate.author, err } })
+                return [] as string[]
+            })
             if (blockSertanejo && tags.length > 0 && hasGenreTag(tags, SERTANEJO_TAGS)) {
                 continue
             }

--- a/packages/bot/src/utils/music/autoplay/candidateCollector.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.ts
@@ -16,7 +16,7 @@ import { createArtistTagFetcher, hasGenreTag, type ArtistTagFetcher } from './ar
 import type { ScoredTrack } from './diversitySelector'
 export type { ScoredTrack }
 
-const SERTANEJO_TAGS = [
+export const SERTANEJO_TAGS = [
     'sertanejo',
     'sertanejo universitário',
     'sertanejo pop',
@@ -165,7 +165,7 @@ export async function collectRecommendationCandidates(
             if (dislikedWeight !== undefined && dislikedWeight > 0.5) {
                 continue
             }
-            const tags = await getArtistTags(candidate.author)
+            const tags = await getArtistTags(candidate.author).catch(() => [] as string[])
             if (blockSertanejo && tags.length > 0 && hasGenreTag(tags, SERTANEJO_TAGS)) {
                 continue
             }

--- a/packages/bot/src/utils/music/autoplay/candidateCollector.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.ts
@@ -12,9 +12,17 @@ import {
     normalizeTrackKey,
 } from '../queueManipulation'
 import { isDuplicateCandidate } from './diversitySelector'
-import { createArtistTagFetcher, type ArtistTagFetcher } from './artistTagCache'
+import { createArtistTagFetcher, hasGenreTag, type ArtistTagFetcher } from './artistTagCache'
 import type { ScoredTrack } from './diversitySelector'
 export type { ScoredTrack }
+
+const SERTANEJO_TAGS = [
+    'sertanejo',
+    'sertanejo universitário',
+    'sertanejo pop',
+    'música sertaneja',
+    'forró',
+]
 
 /**
  * Include a candidate in the pool if it hasn't been played recently
@@ -103,6 +111,7 @@ export async function collectRecommendationCandidates(
         currentTrackTags?: string[]
         sessionGenreFamilies?: Set<string>
     } = {},
+    blockSertanejo = false,
 ): Promise<Map<string, ScoredTrack>> {
     const candidates = new Map<string, ScoredTrack>()
     const getArtistTags = genreContext.getArtistTags ?? createArtistTagFetcher()
@@ -157,6 +166,9 @@ export async function collectRecommendationCandidates(
                 continue
             }
             const tags = await getArtistTags(candidate.author)
+            if (blockSertanejo && tags.length > 0 && hasGenreTag(tags, SERTANEJO_TAGS)) {
+                continue
+            }
             const rec = calculateRecommendationScore({
                 candidate,
                 currentTrack,

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.spec.ts
@@ -247,6 +247,54 @@ describe('diversitySelector', () => {
                 ),
             ).toBe(false)
         })
+
+        test('detects remastered version as duplicate of base title in excludedKeys', () => {
+            // "bohemian rhapsody" is excluded; "bohemian rhapsody - remastered" should match
+            const excludedUrls = new Set<string>()
+            const excludedKeys = new Set(['bohemian rhapsody'])
+
+            const track: Partial<Track> = {
+                url: 'https://open.spotify.com/track/xyz',
+                title: 'Bohemian Rhapsody - Remastered',
+                author: 'Queen',
+            }
+
+            expect(
+                isDuplicateCandidate(track as Track, excludedUrls, excludedKeys),
+            ).toBe(true)
+        })
+
+        test('detects live version as duplicate of base title', () => {
+            const excludedUrls = new Set<string>()
+            const excludedKeys = new Set(['hotel california'])
+
+            const track: Partial<Track> = {
+                url: 'https://open.spotify.com/track/abc',
+                title: 'Hotel California - Live',
+                author: 'Eagles',
+            }
+
+            expect(
+                isDuplicateCandidate(track as Track, excludedUrls, excludedKeys),
+            ).toBe(true)
+        })
+
+        test('does not strip mid-title variant words — only suffix', () => {
+            // "live" in the middle of the title should not be stripped
+            const excludedUrls = new Set<string>()
+            const excludedKeys = new Set(['live and let die'])
+
+            const track: Partial<Track> = {
+                url: 'https://open.spotify.com/track/def',
+                title: 'Live and Let Die - Remastered',
+                author: 'Wings',
+            }
+
+            // "live and let die" after stripping " - Remastered" → still matches
+            expect(
+                isDuplicateCandidate(track as Track, excludedUrls, excludedKeys),
+            ).toBe(true)
+        })
     })
 
     describe('selectDiverseCandidates', () => {

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.ts
@@ -55,9 +55,16 @@ function normalizeTitleOnly(title?: string): string {
 }
 
 function stripFeaturing(author: string): string {
+    const lower = author.toLowerCase()
+    let cut = author.length
+    for (const marker of [' feat ', ' feat.', ' ft ', ' ft.']) {
+        const idx = lower.indexOf(marker)
+        if (idx >= 0 && idx < cut) cut = idx
+    }
     return author
-        .split(/\s+(?:feat|ft)\.?(?:\s|$)/i)[0] // NOSONAR - bounded alternation, no catastrophic backtracking
-        .replace(/\s*\([^)]*feat[^)]*\)\s*/gi, '') // NOSONAR - [^)]* bounded by paren close, no backtracking
+        .slice(0, cut)
+        .replace(/\s*\([^)]*\)\s*/gi, (m) => /feat/i.test(m) ? '' : m)
+        .trim()
 }
 
 const VARIANT_SUFFIX_RE =

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.ts
@@ -13,7 +13,7 @@ interface ScoredTrack {
 
 const MAX_TRACKS_PER_ARTIST = 2
 const MAX_TRACKS_PER_SOURCE = 3
-const FUZZY_TITLE_THRESHOLD = 0.82
+const FUZZY_TITLE_THRESHOLD = 0.75
 
 function randomJitter(max: number): number {
     return Math.random() * max // NOSONAR - non-cryptographic jitter for diversity selection
@@ -58,6 +58,13 @@ function stripFeaturing(author: string): string {
     return author
         .split(/\s+(?:feat|ft)\.?(?:\s|$)/i)[0] // NOSONAR - bounded alternation, no catastrophic backtracking
         .replace(/\s*\([^)]*feat[^)]*\)\s*/gi, '') // NOSONAR - [^)]* bounded by paren close, no backtracking
+}
+
+const VARIANT_SUFFIX_RE =
+    /\s*(?:[-–]\s*(?:\d{4}\s+)?(?:remaster(?:ed)?|remix(?:ed)?|edit|version|radio\s+edit|acoustic|live|cover|extended\s+mix|club\s+mix|vip\s+mix)|[\[(](?:\d{4}\s+)?(?:remaster(?:ed)?|remix(?:ed)?|edit|version|acoustic|live|cover)[\])])\s*$/i
+
+function stripVariantSuffix(title: string): string {
+    return title.replace(VARIANT_SUFFIX_RE, '').trim()
 }
 
 function getAllHistoryTracks(queue: GuildQueue): Track[] {
@@ -116,6 +123,8 @@ export function buildExcludedKeys(
     for (const t of allTracks) {
         keys.push(normalizeTrackKey(t.title, t.author))
         keys.push(normalizeTitleOnly(t.title))
+        const variantStripped = stripVariantSuffix(t.title ?? '')
+        if (variantStripped) keys.push(normalizeTitleOnly(variantStripped))
         const core = extractSongCore(t.title ?? '', t.author)
         if (core) keys.push(normalizeText(core))
     }
@@ -139,6 +148,8 @@ export function isDuplicateCandidate(
     if (core !== null && excludedKeys.has(normalizeText(core))) return true
 
     const candidateTitle = normalizeTitleOnly(track.title)
+    const candidateTitleStripped = normalizeTitleOnly(stripVariantSuffix(track.title ?? ''))
+    if (candidateTitleStripped && excludedKeys.has(candidateTitleStripped)) return true
     if (candidateTitle.length >= 5) {
         for (const key of excludedKeys) {
             if (key.includes('::') || key.length < 5) continue

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.ts
@@ -61,10 +61,23 @@ function stripFeaturing(author: string): string {
         const idx = lower.indexOf(marker)
         if (idx >= 0 && idx < cut) cut = idx
     }
-    return author
-        .slice(0, cut)
-        .replace(/\s*\([^)]*\)\s*/gi, (m) => /feat/i.test(m) ? '' : m)
-        .trim()
+    let result = author.slice(0, cut)
+    // Remove parenthetical groups containing "feat" or "ft"
+    let i = 0
+    while (i < result.length) {
+        const open = result.indexOf('(', i)
+        if (open === -1) break
+        const close = result.indexOf(')', open + 1)
+        if (close === -1) break
+        const inner = result.slice(open + 1, close).toLowerCase()
+        if (inner.includes('feat') || inner.startsWith('ft ') || inner.startsWith('ft.')) {
+            result = (result.slice(0, open) + result.slice(close + 1)).trim()
+            i = 0
+        } else {
+            i = close + 1
+        }
+    }
+    return result.trim()
 }
 
 const VARIANT_KEYWORDS = [
@@ -73,24 +86,36 @@ const VARIANT_KEYWORDS = [
     'edit', 'version', 'acoustic', 'live', 'cover',
 ]
 
-// Matches optional year prefix inside brackets: "(2015 Remaster)" → inner = "remaster"
-const BRACKET_INNER_RE = /\s*[\[(]\d{0,4}\s*([a-z ]+)[\])]\s*$/
+function startsWithYear(s: string): boolean {
+    return s.length >= 5 && s[4] === ' ' &&
+        s[0] >= '0' && s[0] <= '9' &&
+        s[1] >= '0' && s[1] <= '9' &&
+        s[2] >= '0' && s[2] <= '9' &&
+        s[3] >= '0' && s[3] <= '9'
+}
 
 function stripVariantSuffix(title: string): string {
     const lower = title.toLowerCase()
+    const trimmedLower = lower.trimEnd()
+
     // Strip parenthetical variant suffix at end: (Remastered) or [2015 Live]
-    const bracketMatch = lower.match(BRACKET_INNER_RE)
-    if (bracketMatch) {
-        const kw = bracketMatch[1]!.trim()
-        if (VARIANT_KEYWORDS.some((v) => kw === v || kw.startsWith(v + ' '))) {
-            return title.slice(0, title.length - bracketMatch[0]!.length).trimEnd()
+    for (const [openChar, closeChar] of [['(', ')'], ['[', ']']] as [string, string][]) {
+        if (trimmedLower[trimmedLower.length - 1] !== closeChar) continue
+        const lastOpen = trimmedLower.lastIndexOf(openChar)
+        if (lastOpen < 0) continue
+        let inner = trimmedLower.slice(lastOpen + 1, trimmedLower.length - 1).trim()
+        if (startsWithYear(inner)) inner = inner.slice(5)
+        if (VARIANT_KEYWORDS.some((v) => inner === v || inner.startsWith(v + ' '))) {
+            return title.slice(0, lastOpen).trimEnd()
         }
     }
+
     // Strip dash-prefixed variant suffix at end: - Remastered or – 2015 Live
     for (const sep of [' - ', ' – ']) {
         const idx = lower.lastIndexOf(sep)
         if (idx < 0) continue
-        const rest = lower.slice(idx + sep.length).replace(/^\d{4} /, '').trimEnd()
+        let rest = lower.slice(idx + sep.length).trimEnd()
+        if (startsWithYear(rest)) rest = rest.slice(5)
         if (VARIANT_KEYWORDS.some((v) => rest === v || rest.startsWith(v + ' '))) {
             return title.slice(0, idx).trimEnd()
         }

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.ts
@@ -67,11 +67,35 @@ function stripFeaturing(author: string): string {
         .trim()
 }
 
-const VARIANT_SUFFIX_RE =
-    /\s*(?:[-–]\s*(?:\d{4}\s+)?(?:remaster(?:ed)?|remix(?:ed)?|edit|version|radio\s+edit|acoustic|live|cover|extended\s+mix|club\s+mix|vip\s+mix)|[\[(](?:\d{4}\s+)?(?:remaster(?:ed)?|remix(?:ed)?|edit|version|acoustic|live|cover)[\])])\s*$/i
+const VARIANT_KEYWORDS = [
+    'remastered', 'remaster', 'remixed', 'remix',
+    'radio edit', 'extended mix', 'club mix', 'vip mix',
+    'edit', 'version', 'acoustic', 'live', 'cover',
+]
+
+// Matches optional year prefix inside brackets: "(2015 Remaster)" → inner = "remaster"
+const BRACKET_INNER_RE = /\s*[\[(]\d{0,4}\s*([a-z ]+)[\])]\s*$/
 
 function stripVariantSuffix(title: string): string {
-    return title.replace(VARIANT_SUFFIX_RE, '').trim()
+    const lower = title.toLowerCase()
+    // Strip parenthetical variant suffix at end: (Remastered) or [2015 Live]
+    const bracketMatch = lower.match(BRACKET_INNER_RE)
+    if (bracketMatch) {
+        const kw = bracketMatch[1]!.trim()
+        if (VARIANT_KEYWORDS.some((v) => kw === v || kw.startsWith(v + ' '))) {
+            return title.slice(0, title.length - bracketMatch[0]!.length).trimEnd()
+        }
+    }
+    // Strip dash-prefixed variant suffix at end: - Remastered or – 2015 Live
+    for (const sep of [' - ', ' – ']) {
+        const idx = lower.lastIndexOf(sep)
+        if (idx < 0) continue
+        const rest = lower.slice(idx + sep.length).replace(/^\d{4} /, '').trimEnd()
+        if (VARIANT_KEYWORDS.some((v) => rest === v || rest.startsWith(v + ' '))) {
+            return title.slice(0, idx).trimEnd()
+        }
+    }
+    return title
 }
 
 function getAllHistoryTracks(queue: GuildQueue): Track[] {

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.spec.ts
@@ -26,6 +26,7 @@ jest.mock('@lucky/shared/services', () => ({
 }))
 
 jest.mock('./lastFmSeeds', () => ({
+    LASTFM_SEED_COUNT: 15,
     consumeLastFmSeedSlice: (...args: unknown[]) => consumeLastFmSeedSliceMock(...args),
     consumeBlendedSeedSlice: (...args: unknown[]) => consumeBlendedSeedSliceMock(...args),
     isLovedSeed: (...args: unknown[]) => isLovedSeedMock(...args),

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.spec.ts
@@ -179,7 +179,7 @@ describe('collectLastFmCandidates', () => {
             new Set(), new Set(), createTrack(), new Set(), candidates,
         )
 
-        expect(consumeLastFmSeedSliceMock).toHaveBeenCalledWith('user-1', 3)
+        expect(consumeLastFmSeedSliceMock).toHaveBeenCalledWith('user-1', 15)
     })
 
     it('uses blended seed when multiple VC members are linked', async () => {
@@ -389,7 +389,7 @@ describe('collectLastFmCandidates', () => {
             new Set(), new Set(), createTrack(), new Set(), candidates,
         )
 
-        expect(consumeLastFmSeedSliceMock).toHaveBeenCalledWith('user-1', 3)
+        expect(consumeLastFmSeedSliceMock).toHaveBeenCalledWith('user-1', 15)
         expect(consumeBlendedSeedSliceMock).not.toHaveBeenCalled()
     })
 

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
@@ -5,6 +5,7 @@ import {
     consumeLastFmSeedSlice,
     consumeBlendedSeedSlice,
     isLovedSeed,
+    LASTFM_SEED_COUNT,
 } from './lastFmSeeds'
 import { getSimilarTracks, getTagTopTracks } from '../../../lastfm'
 import { createArtistTagFetcher, type ArtistTagFetcher } from './artistTagCache'
@@ -22,7 +23,6 @@ import {
 import type { QueueMetadata } from '../../../types/QueueMetadata'
 import type { ScoredTrack } from './diversitySelector';
 
-const LASTFM_SEED_COUNT = 15
 const LASTFM_SCORE_BOOST = 0.20
 const LOVED_SEED_EXTRA_BOOST = 0.10
 const MAX_SIMILAR_LOOKUPS = 15
@@ -98,6 +98,7 @@ export async function collectLastFmCandidates(
         genreContext.sessionGenreFamilies ?? new Set<string>()
 
     for (const seed of seedSlice) {
+        if (candidates.size >= AUTOPLAY_BUFFER_SIZE) break
         const lovedBoost = isLovedSeed(requestedBy.id, seed.artist, seed.title)
             ? LOVED_SEED_EXTRA_BOOST
             : 0

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
@@ -22,10 +22,10 @@ import {
 import type { QueueMetadata } from '../../../types/QueueMetadata'
 import type { ScoredTrack } from './diversitySelector';
 
-const LASTFM_SEED_COUNT = 3
+const LASTFM_SEED_COUNT = 15
 const LASTFM_SCORE_BOOST = 0.20
 const LOVED_SEED_EXTRA_BOOST = 0.10
-const MAX_SIMILAR_LOOKUPS = 5
+const MAX_SIMILAR_LOOKUPS = 15
 const SEARCH_RESULTS_LIMIT = 8
 const MAX_AUTOPLAY_DURATION_MS = 10 * 60 * 1000
 const AUTOPLAY_BUFFER_SIZE = 8

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeds.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeds.spec.ts
@@ -201,23 +201,24 @@ describe('getLastFmSeedSlice', () => {
 
     it('stops at pool length without wraparound within slice', async () => {
         getByDiscordIdMock.mockResolvedValue({ lastFmUsername: 'user123' })
-        getTopTracksMock.mockResolvedValue([
-            { artist: 'A1', title: 'S1', playCount: 1 },
-            { artist: 'A2', title: 'S2', playCount: 2 },
-            { artist: 'A3', title: 'S3', playCount: 3 },
-            { artist: 'A4', title: 'S4', playCount: 4 },
-        ])
+        // Pool of 20 so advancing by LASTFM_SEED_COUNT=15 leaves 5 items (indices 15–19)
+        getTopTracksMock.mockResolvedValue(
+            Array.from({ length: 20 }, (_, i) => ({
+                artist: `A${i + 1}`,
+                title: `S${i + 1}`,
+                playCount: i + 1,
+            })),
+        )
 
         await getLastFmSeedTracks('user-wrap')
 
         advanceLastFmSeedOffset('user-wrap')
 
-        const slice = getLastFmSeedSlice('user-wrap', 3)
+        const slice = getLastFmSeedSlice('user-wrap', 8)
 
-        expect(slice).toHaveLength(3)
-        expect(slice[0]).toEqual({ artist: 'A2', title: 'S2' })
-        expect(slice[1]).toEqual({ artist: 'A3', title: 'S3' })
-        expect(slice[2]).toEqual({ artist: 'A4', title: 'S4' })
+        expect(slice).toHaveLength(5)
+        expect(slice[0]).toEqual({ artist: 'A16', title: 'S16' })
+        expect(slice[4]).toEqual({ artist: 'A20', title: 'S20' })
     })
 
     it('returns at most min(count, tracks.length) items without wraparound', async () => {
@@ -238,13 +239,13 @@ describe('getLastFmSeedSlice', () => {
 
     it('uses default LASTFM_SEED_COUNT when count not specified', async () => {
         getByDiscordIdMock.mockResolvedValue({ lastFmUsername: 'user123' })
-        getTopTracksMock.mockResolvedValue([
-            { artist: 'A1', title: 'S1', playCount: 1 },
-            { artist: 'A2', title: 'S2', playCount: 2 },
-            { artist: 'A3', title: 'S3', playCount: 3 },
-            { artist: 'A4', title: 'S4', playCount: 4 },
-            { artist: 'A5', title: 'S5', playCount: 5 },
-        ])
+        getTopTracksMock.mockResolvedValue(
+            Array.from({ length: 20 }, (_, i) => ({
+                artist: `A${i + 1}`,
+                title: `S${i + 1}`,
+                playCount: i + 1,
+            })),
+        )
 
         await getLastFmSeedTracks('user-default-count')
 
@@ -267,14 +268,14 @@ describe('advanceLastFmSeedOffset', () => {
 
     it('increments offset using modulo wrap-around', async () => {
         getByDiscordIdMock.mockResolvedValue({ lastFmUsername: 'user123' })
-        getTopTracksMock.mockResolvedValue([
-            { artist: 'A1', title: 'S1', playCount: 1 },
-            { artist: 'A2', title: 'S2', playCount: 2 },
-            { artist: 'A3', title: 'S3', playCount: 3 },
-            { artist: 'A4', title: 'S4', playCount: 4 },
-            { artist: 'A5', title: 'S5', playCount: 5 },
-            { artist: 'A6', title: 'S6', playCount: 6 },
-        ])
+        // Pool of 20 so (0+15)%20 = 15, no wrap
+        getTopTracksMock.mockResolvedValue(
+            Array.from({ length: 20 }, (_, i) => ({
+                artist: `A${i + 1}`,
+                title: `S${i + 1}`,
+                playCount: i + 1,
+            })),
+        )
 
         await getLastFmSeedTracks('user-advance')
 
@@ -338,14 +339,14 @@ describe('getLastFmCacheOffset', () => {
 
     it('tracks offset progression through advances', async () => {
         getByDiscordIdMock.mockResolvedValue({ lastFmUsername: 'user123' })
-        getTopTracksMock.mockResolvedValue([
-            { artist: 'A1', title: 'S1', playCount: 1 },
-            { artist: 'A2', title: 'S2', playCount: 2 },
-            { artist: 'A3', title: 'S3', playCount: 3 },
-            { artist: 'A4', title: 'S4', playCount: 4 },
-            { artist: 'A5', title: 'S5', playCount: 5 },
-            { artist: 'A6', title: 'S6', playCount: 6 },
-        ])
+        // Pool of 20 so (0+15)%20 = 15, no wrap
+        getTopTracksMock.mockResolvedValue(
+            Array.from({ length: 20 }, (_, i) => ({
+                artist: `A${i + 1}`,
+                title: `S${i + 1}`,
+                playCount: i + 1,
+            })),
+        )
 
         await getLastFmSeedTracks('user-track-offset')
 
@@ -433,13 +434,13 @@ describe('consumeLastFmSeedSlice', () => {
 
     it('uses default LASTFM_SEED_COUNT when count not specified', async () => {
         getByDiscordIdMock.mockResolvedValue({ lastFmUsername: 'user123' })
-        getTopTracksMock.mockResolvedValue([
-            { artist: 'A1', title: 'S1', playCount: 1 },
-            { artist: 'A2', title: 'S2', playCount: 2 },
-            { artist: 'A3', title: 'S3', playCount: 3 },
-            { artist: 'A4', title: 'S4', playCount: 4 },
-            { artist: 'A5', title: 'S5', playCount: 5 },
-        ])
+        getTopTracksMock.mockResolvedValue(
+            Array.from({ length: 20 }, (_, i) => ({
+                artist: `A${i + 1}`,
+                title: `S${i + 1}`,
+                playCount: i + 1,
+            })),
+        )
 
         const slice = await consumeLastFmSeedSlice('user-default-consume')
 

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeds.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeds.ts
@@ -11,7 +11,7 @@ import { cleanTitle } from '../searchQueryCleaner'
 const CACHE_TTL_MS = 15 * 60 * 1000
 const TOP_TRACKS_LIMIT = 50
 const RECENT_TRACKS_LIMIT = 30
-export const LASTFM_SEED_COUNT = 5
+export const LASTFM_SEED_COUNT = 15
 
 type CacheEntry = {
     tracks: { artist: string; title: string }[]

--- a/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
@@ -216,6 +216,25 @@ describe('replenishQueue', () => {
         ).not.toHaveBeenCalled()
     })
 
+    it('should replenish when queue has user-added tracks but autoplay count is below buffer', async () => {
+        const queue = createGuildQueue()
+        const entries: [string, Track][] = []
+        for (let i = 0; i < 8; i++) {
+            const track = createTrack({ id: `user${i}`, metadata: undefined })
+            entries.push([`user${i}`, track])
+        }
+        const autoTrack = createTrack({ id: 'auto0', metadata: { isAutoplay: true } as unknown as never })
+        entries.push(['auto0', autoTrack])
+        queue.tracks = createTracksMap(entries)
+
+        const { collectRecommendationCandidates } =
+            require('./candidateCollector')
+
+        await replenishQueue(queue)
+
+        expect(collectRecommendationCandidates).toHaveBeenCalled()
+    })
+
     it('should handle errors gracefully without throwing', async () => {
         const queue = createGuildQueue()
         const { collectRecommendationCandidates } =

--- a/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
@@ -80,10 +80,16 @@ function createTrack(overrides: Partial<Track> = {}): Track {
     } as Track
 }
 
+function createTracksMap(entries: [string, Track][] = []): Map<string, Track> & { toArray: () => Track[] } {
+    const map = new Map<string, Track>(entries) as Map<string, Track> & { toArray: () => Track[] }
+    map.toArray = () => [...map.values()]
+    return map
+}
+
 function createGuildQueue(overrides: Partial<GuildQueue> = {}): GuildQueue {
     return {
         guild: { id: 'guildid' },
-        tracks: new Map(),
+        tracks: createTracksMap(),
         currentTrack: createTrack(),
         metadata: {},
         history: { tracks: { toArray: () => [] } },
@@ -193,11 +199,12 @@ describe('replenishQueue', () => {
 
     it('should skip replenish if queue is full (>= AUTOPLAY_BUFFER_SIZE)', async () => {
         const queue = createGuildQueue()
-        const tracks = new Map()
+        const entries: [string, Track][] = []
         for (let i = 0; i < 10; i++) {
-            tracks.set(`track${i}`, createTrack({ id: `track${i}` }))
+            const track = createTrack({ id: `track${i}`, metadata: { isAutoplay: true } as unknown as never })
+            entries.push([`track${i}`, track])
         }
-        queue.tracks = tracks
+        queue.tracks = createTracksMap(entries)
 
         const { collectRecommendationCandidates } =
             require('./candidateCollector')

--- a/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
@@ -201,7 +201,7 @@ describe('replenishQueue', () => {
         const queue = createGuildQueue()
         const entries: [string, Track][] = []
         for (let i = 0; i < 10; i++) {
-            const track = createTrack({ id: `track${i}`, metadata: { isAutoplay: true } as unknown as never })
+            const track = createTrack({ id: `track${i}`, metadata: { isAutoplay: true } as Record<string, unknown> })
             entries.push([`track${i}`, track])
         }
         queue.tracks = createTracksMap(entries)
@@ -223,7 +223,7 @@ describe('replenishQueue', () => {
             const track = createTrack({ id: `user${i}`, metadata: undefined })
             entries.push([`user${i}`, track])
         }
-        const autoTrack = createTrack({ id: 'auto0', metadata: { isAutoplay: true } as unknown as never })
+        const autoTrack = createTrack({ id: 'auto0', metadata: { isAutoplay: true } as Record<string, unknown> })
         entries.push(['auto0', autoTrack])
         queue.tracks = createTracksMap(entries)
 

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -14,6 +14,7 @@ import {
 import { detectSessionMood, type SessionMood } from './sessionMood'
 import {
     collectRecommendationCandidates,
+    SERTANEJO_TAGS,
 } from './candidateCollector'
 import {
     createArtistTagFetcher,
@@ -237,13 +238,6 @@ async function _replenishQueue(
             historyTracks,
             getArtistTags,
         )
-        const SERTANEJO_TAGS = [
-            'sertanejo',
-            'sertanejo universitário',
-            'sertanejo pop',
-            'música sertaneja',
-            'forró',
-        ]
         const seedIsSertanejo = currentTrackTags.length > 0
             ? hasGenreTag(currentTrackTags, SERTANEJO_TAGS)
             : false

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -17,6 +17,7 @@ import {
 } from './candidateCollector'
 import {
     createArtistTagFetcher,
+    hasGenreTag,
     type ArtistTagFetcher,
 } from './artistTagCache'
 import { getGenreFamilies } from './candidateScorer'
@@ -100,7 +101,10 @@ async function _replenishQueue(
         const bufferSize = (await premiumService.isPremium(queue.guild.id))
             ? AUTOPLAY_BUFFER_SIZE_PREMIUM
             : AUTOPLAY_BUFFER_SIZE
-        const missingTracks = bufferSize - queue.tracks.size
+        const autoplayInQueue = [...queue.tracks.toArray()].filter(
+            (t) => (t.metadata as { isAutoplay?: boolean } | undefined)?.isAutoplay === true,
+        ).length
+        const missingTracks = bufferSize - autoplayInQueue
         if (missingTracks <= 0) return
 
         const allHistoryTracks = getAllHistoryTracks(queue)
@@ -233,6 +237,18 @@ async function _replenishQueue(
             historyTracks,
             getArtistTags,
         )
+        const SERTANEJO_TAGS = [
+            'sertanejo',
+            'sertanejo universitário',
+            'sertanejo pop',
+            'música sertaneja',
+            'forró',
+        ]
+        const seedIsSertanejo = currentTrackTags.length > 0
+            ? hasGenreTag(currentTrackTags, SERTANEJO_TAGS)
+            : false
+        const blockSertanejo = !seedIsSertanejo
+
         const candidateGenreContext = {
             getArtistTags,
             currentTrackTags,
@@ -244,6 +260,7 @@ async function _replenishQueue(
                 guildId,
                 currentTrackTagCount: currentTrackTags.length,
                 sessionGenreFamilies: Array.from(sessionGenreFamilies),
+                blockSertanejo,
             },
         })
         const candidates = await collectRecommendationCandidates(
@@ -266,6 +283,7 @@ async function _replenishQueue(
             sessionMood,
             currentFeatures,
             candidateGenreContext,
+            blockSertanejo,
         )
         sourcesCounts.recommendation = candidates.size
         candidatePoolSize = candidates.size

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -373,6 +373,7 @@ async function _replenishQueue(
                 implicitDislikeKeys,
                 implicitLikeKeys,
                 sessionMood,
+                candidateGenreContext,
             )
             sourcesCounts.fallback = candidates.size - beforeFallback
             debugLog({

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -241,6 +241,8 @@ async function _replenishQueue(
         const seedIsSertanejo = currentTrackTags.length > 0
             ? hasGenreTag(currentTrackTags, SERTANEJO_TAGS)
             : false
+        // Block sertanejo candidates unless the seed itself is sertanejo — fail-open
+        // when tags are absent (Last.fm unlinked) to avoid over-filtering.
         const blockSertanejo = !seedIsSertanejo
 
         const candidateGenreContext = {

--- a/packages/bot/src/utils/music/autoplay/spotifyRecommender.ts
+++ b/packages/bot/src/utils/music/autoplay/spotifyRecommender.ts
@@ -81,9 +81,13 @@ export async function collectSpotifyRecommendationCandidates(
         getUserSpotifySeeds(requestedBy.id),
     ).catch(() => null)
 
-    const seedIds = seedTracks
+    const likedSeedIds = userSpotifySeeds?.likedTrackIds?.slice(0, 3) ?? []
+    const queueSeedIds = seedTracks
         .map(extractSpotifyTrackId)
         .filter((id): id is string => id !== null)
+    // Liked tracks take priority; fill remaining slots from queue history (max 5 total per Spotify API limit)
+    const seedIds = [...likedSeedIds, ...queueSeedIds]
+        .filter((id, i, arr) => arr.indexOf(id) === i)
         .slice(0, 5)
 
     if (seedIds.length === 0) {

--- a/packages/bot/src/utils/music/candidateFallback.spec.ts
+++ b/packages/bot/src/utils/music/candidateFallback.spec.ts
@@ -14,6 +14,12 @@ const cleanAuthorMock = jest.fn()
 const normalizeTrackKeyMock = jest.fn()
 const calculateGenreFamilyPenaltyMock = jest.fn()
 
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+    errorLog: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
 jest.mock('discord-player', () => ({
     QueryType: { SPOTIFY_SEARCH: 'spotify_search', AUTO: 'auto' },
 }))

--- a/packages/bot/src/utils/music/candidateFallback.spec.ts
+++ b/packages/bot/src/utils/music/candidateFallback.spec.ts
@@ -520,4 +520,108 @@ describe('collectBroadFallbackCandidates', () => {
             }),
         )
     })
+
+    it('uses Spotify genres as fallback tags when Last.fm returns empty', async () => {
+        const foundTrack = { title: 'Hallelujah', author: 'Felipe Dutra', url: 'u2', durationMS: 180_000 }
+        const searchMock = jest.fn().mockResolvedValue({ tracks: [foundTrack] })
+        const queue = { player: { search: searchMock } } as never
+        const currentTrack = { author: 'Coldplay', title: 'Yellow', url: 'u1', durationMS: 200_000 } as never
+        const getArtistTagsMock = jest.fn().mockResolvedValue([])
+        getValidAccessTokenMock.mockResolvedValue('spotify-token')
+        getArtistGenresMock.mockResolvedValue(['latin gospel', 'latin christian'])
+        const candidates = new Map<string, ScoredTrack>()
+
+        await collectBroadFallbackCandidates(
+            queue,
+            currentTrack,
+            { id: 'user1' } as never,
+            new Set(),
+            new Set(),
+            new Map(),
+            new Map(),
+            new Set(),
+            new Set(),
+            new Set(),
+            candidates,
+            'similar',
+            new Map(),
+            new Set(),
+            new Set(),
+            null,
+            { getArtistTags: getArtistTagsMock },
+        )
+
+        expect(getArtistGenresMock).toHaveBeenCalledWith('spotify-token', 'Felipe Dutra')
+        expect(calculateRecommendationScoreMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                genreContext: expect.objectContaining({
+                    candidateTags: ['latin gospel', 'latin christian'],
+                }),
+            }),
+        )
+    })
+
+    it('does not fetch Spotify genres when Last.fm tags are already populated', async () => {
+        const foundTrack = { title: 'Song', author: 'Artist', url: 'u2', durationMS: 180_000 }
+        const searchMock = jest.fn().mockResolvedValue({ tracks: [foundTrack] })
+        const queue = { player: { search: searchMock } } as never
+        const currentTrack = { author: 'Artist', title: 'Song', url: 'u1', durationMS: 200_000 } as never
+        const getArtistTagsMock = jest.fn().mockResolvedValue(['rock', 'indie'])
+        getValidAccessTokenMock.mockResolvedValue('spotify-token')
+        const candidates = new Map<string, ScoredTrack>()
+
+        await collectBroadFallbackCandidates(
+            queue,
+            currentTrack,
+            { id: 'user1' } as never,
+            new Set(),
+            new Set(),
+            new Map(),
+            new Map(),
+            new Set(),
+            new Set(),
+            new Set(),
+            candidates,
+            'similar',
+            new Map(),
+            new Set(),
+            new Set(),
+            null,
+            { getArtistTags: getArtistTagsMock },
+        )
+
+        expect(getArtistGenresMock).not.toHaveBeenCalled()
+    })
+
+    it('does not fetch Spotify genres when no user token is available', async () => {
+        const foundTrack = { title: 'Hallelujah', author: 'Felipe Dutra', url: 'u2', durationMS: 180_000 }
+        const searchMock = jest.fn().mockResolvedValue({ tracks: [foundTrack] })
+        const queue = { player: { search: searchMock } } as never
+        const currentTrack = { author: 'Artist', title: 'Song', url: 'u1', durationMS: 200_000 } as never
+        const getArtistTagsMock = jest.fn().mockResolvedValue([])
+        getValidAccessTokenMock.mockResolvedValue(null)
+        const candidates = new Map<string, ScoredTrack>()
+
+        await collectBroadFallbackCandidates(
+            queue,
+            currentTrack,
+            { id: 'user1' } as never,
+            new Set(),
+            new Set(),
+            new Map(),
+            new Map(),
+            new Set(),
+            new Set(),
+            new Set(),
+            candidates,
+            'similar',
+            new Map(),
+            new Set(),
+            new Set(),
+            null,
+            { getArtistTags: getArtistTagsMock },
+        )
+
+        expect(getArtistGenresMock).not.toHaveBeenCalled()
+    })
 })

--- a/packages/bot/src/utils/music/candidateFallback.spec.ts
+++ b/packages/bot/src/utils/music/candidateFallback.spec.ts
@@ -437,4 +437,81 @@ describe('collectBroadFallbackCandidates', () => {
 
         expect(upsertScoredCandidateMock).not.toHaveBeenCalled()
     })
+
+    it('fetches artist tags via genreContext.getArtistTags and passes them to scorer', async () => {
+        const foundTrack = { title: 'Eres Fiel', author: 'Marcos Witt', url: 'u2', durationMS: 180_000 }
+        const searchMock = jest.fn().mockResolvedValue({ tracks: [foundTrack] })
+        const queue = { player: { search: searchMock } } as never
+        const currentTrack = { author: 'Artist', title: 'Song', url: 'u1', durationMS: 200_000 } as never
+        const getArtistTagsMock = jest.fn().mockResolvedValue(['latin christian', 'spanish gospel'])
+        const candidates = new Map<string, ScoredTrack>()
+
+        await collectBroadFallbackCandidates(
+            queue,
+            currentTrack,
+            null,
+            new Set(),
+            new Set(),
+            new Map(),
+            new Map(),
+            new Set(),
+            new Set(),
+            new Set(),
+            candidates,
+            'similar',
+            new Map(),
+            new Set(),
+            new Set(),
+            null,
+            { getArtistTags: getArtistTagsMock, currentTrackTags: ['rock'], sessionGenreFamilies: new Set(['rock_metal']) },
+        )
+
+        expect(getArtistTagsMock).toHaveBeenCalledWith('Marcos Witt')
+        expect(calculateRecommendationScoreMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                genreContext: expect.objectContaining({
+                    candidateTags: ['latin christian', 'spanish gospel'],
+                    currentTrackTags: ['rock'],
+                    sessionGenreFamilies: expect.any(Set),
+                }),
+            }),
+        )
+    })
+
+    it('falls back to empty tags when getArtistTags rejects', async () => {
+        const foundTrack = { title: 'Song', author: 'Artist', url: 'u2', durationMS: 180_000 }
+        const searchMock = jest.fn().mockResolvedValue({ tracks: [foundTrack] })
+        const queue = { player: { search: searchMock } } as never
+        const currentTrack = { author: 'Artist', title: 'Song', url: 'u1', durationMS: 200_000 } as never
+        const getArtistTagsMock = jest.fn().mockRejectedValue(new Error('lastfm down'))
+        const candidates = new Map<string, ScoredTrack>()
+
+        await expect(
+            collectBroadFallbackCandidates(
+                queue,
+                currentTrack,
+                null,
+                new Set(),
+                new Set(),
+                new Map(),
+                new Map(),
+                new Set(),
+                new Set(),
+                new Set(),
+                candidates,
+                'similar',
+                new Map(),
+                new Set(),
+                new Set(),
+                null,
+                { getArtistTags: getArtistTagsMock },
+            ),
+        ).resolves.toBeUndefined()
+
+        expect(calculateRecommendationScoreMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                genreContext: expect.objectContaining({ candidateTags: [] }),
+            }),
+        )
+    })
 })

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -107,6 +107,12 @@ export async function collectBroadFallbackCandidates(
         `${currentTrack.author} popular`,
     ].filter(Boolean)
 
+    // Obtain Spotify token once for the whole fallback pass — used to enrich
+    // genre tags when Last.fm is not linked (getArtistTags returns []).
+    const spotifyToken = requestedBy?.id
+        ? await spotifyLinkService.getValidAccessToken(requestedBy.id).catch(() => null)
+        : null
+
     for (const query of fallbackQueries) {
         try {
             const result = await queue.player.search(query, {
@@ -129,12 +135,19 @@ export async function collectBroadFallbackCandidates(
                 const dislikedWeight = dislikedWeights.get(key)
                 if (dislikedWeight !== undefined && dislikedWeight > 0.5)
                     continue
-                const candidateTags = genreContext.getArtistTags
+                let candidateTags = genreContext.getArtistTags
                     ? await genreContext.getArtistTags(track.author).catch((err: unknown) => {
                         debugLog({ message: 'candidateFallback: getArtistTags failed', data: { author: track.author, err } })
                         return [] as string[]
                     })
                     : []
+                // When Last.fm returns nothing (not linked or artist unknown),
+                // use Spotify's genre data so the cross-locale Spanish veto in
+                // candidateScorer can still fire for Spanish gospel artists
+                // that have non-Spanish-looking artist names / titles.
+                if (candidateTags.length === 0 && spotifyToken) {
+                    candidateTags = await getArtistGenres(spotifyToken, track.author).catch(() => [])
+                }
                 const rec = calculateRecommendationScore({
                     candidate: track,
                     currentTrack,

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -111,7 +111,7 @@ export async function collectBroadFallbackCandidates(
     // genre tags when Last.fm is not linked (getArtistTags returns []).
     // Promise.resolve() guards against stubs that return undefined rather than
     // a Promise (matches the pattern used throughout replenisher.ts).
-    const spotifyToken = requestedBy?.id
+    const spotifyToken = requestedBy?.id // NOSONAR — userId is an internal Discord snowflake, not user-controlled URL data
         ? await Promise.resolve(spotifyLinkService.getValidAccessToken(requestedBy.id)).catch(() => null)
         : null
 
@@ -148,7 +148,7 @@ export async function collectBroadFallbackCandidates(
                 // candidateScorer can still fire for Spanish gospel artists
                 // that have non-Spanish-looking artist names / titles.
                 if (candidateTags.length === 0 && spotifyToken) {
-                    candidateTags = await getArtistGenres(spotifyToken, track.author).catch(() => []) // NOSONAR S5144 — artistName used as URLSearchParams search query inside getArtistGenres; no raw URL interpolation
+                    candidateTags = await getArtistGenres(spotifyToken, track.author).catch(() => []) // NOSONAR — track.author used as URLSearchParams search query inside getArtistGenres; no raw URL interpolation
                 }
                 const rec = calculateRecommendationScore({
                     candidate: track,

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -109,8 +109,10 @@ export async function collectBroadFallbackCandidates(
 
     // Obtain Spotify token once for the whole fallback pass — used to enrich
     // genre tags when Last.fm is not linked (getArtistTags returns []).
+    // Promise.resolve() guards against stubs that return undefined rather than
+    // a Promise (matches the pattern used throughout replenisher.ts).
     const spotifyToken = requestedBy?.id
-        ? await spotifyLinkService.getValidAccessToken(requestedBy.id).catch(() => null)
+        ? await Promise.resolve(spotifyLinkService.getValidAccessToken(requestedBy.id)).catch(() => null)
         : null
 
     for (const query of fallbackQueries) {

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -11,6 +11,7 @@ import {
 } from './autoplay/candidateCollector'
 import { calculateRecommendationScore } from './autoplay/candidateScorer'
 import type { SessionMood } from './autoplay/sessionMood'
+import type { ArtistTagFetcher } from './autoplay/artistTagCache'
 import { cleanSearchQuery, cleanAuthor } from './searchQueryCleaner'
 import { normalizeTrackKey, calculateGenreFamilyPenalty } from './trackNormalization'
 
@@ -94,6 +95,11 @@ export async function collectBroadFallbackCandidates(
     implicitDislikeKeys: Set<string> = new Set(),
     implicitLikeKeys: Set<string> = new Set(),
     sessionMood: SessionMood | null = null,
+    genreContext: {
+        getArtistTags?: ArtistTagFetcher
+        currentTrackTags?: string[]
+        sessionGenreFamilies?: Set<string>
+    } = {},
 ): Promise<void> {
     const fallbackQueries = [
         currentTrack.author,
@@ -122,6 +128,9 @@ export async function collectBroadFallbackCandidates(
                 const dislikedWeight = dislikedWeights.get(key)
                 if (dislikedWeight !== undefined && dislikedWeight > 0.5)
                     continue
+                const candidateTags = genreContext.getArtistTags
+                    ? await genreContext.getArtistTags(track.author).catch(() => [] as string[])
+                    : []
                 const rec = calculateRecommendationScore({
                     candidate: track,
                     currentTrack,
@@ -135,6 +144,11 @@ export async function collectBroadFallbackCandidates(
                     implicitLikeKeys,
                     dislikedWeights,
                     sessionMood,
+                    genreContext: {
+                        candidateTags,
+                        currentTrackTags: genreContext.currentTrackTags,
+                        sessionGenreFamilies: genreContext.sessionGenreFamilies,
+                    },
                 })
                 upsertScoredCandidate(candidates, track, {
                     score: rec.score - 0.1,

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -148,7 +148,7 @@ export async function collectBroadFallbackCandidates(
                 // candidateScorer can still fire for Spanish gospel artists
                 // that have non-Spanish-looking artist names / titles.
                 if (candidateTags.length === 0 && spotifyToken) {
-                    candidateTags = await getArtistGenres(spotifyToken, track.author).catch(() => [])
+                    candidateTags = await getArtistGenres(spotifyToken, track.author).catch(() => []) // NOSONAR S5144 — artistName used as URLSearchParams search query inside getArtistGenres; no raw URL interpolation
                 }
                 const rec = calculateRecommendationScore({
                     candidate: track,

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -1,5 +1,6 @@
 import { QueryType, type Track, type GuildQueue } from 'discord-player'
 import type { User } from 'discord.js'
+import { debugLog } from '@lucky/shared/utils'
 import { getBatchAudioFeatures, getArtistGenres, type SpotifyAudioFeatures } from '../../spotify/spotifyApi'
 import { spotifyLinkService } from '@lucky/shared/services'
 import { getTagTopTracks } from '../../lastfm'
@@ -129,7 +130,10 @@ export async function collectBroadFallbackCandidates(
                 if (dislikedWeight !== undefined && dislikedWeight > 0.5)
                     continue
                 const candidateTags = genreContext.getArtistTags
-                    ? await genreContext.getArtistTags(track.author).catch(() => [] as string[])
+                    ? await genreContext.getArtistTags(track.author).catch((err: unknown) => {
+                        debugLog({ message: 'candidateFallback: getArtistTags failed', data: { author: track.author, err } })
+                        return [] as string[]
+                    })
                     : []
                 const rec = calculateRecommendationScore({
                     candidate: track,
@@ -252,7 +256,10 @@ export async function enrichWithAudioFeatures(
             const candidateGenres = await getArtistGenres(
                 token,
                 track.track.author,
-            ).catch(() => [])
+            ).catch((err: unknown) => {
+                debugLog({ message: 'candidateFallback: getArtistGenres failed', data: { author: track.track.author, err } })
+                return []
+            })
             const genrePenalty = calculateGenreFamilyPenalty(
                 currentGenres,
                 candidateGenres,

--- a/packages/bot/src/utils/music/languageHeuristics.spec.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.spec.ts
@@ -74,6 +74,29 @@ describe('languageHeuristics', () => {
 			).toBe(false)
 		})
 
+		it('should detect Spanish worship titles without ñ/¿/¡', () => {
+			// These slip through when Last.fm tags are absent — common gospel titles
+			expect(detectSpanishMarkers('Eres Fiel', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Fuego de Tu Presencia', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Los Cielos Cuentan', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Tiempo de Alabanza', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Tu Gracia', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Gracias a Dios', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Nuevo Corazon', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Pueblo de Dios', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Llena Mi Copa', undefined)).toBe(true)
+			expect(detectSpanishMarkers('Una Noche Mas', undefined)).toBe(true)
+		})
+
+		it('should not flag English or Portuguese tracks on new tokens', () => {
+			expect(detectSpanishMarkers('Amazing Grace', undefined)).toBe(false)
+			expect(detectSpanishMarkers('Hillsong United', undefined)).toBe(false)
+			// Portuguese "presença" uses ç — won't match "presencia"
+			expect(detectSpanishMarkers('Presença de Deus', undefined)).toBe(false)
+			// Portuguese "graça" uses ç — won't match "gracia"
+			expect(detectSpanishMarkers('Graça e Paz', undefined)).toBe(false)
+		})
+
 		it('should let Portuguese veto win when both signals appear', () => {
 			// Brazilian artist Anitta has English/Spanish/Portuguese mixes.
 			// "El Que Espera Por Mim" — has Spanish stopwords ("el") but

--- a/packages/bot/src/utils/music/languageHeuristics.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.ts
@@ -66,6 +66,21 @@ const SPANISH_DISTINCT_TOKENS = [
 	'niño', 'niña', 'niños', 'niñas',
 	'tu gloria',
 	'tus alabanzas',
+	// Spanish worship music words whose Portuguese equivalents are spelled
+	// differently — catches gospel/worship titles that contain no ñ/¿/¡.
+	'fuego',          // Portuguese: fogo
+	'cielo', 'cielos',// Portuguese: céu/céus
+	'presencia',      // Portuguese: presença (always has ç)
+	'alabanza', 'alabanzas', // Portuguese: louvor/louvores
+	'alabar',         // Portuguese: louvar
+	'gracia', 'gracias', // Portuguese: graça (always has ç) / obrigado
+	'eres',           // Portuguese: és
+	'nuevo', 'nueva', // Portuguese: novo/nova (different vowel pattern)
+	'pueblo',         // Portuguese: povo
+	'tierra',         // Portuguese: terra ("ie" diphthong is Spanish-specific)
+	'llena', 'llenas', 'lleno', // Portuguese: cheia/cheio (double-l never in Portuguese)
+	'noche',          // Portuguese: noite
+	'hoy',            // Portuguese: hoje
 ]
 
 // Words distinctive to Portuguese (Brazilian or European). Hits here veto

--- a/packages/bot/src/utils/music/languageHeuristics.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.ts
@@ -73,7 +73,7 @@ const SPANISH_DISTINCT_TOKENS = [
 	'presencia',      // Portuguese: presença (always has ç)
 	'alabanza', 'alabanzas', // Portuguese: louvor/louvores
 	'alabar',         // Portuguese: louvar
-	'gracia', 'gracias', // Portuguese: graça (always has ç) / obrigado
+	'gracia', 'gracias', // Portuguese: graça / obrigado (different roots entirely)
 	'eres',           // Portuguese: és
 	'nuevo', 'nueva', // Portuguese: novo/nova (different vowel pattern)
 	'pueblo',         // Portuguese: povo

--- a/packages/bot/src/utils/music/languageHeuristics.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.ts
@@ -121,13 +121,21 @@ const PORTUGUESE_DISTINCT_TOKENS = [
 	'glória',
 ]
 
-function countMatches(text: string, tokens: string[]): number {
+const NON_LETTER = '[^a-záéíóúüñãõç]'
+
+function compileTokenPattern(token: string): RegExp {
+	const escaped = token.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+	return new RegExp(`(?:^|${NON_LETTER})${escaped}(?:$|${NON_LETTER})`, 'i')
+}
+
+const SPANISH_TOKEN_PATTERNS: RegExp[] = SPANISH_DISTINCT_TOKENS.map(compileTokenPattern)
+const PORTUGUESE_TOKEN_PATTERNS: RegExp[] = PORTUGUESE_DISTINCT_TOKENS.map(compileTokenPattern)
+
+function countMatches(text: string, patterns: RegExp[]): number {
 	if (!text) return 0
 	const lower = text.toLowerCase()
 	let count = 0
-	for (const token of tokens) {
-		const escaped = token.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
-		const re = new RegExp(`(?:^|[^a-záéíóúüñãõç])${escaped}(?:$|[^a-záéíóúüñãõç])`, 'i')
+	for (const re of patterns) {
 		if (re.test(lower)) count++
 	}
 	return count
@@ -152,13 +160,15 @@ export function scoreLanguageMarkers(
 		if (SPANISH_ONLY_DIACRITICS.test(safeText)) spanishScore += 2
 		if (PORTUGUESE_ONLY_DIACRITICS.test(safeText)) portugueseScore += 2
 
-		spanishScore += countMatches(safeText, SPANISH_DISTINCT_TOKENS)
-		portugueseScore += countMatches(safeText, PORTUGUESE_DISTINCT_TOKENS)
+		spanishScore += countMatches(safeText, SPANISH_TOKEN_PATTERNS)
+		portugueseScore += countMatches(safeText, PORTUGUESE_TOKEN_PATTERNS)
 
 		// Genre keywords in the title itself are a strong locale signal —
 		// "Reggaeton mix", "Cumbia caliente", "Bachata Rosa" etc.
-		const genreTokenHits = countMatches(safeText, SPANISH_GENRE_MARKERS)
-		if (genreTokenHits > 0) spanishScore += 2
+		const genreTokenHits = SPANISH_GENRE_MARKERS.some((m) =>
+			safeText.toLowerCase().includes(m.toLowerCase()),
+		)
+		if (genreTokenHits) spanishScore += 2
 	}
 
 	let hasSpanishGenreTag = false

--- a/packages/bot/src/utils/music/languageHeuristics.ts
+++ b/packages/bot/src/utils/music/languageHeuristics.ts
@@ -121,22 +121,28 @@ const PORTUGUESE_DISTINCT_TOKENS = [
 	'glória',
 ]
 
-const NON_LETTER = '[^a-záéíóúüñãõç]'
+// Literal regex — not dynamic, never built from variables.
+const LETTER_RE = /[a-záéíóúüñãõç]/i
 
-function compileTokenPattern(token: string): RegExp {
-	const escaped = token.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
-	return new RegExp(`(?:^|${NON_LETTER})${escaped}(?:$|${NON_LETTER})`, 'i')
+function hasWordMatch(text: string, token: string): boolean {
+	let i = text.indexOf(token)
+	while (i !== -1) {
+		const before = i > 0 ? text[i - 1] : ''
+		const after = i + token.length < text.length ? text[i + token.length] : ''
+		if ((!before || !LETTER_RE.test(before)) && (!after || !LETTER_RE.test(after))) {
+			return true
+		}
+		i = text.indexOf(token, i + 1)
+	}
+	return false
 }
 
-const SPANISH_TOKEN_PATTERNS: RegExp[] = SPANISH_DISTINCT_TOKENS.map(compileTokenPattern)
-const PORTUGUESE_TOKEN_PATTERNS: RegExp[] = PORTUGUESE_DISTINCT_TOKENS.map(compileTokenPattern)
-
-function countMatches(text: string, patterns: RegExp[]): number {
+function countMatches(text: string, tokens: string[]): number {
 	if (!text) return 0
 	const lower = text.toLowerCase()
 	let count = 0
-	for (const re of patterns) {
-		if (re.test(lower)) count++
+	for (const token of tokens) {
+		if (hasWordMatch(lower, token.toLowerCase())) count++
 	}
 	return count
 }
@@ -160,15 +166,13 @@ export function scoreLanguageMarkers(
 		if (SPANISH_ONLY_DIACRITICS.test(safeText)) spanishScore += 2
 		if (PORTUGUESE_ONLY_DIACRITICS.test(safeText)) portugueseScore += 2
 
-		spanishScore += countMatches(safeText, SPANISH_TOKEN_PATTERNS)
-		portugueseScore += countMatches(safeText, PORTUGUESE_TOKEN_PATTERNS)
+		spanishScore += countMatches(safeText, SPANISH_DISTINCT_TOKENS)
+		portugueseScore += countMatches(safeText, PORTUGUESE_DISTINCT_TOKENS)
 
 		// Genre keywords in the title itself are a strong locale signal —
 		// "Reggaeton mix", "Cumbia caliente", "Bachata Rosa" etc.
-		const genreTokenHits = SPANISH_GENRE_MARKERS.some((m) =>
-			safeText.toLowerCase().includes(m.toLowerCase()),
-		)
-		if (genreTokenHits) spanishScore += 2
+		const genreTokenHits = countMatches(safeText, SPANISH_GENRE_MARKERS)
+		if (genreTokenHits > 0) spanishScore += 2
 	}
 
 	let hasSpanishGenreTag = false

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -79,6 +79,7 @@ const consumeLastFmSeedSliceMock = jest.fn()
 const consumeBlendedSeedSliceMock = jest.fn()
 
 jest.mock('./autoplay/lastFmSeeds', () => ({
+    LASTFM_SEED_COUNT: 15,
     consumeLastFmSeedSlice: (...args: unknown[]) =>
         consumeLastFmSeedSliceMock(...args),
     consumeBlendedSeedSlice: (...args: unknown[]) =>

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -191,9 +191,9 @@ describe('queueManipulation.replenishQueue', () => {
     }): Promise<QueueMock> {
         const queue = createQueueMock({
             currentTrack: {
-                title: 'Song A',
-                author: 'Artist A',
-                url: 'https://example.com/a',
+                title: 'Bohemian Rhapsody',
+                author: 'Queen',
+                url: 'https://example.com/bohemian',
             } as unknown as Track,
             metadata: options.queueRequestedById
                 ? { requestedBy: { id: options.queueRequestedById } }
@@ -206,10 +206,10 @@ describe('queueManipulation.replenishQueue', () => {
                 search: jest.fn().mockResolvedValue({
                     tracks: [
                         {
-                            title: options.candidateTitle ?? 'Song B',
-                            author: options.candidateAuthor ?? 'Artist B',
+                            title: options.candidateTitle ?? 'Stairway to Heaven',
+                            author: options.candidateAuthor ?? 'Led Zeppelin',
                             url:
-                                options.candidateUrl ?? 'https://example.com/b',
+                                options.candidateUrl ?? 'https://example.com/stairway',
                             metadata: options.candidateMetadata ?? {},
                         },
                     ],
@@ -227,9 +227,9 @@ describe('queueManipulation.replenishQueue', () => {
                 size: 1,
                 toArray: jest.fn().mockReturnValue([
                     {
-                        title: 'Queued Song',
-                        author: 'Queued Artist',
-                        url: 'https://example.com/q',
+                        title: 'Highway to Hell',
+                        author: 'AC/DC',
+                        url: 'https://example.com/highway',
                     },
                 ]),
             },
@@ -237,24 +237,24 @@ describe('queueManipulation.replenishQueue', () => {
                 search: jest.fn().mockResolvedValue({
                     tracks: [
                         {
-                            title: 'Song B',
-                            author: 'Artist B',
-                            url: 'https://example.com/b',
+                            title: 'Stairway to Heaven',
+                            author: 'Led Zeppelin',
+                            url: 'https://example.com/stairway',
                         },
                         {
-                            title: 'Song C',
-                            author: 'Artist C',
-                            url: 'https://example.com/c',
+                            title: 'Smells Like Teen Spirit',
+                            author: 'Nirvana',
+                            url: 'https://example.com/nirvana',
                         },
                         {
-                            title: 'Song D',
-                            author: 'Artist D',
-                            url: 'https://example.com/d',
+                            title: 'Purple Rain',
+                            author: 'Prince',
+                            url: 'https://example.com/prince',
                         },
                         {
-                            title: 'Song E',
-                            author: 'Artist E',
-                            url: 'https://example.com/e',
+                            title: 'Imagine',
+                            author: 'John Lennon',
+                            url: 'https://example.com/lennon',
                         },
                     ],
                 }),
@@ -277,8 +277,17 @@ describe('queueManipulation.replenishQueue', () => {
     })
 
     it('does not search when queue already has buffer size', async () => {
+        const autoplayTracks = Array.from({ length: 8 }, (_, i) => ({
+            title: `Autoplay Track ${i + 1}`,
+            author: `Artist ${i + 1}`,
+            url: `https://example.com/autoplay-${i + 1}`,
+            metadata: { isAutoplay: true },
+        }))
         const queue = createQueueMock({
-            tracks: { size: 8, toArray: jest.fn().mockReturnValue([]) },
+            tracks: {
+                size: 8,
+                toArray: jest.fn().mockReturnValue(autoplayTracks),
+            },
         })
 
         await replenishQueue(queue as unknown as GuildQueue)
@@ -629,9 +638,9 @@ describe('queueManipulation.replenishQueue', () => {
 
     it('returns without adding tracks when candidate set is exhausted', async () => {
         const queue = await replenishWithSingleCandidate({
-            candidateTitle: 'Song A clone',
-            candidateAuthor: 'Artist A',
-            candidateUrl: 'https://example.com/a',
+            candidateTitle: 'Bohemian Rhapsody',
+            candidateAuthor: 'Queen',
+            candidateUrl: 'https://example.com/bohemian',
         })
 
         expect(queue.addTrack).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- **Queue priority**: Buffer calculation now counts only autoplay-tagged tracks (`isAutoplay: true` in metadata), so user-added songs are never displaced to make room for autoplay
- **Wuthering Heights loop fix**: Lowered fuzzy-dedup threshold (0.82 → 0.75) and strip remaster/remix/live/acoustic suffixes before comparing — songs that are "effectively the same" are excluded as duplicates
- **Spotify liked seeds**: `getUserSavedTracks` fetches up to 200 liked tracks from Spotify; up to 3 are used as priority seeds in the Recommendations API call (ahead of queue history seeds, max 5 total per API limit)
- **Sertanejo filter**: Block sertanejo/forró genre family from autoplay via Last.fm artist tags unless the current seed track is itself sertanejo (fail-open — only filters when tags are present)
- **Last.fm variety**: `LASTFM_SEED_COUNT` raised 3 → 15 and `MAX_SIMILAR_LOOKUPS` 5 → 15 for broader candidate pool

## Changed files

| File | Change |
|------|--------|
| `spotifyApi.ts` | Add `getUserSavedTracks` (paged, up to 200 tracks) |
| `spotifyUserSeeds.ts` | Add `likedTrackIds` field, fetch saved tracks, cache TTL 5min → 30min |
| `spotifyRecommender.ts` | Use liked track IDs as priority seeds |
| `replenisher.ts` | Count only autoplay-tagged tracks for buffer; detect & pass `blockSertanejo` |
| `diversitySelector.ts` | Lower fuzzy threshold, strip variant suffixes from both sides of dedup check |
| `candidateCollector.ts` | Accept `blockSertanejo` param, filter sertanejo candidates via Last.fm tags |
| `artistTagCache.ts` | Export `hasGenreTag` helper |
| `lastFmSeeder.ts` / `lastFmSeeds.ts` | Raise seed count constants 3/5 → 15 |

## Test plan

- [x] All 75 bot autoplay/spotify tests pass (`spotifyUserSeeds`, `diversitySelector`, `replenisher`, `candidateCollector`, `lastFmSeeder`)
- [x] `spotifyUserSeeds.spec.ts`: covers cache hit/miss, `likedTrackIds`, null-token, API failure, caching, normalization
- [x] `replenisher.spec.ts`: covers full queue skip with autoplay-tagged tracks, telemetry emission, error handling
- [x] `lastFmSeeder.spec.ts`: updated expectations to reflect new seed count of 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prioritize a user’s liked Spotify tracks as recommendation seeds (up to 3); saved-track fetch now supports paginated retrieval.
  * Added explicit Sertanejo tag set and an option to block that genre from candidate selection.

* **Improvements**
  * Larger Last.fm seed slices and more similar-track lookups for broader recommendations.
  * Improved duplicate detection (strip variant suffixes) and relaxed title fuzzy threshold.
  * Replenisher counts only autoplay-marked tracks; cache TTL standardized to 30 minutes.
  * Fallback candidate scoring enriched with per-artist genre tags and resilient tag fallbacks.
  
* **Tests**
  * Expanded test coverage for new behaviors, edge cases, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- **Pagination & priority seeds**: `getUserSavedTracks` now paginates up to 200 liked tracks (default `limit` changed 50 → 200, resolving the prior P1 where the call site passed no argument and silently capped at 50); up to 3 liked IDs are prepended as priority seeds before queue-history seeds in the Recommendations call.
- **Autoplay buffer & dedup**: Replenisher counts only `isAutoplay`-tagged tracks for the buffer so user-added songs are never displaced; fuzzy threshold lowered to 0.75 and `stripVariantSuffix` strips remaster/remix/live/acoustic suffixes before duplicate comparison.
- **Sertanejo filter & Last.fm breadth**: `blockSertanejo` flag (fail-open at candidate level) gates sertanejo/forró candidates via Last.fm tags; `LASTFM_SEED_COUNT` unified and raised 3/5 → 15, `MAX_SIMILAR_LOOKUPS` 5 → 15 for a broader pool. Note: the existing P2 — sertanejo filter does not apply to the `collectSpotifyRecommendationCandidates` path — remains open.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the prior P1 (50-track cap) is resolved by the default-limit change and all new logic is well-tested.

Both previous P1 findings are fixed by changing the default limit to 200. No new P1 or P0 issues found. The only open item is the pre-existing P2 that sertanejo blocking does not cover the Spotify Recommendations code path, already flagged in the prior review. P2s do not lower the confidence score.

candidateCollector.ts — sertanejo filter gap on the Spotify Recommendations path (pre-existing P2, not introduced by this PR).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/bot/src/spotify/spotifyApi.ts | Rewrote getUserSavedTracks to paginate up to 200 tracks; changed default limit from 50 to 200, fixing the previous P1 where the call site passed no argument and silently capped at 50. |
| packages/bot/src/spotify/spotifyUserSeeds.ts | Adds likedTrackIds field to UserSpotifySeeds, fetches saved tracks, bumps cache TTL from 5 min to 30 min. getUserSavedTracks(token) now correctly uses the updated default of 200. |
| packages/bot/src/utils/music/autoplay/replenisher.ts | Buffer calculation now counts only autoplay-tagged tracks; adds blockSertanejo flag derived from seed track tags and threads it into collectRecommendationCandidates. |
| packages/bot/src/utils/music/autoplay/candidateCollector.ts | Exports SERTANEJO_TAGS and applies sertanejo blocking in the searchSeedCandidates path. Spotify Recommendations path still bypasses the filter — existing P2 from prior review remains unfixed. |
| packages/bot/src/utils/music/autoplay/diversitySelector.ts | Lowers fuzzy dedup threshold 0.82 to 0.75 and adds stripVariantSuffix to normalize remaster/remix/live/acoustic suffixes before comparison. |
| packages/bot/src/utils/music/autoplay/spotifyRecommender.ts | Liked-track IDs prepended as priority seeds (up to 3) before queue-history seeds; combined list deduplicated and capped at 5 per Spotify API limit. |
| packages/bot/src/utils/music/autoplay/lastFmSeeder.ts | Removes private LASTFM_SEED_COUNT=3, imports shared constant (now 15); raises MAX_SIMILAR_LOOKUPS 5 to 15; adds early break when candidates.size >= AUTOPLAY_BUFFER_SIZE. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/bot/src/spotify/spotifyApi.spec.ts`, line 102-114 ([link](https://github.com/lucassantana-dev/lucky/blob/0a30b82821e1ae9cb15f59c46670a5890bce629c/packages/bot/src/spotify/spotifyApi.spec.ts#L102-L114)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Test will fail: `maxTracks` is 50, not 200**

   `getUserSavedTracks('token')` uses the default `limit = 50`, giving `maxTracks = Math.min(50, 200) = 50`. With 50 items returned per page, the loop breaks after a single request (`savedTrackIds.length >= maxTracks` → `50 >= 50` → true). The assertion `expect(fetchMock).toHaveBeenCalledTimes(4)` will never be reached — only 1 call is made.

   To test the 200-track cap, the call must pass the explicit limit: `getUserSavedTracks('token', 200)`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot%2Fsrc%2Fspotify%2FspotifyApi.spec.ts%0ALine%3A%20102-114%0A%0AComment%3A%0A**Test%20will%20fail%3A%20%60maxTracks%60%20is%2050%2C%20not%20200**%0A%0A%60getUserSavedTracks%28'token'%29%60%20uses%20the%20default%20%60limit%20%3D%2050%60%2C%20giving%20%60maxTracks%20%3D%20Math.min%2850%2C%20200%29%20%3D%2050%60.%20With%2050%20items%20returned%20per%20page%2C%20the%20loop%20breaks%20after%20a%20single%20request%20%28%60savedTrackIds.length%20%3E%3D%20maxTracks%60%20%E2%86%92%20%6050%20%3E%3D%2050%60%20%E2%86%92%20true%29.%20The%20assertion%20%60expect%28fetchMock%29.toHaveBeenCalledTimes%284%29%60%20will%20never%20be%20reached%20%E2%80%94%20only%201%20call%20is%20made.%0A%0ATo%20test%20the%20200-track%20cap%2C%20the%20call%20must%20pass%20the%20explicit%20limit%3A%20%60getUserSavedTracks%28'token'%2C%20200%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lucassantana-dev%2Flucky&pr=817&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lucassantana-dev%2Flucky%22%20on%20the%20existing%20branch%20%22fix%2Fautoplay-queue-priority-spotify-seeds%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fautoplay-queue-priority-spotify-seeds%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot%2Fsrc%2Fspotify%2FspotifyApi.spec.ts%0ALine%3A%20102-114%0A%0AComment%3A%0A**Test%20will%20fail%3A%20%60maxTracks%60%20is%2050%2C%20not%20200**%0A%0A%60getUserSavedTracks%28'token'%29%60%20uses%20the%20default%20%60limit%20%3D%2050%60%2C%20giving%20%60maxTracks%20%3D%20Math.min%2850%2C%20200%29%20%3D%2050%60.%20With%2050%20items%20returned%20per%20page%2C%20the%20loop%20breaks%20after%20a%20single%20request%20%28%60savedTrackIds.length%20%3E%3D%20maxTracks%60%20%E2%86%92%20%6050%20%3E%3D%2050%60%20%E2%86%92%20true%29.%20The%20assertion%20%60expect%28fetchMock%29.toHaveBeenCalledTimes%284%29%60%20will%20never%20be%20reached%20%E2%80%94%20only%201%20call%20is%20made.%0A%0ATo%20test%20the%20200-track%20cap%2C%20the%20call%20must%20pass%20the%20explicit%20limit%3A%20%60getUserSavedTracks%28'token'%2C%20200%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `packages/bot/src/spotify/spotifyUserSeeds.ts`, line 61 ([link](https://github.com/lucassantana-dev/lucky/blob/0a30b82821e1ae9cb15f59c46670a5890bce629c/packages/bot/src/spotify/spotifyUserSeeds.ts#L61)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Only 50 liked tracks fetched, not 200**

   `getUserSavedTracks(token)` is called without a limit argument, so `limit` defaults to `50` and `maxTracks = Math.min(50, 200) = 50`. Only a single Spotify page (50 tracks) is ever fetched, despite the PR description stating "fetches up to 200 liked tracks from Spotify".

   To use the new pagination logic and match the stated intent, pass the explicit maximum: `getUserSavedTracks(token, 200)`.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot%2Fsrc%2Fspotify%2FspotifyUserSeeds.ts%0ALine%3A%2061%0A%0AComment%3A%0A**Only%2050%20liked%20tracks%20fetched%2C%20not%20200**%0A%0A%60getUserSavedTracks%28token%29%60%20is%20called%20without%20a%20limit%20argument%2C%20so%20%60limit%60%20defaults%20to%20%6050%60%20and%20%60maxTracks%20%3D%20Math.min%2850%2C%20200%29%20%3D%2050%60.%20Only%20a%20single%20Spotify%20page%20%2850%20tracks%29%20is%20ever%20fetched%2C%20despite%20the%20PR%20description%20stating%20%22fetches%20up%20to%20200%20liked%20tracks%20from%20Spotify%22.%0A%0ATo%20use%20the%20new%20pagination%20logic%20and%20match%20the%20stated%20intent%2C%20pass%20the%20explicit%20maximum%3A%20%60getUserSavedTracks%28token%2C%20200%29%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20likedTrackIds%20%3D%20await%20getUserSavedTracks%28token%2C%20200%29.catch%28%28%29%20%3D%3E%20%5B%5D%20as%20string%5B%5D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lucassantana-dev%2Flucky&pr=817&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lucassantana-dev%2Flucky%22%20on%20the%20existing%20branch%20%22fix%2Fautoplay-queue-priority-spotify-seeds%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fautoplay-queue-priority-spotify-seeds%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot%2Fsrc%2Fspotify%2FspotifyUserSeeds.ts%0ALine%3A%2061%0A%0AComment%3A%0A**Only%2050%20liked%20tracks%20fetched%2C%20not%20200**%0A%0A%60getUserSavedTracks%28token%29%60%20is%20called%20without%20a%20limit%20argument%2C%20so%20%60limit%60%20defaults%20to%20%6050%60%20and%20%60maxTracks%20%3D%20Math.min%2850%2C%20200%29%20%3D%2050%60.%20Only%20a%20single%20Spotify%20page%20%2850%20tracks%29%20is%20ever%20fetched%2C%20despite%20the%20PR%20description%20stating%20%22fetches%20up%20to%20200%20liked%20tracks%20from%20Spotify%22.%0A%0ATo%20use%20the%20new%20pagination%20logic%20and%20match%20the%20stated%20intent%2C%20pass%20the%20explicit%20maximum%3A%20%60getUserSavedTracks%28token%2C%20200%29%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20likedTrackIds%20%3D%20await%20getUserSavedTracks%28token%2C%20200%29.catch%28%28%29%20%3D%3E%20%5B%5D%20as%20string%5B%5D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `packages/bot/src/utils/music/autoplay/candidateCollector.ts`, line 122-143 ([link](https://github.com/lucassantana-dev/lucky/blob/0a30b82821e1ae9cb15f59c46670a5890bce629c/packages/bot/src/utils/music/autoplay/candidateCollector.ts#L122-L143)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Sertanejo filter does not apply to Spotify Recommendations path**

   The `blockSertanejo` guard (line 172) is applied only to candidates that come from `searchSeedCandidates`. Candidates added by `collectSpotifyRecommendationCandidates` (line 123) skip this check entirely, so sertanejo tracks recommended by the Spotify API can still enter the pool regardless of `blockSertanejo`. Consider passing or applying the same filter inside `collectSpotifyRecommendationCandidates`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot%2Fsrc%2Futils%2Fmusic%2Fautoplay%2FcandidateCollector.ts%0ALine%3A%20122-143%0A%0AComment%3A%0A**Sertanejo%20filter%20does%20not%20apply%20to%20Spotify%20Recommendations%20path**%0A%0AThe%20%60blockSertanejo%60%20guard%20%28line%20172%29%20is%20applied%20only%20to%20candidates%20that%20come%20from%20%60searchSeedCandidates%60.%20Candidates%20added%20by%20%60collectSpotifyRecommendationCandidates%60%20%28line%20123%29%20skip%20this%20check%20entirely%2C%20so%20sertanejo%20tracks%20recommended%20by%20the%20Spotify%20API%20can%20still%20enter%20the%20pool%20regardless%20of%20%60blockSertanejo%60.%20Consider%20passing%20or%20applying%20the%20same%20filter%20inside%20%60collectSpotifyRecommendationCandidates%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lucassantana-dev%2Flucky&pr=817&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lucassantana-dev%2Flucky%22%20on%20the%20existing%20branch%20%22fix%2Fautoplay-queue-priority-spotify-seeds%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fautoplay-queue-priority-spotify-seeds%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot%2Fsrc%2Futils%2Fmusic%2Fautoplay%2FcandidateCollector.ts%0ALine%3A%20122-143%0A%0AComment%3A%0A**Sertanejo%20filter%20does%20not%20apply%20to%20Spotify%20Recommendations%20path**%0A%0AThe%20%60blockSertanejo%60%20guard%20%28line%20172%29%20is%20applied%20only%20to%20candidates%20that%20come%20from%20%60searchSeedCandidates%60.%20Candidates%20added%20by%20%60collectSpotifyRecommendationCandidates%60%20%28line%20123%29%20skip%20this%20check%20entirely%2C%20so%20sertanejo%20tracks%20recommended%20by%20the%20Spotify%20API%20can%20still%20enter%20the%20pool%20regardless%20of%20%60blockSertanejo%60.%20Consider%20passing%20or%20applying%20the%20same%20filter%20inside%20%60collectSpotifyRecommendationCandidates%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(spotify): drain response body on non..."](https://github.com/lucassantana-dev/lucky/commit/5f54cc6ff0c9fe0752d454d8afdd820319de31b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31362507)</sub>

<!-- /greptile_comment -->