### PR TITLE
ui(moderation,automod): redesign admin surfaces via /ui-expert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1464,7 +1464,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1474,7 +1474,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1508,7 +1508,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1806,7 +1806,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -9665,6 +9665,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9681,6 +9682,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9697,6 +9699,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9713,6 +9716,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9729,6 +9733,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9745,6 +9750,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9761,6 +9767,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9777,6 +9784,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9793,6 +9801,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9809,6 +9818,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9825,6 +9835,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9841,6 +9852,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -18993,7 +19005,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",

--- a/packages/frontend/src/pages/AutoMod.tsx
+++ b/packages/frontend/src/pages/AutoMod.tsx
@@ -34,7 +34,6 @@ import { toast } from 'sonner'
 import { api } from '@/services/api'
 import { ApiError } from '@/services/ApiError'
 import { useGuildStore } from '@/stores/guildStore'
-import { cn } from '@/lib/utils'
 import type {
     AutoModSettings,
     AutoModTemplate,

--- a/packages/frontend/src/pages/AutoMod.tsx
+++ b/packages/frontend/src/pages/AutoMod.tsx
@@ -42,39 +42,31 @@ import type {
     GuildRoleOption,
 } from '@/types'
 
-interface FilterCardProps {
+interface FilterRowProps {
     title: string
     description: string
     icon: React.ComponentType<{ className?: string }>
     enabled: boolean
     onToggle: (enabled: boolean) => void
-    accent: string
     children?: React.ReactNode
 }
 
-function FilterCard({
+function FilterRow({
     title,
     description,
     icon: Icon,
     enabled,
     onToggle,
-    accent,
     children,
-}: FilterCardProps) {
+}: FilterRowProps) {
     return (
-        <Card
-            className={cn(
-                'p-0 overflow-hidden transition-all',
-                enabled
-                    ? 'border-lucky-border/80 ring-1 ring-lucky-border/30'
-                    : 'opacity-80',
-            )}
-        >
-            <div className='flex items-center justify-between p-4 pb-3'>
-                <div className='flex items-center gap-3'>
-                    <div className={cn('p-2 rounded-lg', accent)}>
-                        <Icon className='w-4 h-4 text-white' />
-                    </div>
+        <div className='border-b border-lucky-border/50 last:border-b-0'>
+            <button
+                onClick={() => onToggle(!enabled)}
+                className='w-full flex items-center justify-between px-6 py-3 hover:bg-[rgba(236,72,153,0.02)] transition-colors'
+            >
+                <div className='flex items-center gap-3 flex-1 text-left'>
+                    <Icon className='w-4 h-4 text-lucky-brand flex-shrink-0' />
                     <div>
                         <h3 className='text-sm font-semibold text-white'>
                             {title}
@@ -85,19 +77,21 @@ function FilterCard({
                     </div>
                 </div>
                 <Switch checked={enabled} onCheckedChange={onToggle} />
-            </div>
+            </button>
             {enabled && children && (
                 <motion.div
                     initial={{ height: 0, opacity: 0 }}
                     animate={{ height: 'auto', opacity: 1 }}
                     exit={{ height: 0, opacity: 0 }}
                     transition={{ duration: 0.2 }}
-                    className='border-t border-lucky-border'
+                    className='border-t border-lucky-border/30'
                 >
-                    <div className='p-4 pt-3 space-y-3'>{children}</div>
+                    <div className='px-6 py-3 space-y-3 bg-lucky-bg-secondary/20'>
+                        {children}
+                    </div>
                 </motion.div>
             )}
-        </Card>
+        </div>
     )
 }
 
@@ -253,7 +247,7 @@ function ChannelPicker({
             )}
             {channels.length === 0 && (
                 <p className='text-xs text-lucky-text-tertiary'>
-                    Channels unavailable — enter IDs manually below
+                    Channels unavailable, enter IDs manually below
                 </p>
             )}
         </div>
@@ -317,7 +311,7 @@ function RolePicker({
             )}
             {roles.length === 0 && (
                 <p className='text-xs text-lucky-text-tertiary'>
-                    Roles unavailable — enter IDs manually below
+                    Roles unavailable, enter IDs manually below
                 </p>
             )}
         </div>
@@ -680,9 +674,9 @@ export default function AutoModPage() {
                 </Button>
             </div>
 
-            <div className='grid grid-cols-1 lg:grid-cols-2 gap-4'>
+            <div className='space-y-6'>
+                {/* Templates Section */}
                 <motion.div
-                    className='lg:col-span-2'
                     initial={{ opacity: 0, y: 8 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0 }}
@@ -702,157 +696,127 @@ export default function AutoModPage() {
                     </Card>
                 </motion.div>
 
-                {/* Spam Detection */}
+                {/* Content Filters */}
                 <motion.div
                     initial={{ opacity: 0, y: 8 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.05 }}
                 >
-                    <FilterCard
-                        title='Spam Detection'
-                        description='Detect and act on message spam'
-                        icon={MessageSquare}
-                        enabled={settings.spamEnabled}
-                        onToggle={(v) => update('spamEnabled', v)}
-                        accent='bg-orange-500/20'
-                    >
-                        <div className='grid grid-cols-2 gap-3'>
-                            <NumberInput
-                                label='Max messages'
-                                value={settings.spamThreshold}
-                                onChange={(v) => update('spamThreshold', v)}
-                                min={2}
-                                max={20}
-                            />
-                            <NumberInput
-                                label='Time window (s)'
-                                value={settings.spamTimeWindow}
-                                onChange={(v) => update('spamTimeWindow', v)}
-                                min={1}
-                                max={60}
-                            />
+                    <Card className='overflow-hidden'>
+                        <div className='px-6 py-4 border-b border-lucky-border/50'>
+                            <h2 className='text-base font-semibold text-white'>
+                                Content Filters
+                            </h2>
                         </div>
-                    </FilterCard>
-                </motion.div>
-
-                {/* Caps Detection */}
-                <motion.div
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: 0.05 }}
-                >
-                    <FilterCard
-                        title='Caps Lock Detection'
-                        description='Detect excessive use of capital letters'
-                        icon={Type}
-                        enabled={settings.capsEnabled}
-                        onToggle={(v) => update('capsEnabled', v)}
-                        accent='bg-yellow-500/20'
-                    >
-                        <NumberInput
-                            label='Caps threshold (%)'
-                            value={settings.capsThreshold}
-                            onChange={(v) => update('capsThreshold', v)}
-                            min={50}
-                            max={100}
+                        <FilterRow
+                            title='Spam Detection'
+                            description='Detect and act on message spam'
+                            icon={MessageSquare}
+                            enabled={settings.spamEnabled}
+                            onToggle={(v) => update('spamEnabled', v)}
+                        >
+                            <div className='grid grid-cols-2 gap-3'>
+                                <NumberInput
+                                    label='Max messages'
+                                    value={settings.spamThreshold}
+                                    onChange={(v) => update('spamThreshold', v)}
+                                    min={2}
+                                    max={20}
+                                />
+                                <NumberInput
+                                    label='Time window (s)'
+                                    value={settings.spamTimeWindow}
+                                    onChange={(v) => update('spamTimeWindow', v)}
+                                    min={1}
+                                    max={60}
+                                />
+                            </div>
+                        </FilterRow>
+                        <FilterRow
+                            title='Caps Lock Detection'
+                            description='Detect excessive use of capital letters'
+                            icon={Type}
+                            enabled={settings.capsEnabled}
+                            onToggle={(v) => update('capsEnabled', v)}
+                        >
+                            <NumberInput
+                                label='Caps threshold (%)'
+                                value={settings.capsThreshold}
+                                onChange={(v) => update('capsThreshold', v)}
+                                min={50}
+                                max={100}
+                            />
+                        </FilterRow>
+                        <FilterRow
+                            title='Link Filtering'
+                            description='Block or restrict links in messages'
+                            icon={Link2}
+                            enabled={settings.linksEnabled}
+                            onToggle={(v) => update('linksEnabled', v)}
+                        >
+                            <div className='space-y-1.5'>
+                                <Label className='text-xs text-lucky-text-secondary'>
+                                    Allowed domains
+                                </Label>
+                                <TagList
+                                    items={settings.allowedDomains}
+                                    onAdd={(d) =>
+                                        update('allowedDomains', [
+                                            ...settings.allowedDomains,
+                                            d,
+                                        ])
+                                    }
+                                    onRemove={(d) =>
+                                        update(
+                                            'allowedDomains',
+                                            settings.allowedDomains.filter(
+                                                (x) => x !== d,
+                                            ),
+                                        )
+                                    }
+                                    placeholder='e.g. youtube.com'
+                                />
+                            </div>
+                        </FilterRow>
+                        <FilterRow
+                            title='Invite Link Filtering'
+                            description='Block Discord invite links'
+                            icon={Mail}
+                            enabled={settings.invitesEnabled}
+                            onToggle={(v) => update('invitesEnabled', v)}
                         />
-                    </FilterCard>
-                </motion.div>
-
-                {/* Link Filtering */}
-                <motion.div
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: 0.1 }}
-                >
-                    <FilterCard
-                        title='Link Filtering'
-                        description='Block or restrict links in messages'
-                        icon={Link2}
-                        enabled={settings.linksEnabled}
-                        onToggle={(v) => update('linksEnabled', v)}
-                        accent='bg-blue-500/20'
-                    >
-                        <div className='space-y-1.5'>
-                            <Label className='text-xs text-lucky-text-secondary'>
-                                Allowed domains
-                            </Label>
-                            <TagList
-                                items={settings.allowedDomains}
-                                onAdd={(d) =>
-                                    update('allowedDomains', [
-                                        ...settings.allowedDomains,
-                                        d,
-                                    ])
-                                }
-                                onRemove={(d) =>
-                                    update(
-                                        'allowedDomains',
-                                        settings.allowedDomains.filter(
-                                            (x) => x !== d,
-                                        ),
-                                    )
-                                }
-                                placeholder='e.g. youtube.com'
-                            />
-                        </div>
-                    </FilterCard>
-                </motion.div>
-
-                {/* Invite Filtering */}
-                <motion.div
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: 0.15 }}
-                >
-                    <FilterCard
-                        title='Invite Link Filtering'
-                        description='Block Discord invite links'
-                        icon={Mail}
-                        enabled={settings.invitesEnabled}
-                        onToggle={(v) => update('invitesEnabled', v)}
-                        accent='bg-purple-500/20'
-                    />
-                </motion.div>
-
-                {/* Banned Words */}
-                <motion.div
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: 0.2 }}
-                >
-                    <FilterCard
-                        title='Banned Words'
-                        description='Filter messages containing specific words'
-                        icon={Ban}
-                        enabled={settings.wordsEnabled}
-                        onToggle={(v) => update('wordsEnabled', v)}
-                        accent='bg-red-500/20'
-                    >
-                        <div className='space-y-1.5'>
-                            <Label className='text-xs text-lucky-text-secondary'>
-                                Banned words
-                            </Label>
-                            <TagList
-                                items={settings.bannedWords}
-                                onAdd={(w) =>
-                                    update('bannedWords', [
-                                        ...settings.bannedWords,
-                                        w,
-                                    ])
-                                }
-                                onRemove={(w) =>
-                                    update(
-                                        'bannedWords',
-                                        settings.bannedWords.filter(
-                                            (x) => x !== w,
-                                        ),
-                                    )
-                                }
-                                placeholder='Add a word to ban...'
-                            />
-                        </div>
-                    </FilterCard>
+                        <FilterRow
+                            title='Banned Words'
+                            description='Filter messages containing specific words'
+                            icon={Ban}
+                            enabled={settings.wordsEnabled}
+                            onToggle={(v) => update('wordsEnabled', v)}
+                        >
+                            <div className='space-y-1.5'>
+                                <Label className='text-xs text-lucky-text-secondary'>
+                                    Banned words
+                                </Label>
+                                <TagList
+                                    items={settings.bannedWords}
+                                    onAdd={(w) =>
+                                        update('bannedWords', [
+                                            ...settings.bannedWords,
+                                            w,
+                                        ])
+                                    }
+                                    onRemove={(w) =>
+                                        update(
+                                            'bannedWords',
+                                            settings.bannedWords.filter(
+                                                (x) => x !== w,
+                                            ),
+                                        )
+                                    }
+                                    placeholder='Add a word to ban...'
+                                />
+                            </div>
+                        </FilterRow>
+                    </Card>
                 </motion.div>
             </div>
 
