### PR TITLE
fix(ci): lowercase image ref in yt-dlp smoke test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,4 +83,8 @@ jobs:
 
             - name: Smoke test yt-dlp
               if: matrix.service == 'bot'
-              run: docker run --rm "${{ env.IMAGE_PREFIX }}-${{ matrix.service }}:${{ steps.meta.outputs.version }}" yt-dlp --version
+              run: |
+                # Docker registry refs must be lowercase; IMAGE_PREFIX preserves
+                # the GitHub owner's case (LucasSantana-Dev), so normalize here.
+                IMAGE="$(printf '%s' "${{ env.IMAGE_PREFIX }}-${{ matrix.service }}" | tr '[:upper:]' '[:lower:]')"
+                docker run --rm "$IMAGE:${{ steps.meta.outputs.version }}" yt-dlp --version


### PR DESCRIPTION
**Hotfix for failing docker-publish on main (post-v2.11.0).**

The yt-dlp smoke test introduced in #854 references `${{ env.IMAGE_PREFIX }}-bot` directly, which preserves the GitHub owner's case (`LucasSantana-Dev`). Docker registry refs must be lowercase, so every main-branch build since #854 has failed with:

```
docker: invalid reference format: repository name (LucasSantana-Dev/lucky-bot) must be lowercase
```

This cascades into homelab deploy being skipped (workflow_run guard fails when docker-publish fails).

**Fix:** pipe the image ref through `tr '[:upper:]' '[:lower:]'` before `docker run`. The image was already pushed to the registry under the lowercase tag (`docker/metadata-action` lowercases automatically) — only the smoke-test step referenced the wrong case.

Blocks v2.11.0 deploy until merged.