### PR TITLE
ci(docker): add workflow_dispatch + retrigger on own workflow edits

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 name: Build & Push Docker Images
 
 on:
+    workflow_dispatch:
     push:
         branches: [main]
         paths:
@@ -10,6 +11,7 @@ on:
             - 'Dockerfile.*'
             - 'nginx/**'
             - 'package*.json'
+            - '.github/workflows/docker-publish.yml'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Follow-up to #866. The hotfix only touched `.github/workflows/docker-publish.yml`, but that path was not in the workflow's own push trigger — so the workflow did not re-run and v2.11.0 was never re-published.

Adds `workflow_dispatch` and adds the workflow file itself to the push path filter so future workflow edits self-trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker workflow configuration to support manual triggering and rebuild when workflow files change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/867)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->