@@ -860,21 +824,23 @@ export default function AutoModPage() {
             <motion.div
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.3 }}
+                transition={{ delay: 0.1 }}
             >
-                <Card className='p-5'>
-                    <div className='flex items-center gap-2 mb-4'>
-                        <CheckCircle2 className='w-5 h-5 text-lucky-success' />
-                        <h2 className='text-base font-semibold text-white'>
-                            Exemptions
-                        </h2>
+                <Card className='overflow-hidden'>
+                    <div className='px-6 py-4 border-b border-lucky-border/50'>
+                        <div className='flex items-center gap-2 mb-2'>
+                            <CheckCircle2 className='w-5 h-5 text-lucky-success' />
+                            <h2 className='text-base font-semibold text-white'>
+                                Exemptions
+                            </h2>
+                        </div>
+                        <p className='text-xs text-lucky-text-tertiary'>
+                            Channels and roles exempt from auto-moderation
+                            filters
+                        </p>
                     </div>
-                    <p className='text-xs text-lucky-text-tertiary mb-4'>
-                        Channels and roles that are exempt from auto-moderation
-                        filters
-                    </p>
-                    <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-                        <div className='space-y-2'>
+                    <div className='grid grid-cols-1 md:grid-cols-2'>
+                        <div className='p-6 space-y-3 border-r border-lucky-border/50 md:border-r md:border-b-0 border-b md:border-b-0'>
                             <Label className='text-xs text-lucky-text-secondary'>
                                 Exempt Channels
                             </Label>
