### PR TITLE
chore(docker): overhaul container surface (build context, healthchecks, hardening)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,22 @@
 .gitignore
 .gitattributes
 
+# Worktrees (4.5GB+ of duplicated trees — must be excluded)
+.worktrees/
+worktrees/
+.wt-specs/
+
+# AI agent state / caches (115MB+ — never needed at build time)
+.claude/
+.claude-env/
+.claude-mem/
+.claude-server-commander/
+.agents/
+
+# Archived branches + downloaded media (host-only)
+archive/
+downloads/
+
 # Documentation
 docs/
 *.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,8 +99,11 @@ RUN mkdir -p downloads logs && \
 
 USER bot
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD node -e "console.log('Service is running')" || exit 1
+# Liveness via Redis TCP PING — confirms node can run AND the bot's
+# Redis dependency is reachable. A wedged node process or broken Redis
+# link both fail this; the old `console.log` check did neither.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD node -e "const net=require('net');const s=net.createConnection({host:process.env.REDIS_HOST||'redis',port:+(process.env.REDIS_PORT||6379)},()=>s.write('*1\r\n\$4\r\nPING\r\n'));s.on('data',d=>process.exit(d.toString().startsWith('+PONG')?0:1));s.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),3000);" || exit 1
 
 CMD ["sh", "-c", "npx prisma migrate deploy --config prisma/prisma.config.ts && node packages/bot/dist/index.js"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,20 @@ ARG NODE_VERSION=22-alpine
 
 FROM node:${NODE_VERSION} AS base-runtime
 
+# yt-dlp is installed into a dedicated venv at /opt/ytdlp so we avoid
+# `--break-system-packages` (Alpine's PEP 668 marker). The venv binary
+# is symlinked into /usr/local/bin so callers don't need to know the path.
 RUN apk add --no-cache \
     python3 \
     py3-pip \
     ffmpeg \
     opus \
     opus-tools \
-    && rm -rf /var/cache/apk/*
+    && python3 -m venv /opt/ytdlp \
+    && /opt/ytdlp/bin/pip install --no-cache-dir --upgrade pip yt-dlp \
+    && ln -s /opt/ytdlp/bin/yt-dlp /usr/local/bin/yt-dlp \
+    && rm -rf /var/cache/apk/* /root/.cache
 
-RUN pip3 install --break-system-packages --no-cache-dir yt-dlp
-
-WORKDIR /app
-
-FROM node:${NODE_VERSION} AS base-runtime-backend
 WORKDIR /app
 
 # Development stage — full deps + native build tools + media binaries.
@@ -120,15 +121,16 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
 
 CMD ["sh", "-c", "npx prisma migrate deploy --config prisma/prisma.config.ts && node packages/bot/dist/index.js"]
 
-# Production stage — backend (slim runtime, no media tools)
-FROM base-runtime-backend AS production-backend
+# Production stage — backend (slim runtime, no media tools).
+# Derives directly from node:${NODE_VERSION} instead of a no-op intermediate
+# `base-runtime-backend` stage.
+FROM node:${NODE_VERSION} AS production-backend
+WORKDIR /app
 
 ARG COMMIT_SHA
 ENV NODE_ENV=production \
     NPM_CONFIG_LOGLEVEL=silent \
     COMMIT_SHA=$COMMIT_SHA
-
-WORKDIR /app
 
 COPY --from=deps-production /app/node_modules ./node_modules
 COPY --from=deps-production /app/package*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,19 @@ WORKDIR /app
 FROM node:${NODE_VERSION} AS base-runtime-backend
 WORKDIR /app
 
+# Development stage — full deps + native build tools + media binaries.
+# Source is bind-mounted by docker-compose.dev.yml (`.:/app`), so this
+# image only needs the runtime + global tooling. node_modules is preserved
+# inside the container via an anonymous volume.
+FROM base-runtime AS development
+RUN apk add --no-cache git build-base python3-dev opus-dev && rm -rf /var/cache/apk/*
+WORKDIR /app
+ENV NODE_ENV=development \
+    NPM_CONFIG_LOGLEVEL=warn
+# Compose mounts host source over /app; node_modules is installed at first
+# run via the entrypoint to populate the anonymous volume.
+CMD ["sh", "-c", "npm ci --legacy-peer-deps --no-audit --no-fund && npx prisma generate && npm run dev --workspace=packages/bot"]
+
 # Build stage — installs all deps, generates prisma, builds shared + target
 FROM node:${NODE_VERSION} AS build
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -24,12 +24,15 @@ RUN npx prisma generate
 RUN npm run build --workspace=packages/shared
 RUN npm run build --workspace=packages/frontend
 
-# NOSONAR: nginx requires root to bind port 80
-FROM nginx:alpine
+# Runtime: nginx-unprivileged listens on 8080 as UID 101 (no root, no port-80 cap).
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 COPY --from=builder /app/packages/frontend/dist /usr/share/nginx/html
 COPY nginx/frontend.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget -q --spider http://127.0.0.1:8080/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,8 +1,12 @@
-# NOSONAR: nginx requires root to bind port 80
-FROM nginx:alpine
+# Non-root nginx listening on 8080 (UID 101). Cloudflared / docker port
+# publishing maps host 8080 → container 8080.
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget -q --spider http://127.0.0.1:8080/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,10 @@
-FROM almir/webhook:latest
+# Pinned to almir/webhook 2.8.3 (released 2026-02-12). Avoid :latest because
+# this service has /var/run/docker.sock mounted — any silent base-image change
+# is a supply-chain incident waiting to happen.
+FROM almir/webhook:2.8.3
 
-USER root # NOSONAR: privileged operations required for apk and docker socket
+# NOSONAR: privileged operations required for apk and docker socket mount
+USER root
 RUN apk add --no-cache git docker-cli docker-cli-compose bash
 
 # Copy hooks config to /hooks/ — a path NOT declared as VOLUME by the

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,7 @@
-# Pinned to almir/webhook 2.8.3 (released 2026-02-12). Avoid :latest because
-# this service has /var/run/docker.sock mounted — any silent base-image change
-# is a supply-chain incident waiting to happen.
-FROM almir/webhook:2.8.3
+# Pinned to almir/webhook 2.8.3 by manifest digest (released 2026-02-12). The
+# tag alone is mutable on Docker Hub — the digest guarantees immutability since
+# this service has /var/run/docker.sock mounted (supply-chain risk).
+FROM almir/webhook:2.8.3@sha256:f77cc91c91d1527b48052280af38b50791e842ad8dd291e9b360a0c13c9ca991
 
 # NOSONAR: privileged operations required for apk and docker socket mount
 USER root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,10 @@ services:
             - backend
             - frontend
         ports:
-            - "${NGINX_PORT:-8080}:80"
+            # Container now listens on 8080 (non-root nginx).
+            # NOTE: update cloudflared config-lucky.yml service entry to
+            # `http://nginx:8080` after deploying this change.
+            - "${NGINX_PORT:-8080}:8080"
         networks:
             - lucky-network
         logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,24 @@
+# Shared resource defaults — applied per service via `<<: *small-svc` etc.
+x-small-svc: &small-svc
+    mem_limit: 128m
+    cpus: 0.25
+    restart: unless-stopped
+
+x-medium-svc: &medium-svc
+    mem_limit: 512m
+    cpus: 0.5
+    restart: unless-stopped
+
+x-large-svc: &large-svc
+    mem_limit: 1g
+    cpus: 1.0
+    restart: unless-stopped
+
 services:
     postgres:
+        <<: *large-svc
         image: postgres:18-alpine
         container_name: lucky-postgres
-        restart: unless-stopped
         environment:
             POSTGRES_DB: discordbot
             POSTGRES_USER: discordbot
@@ -24,9 +40,9 @@ services:
                 max-file: "3"
 
     redis:
+        <<: *medium-svc
         image: redis:8-alpine
         container_name: lucky-redis
-        restart: unless-stopped
         command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
         volumes:
             - redis_data:/data
@@ -44,6 +60,7 @@ services:
                 max-file: "3"
 
     bot:
+        <<: *large-svc
         image: ${IMAGE_PREFIX:-ghcr.io/lucassantana-dev/lucky}-bot:${IMAGE_TAG:-latest}
         build:
             context: .
@@ -53,7 +70,8 @@ services:
                 SERVICE: bot
                 NODE_ENV: production
         container_name: lucky-bot
-        restart: unless-stopped
+        env_file:
+            - .env
         depends_on:
             postgres:
                 condition: service_healthy
@@ -108,6 +126,7 @@ services:
                 max-file: "3"
 
     backend:
+        <<: *medium-svc
         image: ${IMAGE_PREFIX:-ghcr.io/lucassantana-dev/lucky}-backend:${IMAGE_TAG:-latest}
         build:
             context: .
@@ -117,7 +136,8 @@ services:
                 SERVICE: backend
                 NODE_ENV: production
         container_name: lucky-backend
-        restart: unless-stopped
+        env_file:
+            - .env
         depends_on:
             postgres:
                 condition: service_healthy
@@ -164,12 +184,12 @@ services:
                 max-file: "3"
 
     frontend:
+        <<: *small-svc
         image: ${IMAGE_PREFIX:-ghcr.io/lucassantana-dev/lucky}-frontend:${IMAGE_TAG:-latest}
         build:
             context: .
             dockerfile: Dockerfile.frontend
         container_name: lucky-frontend
-        restart: unless-stopped
         networks:
             - lucky-network
         logging:
@@ -179,12 +199,12 @@ services:
                 max-file: "3"
 
     nginx:
+        <<: *small-svc
         image: ${IMAGE_PREFIX:-ghcr.io/lucassantana-dev/lucky}-nginx:${IMAGE_TAG:-latest}
         build:
             context: .
             dockerfile: Dockerfile.nginx
         container_name: lucky-nginx
-        restart: unless-stopped
         depends_on:
             - backend
             - frontend
@@ -202,11 +222,11 @@ services:
                 max-file: "3"
 
     webhook:
+        <<: *small-svc
         build:
             context: ./deploy
             dockerfile: Dockerfile
         container_name: lucky-webhook
-        restart: unless-stopped
         command: >
             -hooks /hooks/hooks.json
             -verbose
@@ -231,11 +251,10 @@ services:
 
     # Cloudflare Tunnel — exposes nginx to lucky.lucassantana.tech
     cloudflared:
+        <<: *small-svc
         image: cloudflare/cloudflared:latest
         container_name: lucky-tunnel
-        restart: unless-stopped
         command: tunnel --config /etc/cloudflared/config-lucky.yml run
-        user: root
         volumes:
             - ${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:/etc/cloudflared:ro
         depends_on:

--- a/docs/decisions/2026-05-13-docker-overhaul.md
+++ b/docs/decisions/2026-05-13-docker-overhaul.md
@@ -1,0 +1,91 @@
+# ADR — Docker Surface Overhaul (chore/docker-overhaul)
+
+- **Status:** Proposed
+- **Date:** 2026-05-13
+- **Branch:** `chore/docker-overhaul`
+- **Base:** `release/v2.11.0`
+
+## Context
+
+The Lucky container surface accumulated friction:
+
+- `0eb13d0f` (PR #846) reverted the frontend image to `node:22-alpine`, signalling
+  Docker drift between dev and prod was already biting.
+- Build context was shipping the entire repo, including `.worktrees/` (3.4GB),
+  `worktrees/` (707MB), `.wt-specs/` (41MB), `.claude/` (115MB), and `.agents/`
+  (183MB) — ~4.5GB of redundant data sent to the daemon on every build.
+- `docker-compose.dev.yml` referenced a `target: development` stage that did
+  not exist in `Dockerfile`, so dev compose was broken.
+- The bot `HEALTHCHECK` was `node -e "console.log('Service is running')"` —
+  always exit 0, completely useless as a liveness signal.
+- `Dockerfile.nginx` and `Dockerfile.frontend` ran as root to bind port 80
+  with `nginx:alpine`.
+- No memory or CPU limits on any compose service.
+- `almir/webhook:latest` was unpinned despite the service having
+  `/var/run/docker.sock` mounted (effective host root).
+- `cloudflared` ran as `user: root` unnecessarily.
+- A no-op `base-runtime-backend` intermediate stage existed.
+- yt-dlp installed via `pip3 install --break-system-packages`.
+
+## Decision
+
+Single PR (`chore/docker-overhaul`) ships eight focused commits:
+
+1. `.dockerignore` excludes worktrees, agent state, archive, downloads.
+2. Real bot HEALTHCHECK via raw RESP `PING` over TCP to `${REDIS_HOST}`.
+3. `development` stage added to `Dockerfile`, wired by dev compose.
+4. nginx + frontend switched to `nginxinc/nginx-unprivileged:1.27-alpine`
+   (UID 101, port 8080). Compose port mapping + nginx confs adjusted.
+   Cloudflared config on the homelab must be updated to point at `:8080`
+   before merge.
+5. Resource limits via three YAML anchors (`small-svc` / `medium-svc` /
+   `large-svc`) applied to every service. `env_file: .env` added as
+   fallback for bot + backend. Cloudflared `user: root` removed.
+6. `almir/webhook` pinned to `2.8.3`.
+7. Stage consolidation, venv-based yt-dlp, frontend dev image aligned to
+   node 22, BuildKit cache mount preserved.
+8. This ADR + audit doc.
+
+## Consequences
+
+**Positive**
+
+- Build context shrinks by ~4.5GB → faster local + CI builds and lower
+  daemon memory pressure.
+- Dev compose actually works (`docker compose -f docker-compose.dev.yml up`).
+- Orchestrators can detect a wedged bot (Redis-unreachable or node-stuck).
+- nginx no longer needs root; minor but durable hardening win.
+- No service can OOM the homelab host.
+- Supply-chain risk on the webhook container (which holds docker.sock)
+  drops to "Almir's account stays uncompromised" only.
+
+**Negative / Required follow-ups**
+
+- The homelab `cloudflared/config-lucky.yml` ingress entry must be edited
+  from `http://nginx:80` to `http://nginx:8080` BEFORE merging this PR.
+- `env_file: .env` introduces a precedence layer; verified explicit
+  `environment:` still wins, so behavior is preserved.
+- Resource limits are best-guess; revisit if any service hits OOM under
+  steady-state traffic.
+
+## Out of scope
+
+- Migrating from compose to k8s / nomad.
+- Switching to a distroless or wolfi base.
+- BuildKit `--secret` for build-time credentials (not currently needed).
+- Frontend Dockerfile sharing the main multi-stage build (worth doing,
+  but would couple frontend builds to the bot/backend build cache and
+  inflate PR scope).
+
+## Revisit triggers
+
+- Container OOM events in homelab journalctl.
+- Cloudflared / nginx 502s after merge → first check tunnel config port.
+- `almir/webhook` reaches end-of-life or upstream publishes a CVE fix
+  newer than 2.8.3.
+
+## References
+
+- PR #846 (`fix(docker): revert frontend image to node:22-alpine`)
+- Audit memory: `audit_deep_lucky_2026-05-13`
+- TBD policy memory: `feedback_tbd_release_branches`

--- a/docs/decisions/2026-05-13-docker-overhaul.md
+++ b/docs/decisions/2026-05-13-docker-overhaul.md
@@ -44,7 +44,7 @@ Single PR (`chore/docker-overhaul`) ships eight focused commits:
 6. `almir/webhook` pinned to `2.8.3`.
 7. Stage consolidation, venv-based yt-dlp, frontend dev image aligned to
    node 22, BuildKit cache mount preserved.
-8. This ADR + audit doc.
+8. This ADR (audit findings inline above; no separate audit doc).
 
 ## Consequences
 

--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,7 +7,7 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
 }
 
 server {
-    listen 80;
+    listen 8080;
     server_name _;
 
     client_max_body_size 50M;
@@ -38,7 +38,7 @@ server {
     }
 
     location / {
-        set $frontend_upstream http://frontend:80;
+        set $frontend_upstream http://frontend:8080;
         proxy_pass $frontend_upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/packages/frontend/Dockerfile.dev
+++ b/packages/frontend/Dockerfile.dev
@@ -1,13 +1,16 @@
 # syntax=docker/dockerfile:1
-FROM node:24-alpine
+# Pinned to node:22-alpine to match the production frontend (PR #846 reverted
+# from node:24). Drift between dev + prod silently breaks native modules.
+FROM node:22-alpine
 
 WORKDIR /app
 
 COPY package*.json ./
 
+# Keep BuildKit's cache mount — DO NOT run `npm cache clean --force` here,
+# it defeats the mount and slows every rebuild.
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --no-audit --no-fund && \
-    npm cache clean --force
+    npm ci --no-audit --no-fund
 
 USER node
 


### PR DESCRIPTION
## Summary

Multi-area Docker surface review on `chore/docker-overhaul`, branched off `release/v2.11.0`. Eight focused commits land together because the changes are interlocking (port move + compose mapping + nginx confs travel together).

Full rationale + revisit triggers in `docs/decisions/2026-05-13-docker-overhaul.md`.

## Commits

| # | Severity | Commit |
|---|----------|--------|
| 1 | 🔴 Crit  | `fix(docker): exclude worktrees + agent dirs from build context` — shrinks build context by ~4.5GB (`.worktrees/` 3.4GB, `worktrees/` 707MB, `.claude/` 115MB, `.agents/` 183MB, `.wt-specs/` 41MB) |
| 2 | 🔴 Crit  | `fix(docker): real bot healthcheck via Redis TCP PING` — replaces fake `console.log` check |
| 3 | 🔴 Crit  | `fix(docker): add development stage for dev compose` — `docker-compose.dev.yml` was broken (referenced a non-existent target) |
| 4 | 🟠 High  | `chore(docker): non-root nginx (UID 101) + healthchecks` — `nginxinc/nginx-unprivileged:1.27-alpine`, ports 80→8080 inside container |
| 5 | 🟠 High  | `chore(docker): add resource limits + env_file fallback` — tiered `mem_limit`/`cpus` anchors; cloudflared `user: root` removed |
| 6 | 🟠 High  | `chore(docker): pin webhook base to almir/webhook:2.8.3` — service mounts `/var/run/docker.sock` |
| 7 | 🟡 Med   | `chore(docker): consolidate stages, venv yt-dlp, align frontend dev to node 22` |
| 8 | 📝 Docs  | `docs(docker): ADR for chore/docker-overhaul` |

## ⚠️ Deploy action required BEFORE merge

The reverse-proxy nginx container now listens on **8080** instead of 80. The Cloudflare Tunnel config on the homelab must be updated:

```yaml
# ~/.cloudflared/config-lucky.yml  (homelab host)
ingress:
  - hostname: lucky.lucassantana.tech
    service: http://nginx:8080   # was http://nginx:80
```

Restart `lucky-tunnel` after the edit. Without this, the public URL 502s after rollout.

## Test plan

- [x] `docker-compose -f docker-compose.yml config -q` passes
- [x] `docker-compose -f docker-compose.dev.yml config -q` passes
- [ ] CI build (bot + backend + frontend + nginx + webhook images)
- [ ] Local `docker compose up` for prod compose with secrets stub
- [ ] After merge: update cloudflared config + restart tunnel, verify `lucky.lucassantana.tech`

## Out of scope

- k8s/nomad migration
- distroless / wolfi bases
- Frontend Dockerfile sharing the main multi-stage build cache (worth doing, scoped out for blast radius)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment infrastructure with improved security measures including containerization updates and dependency version pinning.
  * Implemented standardized resource management and health monitoring across services.
  * Updated service port configuration for improved system compatibility.
  * Added infrastructure documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/848)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->