### PR TITLE
docs: add GitHub issue templates for bug/feature reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,10 @@ What should have happened.
 What actually happened. Include any error messages or screenshots.
 
 **Environment**
-- Deployment: [ ] Self-hosted (Docker)  [ ] Self-hosted (bare metal)  [ ] Public bot
+- Deployment:
+  - [ ] Self-hosted (Docker)
+  - [ ] Self-hosted (bare metal)
+  - [ ] Public bot
 - Lucky version / Docker image tag: `v`
 - Node.js version (if bare metal): `node -v`
 - Discord.js version: (from `package.json`)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: '[bug] '
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what went wrong.
+
+**Steps to reproduce**
+1. Run command `/...`
+2. See error
+
+**Expected behaviour**
+What should have happened.
+
+**Actual behaviour**
+What actually happened. Include any error messages or screenshots.
+
+**Environment**
+- Deployment: [ ] Self-hosted (Docker)  [ ] Self-hosted (bare metal)  [ ] Public bot
+- Lucky version / Docker image tag: `v`
+- Node.js version (if bare metal): `node -v`
+- Discord.js version: (from `package.json`)
+
+**Logs**
+Paste relevant logs here (redact any tokens or secrets).
+
+```
+```
+
+**Additional context**
+Anything else that might help — guild size, voice channel setup, music source (YouTube / Spotify / SoundCloud), etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: '[feature] '
+labels: enhancement
+assignees: ''
+---
+
+**Problem / motivation**
+What problem does this solve? Why do you need this?
+
+**Proposed solution**
+Describe what you'd like to happen.
+
+**Alternatives considered**
+Any other approaches you thought of and why you ruled them out.
+
+**Additional context**
+Links, screenshots, or examples that help explain the idea.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 Thanks for working on Lucky. This file documents the small repo-specific rules that are easy to miss; everything else (style, tests, formatting) is enforced by CI and lives in code.
 
+## Reporting bugs and requesting features
+
+Use the GitHub issue tracker: https://github.com/LucasSantana-Dev/Lucky/issues
+
+Issue templates guide you through the required information:
+- **Bug report** — steps to reproduce, expected vs actual behaviour, Lucky version, deployment type
+- **Feature request** — problem statement and proposed solution
+
 ## Getting started
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/bug_report.md` — collects deployment type, Lucky version, steps to reproduce, expected vs actual, logs
- Adds `.github/ISSUE_TEMPLATE/feature_request.md` — minimal template for feature requests
- Updates `CONTRIBUTING.md` with a "Reporting bugs and requesting features" section linking to the issue tracker

New users arriving from bot directories (top.gg, discord.bots.gg, discordbotlist.com) will have structured templates when filing issues.

## Test plan

- [ ] Open a test issue on GitHub — template selection screen appears
- [ ] Select bug report — all required fields are present
- [ ] Select feature request — form appears


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds two GitHub issue templates (`.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`) to guide reporters through structured bug and feature submissions.
- Updates `CONTRIBUTING.md` with a new \"Reporting bugs and requesting features\" section linking to the issue tracker.
- One P2 style note: inline `[ ]` markers in the Deployment field of the bug report template will not render as interactive GitHub checkboxes.

<h3>Confidence Score: 5/5</h3>

Documentation-only PR with no code changes — safe to merge.

All three files are purely additive documentation. The single P2 finding (inline checkbox syntax) does not affect functionality or safety.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug_report.md | New bug report template — well-structured with environment, logs, and reproduction steps; inline checkbox syntax in the Deployment field won't render as interactive checkboxes on GitHub (P2 style note). |
| .github/ISSUE_TEMPLATE/feature_request.md | New feature request template — clean and minimal with motivation, solution, and alternatives sections; no issues. |
| CONTRIBUTING.md | Adds "Reporting bugs and requesting features" section linking to the issue tracker; URL casing is consistent with the rest of the file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    U([User arrives at repo]) --> IT[Opens new GitHub Issue]
    IT --> TS{Template selection screen}
    TS --> BR[Bug report template\n.github/ISSUE_TEMPLATE/bug_report.md]
    TS --> FR[Feature request template\n.github/ISSUE_TEMPLATE/feature_request.md]
    BR --> BF[Fills: description · steps · environment\nLucky version · logs]
    FR --> FF[Fills: motivation · proposed solution\nalternatives · context]
    BF --> SI[Submits issue → label: bug]
    FF --> SI2[Submits issue → label: enhancement]
    SI --> TK[Maintainer triages]
    SI2 --> TK
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2FISSUE_TEMPLATE%2Fbug_report.md%3A23%0A**Inline%20%60%5B%20%5D%60%20won't%20render%20as%20checkboxes**%0A%0AGitHub%20only%20renders%20interactive%20checkboxes%20for%20%60-%20%5B%20%5D%60%20list%20items.%20The%20inline%20%60%5B%20%5D%60%20markers%20here%20will%20display%20as%20literal%20text%20%28%60%5B%20%5D%20Self-hosted%20%28Docker%29%60%29%20rather%20than%20tappable%20checkboxes%2C%20which%20can%20confuse%20reporters%20who%20expect%20them%20to%20be%20interactive.%0A%0A%60%60%60suggestion%0A-%20Deployment%3A%20%0A%20%20-%20%5B%20%5D%20Self-hosted%20%28Docker%29%0A%20%20-%20%5B%20%5D%20Self-hosted%20%28bare%20metal%29%0A%20%20-%20%5B%20%5D%20Public%20bot%0A%60%60%60%0A%0A&repo=lucassantana-dev%2Flucky&pr=828&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lucassantana-dev%2Flucky%22%20on%20the%20existing%20branch%20%22docs%2Fgithub-issue-templates-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fgithub-issue-templates-v2%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2FISSUE_TEMPLATE%2Fbug_report.md%3A23%0A**Inline%20%60%5B%20%5D%60%20won't%20render%20as%20checkboxes**%0A%0AGitHub%20only%20renders%20interactive%20checkboxes%20for%20%60-%20%5B%20%5D%60%20list%20items.%20The%20inline%20%60%5B%20%5D%60%20markers%20here%20will%20display%20as%20literal%20text%20%28%60%5B%20%5D%20Self-hosted%20%28Docker%29%60%29%20rather%20than%20tappable%20checkboxes%2C%20which%20can%20confuse%20reporters%20who%20expect%20them%20to%20be%20interactive.%0A%0A%60%60%60suggestion%0A-%20Deployment%3A%20%0A%20%20-%20%5B%20%5D%20Self-hosted%20%28Docker%29%0A%20%20-%20%5B%20%5D%20Self-hosted%20%28bare%20metal%29%0A%20%20-%20%5B%20%5D%20Public%20bot%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;release/v2.10.0&#39; into docs..."](https://github.com/lucassantana-dev/lucky/commit/0de0e589da5eee1a2ec5ab4b9a9b32efbd4eb85c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31372491)</sub>

<!-- /greptile_comment -->