### PR TITLE
fix(docker): revert frontend image to node:22-alpine (unblock docker-publish)

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:26-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Production-blocker fix

`docker-publish.yml` has failed every run since 2026-05-10 (when Dependabot #831 bumped `Dockerfile.frontend` from `node:22-alpine` → `node:26-alpine`). v2.10.0's container images never built — the GitHub release shipped a tag but not a deployed image.

## Root cause

`Dockerfile.frontend`'s builder stage runs `npm ci --legacy-peer-deps` in the workspace root, which installs **all** workspace deps — including `@discordjs/opus` from the bot workspace.

`@discordjs/opus@0.10.0` uses `@discordjs/node-pre-gyp@0.4.5` for prebuilt binaries. That version doesn't ship a Node 26 ABI prebuilt. The fallback path would be to compile from source, but `node:26-alpine` doesn't include the C toolchain, so:

```
npm error node-pre-gyp ERR! cwd /app/node_modules/@discordjs/opus
npm error node-pre-gyp ERR! node -v v26.1.0
npm error node-pre-gyp ERR! not ok
ERROR: failed to build: failed to solve: process "/bin/sh -c YOUTUBE_DL_SKIP_DOWNLOAD=1 ... npm ci ..."
       did not complete successfully: exit code: 1
```

## Why it slipped past PR #831's CI

PR #831's CI ran unit tests on GitHub-hosted Ubuntu runners (toolchain present). `docker-publish` runs full image builds post-merge via `workflow_run` trigger — it never gated #831's merge.

## Why this is a 1-line revert (not a Node 26 fix)

Three viable fixes, in increasing scope:

| Option | Scope | Risk |
|---|---|---|
| **Revert to node:22-alpine** (this PR) | 1 line | None — root `Dockerfile` already uses 22-alpine via ARG |
| Add `apk add --no-cache make g++ python3` to the frontend builder | 4 lines | Slower builds (~30s/build), but works on any Node version |
| Bump `@discordjs/opus` to a version with Node 26 prebuilts | Multiple files | No such version exists yet on npm (latest is 0.10.0, published a year ago) |

This PR takes Option 1 because it matches the rest of Lucky's images and unblocks shipping immediately.

## Follow-up issue worth filing

When `@discordjs/opus` ships Node 24/26 ABI prebuilts (or migrates to Node-API), revisit Option 3. Until then, Lucky stays on Node 22 LTS.

## Related work in this session

- PR #845 (just merged) fixed a separate `deploy.yml` bash typo. That was real, but the actual production blocker is this one — `deploy` is gated on `docker-publish` success.
- Audit memory `audit_deep_lucky_2026-05-13.md` listed deploy as the RED finding; the real fix splits into two PRs (#845 + this one).