### PR TITLE
chore: bootstrap release-branch workflow configs

### DIFF
--- a/.claude/branch-hygiene-config.json
+++ b/.claude/branch-hygiene-config.json
@@ -1,0 +1,20 @@
+{
+  "worktree_root": "/Volumes/External HD/Desenvolvimento/.worktrees",
+  "secondary_worktree_roots": [
+    "/Volumes/External HD/Desenvolvimento/Lucky/.claude/worktrees",
+    "/Volumes/External HD/Desenvolvimento/Lucky/.worktrees"
+  ],
+  "stale_pr_threshold_days": 7,
+  "protect_branches": [
+    "main",
+    "master",
+    "develop",
+    "staging"
+  ],
+  "protect_patterns": [
+    "release/*",
+    "hotfix/*"
+  ],
+  "skip_phases": [],
+  "notes": "Lucky has historically scattered worktrees across three roots. `worktree_root` is the canonical target going forward; `secondary_worktree_roots` are tolerated until /branch-hygiene consolidation completes. Release branches (`release/*`) are versioned and protected — never auto-delete."
+}

--- a/.claude/dep-sweep-config.json
+++ b/.claude/dep-sweep-config.json
@@ -1,0 +1,28 @@
+{
+  "base_branch": "release/v2.10.0",
+  "base_branch_strategy": "versioned",
+  "sensitive": [
+    "discord.js",
+    "@discordjs/voice",
+    "discord-player",
+    "@prisma/client",
+    "prisma",
+    "next",
+    "vite",
+    "react",
+    "react-dom",
+    "express"
+  ],
+  "always_hold": [
+    "react",
+    "react-dom",
+    "vite",
+    "next",
+    "@types/node",
+    "@types/react",
+    "discord.js"
+  ],
+  "auto_merge_minor": false,
+  "auto_merge_dev_deps": true,
+  "notes": "Lucky uses versioned release branches (release/vX.Y.Z). 'base_branch' points at the currently-active release-staging branch and is bumped when a new release is cut. Bot deps (discord.js, discord-player) and ORM (prisma) are sensitive — manual review even on patches. Frontend frameworks always hold for review."
+}

