### PR TITLE
feat(autoplay): wire recentSkipCount into mood detection

### DIFF
--- a/packages/bot/src/handlers/player/trackHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.spec.ts
@@ -4,6 +4,7 @@ import {
     lastPlayedTracks,
     recentlyPlayedTracks,
     setupTrackHandlers,
+    getRecentSkipCount,
 } from './trackHandlers'
 
 const QueueRepeatMode = {
@@ -567,6 +568,48 @@ describe('trackHandlers autoplay replenishment', () => {
             'testsong::testartist',
             'implicit_dislike',
         )
+    })
+
+    it('increments getRecentSkipCount on early skip and resets on track completion', async () => {
+        jest.useFakeTimers()
+        const handlers = setupHandlers()
+        const queue = {
+            ...createQueue(QueueRepeatMode.AUTOPLAY),
+            guild: { id: 'guild-skip-count', name: 'Skip Count Guild' },
+        } as unknown as GuildQueue
+        const track = { ...createTrack('skip-count-user'), durationMS: 100000 }
+
+        await handlers.playerStart(queue, track)
+        jest.advanceTimersByTime(10000) // 10% through — early skip
+        await handlers.playerSkip(queue, track)
+        expect(getRecentSkipCount(queue.guild.id)).toBe(1)
+
+        // Another early skip increments further
+        await handlers.playerStart(queue, track)
+        jest.advanceTimersByTime(10000)
+        await handlers.playerSkip(queue, track)
+        expect(getRecentSkipCount(queue.guild.id)).toBe(2)
+
+        // Completing a track (>80%) resets the counter
+        await handlers.playerStart(queue, track)
+        jest.advanceTimersByTime(90000)
+        await handlers.playerFinish(queue, track)
+        expect(getRecentSkipCount(queue.guild.id)).toBe(0)
+    })
+
+    it('does not increment getRecentSkipCount when skip is after 30% of track', async () => {
+        jest.useFakeTimers()
+        const handlers = setupHandlers()
+        const queue = {
+            ...createQueue(QueueRepeatMode.AUTOPLAY),
+            guild: { id: 'guild-skip-late', name: 'Skip Late Guild' },
+        } as unknown as GuildQueue
+        const track = { ...createTrack('skip-late-user'), durationMS: 100000 }
+
+        await handlers.playerStart(queue, track)
+        jest.advanceTimersByTime(50000) // 50% through — late skip
+        await handlers.playerSkip(queue, track)
+        expect(getRecentSkipCount(queue.guild.id)).toBe(0)
     })
 
     it('does not record feedback on playerSkip when track < 20 seconds duration', async () => {

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -43,6 +43,16 @@ const guildTrackStartTimes = new LRUCache<string, number>({
     updateAgeOnGet: true,
 })
 
+const guildRecentSkipCounts = new LRUCache<string, number>({
+    max: MAX_GUILD_ENTRIES,
+    ttl: TRACK_STATE_TTL_MS,
+    updateAgeOnGet: true,
+})
+
+export function getRecentSkipCount(guildId: string): number {
+    return guildRecentSkipCounts.get(guildId) ?? 0
+}
+
 export type TrackHistoryEntry = {
     url: string
     title: string
@@ -278,6 +288,7 @@ const handlePlayerFinish = async (
                     (Date.now() - startTime) / track.durationMS
                 if (completionRatio > 0.8) {
                     await recordImplicitTrackFeedback(track, 'implicit_like')
+                    guildRecentSkipCounts.delete(queue.guild.id)
                 }
             }
             guildTrackStartTimes.delete(queue.guild.id)
@@ -317,6 +328,8 @@ const handlePlayerSkip = async (
                 const skipRatio = (Date.now() - startTime) / track.durationMS
                 if (skipRatio < 0.3) {
                     await recordImplicitTrackFeedback(track, 'implicit_dislike')
+                    const current = guildRecentSkipCounts.get(queue.guild.id) ?? 0
+                    guildRecentSkipCounts.set(queue.guild.id, current + 1)
                 }
             }
             guildTrackStartTimes.delete(queue.guild.id)

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -12,6 +12,7 @@ import {
     getArtistPopularity,
 } from '../../../spotify/spotifyApi'
 import { detectSessionMood, type SessionMood } from './sessionMood'
+import { getRecentSkipCount } from '../../../handlers/player/trackHandlers'
 import {
     collectRecommendationCandidates,
     SERTANEJO_TAGS,
@@ -116,7 +117,7 @@ async function _replenishQueue(
             Math.abs(allHistoryTracks.length - guildMoodCache.historyLen) < 3
                 ? guildMoodCache.mood
                 : (() => {
-                      const mood = detectSessionMood(allHistoryTracks, 0 /* TODO: wire recentSkipCount from skip tracking */)
+                      const mood = detectSessionMood(allHistoryTracks, getRecentSkipCount(replenishGuildId))
                       sessionMoodCache.set(replenishGuildId, {
                           mood,
                           historyLen: allHistoryTracks.length,


### PR DESCRIPTION
## Summary

- Adds `guildRecentSkipCounts` LRU cache (per-guild, 30-min TTL) in `trackHandlers.ts` to track early skips
- Increments counter when a track is skipped before 30% completion (same threshold as implicit dislike feedback)
- Resets counter when a track plays past 80% completion (natural session settling)
- Exports `getRecentSkipCount(guildId)` for use in replenisher
- Wires `getRecentSkipCount(replenishGuildId)` into `detectSessionMood()` in `replenisher.ts` — replaces the hardcoded `0` TODO

## Why

`detectSessionMood` had a `0 /* TODO: wire recentSkipCount */` for 6 months. A guild that skips 5 tracks in a row was still being served "similar" mood recommendations instead of shifting to exploratory/energetic mode. This connects the skip signal to the mood algorithm.

## Test plan

- [x] `trackHandlers.spec.ts`: 22 tests (added 2 new — skip count increments, reset on completion)
- [x] `replenisher.spec.ts`: 8 tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR wires `getRecentSkipCount` into `detectSessionMood`, replacing a 6-month-old hardcoded `0`. A per-guild LRU cache tracks early skips and resets on natural track completion. One new P2 finding: the `sessionMoodCache` in `replenisher.ts` is not invalidated when the skip count resets, causing `restless: true` to persist for 1–2 extra replenish cycles after a settling track completes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2; the skip count wiring is correct and tests pass.

Only P2 findings remain after prior review rounds addressed the most critical concerns. The stale mood cache window is a minor behavioral imprecision that self-corrects within 2 tracks.

No files require blocking attention; `replenisher.ts` has the stale-mood-cache edge case worth a follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/bot/src/handlers/player/trackHandlers.ts | Adds `guildRecentSkipCounts` LRU cache with increment on early skip and delete on >80% completion; `updateAgeOnGet: true` flag means TTL resets on every read from replenisher, not just on writes. |
| packages/bot/src/utils/music/autoplay/replenisher.ts | Wires `getRecentSkipCount` into `detectSessionMood`; introduces a circular module dependency and a stale mood cache window of 1–2 cycles after skip count resets. |
| packages/bot/src/handlers/player/trackHandlers.spec.ts | Adds two new tests covering skip count increment on early skip, reset on >80% completion, and no-increment on late skip; correct timer setup with existing `afterEach` cleanup. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/bot/src/handlers/player/trackHandlers.ts`, line 285-292 ([link](https://github.com/lucassantana-dev/lucky/blob/9981f20a6f851612f40b3106f7fd022a9b7bb127/packages/bot/src/handlers/player/trackHandlers.ts#L285-L292)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Reset missing the `durationMS > 20_000` guard present in the skip path**

   `handlePlayerSkip` only increments the count when `track.durationMS > 20_000`, but `handlePlayerFinish` resets the count for _any_ track duration that reaches >80% completion. A jingle or interstitial shorter than 20 s that autoplays to completion would silently clear an active "skip storm" signal. Adding the same duration guard keeps the two sides of the state machine symmetric.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot%2Fsrc%2Fhandlers%2Fplayer%2FtrackHandlers.ts%0ALine%3A%20285-292%0A%0AComment%3A%0A**Reset%20missing%20the%20%60durationMS%20%3E%2020_000%60%20guard%20present%20in%20the%20skip%20path**%0A%0A%60handlePlayerSkip%60%20only%20increments%20the%20count%20when%20%60track.durationMS%20%3E%2020_000%60%2C%20but%20%60handlePlayerFinish%60%20resets%20the%20count%20for%20_any_%20track%20duration%20that%20reaches%20%3E80%25%20completion.%20A%20jingle%20or%20interstitial%20shorter%20than%2020%20s%20that%20autoplays%20to%20completion%20would%20silently%20clear%20an%20active%20%22skip%20storm%22%20signal.%20Adding%20the%20same%20duration%20guard%20keeps%20the%20two%20sides%20of%20the%20state%20machine%20symmetric.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28completionRatio%20%3E%200.8%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20recordImplicitTrackFeedback%28track%2C%20'implicit_like'%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28track.durationMS%20%3E%2020_000%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20guildRecentSkipCounts.delete%28queue.guild.id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lucassantana-dev%2Flucky&pr=829&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lucassantana-dev%2Flucky%22%20on%20the%20existing%20branch%20%22fix%2Fwire-recent-skip-count%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwire-recent-skip-count%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot%2Fsrc%2Fhandlers%2Fplayer%2FtrackHandlers.ts%0ALine%3A%20285-292%0A%0AComment%3A%0A**Reset%20missing%20the%20%60durationMS%20%3E%2020_000%60%20guard%20present%20in%20the%20skip%20path**%0A%0A%60handlePlayerSkip%60%20only%20increments%20the%20count%20when%20%60track.durationMS%20%3E%2020_000%60%2C%20but%20%60handlePlayerFinish%60%20resets%20the%20count%20for%20_any_%20track%20duration%20that%20reaches%20%3E80%25%20completion.%20A%20jingle%20or%20interstitial%20shorter%20than%2020%20s%20that%20autoplays%20to%20completion%20would%20silently%20clear%20an%20active%20%22skip%20storm%22%20signal.%20Adding%20the%20same%20duration%20guard%20keeps%20the%20two%20sides%20of%20the%20state%20machine%20symmetric.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28completionRatio%20%3E%200.8%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20recordImplicitTrackFeedback%28track%2C%20'implicit_like'%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28track.durationMS%20%3E%2020_000%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20guildRecentSkipCounts.delete%28queue.guild.id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot%2Fsrc%2Futils%2Fmusic%2Fautoplay%2Freplenisher.ts%3A120%0A**Stale%20mood%20cache%20not%20invalidated%20on%20skip%20count%20reset**%0A%0AWhen%20%60handlePlayerFinish%60%20deletes%20%60guildRecentSkipCounts%60%20%28the%20skip%20storm%20clears%29%2C%20%60sessionMoodCache%60%20in%20%60replenisher.ts%60%20is%20not%20touched.%20Because%20the%20mood%20cache%20is%20only%20recomputed%20when%20%60%7ChistoryLen%20-%20cachedLen%7C%20%3E%3D%203%60%2C%20a%20guild%20that%20completes%20a%20settling%20track%20will%20continue%20receiving%20%60restless%3A%20true%60%20recommendations%20for%20the%20next%201%E2%80%932%20replenish%20cycles.%0A%0AConcretely%3A%20skip%204%20tracks%20%E2%86%92%20mood%20cached%20as%20%60restless%3A%20true%60%20at%20%60historyLen%3DN%60%3B%20complete%20one%20track%20%E2%86%92%20skip%20count%20deleted%2C%20but%20%60%7CN%2B1%20-%20N%7C%20%3D%201%20%3C%203%60%20keeps%20the%20stale%20mood%20active%20through%20the%20next%20replenish.%0A%0A&repo=lucassantana-dev%2Flucky&pr=829&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lucassantana-dev%2Flucky%22%20on%20the%20existing%20branch%20%22fix%2Fwire-recent-skip-count%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwire-recent-skip-count%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot%2Fsrc%2Futils%2Fmusic%2Fautoplay%2Freplenisher.ts%3A120%0A**Stale%20mood%20cache%20not%20invalidated%20on%20skip%20count%20reset**%0A%0AWhen%20%60handlePlayerFinish%60%20deletes%20%60guildRecentSkipCounts%60%20%28the%20skip%20storm%20clears%29%2C%20%60sessionMoodCache%60%20in%20%60replenisher.ts%60%20is%20not%20touched.%20Because%20the%20mood%20cache%20is%20only%20recomputed%20when%20%60%7ChistoryLen%20-%20cachedLen%7C%20%3E%3D%203%60%2C%20a%20guild%20that%20completes%20a%20settling%20track%20will%20continue%20receiving%20%60restless%3A%20true%60%20recommendations%20for%20the%20next%201%E2%80%932%20replenish%20cycles.%0A%0AConcretely%3A%20skip%204%20tracks%20%E2%86%92%20mood%20cached%20as%20%60restless%3A%20true%60%20at%20%60historyLen%3DN%60%3B%20complete%20one%20track%20%E2%86%92%20skip%20count%20deleted%2C%20but%20%60%7CN%2B1%20-%20N%7C%20%3D%201%20%3C%203%60%20keeps%20the%20stale%20mood%20active%20through%20the%20next%20replenish.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["feat(autoplay): wire recentSkipCount int..."](https://github.com/lucassantana-dev/lucky/commit/a634b91b3eb9ca6c0f807d686ead00ce26419a3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31374362)</sub>

<!-- /greptile_comment -->