@@ -917,7 +883,7 @@ export default function AutoModPage() {
                                 />
                             )}
                         </div>
-                        <div className='space-y-2'>
+                        <div className='p-6 space-y-3'>
                             <Label className='text-xs text-lucky-text-secondary'>
                                 Exempt Roles
                             </Label>

--- a/packages/frontend/src/pages/Moderation.tsx
+++ b/packages/frontend/src/pages/Moderation.tsx
@@ -11,12 +11,7 @@ import {
     ChevronLeft,
     ChevronRight,
     X,
-    Eye,
-    Hash,
-    User,
-    Calendar,
     BarChart3,
-    ChevronDown,
 } from 'lucide-react'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
@@ -34,7 +29,6 @@ import {
 import Skeleton from '@/components/ui/Skeleton'
 import { api } from '@/services/api'
 import { useGuildStore } from '@/stores/guildStore'
-import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import type { ModerationCase, ModerationStats } from '@/types'
 

--- a/packages/frontend/src/pages/Moderation.tsx
+++ b/packages/frontend/src/pages/Moderation.tsx
@@ -16,6 +16,7 @@ import {
     User,
     Calendar,
     BarChart3,
+    ChevronDown,
 } from 'lucide-react'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
@@ -30,12 +31,6 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select'
-import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog'
 import Skeleton from '@/components/ui/Skeleton'
 import { api } from '@/services/api'
 import { useGuildStore } from '@/stores/guildStore'
@@ -120,7 +115,7 @@ function timeAgo(dateStr: string): string {
 }
 
 
-function CaseDetailModal({
+function CaseDetailPanel({
     caseData,
     open,
     onClose,
@@ -138,126 +133,148 @@ function CaseDetailModal({
     const ActionIcon = ACTION_ICONS[caseData.type] || Shield
 
     return (
-        <Dialog open={open} onOpenChange={onClose}>
-            <DialogContent className='bg-lucky-bg-secondary border-lucky-border max-w-lg'>
-                <DialogHeader>
-                    <DialogTitle className='flex items-center gap-3 text-lucky-text-primary'>
-                        <div className={cn('p-2 rounded-lg', style.bg)}>
-                            <ActionIcon className={cn('w-5 h-5', style.text)} />
-                        </div>
-                        Case #{caseData.caseNumber}
-                    </DialogTitle>
-                </DialogHeader>
-                <div className='space-y-4 mt-2'>
-                    <div className='grid grid-cols-2 gap-4'>
-                        <div className='space-y-1'>
-                            <p className='type-meta text-lucky-text-tertiary flex items-center gap-1.5'>
-                                <User className='w-3 h-3' /> User
-                            </p>
-                            <p className='type-body-sm font-medium text-lucky-text-primary'>
-                                {caseData.userName || caseData.userId}
-                            </p>
-                        </div>
-                        <div className='space-y-1'>
-                            <p className='type-meta text-lucky-text-tertiary flex items-center gap-1.5'>
-                                <Shield className='w-3 h-3' /> Moderator
-                            </p>
-                            <p className='type-body-sm font-medium text-lucky-text-primary'>
-                                {caseData.moderatorName || caseData.moderatorId}
-                            </p>
-                        </div>
-                        <div className='space-y-1'>
-                            <p className='type-meta text-lucky-text-tertiary flex items-center gap-1.5'>
-                                <Hash className='w-3 h-3' /> Action
-                            </p>
-                            <Badge
-                                variant='outline'
-                                className={cn(
-                                    'type-meta uppercase font-semibold border',
-                                    style.bg,
-                                    style.text,
-                                    style.border,
-                                )}
+        <AnimatePresence>
+            {open && (
+                <>
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        onClick={onClose}
+                        className='fixed inset-0 z-40 bg-black/40'
+                    />
+                    <motion.div
+                        initial={{ x: '100%' }}
+                        animate={{ x: 0 }}
+                        exit={{ x: '100%' }}
+                        transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+                        className='fixed right-0 top-0 h-screen w-96 bg-lucky-bg-secondary border-l border-lucky-border z-50 flex flex-col'
+                    >
+                        <div className='flex items-center justify-between p-6 border-b border-lucky-border'>
+                            <div className='flex items-center gap-3'>
+                                <div className={cn('p-2 rounded-lg', style.bg)}>
+                                    <ActionIcon className={cn('w-5 h-5', style.text)} />
+                                </div>
+                                <h2 className='type-title text-lucky-text-primary'>
+                                    Case #{caseData.caseNumber}
+                                </h2>
+                            </div>
+                            <button
+                                onClick={onClose}
+                                className='text-lucky-text-tertiary hover:text-lucky-text-primary transition-colors p-1'
                             >
-                                {caseData.type}
-                            </Badge>
+                                <X className='w-5 h-5' />
+                            </button>
                         </div>
-                        <div className='space-y-1'>
-                            <p className='type-meta text-lucky-text-tertiary flex items-center gap-1.5'>
-                                <Calendar className='w-3 h-3' /> Date
-                            </p>
-                            <p className='type-body-sm text-lucky-text-secondary'>
-                                {formatDate(caseData.createdAt)}
-                            </p>
-                        </div>
-                    </div>
-                    <div className='p-3 rounded-lg bg-lucky-bg-tertiary border border-lucky-border'>
-                        <p className='type-meta text-lucky-text-tertiary mb-1'>
-                            Reason
-                        </p>
-                        <p className='type-body-sm text-lucky-text-secondary'>
-                            {caseData.reason || 'No reason provided'}
-                        </p>
-                    </div>
-                    {caseData.duration && (
-                        <div className='flex items-center gap-2'>
-                            <Clock className='w-4 h-4 text-lucky-text-tertiary' />
-                            <span className='type-body-sm text-lucky-text-secondary'>
-                                Duration: {Math.floor(caseData.duration / 60)}{' '}
-                                minutes
-                            </span>
-                        </div>
-                    )}
-                    <div className='flex items-center gap-3'>
-                        <div
-                            className={cn(
-                                'flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border',
-                                caseData.active
-                                    ? 'bg-green-500/10 text-green-400 border-green-500/20'
-                                    : 'bg-lucky-bg-tertiary text-lucky-text-tertiary border-lucky-border',
+
+                        <div className='flex-1 overflow-y-auto p-6 space-y-4'>
+                            <div className='space-y-1'>
+                                <p className='type-meta text-lucky-text-tertiary'>
+                                    User
+                                </p>
+                                <p className='type-body text-lucky-text-primary'>
+                                    {caseData.userName || caseData.userId}
+                                </p>
+                            </div>
+
+                            <div className='space-y-1'>
+                                <p className='type-meta text-lucky-text-tertiary'>
+                                    Moderator
+                                </p>
+                                <p className='type-body text-lucky-text-primary'>
+                                    {caseData.moderatorName || caseData.moderatorId}
+                                </p>
+                            </div>
+
+                            <div className='space-y-1'>
+                                <p className='type-meta text-lucky-text-tertiary'>
+                                    Action
+                                </p>
+                                <Badge
+                                    variant='outline'
+                                    className={cn(
+                                        'type-meta uppercase font-semibold border',
+                                        style.bg,
+                                        style.text,
+                                        style.border,
+                                    )}
+                                >
+                                    {caseData.type}
+                                </Badge>
+                            </div>
+
+                            <div className='space-y-1'>
+                                <p className='type-meta text-lucky-text-tertiary'>
+                                    Date
+                                </p>
+                                <p className='type-body-sm text-lucky-text-secondary'>
+                                    {formatDate(caseData.createdAt)}
+                                </p>
+                            </div>
+
+                            <div className='space-y-1 pt-2'>
+                                <p className='type-meta text-lucky-text-tertiary mb-2'>
+                                    Reason
+                                </p>
+                                <p className='type-body-sm text-lucky-text-secondary bg-lucky-bg-tertiary border border-lucky-border rounded-lg p-3'>
+                                    {caseData.reason || 'No reason provided'}
+                                </p>
+                            </div>
+
+                            {caseData.duration && (
+                                <div className='space-y-1'>
+                                    <p className='type-meta text-lucky-text-tertiary'>
+                                        Duration
+                                    </p>
+                                    <p className='type-body-sm text-lucky-text-secondary'>
+                                        {Math.floor(caseData.duration / 60)} minutes
+                                    </p>
+                                </div>
                             )}
-                        >
-                            <div
-                                className={cn(
-                                    'w-1.5 h-1.5 rounded-full',
-                                    caseData.active
-                                        ? 'bg-green-400'
-                                        : 'bg-lucky-text-disabled',
+
+                            <div className='flex gap-2 pt-4'>
+                                <div
+                                    className={cn(
+                                        'flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border',
+                                        caseData.active
+                                            ? 'bg-green-500/10 text-green-400 border-green-500/20'
+                                            : 'bg-lucky-bg-tertiary text-lucky-text-tertiary border-lucky-border',
+                                    )}
+                                >
+                                    <div
+                                        className={cn(
+                                            'w-1.5 h-1.5 rounded-full',
+                                            caseData.active
+                                                ? 'bg-green-400'
+                                                : 'bg-lucky-text-disabled',
+                                        )}
+                                    />
+                                    {caseData.active ? 'Active' : 'Expired'}
+                                </div>
+                                {caseData.appealed && (
+                                    <div className='flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'>
+                                        Appealed
+                                    </div>
                                 )}
-                            />
-                            {caseData.active ? 'Active' : 'Expired'}
+                            </div>
                         </div>
-                        {caseData.appealed && (
-                            <div className='flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-yellow-500/10 text-yellow-400 border border-yellow-500/20'>
-                                Appealed
+
+                        {caseData.active && (
+                            <div className='border-t border-lucky-border p-4'>
+                                <Button
+                                    onClick={() => onDeactivate(caseData.id)}
+                                    disabled={deactivating}
+                                    variant='destructive'
+                                    className='w-full'
+                                >
+                                    {deactivating ? 'Deactivating...' : 'Deactivate Case'}
+                                </Button>
                             </div>
                         )}
-                    </div>
-                    <div className='flex justify-end gap-2 pt-2 border-t border-lucky-border'>
-                        <Button
-                            size='sm'
-                            variant='ghost'
-                            onClick={onClose}
-                            disabled={deactivating}
-                        >
-                            Close
-                        </Button>
-                        {caseData.active && (
-                            <Button
-                                size='sm'
-                                variant='destructive'
-                                onClick={() => onDeactivate(caseData.id)}
-                                disabled={deactivating}
-                            >
-                                {deactivating
-                                    ? 'Deactivating...'
-                                    : 'Deactivate Case'}
-                            </Button>
-                        )}
-                    </div>
-                </div>
-            </DialogContent>
-        </Dialog>
+                    </motion.div>
+                </>
+            )}
+        </AnimatePresence>
     )
 }
 
@@ -467,7 +484,7 @@ export default function ModerationPage() {
             {/* Cases Table */}
             <Card className='overflow-hidden p-0'>
                 {/* Header */}
-                <div className='hidden md:grid grid-cols-[60px_1fr_1fr_100px_100px_140px_48px] gap-4 px-5 py-3 border-b border-lucky-border bg-lucky-bg-tertiary/30'>
+                <div className='hidden md:grid grid-cols-[40px_1fr_1fr_80px_80px_120px] gap-4 px-6 py-3 border-b border-lucky-border bg-lucky-bg-tertiary/20'>
                     {[
                         '#',
                         'User',
@@ -475,11 +492,10 @@ export default function ModerationPage() {
                         'Type',
                         'Status',
                         'Date',
-                        '',
                     ].map((h) => (
                         <span
                             key={h}
-                            className='type-meta text-lucky-text-tertiary'
+                            className='type-meta text-lucky-text-tertiary text-xs'
                         >
                             {h}
                         </span>
@@ -492,16 +508,14 @@ export default function ModerationPage() {
                         Array.from({ length: 8 }).map((_, i) => (
                             <div
                                 key={i}
-                                className='flex items-center gap-4 px-5 py-3.5'
+                                className='grid grid-cols-1 md:grid-cols-[40px_1fr_1fr_80px_80px_120px] gap-2 md:gap-4 px-6 py-3'
                             >
-                                <Skeleton className='w-10 h-4' />
-                                <Skeleton className='w-8 h-8 rounded-full' />
-                                <div className='flex-1 space-y-1'>
-                                    <Skeleton className='h-4 w-28' />
-                                    <Skeleton className='h-3 w-20' />
-                                </div>
-                                <Skeleton className='h-5 w-16 rounded-full' />
-                                <Skeleton className='h-4 w-20' />
+                                <Skeleton className='h-3 w-6' />
+                                <Skeleton className='h-3 w-32' />
+                                <Skeleton className='h-3 w-28' />
+                                <Skeleton className='h-5 w-12 rounded-full' />
+                                <Skeleton className='h-4 w-16' />
+                                <Skeleton className='h-3 w-20' />
                             </div>
                         ))
                     ) : cases.length > 0 ? (
@@ -520,76 +534,53 @@ export default function ModerationPage() {
                                             duration: 0.15,
                                             delay: prefersReducedMotion ? 0 : i * 0.02,
                                         }}
-                                        className='grid grid-cols-1 md:grid-cols-[60px_1fr_1fr_100px_100px_140px_48px] gap-2 md:gap-4 px-5 py-3.5 hover:bg-lucky-bg-tertiary/30 transition-colors cursor-pointer group'
+                                        className='grid grid-cols-1 md:grid-cols-[40px_1fr_1fr_80px_80px_120px] gap-2 md:gap-4 px-6 py-3 items-center hover:bg-[rgba(236,72,153,0.04)] transition-colors cursor-pointer'
                                         onClick={() => setSelectedCase(c)}
                                     >
-                                        <div className='flex items-center'>
-                                            <span className='type-meta font-mono text-lucky-text-tertiary normal-case tracking-normal'>
-                                                #{c.caseNumber}
-                                            </span>
-                                        </div>
-                                        <div className='flex items-center gap-2.5 min-w-0'>
-                                            <div className='w-7 h-7 rounded-full bg-lucky-bg-active flex items-center justify-center shrink-0'>
-                                                <span className='type-meta font-medium text-lucky-text-secondary normal-case tracking-normal'>
-                                                    {(c.userName || c.userId)
-                                                        .substring(0, 2)
-                                                        .toUpperCase()}
-                                                </span>
-                                            </div>
-                                            <span className='type-body-sm text-lucky-text-primary truncate'>
-                                                {c.userName || c.userId}
-                                            </span>
-                                        </div>
-                                        <div className='flex items-center min-w-0'>
-                                            <span className='type-body-sm text-lucky-text-secondary truncate'>
-                                                {c.moderatorName ||
-                                                    c.moderatorId}
-                                            </span>
-                                        </div>
-                                        <div className='flex items-center'>
-                                            <Badge
-                                                variant='outline'
-                                                className={cn(
-                                                    'text-[10px] uppercase font-semibold gap-1 border',
-                                                    style.bg,
-                                                    style.text,
-                                                    style.border,
-                                                )}
-                                            >
-                                                <ActionIcon className='w-3 h-3' />
-                                                {c.type}
-                                            </Badge>
-                                        </div>
-                                        <div className='flex items-center'>
+                                        <span className='type-meta font-mono text-lucky-text-tertiary text-xs'>
+                                            {c.caseNumber}
+                                        </span>
+                                        <span className='type-body-sm text-lucky-text-primary truncate'>
+                                            {c.userName || c.userId}
+                                        </span>
+                                        <span className='type-body-sm text-lucky-text-secondary truncate'>
+                                            {c.moderatorName || c.moderatorId}
+                                        </span>
+                                        <Badge
+                                            variant='outline'
+                                            className={cn(
+                                                'text-[10px] uppercase font-semibold gap-1 border w-fit',
+                                                style.bg,
+                                                style.text,
+                                                style.border,
+                                            )}
+                                        >
+                                            <ActionIcon className='w-3 h-3' />
+                                            {c.type}
+                                        </Badge>
+                                        <div
+                                            className={cn(
+                                                'type-body-sm flex items-center gap-1',
+                                                c.active
+                                                    ? 'text-green-400'
+                                                    : 'text-lucky-text-tertiary',
+                                            )}
+                                        >
                                             <div
                                                 className={cn(
-                                                    'type-body-sm flex items-center gap-1.5',
+                                                    'w-1.5 h-1.5 rounded-full shrink-0',
                                                     c.active
-                                                        ? 'text-green-400'
-                                                        : 'text-lucky-text-tertiary',
+                                                        ? 'bg-green-400'
+                                                        : 'bg-lucky-text-disabled',
                                                 )}
-                                            >
-                                                <div
-                                                    className={cn(
-                                                        'w-1.5 h-1.5 rounded-full shrink-0',
-                                                        c.active
-                                                            ? 'bg-green-400'
-                                                            : 'bg-lucky-text-disabled',
-                                                    )}
-                                                />
-                                                {c.active
-                                                    ? 'Active'
-                                                    : 'Expired'}
-                                            </div>
-                                        </div>
-                                        <div className='flex items-center'>
-                                            <span className='type-body-sm text-lucky-text-tertiary'>
-                                                {timeAgo(c.createdAt)}
+                                            />
+                                            <span className='text-xs'>
+                                                {c.active ? 'Active' : 'Expired'}
                                             </span>
                                         </div>
-                                        <div className='flex items-center justify-center'>
-                                            <Eye className='w-4 h-4 text-lucky-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity' />
-                                        </div>
+                                        <span className='type-body-sm text-lucky-text-tertiary text-xs'>
+                                            {timeAgo(c.createdAt)}
+                                        </span>
                                     </motion.div>
                                 )
                             })}
@@ -612,7 +603,7 @@ export default function ModerationPage() {
                 {total > limit && (
                     <div className='flex items-center justify-between px-5 py-3 border-t border-lucky-border'>
                         <span className='type-body-sm text-lucky-text-tertiary'>
-                            Showing {(page - 1) * limit + 1}–
+                            Showing {(page - 1) * limit + 1} to
                             {Math.min(page * limit, total)} of {total}
                         </span>
                         <div className='flex items-center gap-1'>


### PR DESCRIPTION
## Summary
- **Register:** enterprise-admin (operator surfaces, dense data + dense forms)
- **Anchors:** Linear table density + Carbon admin pattern (Moderation); Linear settings rows + Polaris action bar (AutoMod)
- **Tokens:** Lucky locked palette (no new colors)

### Moderation.tsx
Linear issue-list table (36-40px rows, monospace case numbers, status pills, hover bg tint). Slide-over panel for case detail (NOT modal — anti-pattern #7 avoided).

### AutoMod.tsx
Compact row-based filter settings (Carbon admin pattern). Inline edit per rule; no card grid for rules.

### Slop audit
3 em dashes fixed. 1 `backdrop-blur` retained on mobile slide-over backdrop (atmosphere-goal exception per hard-bans table). All other patterns CLEAN.

## Test plan
- [ ] CI passes
- [ ] Manual: `/moderation` table + slide-over open/close
- [ ] Manual: `/automod` rule inline edit + save