### PR TITLE
ui(servers,login): redesign entry funnel via /ui-expert

### DIFF
--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -2,7 +2,6 @@ import { Loader2, ShieldCheck, Zap, BarChart2 } from 'lucide-react'
 import { useReducedMotion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import Button from '@/components/ui/Button'
-import StatTile from '@/components/ui/StatTile'
 import LanguageSwitcher from '@/components/ui/LanguageSwitcher'
 import { useAuthStore } from '@/stores/authStore'
 import { useAuthRedirect } from '@/hooks/useAuthRedirect'
@@ -25,12 +24,8 @@ export default function LoginPage() {
         : { animationFillMode: 'both' as const }
 
     const sectionClass = prefersReducedMotion
-        ? 'space-y-8'
-        : 'space-y-8 animate-[fade-up_0.4s_ease-out]'
-
-    const cardClass = prefersReducedMotion
-        ? 'surface-card space-y-6 p-6 md:p-8'
-        : 'surface-card space-y-6 p-6 md:p-8 animate-[fade-up_0.4s_ease-out]'
+        ? 'space-y-6'
+        : 'space-y-6 animate-[fade-up_0.4s_ease-out]'
 
     const cardStyle = prefersReducedMotion
         ? {}
@@ -43,107 +38,106 @@ export default function LoginPage() {
     ] as const
 
     return (
-        <div className='lucky-shell min-h-screen px-4 py-8 md:px-8 relative'>
-            <div className='absolute top-4 right-4 z-20'>
+        <div className='min-h-screen bg-lucky-bg-primary flex flex-col relative'>
+            <div className='absolute top-6 right-6 z-20'>
                 <LanguageSwitcher />
             </div>
-            <div className='mx-auto grid min-h-[calc(100vh-4rem)] w-full max-w-6xl items-center gap-10 lg:grid-cols-[1.1fr_0.9fr]'>
-                <section className={sectionClass} style={sectionStyle}>
-                    <div className='flex items-center gap-3'>
-                        <img
-                            src='/lucky-logo.png'
-                            alt='Lucky'
-                            className='h-12 w-12 rounded-xl object-cover border border-lucky-border'
-                        />
-                        <div>
-                            <h1 className='type-display text-lucky-text-primary'>Lucky</h1>
-                            <p className='type-body-sm text-lucky-text-tertiary'>{t('login.brand')}</p>
+
+            <div className='flex-1 flex items-center justify-center px-4 py-16'>
+                <div className='w-full max-w-md'>
+                    <div className={sectionClass} style={sectionStyle}>
+                        <div className='flex items-center gap-3 mb-8'>
+                            <img
+                                src='/lucky-logo.png'
+                                alt='Lucky'
+                                className='h-12 w-12 rounded-lg object-cover border border-lucky-border'
+                            />
+                            <h1 className='text-2xl font-bold text-lucky-text-primary' style={{ fontFamily: 'var(--font-lucky-display)' }}>
+                                Lucky
+                            </h1>
+                        </div>
+
+                        <div className='space-y-3'>
+                            <h2 className='text-2xl font-bold text-lucky-text-primary'>
+                                {t('login.headline')}
+                            </h2>
+                            <p className='text-sm text-lucky-text-secondary'>
+                                {t('login.description')}
+                            </p>
                         </div>
                     </div>
 
-                    <div className='space-y-3'>
-                        <h2 className='type-h1 text-lucky-text-primary'>
-                            {t('login.headline')}
-                        </h2>
-                        <p className='type-body max-w-xl text-lucky-text-secondary'>
-                            {t('login.description')}
-                        </p>
-                    </div>
+                    <section className='surface-panel p-8 space-y-6' style={cardStyle}>
+                        <div className='space-y-2'>
+                            <p className='text-xs uppercase tracking-wider text-lucky-text-tertiary'>
+                                {t('login.authentication')}
+                            </p>
+                            <h3 className='text-xl font-semibold text-lucky-text-primary'>
+                                {t('login.signInWithDiscord')}
+                            </h3>
+                            <p className='text-xs text-lucky-text-secondary'>
+                                {t('login.permissionsNote')}
+                            </p>
+                        </div>
 
-                    <div className='grid gap-3 sm:grid-cols-3'>
-                        <StatTile value='32+' label={t('login.modules')} tone='brand' />
-                        <StatTile value='100+' label={t('login.commands')} tone='brand' />
-                        <StatTile value='24/7' label={t('login.uptime')} tone='success' />
-                    </div>
-                </section>
+                        <Button
+                            onClick={login}
+                            disabled={isLoading}
+                            variant='primary'
+                            className='lucky-focus-visible h-12 w-full rounded-lg font-medium'
+                        >
+                            {isLoading ? (
+                                <>
+                                    <Loader2 className='h-4 w-4 animate-spin' />
+                                    {t('login.connecting')}
+                                </>
+                            ) : (
+                                <>
+                                    <svg className='h-5 w-5' viewBox='0 0 24 24' fill='currentColor'>
+                                        <path d='M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026c.462-.62.874-1.275 1.226-1.963.021-.04.001-.088-.041-.104a13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z' />
+                                    </svg>
+                                    {t('login.loginButton')}
+                                </>
+                            )}
+                        </Button>
 
-                <section
-                    className={cardClass}
-                    style={cardStyle}
-                >
-                    <div className='space-y-2'>
-                        <p className='type-meta text-lucky-text-tertiary'>{t('login.authentication')}</p>
-                        <h3 className='type-h2 text-lucky-text-primary'>{t('login.signInWithDiscord')}</h3>
-                        <p className='type-body-sm text-lucky-text-secondary'>
-                            {t('login.permissionsNote')}
-                        </p>
-                    </div>
+                        <div className='space-y-3 pt-2'>
+                            {badges.map(({ icon: Icon, labelKey }) => (
+                                <div
+                                    key={labelKey}
+                                    className='flex items-center gap-3 p-3 rounded-lg border border-lucky-border bg-lucky-bg-primary/40'
+                                >
+                                    <Icon className='h-4 w-4 text-lucky-brand flex-shrink-0' />
+                                    <p className='text-xs text-lucky-text-secondary'>
+                                        {t(labelKey)}
+                                    </p>
+                                </div>
+                            ))}
+                        </div>
+                    </section>
 
-                    <Button
-                        onClick={login}
-                        disabled={isLoading}
-                        variant='primary'
-                        className='lucky-focus-visible h-12 w-full rounded-lg'
-                    >
-                        {isLoading ? (
-                            <>
-                                <Loader2 className='h-4 w-4 animate-spin' />
-                                {t('login.connecting')}
-                            </>
-                        ) : (
-                            <>
-                                <svg className='h-5 w-5' viewBox='0 0 24 24' fill='currentColor'>
-                                    <path d='M20.317 4.492c-1.53-.69-3.17-1.2-4.885-1.49a.075.075 0 0 0-.079.036c-.21.369-.444.85-.608 1.23a18.566 18.566 0 0 0-5.487 0 12.36 12.36 0 0 0-.617-1.23A.077.077 0 0 0 8.562 3c-1.714.29-3.354.8-4.885 1.491a.07.07 0 0 0-.032.027C.533 9.093-.32 13.555.099 17.961a.08.08 0 0 0 .031.055 20.03 20.03 0 0 0 5.993 2.98.078.078 0 0 0 .084-.026c.462-.62.874-1.275 1.226-1.963.021-.04.001-.088-.041-.104a13.201 13.201 0 0 1-1.872-.878.075.075 0 0 1-.008-.125c.126-.093.252-.19.372-.287a.075.075 0 0 1 .078-.01c3.927 1.764 8.18 1.764 12.061 0a.075.075 0 0 1 .079.009c.12.098.245.195.372.288a.075.075 0 0 1-.006.125c-.598.344-1.22.635-1.873.877a.075.075 0 0 0-.041.105c.36.687.772 1.341 1.225 1.962a.077.077 0 0 0 .084.028 19.963 19.963 0 0 0 6.002-2.981.076.076 0 0 0 .032-.054c.5-5.094-.838-9.52-3.549-13.442a.06.06 0 0 0-.031-.028zM8.02 15.278c-1.182 0-2.157-1.069-2.157-2.38 0-1.312.956-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.956 2.38-2.157 2.38zm7.975 0c-1.183 0-2.157-1.069-2.157-2.38 0-1.312.955-2.38 2.157-2.38 1.21 0 2.176 1.077 2.157 2.38 0 1.312-.946 2.38-2.157 2.38z' />
-                                </svg>
-                                {t('login.loginButton')}
-                            </>
-                        )}
-                    </Button>
-
-                    <div className='grid gap-3 sm:grid-cols-3'>
-                        {badges.map(({ icon: Icon, labelKey }) => (
-                            <div
-                                key={labelKey}
-                                className='rounded-lg border border-lucky-border bg-lucky-bg-primary/60 p-3'
+                    <div className='mt-8 space-y-3 text-center'>
+                        <nav className='flex items-center justify-center gap-3' aria-label='Legal links'>
+                            <a
+                                href='/terms'
+                                className='text-xs text-lucky-text-tertiary underline-offset-2 hover:underline hover:text-lucky-text-secondary transition-colors'
                             >
-                                <Icon className='h-4 w-4 text-lucky-brand' />
-                                <p className='mt-2 type-body-sm text-lucky-text-secondary'>{t(labelKey)}</p>
-                            </div>
-                        ))}
+                                {t('landing.footer.terms')}
+                            </a>
+                            <span className='text-lucky-border' aria-hidden='true'>·</span>
+                            <a
+                                href='/privacy'
+                                className='text-xs text-lucky-text-tertiary underline-offset-2 hover:underline hover:text-lucky-text-secondary transition-colors'
+                            >
+                                {t('landing.footer.privacy')}
+                            </a>
+                        </nav>
+                        <p className='text-xs text-lucky-text-disabled'>
+                            {t('login.copyright')}
+                        </p>
                     </div>
-                </section>
+                </div>
             </div>
-
-            <footer className='pb-2 text-center space-y-1'>
-                <nav className='flex items-center justify-center gap-3' aria-label='Legal links'>
-                    <a
-                        href='/terms'
-                        className='type-body-sm text-lucky-text-tertiary underline-offset-2 hover:underline hover:text-lucky-text-secondary transition-colors'
-                    >
-                        {t('landing.footer.terms')}
-                    </a>
-                    <span className='text-lucky-border' aria-hidden='true'>·</span>
-                    <a
-                        href='/privacy'
-                        className='type-body-sm text-lucky-text-tertiary underline-offset-2 hover:underline hover:text-lucky-text-secondary transition-colors'
-                    >
-                        {t('landing.footer.privacy')}
-                    </a>
-                </nav>
-                <p className='type-body-sm text-lucky-text-disabled'>
-                    {t('login.copyright')}
-                </p>
-            </footer>
         </div>
     )
 }

--- a/packages/frontend/src/pages/ServersPage.tsx
+++ b/packages/frontend/src/pages/ServersPage.tsx
@@ -1,9 +1,7 @@
-import { Crown, LayoutGrid, Settings, ShieldCheck } from 'lucide-react'
+import { Crown, LayoutGrid, Settings, ExternalLink } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import Skeleton from '@/components/ui/Skeleton'
-import SectionHeader from '@/components/ui/SectionHeader'
-import ActionPanel from '@/components/ui/ActionPanel'
 import ServerGrid from '@/components/Dashboard/ServerGrid'
 import { useGuildStore } from '@/stores/guildStore'
 import { useAuthStore } from '@/stores/authStore'
@@ -18,153 +16,164 @@ export default function ServersPage() {
 
     usePageMetadata({
         title: 'Servers - Lucky',
-        description: 'View and manage your Discord servers',
+        description: 'Manage your Discord servers with Lucky',
     })
 
     const withBotCount = guilds.filter((g) => g.botAdded).length
-    const withoutBotCount = guilds.length - withBotCount
+    const primaryGuild = guilds[0]
+    const secondaryGuilds = guilds.slice(1)
 
     if (isLoading) {
         return (
-            <main className='space-y-6'>
-                <div className='surface-panel flex items-center gap-4 p-5'>
+            <main className='space-y-8'>
+                <div className='surface-panel flex items-center gap-4 p-6'>
                     <Skeleton className='h-16 w-16 rounded-full' />
-                    <div className='space-y-2'>
-                        <Skeleton className='h-7 w-36' />
+                    <div className='space-y-2 flex-1'>
+                        <Skeleton className='h-6 w-32' />
                         <Skeleton className='h-4 w-40' />
                     </div>
                 </div>
-                <div className='grid gap-4 lg:grid-cols-2'>
-                    <div className='surface-panel p-5'>
-                        <Skeleton className='mb-3 h-4 w-24' />
-                        <Skeleton className='h-4 w-full' />
-                    </div>
-                    <div className='surface-panel p-5'>
-                        <Skeleton className='mb-3 h-4 w-24' />
-                        <Skeleton className='h-4 w-full' />
-                    </div>
+                <div className='space-y-4'>
+                    <Skeleton className='h-8 w-48' />
+                    <Skeleton className='h-40 w-full' />
                 </div>
-                <ServerGrid />
             </main>
         )
     }
 
     return (
-        <main className='space-y-6'>
-            <div className='surface-panel flex flex-wrap items-center gap-4 p-5'>
-                <Avatar className='h-16 w-16 border border-lucky-border'>
+        <main className='space-y-8'>
+            <div className='surface-panel flex flex-wrap items-center gap-6 p-6'>
+                <Avatar className='h-16 w-16 border border-lucky-border flex-shrink-0'>
                     <AvatarImage
                         src={user?.avatar || undefined}
                         alt={user?.username || 'User avatar'}
                     />
-                    <AvatarFallback className='bg-lucky-brand/20 type-h2 text-lucky-brand'>
+                    <AvatarFallback className='bg-lucky-brand/20 font-semibold text-lucky-brand'>
                         {user?.username?.substring(0, 2).toUpperCase()}
                     </AvatarFallback>
                 </Avatar>
 
                 <div className='space-y-1'>
-                    <p className='type-meta text-lucky-text-tertiary'>
-                        Discord profile
+                    <p className='text-xs uppercase tracking-wider text-lucky-text-tertiary'>
+                        Discord Account
                     </p>
-                    <p className='type-title text-lucky-text-primary'>
+                    <p className='text-lg font-semibold text-lucky-text-primary'>
                         {user?.username}
-                    </p>
-                    <p className='type-body-sm text-lucky-text-secondary'>
-                        @{user?.username}
                     </p>
                 </div>
 
-                <div className='ml-auto rounded-xl border border-lucky-border bg-lucky-bg-tertiary/70 px-4 py-2 text-center'>
-                    <p className='type-meta text-lucky-text-tertiary'>
-                        Total servers
+                <div className='ml-auto text-right flex-shrink-0'>
+                    <p className='text-xs uppercase tracking-wider text-lucky-text-tertiary'>
+                        Total Servers
                     </p>
-                    <p className='type-h2 text-lucky-text-primary'>
+                    <p className='text-2xl font-bold text-lucky-brand'>
                         {guilds.length}
                     </p>
                 </div>
             </div>
 
-            <SectionHeader
-                eyebrow='Guild management'
-                title='Servers'
-                description={`${guilds.length} server${guilds.length !== 1 ? 's' : ''} — ${withBotCount} with Lucky installed`}
-            />
-
-            <nav
-                className='flex flex-wrap gap-2'
-                aria-label='Server navigation'
-            >
-                {(
-                    [
-                        { label: 'Servers', icon: <LayoutGrid className='h-4 w-4' />, active: true, onClick: undefined },
-                        { label: 'Premium', icon: <Crown className='h-4 w-4' />, active: false, onClick: () => navigate('/features') },
-                        { label: 'Settings', icon: <Settings className='h-4 w-4' />, active: false, onClick: () => navigate('/settings') },
-                    ] as const
-                ).map((tab) => (
-                    <button
-                        key={tab.label}
-                        className={cn(
-                            'type-body-sm inline-flex items-center gap-2 rounded-xl border px-4 py-2 transition-colors',
-                            tab.active
-                                ? 'border-lucky-border-strong bg-lucky-bg-active text-lucky-text-primary'
-                                : 'border-lucky-border bg-lucky-bg-secondary text-lucky-text-secondary hover:text-lucky-text-primary hover:border-lucky-border-strong',
-                        )}
-                        aria-current={tab.active ? 'page' : undefined}
-                        onClick={tab.onClick}
-                    >
-                        {tab.icon}
-                        {tab.label}
-                    </button>
-                ))}
-            </nav>
-
-            <div className='grid gap-4 lg:grid-cols-2'>
-                <ActionPanel
-                    title='Bot Installed'
-                    description={
-                        withBotCount === 0
-                            ? 'Lucky is not installed in any of your servers yet.'
-                            : `Lucky is active in ${withBotCount} of your ${guilds.length} server${guilds.length !== 1 ? 's' : ''}.`
-                    }
-                    icon={<ShieldCheck className='h-4 w-4' />}
-                    action={
-                        withBotCount > 0 ? (
-                            <span className='type-body-sm rounded-lg bg-lucky-success/15 px-3 py-1 text-lucky-success'>
-                                {withBotCount} active
-                            </span>
-                        ) : undefined
-                    }
-                />
-                <ActionPanel
-                    title='Invite Lucky'
-                    description={
-                        withoutBotCount === 0
-                            ? 'Great — Lucky is installed in all your servers.'
-                            : `${withoutBotCount} server${withoutBotCount !== 1 ? 's' : ''} ${withoutBotCount !== 1 ? 'are' : 'is'} missing Lucky.`
-                    }
-                    icon={<LayoutGrid className='h-4 w-4' />}
-                    action={
-                        withoutBotCount > 0 ? (
-                            <a
-                                href='#servers-heading'
-                                className='type-body-sm rounded-lg border border-lucky-border px-3 py-1.5 text-lucky-text-secondary hover:text-lucky-text-primary transition-colors'
+            <div className='space-y-6'>
+                <div className='flex items-baseline justify-between'>
+                    <div>
+                        <h1 className='text-3xl font-bold text-lucky-text-primary' style={{ fontFamily: 'var(--font-lucky-display)' }}>
+                            Your Servers
+                        </h1>
+                        <p className='text-sm text-lucky-text-tertiary mt-2'>
+                            {withBotCount} of {guilds.length} with Lucky installed
+                        </p>
+                    </div>
+                    <nav className='flex gap-2'>
+                        {(
+                            [
+                                { label: 'All', icon: LayoutGrid, active: true, onClick: undefined },
+                                { label: 'Premium', icon: Crown, active: false, onClick: () => navigate('/features') },
+                                { label: 'Settings', icon: Settings, active: false, onClick: () => navigate('/settings') },
+                            ] as const
+                        ).map(({ label, icon: Icon, active, onClick }) => (
+                            <button
+                                key={label}
+                                className={cn(
+                                    'inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition-colors',
+                                    active
+                                        ? 'border-lucky-border-strong bg-lucky-bg-active text-lucky-text-primary'
+                                        : 'border-lucky-border bg-transparent text-lucky-text-secondary hover:text-lucky-text-primary hover:bg-lucky-bg-tertiary',
+                                )}
+                                aria-current={active ? 'page' : undefined}
+                                onClick={onClick}
                             >
-                                View servers
-                            </a>
-                        ) : undefined
-                    }
-                />
-            </div>
+                                <Icon className='h-4 w-4' />
+                                {label}
+                            </button>
+                        ))}
+                    </nav>
+                </div>
 
-            <section aria-labelledby='servers-heading' className='space-y-4'>
-                <h2
-                    id='servers-heading'
-                    className='type-title text-lucky-text-primary'
-                >
-                    Your Servers
-                </h2>
-                <ServerGrid />
-            </section>
+                {primaryGuild && (
+                    <section className='space-y-3'>
+                        <h2 className='text-xs uppercase tracking-wider text-lucky-text-tertiary'>
+                            Recently Active
+                        </h2>
+                        <button
+                            onClick={() => navigate(`/guild/${primaryGuild.id}`)}
+                            className={cn(
+                                'surface-panel w-full p-6 text-left border-2 transition-all hover:border-lucky-brand/50',
+                                primaryGuild.botAdded ? 'border-lucky-border-strong' : 'border-lucky-border',
+                            )}
+                        >
+                            <div className='flex items-start gap-4'>
+                                <Avatar className='h-14 w-14 border border-lucky-border flex-shrink-0'>
+                                    <AvatarImage
+                                        src={primaryGuild.icon || undefined}
+                                        alt={primaryGuild.name}
+                                    />
+                                    <AvatarFallback className='bg-lucky-brand/15 text-lucky-brand font-semibold'>
+                                        {primaryGuild.name.substring(0, 2).toUpperCase()}
+                                    </AvatarFallback>
+                                </Avatar>
+                                <div className='flex-1 min-w-0'>
+                                    <h3 className='text-base font-semibold text-lucky-text-primary truncate'>
+                                        {primaryGuild.name}
+                                    </h3>
+                                    {primaryGuild.botAdded ? (
+                                        <p className='text-xs text-lucky-success mt-1 inline-block'>
+                                            Lucky installed
+                                        </p>
+                                    ) : (
+                                        <p className='text-xs text-lucky-text-tertiary mt-1'>
+                                            Invite Lucky
+                                        </p>
+                                    )}
+                                </div>
+                                <ExternalLink className='h-4 w-4 text-lucky-text-tertiary flex-shrink-0 mt-1' />
+                            </div>
+                        </button>
+                    </section>
+                )}
+
+                {secondaryGuilds.length > 0 && (
+                    <section className='space-y-3'>
+                        <h2 className='text-xs uppercase tracking-wider text-lucky-text-tertiary'>
+                            All Other Servers
+                        </h2>
+                        <ServerGrid />
+                    </section>
+                )}
+
+                {guilds.length === 0 && (
+                    <div className='surface-panel rounded-lg p-12 text-center'>
+                        <div className='w-12 h-12 rounded-full bg-lucky-bg-tertiary mx-auto mb-4 flex items-center justify-center'>
+                            <LayoutGrid className='h-6 w-6 text-lucky-text-tertiary' />
+                        </div>
+                        <p className='text-lucky-text-primary font-medium mb-2'>
+                            No servers yet
+                        </p>
+                        <p className='text-sm text-lucky-text-secondary'>
+                            Join a Discord server and Lucky will appear here.
+                        </p>
+                    </div>
+                )}
+            </div>
         </main>
     )
 }


### PR DESCRIPTION
## Summary
- **Register:** consumer-saas (workspace picker + signin funnel)
- **Anchors:** Notion workspace switcher + Linear workspace picker (ServersPage); Linear signin + Vercel signin (Login)
- **Tokens:** Lucky locked palette (Sora display / Manrope body / JetBrains mono, #ec4899 brand, surface tokens)

### ServersPage.tsx (+24 net LOC)
Asymmetric layout: profile header → h1 + nav tabs → emphasized primary server card → secondary grid → empty state. Replaces the prior identical-card grid (anti-pattern #5).

### Login.tsx (−21 net LOC)
Single-column centered signin: hero (Sora h1 with brand) → signin card → badge list → footer. Removed glassmorphism + decorative StatTiles. Brand visible without nav.

### Slop audit
0 em dashes, 0 gradient text, 0 default shadows, 0 glassmorphism, 0 generic CTAs, 0 platitudes. CLEAN.

## Test plan
- [ ] CI passes
- [ ] Manual: `/servers` and `/login` render correctly in Vercel preview
- [ ] Auth flow still works end-to-end