### PR TITLE
chore(ci): add top-level permissions: to 8 workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     quality-gates:
         name: Quality Gates

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
         types: [completed]
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     deploy:
         runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,9 @@ env:
     REGISTRY: ghcr.io
     IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/lucky
 
+permissions:
+    contents: read
+
 jobs:
     build-and-push:
         runs-on: ubuntu-latest

--- a/.github/workflows/path-portability.yml
+++ b/.github/workflows/path-portability.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main, 'release/**']
 
+permissions:
+  contents: read
+
 jobs:
   portability:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -14,6 +14,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: false
 
+permissions:
+    contents: read
+
 jobs:
     pr-agent:
         name: AI Code Review

--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -31,6 +31,13 @@ concurrency:
   group: review-tools-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Minimum permissions for both reusable workflows:
+#   - claude-review.yml needs to read PR contents and post review comments
+#   - danger.yml needs to read PR diff and post a comment with findings
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   claude-review:
     uses: LucasSantana-Dev/.github/.github/workflows/claude-review.yml@v1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,6 +6,10 @@ on:
     pull_request:
         branches: [main, 'release/**']
 
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     sonarcloud:
         name: SonarCloud Scan

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes the HIGH-severity finding from `audit_deep_lucky_2026-05-13` ("7 workflows missing `permissions:`" — actually 8: missed `path-portability.yml`).

Without explicit top-level `permissions:`, each workflow inherits the repo default token, typically `contents: write` and often more. Least-privilege per workflow:

| Workflow | Top-level | Job-level (unchanged) |
|---|---|---|
| ci.yml | `contents: read` | — |
| deploy.yml | `contents: read` | `actions: read` |
| docker-publish.yml | `contents: read` | `contents: read` + `packages: write` |
| path-portability.yml | `contents: read` | — |
| pr-agent.yml | `contents: read` | `issues: write` + `pull-requests: write` + `contents: read` |
| review-tools.yml | `contents: read` + `pull-requests: write` | — (reusable callees need both) |
| sonarcloud.yml | `contents: read` + `pull-requests: read` | — |
| stale.yml | `contents: read` | `issues: write` + `pull-requests: write` |

## Verification
- All 8 files pass `yaml.safe_load()`
- Job-level scopes preserved where they exist (additive)
- review-tools.yml needs `pull-requests: write` at top because its reusable callees (claude-review + danger) post review comments

## Risk
Low. Changes only restrict the implicit write-all token — no workflow loses needed access (verified by reading every existing job-level permissions block).