--- a/.claude/standards/release-cadence.md
+++ b/.claude/standards/release-cadence.md
@@ -1,0 +1,97 @@
+# Release Cadence — Lucky
+
+How this repo ships.
+
+## Model — versioned release branches
+
+Lucky uses **trunk-based development with versioned release branches**, NOT a
+single long-lived `release` branch. For each upcoming version a dedicated
+`release/vX.Y.Z` branch is created off `main`; PRs targeting the next release
+land there via `/pr-to-release`. When the batch is ready, `/release-cut`
+promotes `release/vX.Y.Z` → `main` with a merge commit (preserves individual
+PR SHAs), tags `vX.Y.Z`, and publishes the GitHub release.
+
+This memory entry is canonical (see `feedback_tbd_release_branches.md` in
+project memory).
+
+```
+main ─────●──────────────────●─────────●──────────────────●─────────
+           \                 ↑          \                 ↑
+            release/v2.9.0 ──┘           release/v2.10.0 ──┘  (next: release/v2.11.0)
+            (15 PRs squashed)            (15 PRs squashed)
+```
+
+## Active release branch
+
+The currently active release-staging branch is recorded in
+`.claude/dep-sweep-config.json#base_branch`. As of 2026-05-13: **v2.10.0
+shipped**; next active branch is `release/v2.11.0` (to be created by the
+first PR that needs to ship in v2.11.0).
+
+`/pr-to-release` falls back to the latest `release/vX.Y.Z` if no version is
+specified.
+
+## Cadence triggers
+
+- **Manual:** user invokes `/release-cut release/vX.Y.Z`
+- **Nudge:** `git rev-list --count main..release/vX.Y.Z` ≥ 5 commits → surface
+  in `/next-priority` and `/session-bootstrap` output
+- **Hotfix exception:** `/hotfix` bypasses the release branch, patches `main`
+  directly, tags `vX.Y.Z+1`, then cherry-picks the fix back to the active
+  release branch
+
+## Bump strategy (proposed by `version-bump` from conventional commits)
+
+| Prefix mix in the batch                  | Bump  |
+|------------------------------------------|-------|
+| any `BREAKING CHANGE` or `feat!:`        | major |
+| at least one `feat:` (no breaking)       | minor |
+| only `fix:`, `chore:`, `ci:`, `docs:`    | patch |
+
+## CHANGELOG hygiene
+
+- Every PR that touches `packages/{bot,backend,frontend}/src/` adds a line
+  under `## [Unreleased]` (see `dangerfile.ts` rule)
+- `chore(deps)`, `chore(deps-dev)`, `ci:`, `build:`, `style:`, `docs:` are
+  exempt — they're internal-only
+- `/release-cut` Phase 3 promotes `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`
+- **Hard stop:** `/release-cut` refuses to proceed if `[Unreleased]` is empty
+  but the branch has > 0 commits ahead of main — caller must populate first
+
+See follow-up issue Lucky #840 for tightening this rule (currently too
+permissive on `fix:` and `refactor:` prefixes).
+
+## Bot PRs (Dependabot)
+
+Handled by `/dep-sweep`. See `.claude/dep-sweep-config.json` for the rules:
+- Dev-deps: auto-merge minor + patch
+- Production deps: manual review (see `sensitive` list)
+- Framework deps (react, vite, next): always hold (see `always_hold`)
+- `discord.js`, `discord-player`, `@prisma/client`: sensitive, manual review
+  even on patches — runtime-critical for the bot's voice / DB layer
+
+## Hotfix policy
+
+`/hotfix` is the **only** acceptable bypass of the release branch.
+Criteria:
+1. The fix is for a production-impacting bug, not new functionality
+2. It can be expressed in ≤ 100 LOC across ≤ 3 files
+3. The fix is reviewed by at least one human before merge
+4. After merge to `main` + tag, the commit is cherry-picked back to the
+   active `release/vX.Y.Z` so the next planned cut includes it
+
+Routine "small fix" work goes through `/pr-to-release`, not `/hotfix`.
+
+## Sync invariant
+
+`release/vX.Y.Z` must always be at-or-ahead-of `main`, never behind. After
+any direct-to-main merge (hotfix, dependabot to main, etc.), fast-forward
+the active release branch. See follow-up issue Lucky #841 for automating
+this guard.
+
+## References
+
+- ADR: `docs/decisions/2026-05-09-branch-strategy-no-stacking.md`
+- ADR: `docs/decisions/2026-05-09-bot-test-suite-cleanup-strategy.md`
+- Memory: `feedback_tbd_release_branches.md`
+- Follow-ups: Lucky #840 (changelog hygiene), Lucky #841 (release sync invariant)

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ packages/*/pnpm-lock.yaml
 
 # AI / IDE tooling (local-only)
 .claude/
+# Repo-level Claude workflow configs ARE committed (single-source-of-truth for
+# /dep-sweep, /branch-hygiene, release-cadence). Per-developer state stays local.
+!.claude/dep-sweep-config.json
+!.claude/branch-hygiene-config.json
+!.claude/standards/
+!.claude/standards/**
 .serena/
 .windsurf/
 .data/


### PR DESCRIPTION
Seeds the repo-level workflow configs that the release-branch composite skills (`/dep-sweep`, `/branch-hygiene`, `/release-cut`) expect to find. Idempotent — re-running `/repo-bootstrap` after this merges is a no-op.

## What this adds

| Path | Purpose |
|------|---------|
| `.claude/dep-sweep-config.json` | Dependabot batching rules with Lucky-specific sensitive deps (discord.js, prisma, framework packages) |
| `.claude/branch-hygiene-config.json` | Worktree root + protect-patterns (`release/*`, `hotfix/*`) |
| `.claude/standards/release-cadence.md` | Documents the versioned-release-branch model |
| `.gitignore` | Allow-list exceptions for the three above; rest of `.claude/` stays per-developer |

## Skipped phases (per idempotency contract)

- **Phase 2 — release branch creation:** Lucky uses versioned release branches (`release/vX.Y.Z`), not the skill's default singular `release`. `release/v2.10.0` and `release/v2.6.61` already exist on origin. The next branch (`release/v2.11.0`) gets created on demand when v2.11.0 work begins.
- **Phase 3 — CHANGELOG seed:** already exists with `[Unreleased]` (populated during the v2.10.0 release cut in `1b924003`).

## Why this matters now

The audit (\`memory/audit_deep_lucky_2026-05-13.md\`) called out `/branch-hygiene` as a MEDIUM-impact, low-effort win (23 merged branches, 8 stale locked worktrees, 3 worktree dirs to consolidate). That skill needs the config file shipping here. Same for `/dep-sweep`, which is the canonical handler for Dependabot PRs going forward.

## Why \`.claude/\` instead of \`.github/\` or \`docs/\`

`.claude/*-config.json` is the skill-defined path; putting the configs elsewhere means every skill needs an extra resolver. The blanket `.claude/` ignore covered per-developer state; explicit allow-list exceptions keep that boundary while letting these three files travel with the repo.

## Refs

- ADR `docs/decisions/2026-05-09-branch-strategy-no-stacking.md` — branch strategy decision
- Memory `feedback_tbd_release_branches.md` — versioned-release-branch model
- Follow-ups: #840 (changelog hygiene), #841 (release sync invariant)
- Audit: \`memory/audit_deep_lucky_2026-05-13.md\` — overall health snapshot post-v2.10.0