### PR TITLE
ci(bot): pin coverage threshold floor before phase-2 cleanup

### DIFF
--- a/packages/bot/jest.config.cjs
+++ b/packages/bot/jest.config.cjs
@@ -11,6 +11,18 @@ module.exports = {
     ],
     coverageDirectory: 'coverage',
     coverageReporters: ['text', 'lcov'],
+    // Floor pinned to the round-down of the post-#821 baseline
+    // (stmts 67 / branches 63 / functions 63 / lines 68). Binding without
+    // forcing emergency work; tighten 2-3 % per cleanup phase as the suite
+    // shrinks. See .agents/plans/test-cleanup-phase2.md.
+    coverageThreshold: {
+        global: {
+            statements: 65,
+            branches: 60,
+            functions: 60,
+            lines: 65,
+        },
+    },
     moduleNameMapper: {
         '^(\\.{1,2}/.*)\\.js$': '$1',
         '^chalk$': '<rootDir>/tests/__mocks__/chalk.ts',


### PR DESCRIPTION
## What

Adds `coverageThreshold` to `packages/bot/jest.config.cjs` so the bot
suite's coverage gate becomes binding before phase-2 test cleanup
begins.

## Why

After PR #821 landed, the bot suite has **2,848 tests / 39k LOC** and
**no coverage threshold** configured. Per the canonical `/test-cleanup`
skill, deletions must run against a configured floor — otherwise pruning
is blind to coverage and a regression slips silently into CI.

This PR is intentionally tiny so the gate exists in CI before the
larger phase-2 deletion PR is opened.

## Numbers

| Metric | Current | Floor | Headroom |
|---|---|---|---|
| Statements | 67.03 % | 65 % | 2.03 |
| Branches | 63.47 % | 60 % | 3.47 |
| Functions | 63.89 % | 60 % | 3.89 |
| Lines | 68.15 % | 65 % | 3.15 |

The floor is the round-down of post-#821 baseline. The plan is to
tighten 2-3 % per cleanup phase as the suite shrinks toward proportional
size (target ~1,500 tests for a 39k LOC full-stack-tier bot).

## Test posture

- 2,848 / 2,848 tests pass on `release/v2.10.0` post-merge.
- Coverage run with new threshold: PASS.
- No source changes — this is a CI-policy patch only.

## Related

- Plan: `.agents/plans/test-cleanup-phase2.md`
- Follow-up: `test/suite-redesign-phase2` will start the actual cleanup
  pass after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Established minimum code coverage thresholds to maintain and improve baseline code quality standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/835)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->