### PR TITLE
ui(landing): redesign with self-hosted developer-tooling register

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -48,16 +48,22 @@ const LastFmPage = lazy(() => import('./pages/LastFm'))
 const SpotifyPage = lazy(() => import('./pages/Spotify'))
 const TermsOfServicePage = lazy(() => import('./pages/TermsOfService'))
 const PrivacyPolicyPage = lazy(() => import('./pages/PrivacyPolicy'))
+const DocsPage = lazy(() => import('./pages/Docs'))
+const ChangelogPage = lazy(() => import('./pages/Changelog'))
 
-const LEGAL_PATHS = [
+const PUBLIC_PATH_PREFIXES = [
     '/terms-of-service',
     '/terms',
     '/privacy-policy',
     '/privacy',
+    '/docs',
+    '/changelog',
 ]
 
-function isLegalPath(pathname: string) {
-    return LEGAL_PATHS.includes(pathname)
+function isPublicPath(pathname: string) {
+    return PUBLIC_PATH_PREFIXES.some(
+        (p) => pathname === p || pathname.startsWith(`${p}/`),
+    )
 }
 
 function ForbiddenModulePage({ module }: { module: ModuleKey }) {
@@ -218,13 +224,15 @@ function AuthenticatedRoutes() {
     )
 }
 
-function LegalRoutes() {
+function PublicRoutes() {
     return (
         <Routes>
             <Route path='/terms-of-service' element={<TermsOfServicePage />} />
             <Route path='/terms' element={<TermsOfServicePage />} />
             <Route path='/privacy-policy' element={<PrivacyPolicyPage />} />
             <Route path='/privacy' element={<PrivacyPolicyPage />} />
+            <Route path='/docs' element={<DocsPage />} />
+            <Route path='/changelog' element={<ChangelogPage />} />
             <Route
                 path='*'
                 element={<Navigate to='/terms-of-service' replace />}
@@ -248,12 +256,12 @@ function App() {
             .catch(() => setIsReady(true))
     }, [checkAuth])
 
-    if (isLegalPath(location.pathname)) {
+    if (isPublicPath(location.pathname)) {
         return (
             <div className='dark'>
                 <ErrorBoundary>
                     <Suspense fallback={<PageLoader />}>
-                        <LegalRoutes />
+                        <PublicRoutes />
                     </Suspense>
                 </ErrorBoundary>
                 <Analytics />

--- a/packages/frontend/src/components/DocsShell/DocsShell.tsx
+++ b/packages/frontend/src/components/DocsShell/DocsShell.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { ArrowUpRight, Menu, X } from 'lucide-react'
+import { ArrowUpRight } from 'lucide-react'
+import PublicHeader from './PublicHeader'
+import { useActiveHeading } from '@/hooks/useActiveHeading'
 
 export type DocsNavItem = {
     label: string
@@ -31,77 +33,19 @@ type Props = {
 export default function DocsShell({ nav, toc, breadcrumb, title, lastUpdated, children }: Props) {
     const location = useLocation()
     const [sidebarOpen, setSidebarOpen] = useState(false)
-    const [activeId, setActiveId] = useState<string | null>(null)
+    const activeId = useActiveHeading(toc?.map((t) => t.id) ?? [])
 
     useEffect(() => {
         setSidebarOpen(false)
     }, [location.pathname])
 
-    useEffect(() => {
-        if (!toc?.length) return
-        const headings = toc
-            .map((t) => document.getElementById(t.id))
-            .filter((el): el is HTMLElement => Boolean(el))
-
-        if (!headings.length) return
-
-        const obs = new IntersectionObserver(
-            (entries) => {
-                const visible = entries
-                    .filter((e) => e.isIntersecting)
-                    .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
-                if (visible[0]) setActiveId(visible[0].target.id)
-            },
-            { rootMargin: '-80px 0px -65% 0px', threshold: 0.1 },
-        )
-        headings.forEach((h) => obs.observe(h))
-        return () => obs.disconnect()
-    }, [toc])
-
     return (
         <div className='min-h-screen bg-lucky-surface-canvas text-white'>
-            <header className='sticky top-0 z-30 border-b border-lucky-border-soft bg-lucky-surface-canvas/85 backdrop-blur supports-[backdrop-filter]:bg-lucky-surface-canvas/65'>
-                <div className='mx-auto flex h-14 max-w-7xl items-center justify-between gap-3 px-4 md:px-6'>
-                    <div className='flex items-center gap-2'>
-                        <button
-                            onClick={() => setSidebarOpen((v) => !v)}
-                            aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
-                            className='lg:hidden inline-flex h-9 w-9 items-center justify-center rounded-md text-lucky-text-muted hover:bg-lucky-surface-panel hover:text-lucky-text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand'
-                        >
-                            {sidebarOpen ? <X size={16} /> : <Menu size={16} />}
-                        </button>
-                        <Link
-                            to='/'
-                            className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
-                        >
-                            <img src='/lucky-logo.png' alt='Lucky' width='24' height='24' className='h-6 w-6 rounded-full' loading='eager' />
-                            <span className='font-mono text-sm font-semibold tracking-tight'>
-                                lucky<span className='text-lucky-brand'>.</span>
-                            </span>
-                        </Link>
-                        <span className='ml-1 hidden text-lucky-border-strong md:inline'>/</span>
-                        <span className='hidden font-mono text-xs uppercase tracking-[0.2em] text-lucky-text-muted md:inline'>
-                            {breadcrumb}
-                        </span>
-                    </div>
-                    <nav className='flex items-center gap-1 font-mono text-xs text-lucky-text-muted'>
-                        <Link to='/docs' className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'>
-                            docs
-                        </Link>
-                        <Link to='/changelog' className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'>
-                            changelog
-                        </Link>
-                        <a
-                            href='https://github.com/LucasSantana-Dev/Lucky'
-                            target='_blank'
-                            rel='noreferrer'
-                            className='inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'
-                        >
-                            github <ArrowUpRight size={11} aria-hidden />
-                        </a>
-                    </nav>
-                </div>
-            </header>
+            <PublicHeader
+                breadcrumb={breadcrumb}
+                sidebarOpen={sidebarOpen}
+                onToggleSidebar={() => setSidebarOpen((v) => !v)}
+            />
 
             <div className='mx-auto grid max-w-7xl gap-0 px-0 md:px-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]'>
                 <DocsSidebar nav={nav} open={sidebarOpen} />

--- a/packages/frontend/src/components/DocsShell/DocsShell.tsx
+++ b/packages/frontend/src/components/DocsShell/DocsShell.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { ArrowUpRight, Menu, X } from 'lucide-react'
+
+export type DocsNavItem = {
+    label: string
+    href: string
+    external?: boolean
+}
+
+export type DocsNavGroup = {
+    heading: string
+    items: DocsNavItem[]
+}
+
+export type DocsTocItem = {
+    id: string
+    label: string
+    depth?: 2 | 3
+}
+
+type Props = {
+    nav: DocsNavGroup[]
+    toc?: DocsTocItem[]
+    breadcrumb: string
+    title: string
+    lastUpdated?: string
+    children: ReactNode
+}
+
+export default function DocsShell({ nav, toc, breadcrumb, title, lastUpdated, children }: Props) {
+    const location = useLocation()
+    const [sidebarOpen, setSidebarOpen] = useState(false)
+    const [activeId, setActiveId] = useState<string | null>(null)
+
+    useEffect(() => {
+        setSidebarOpen(false)
+    }, [location.pathname])
+
+    useEffect(() => {
+        if (!toc?.length) return
+        const headings = toc
+            .map((t) => document.getElementById(t.id))
+            .filter((el): el is HTMLElement => Boolean(el))
+
+        if (!headings.length) return
+
+        const obs = new IntersectionObserver(
+            (entries) => {
+                const visible = entries
+                    .filter((e) => e.isIntersecting)
+                    .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+                if (visible[0]) setActiveId(visible[0].target.id)
+            },
+            { rootMargin: '-80px 0px -65% 0px', threshold: 0.1 },
+        )
+        headings.forEach((h) => obs.observe(h))
+        return () => obs.disconnect()
+    }, [toc])
+
+    return (
+        <div className='min-h-screen bg-lucky-surface-canvas text-white'>
+            <header className='sticky top-0 z-30 border-b border-lucky-border-soft bg-lucky-surface-canvas/85 backdrop-blur supports-[backdrop-filter]:bg-lucky-surface-canvas/65'>
+                <div className='mx-auto flex h-14 max-w-7xl items-center justify-between gap-3 px-4 md:px-6'>
+                    <div className='flex items-center gap-2'>
+                        <button
+                            onClick={() => setSidebarOpen((v) => !v)}
+                            aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
+                            className='lg:hidden inline-flex h-9 w-9 items-center justify-center rounded-md text-lucky-text-muted hover:bg-lucky-surface-panel hover:text-lucky-text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand'
+                        >
+                            {sidebarOpen ? <X size={16} /> : <Menu size={16} />}
+                        </button>
+                        <Link
+                            to='/'
+                            className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
+                        >
+                            <img src='/lucky-logo.png' alt='Lucky' width='24' height='24' className='h-6 w-6' loading='eager' />
+                            <span className='font-mono text-sm font-semibold tracking-tight'>
+                                lucky<span className='text-lucky-brand'>.</span>
+                            </span>
+                        </Link>
+                        <span className='ml-1 hidden text-lucky-border-strong md:inline'>/</span>
+                        <span className='hidden font-mono text-xs uppercase tracking-[0.2em] text-lucky-text-muted md:inline'>
+                            {breadcrumb}
+                        </span>
+                    </div>
+                    <nav className='flex items-center gap-1 font-mono text-xs text-lucky-text-muted'>
+                        <Link to='/docs' className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'>
+                            docs
+                        </Link>
+                        <Link to='/changelog' className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'>
+                            changelog
+                        </Link>
+                        <a
+                            href='https://github.com/LucasSantana-Dev/Lucky'
+                            target='_blank'
+                            rel='noreferrer'
+                            className='inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'
+                        >
+                            github <ArrowUpRight size={11} aria-hidden />
+                        </a>
+                    </nav>
+                </div>
+            </header>
+
+            <div className='mx-auto grid max-w-7xl gap-0 px-0 md:px-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]'>
+                <DocsSidebar nav={nav} open={sidebarOpen} />
+
+                <main className='min-w-0 px-4 py-10 md:px-8 md:py-14 lg:px-10'>
+                    <article className='mx-auto max-w-2xl'>
+                        <header className='mb-10 border-b border-lucky-border-soft pb-6'>
+                            <p className='mb-3 font-mono text-[11px] uppercase tracking-[0.22em] text-lucky-text-muted'>
+                                {breadcrumb}
+                            </p>
+                            <h1 className='text-3xl font-bold tracking-tight text-lucky-text-strong md:text-4xl'>{title}</h1>
+                            {lastUpdated ? (
+                                <p className='mt-3 font-mono text-xs text-lucky-text-muted'>
+                                    last updated: {lastUpdated}
+                                </p>
+                            ) : null}
+                        </header>
+                        <div className='docs-prose'>{children}</div>
+                    </article>
+                </main>
+
+                {toc?.length ? <DocsToc toc={toc} activeId={activeId} /> : <div className='hidden lg:block' />}
+            </div>
+        </div>
+    )
+}
+
+function DocsSidebar({ nav, open }: { nav: DocsNavGroup[]; open: boolean }) {
+    const { pathname } = useLocation()
+
+    return (
+        <aside
+            className={`${open ? 'block' : 'hidden'} lg:block border-r border-lucky-border-soft bg-lucky-surface-canvas`}
+            aria-label='Documentation navigation'
+        >
+            <div className='sticky top-14 max-h-[calc(100vh-3.5rem)] overflow-y-auto px-4 py-8 md:px-6'>
+                <nav className='space-y-7'>
+                    {nav.map((group) => (
+                        <div key={group.heading}>
+                            <h4 className='mb-3 font-mono text-[10px] uppercase tracking-[0.22em] text-lucky-text-muted'>
+                                {group.heading}
+                            </h4>
+                            <ul className='space-y-0.5'>
+                                {group.items.map((item) => {
+                                    const isActive = !item.external && pathname === item.href
+                                    const base =
+                                        'group inline-flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-sm transition-colors'
+                                    const inactiveCls = `${base} text-lucky-text-body hover:bg-lucky-surface-panel hover:text-lucky-text-strong`
+                                    const activeCls = `${base} bg-lucky-surface-panel text-lucky-text-strong shadow-[inset_2px_0_0_var(--color-lucky-brand)]`
+                                    if (item.external) {
+                                        return (
+                                            <li key={item.href}>
+                                                <a
+                                                    href={item.href}
+                                                    target='_blank'
+                                                    rel='noreferrer'
+                                                    className={inactiveCls}
+                                                >
+                                                    <span>{item.label}</span>
+                                                    <ArrowUpRight size={11} aria-hidden className='text-lucky-text-muted' />
+                                                </a>
+                                            </li>
+                                        )
+                                    }
+                                    return (
+                                        <li key={item.href}>
+                                            <Link to={item.href} className={isActive ? activeCls : inactiveCls}>
+                                                <span>{item.label}</span>
+                                            </Link>
+                                        </li>
+                                    )
+                                })}
+                            </ul>
+                        </div>
+                    ))}
+                </nav>
+            </div>
+        </aside>
+    )
+}
+
+function DocsToc({ toc, activeId }: { toc: DocsTocItem[]; activeId: string | null }) {
+    return (
+        <aside className='hidden lg:block' aria-label='On this page'>
+            <div className='sticky top-14 max-h-[calc(100vh-3.5rem)] overflow-y-auto px-6 py-10'>
+                <h4 className='mb-3 font-mono text-[10px] uppercase tracking-[0.22em] text-lucky-text-muted'>
+                    On this page
+                </h4>
+                <ul className='space-y-1.5 border-l border-lucky-border-soft pl-3'>
+                    {toc.map((item) => {
+                        const isActive = activeId === item.id
+                        return (
+                            <li key={item.id} className={item.depth === 3 ? 'pl-3' : ''}>
+                                <a
+                                    href={`#${item.id}`}
+                                    className={`inline-block text-xs leading-snug transition-colors ${
+                                        isActive
+                                            ? 'text-lucky-brand font-medium'
+                                            : 'text-lucky-text-muted hover:text-lucky-text-strong'
+                                    }`}
+                                >
+                                    {item.label}
+                                </a>
+                            </li>
+                        )
+                    })}
+                </ul>
+            </div>
+        </aside>
+    )
+}

--- a/packages/frontend/src/components/DocsShell/DocsShell.tsx
+++ b/packages/frontend/src/components/DocsShell/DocsShell.tsx
@@ -74,7 +74,7 @@ export default function DocsShell({ nav, toc, breadcrumb, title, lastUpdated, ch
                             to='/'
                             className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
                         >
-                            <img src='/lucky-logo.png' alt='Lucky' width='24' height='24' className='h-6 w-6' loading='eager' />
+                            <img src='/lucky-logo.png' alt='Lucky' width='24' height='24' className='h-6 w-6 rounded-full' loading='eager' />
                             <span className='font-mono text-sm font-semibold tracking-tight'>
                                 lucky<span className='text-lucky-brand'>.</span>
                             </span>

--- a/packages/frontend/src/components/DocsShell/PublicHeader.tsx
+++ b/packages/frontend/src/components/DocsShell/PublicHeader.tsx
@@ -1,0 +1,106 @@
+import { Link, useLocation } from 'react-router-dom'
+import { ArrowUpRight, Menu, X } from 'lucide-react'
+
+type NavKey = 'docs' | 'changelog' | 'github'
+
+type Props = {
+    breadcrumb: string
+    sidebarOpen?: boolean
+    onToggleSidebar?: () => void
+    /** Optional override for which top-nav item is highlighted. */
+    activeNav?: NavKey
+}
+
+const GITHUB_URL = 'https://github.com/LucasSantana-Dev/Lucky'
+
+/**
+ * Shared sticky header for /docs, /changelog, /terms, /privacy.
+ *
+ * Right-side nav links auto-derive active state from the URL when `activeNav`
+ * is omitted.
+ */
+export default function PublicHeader({
+    breadcrumb,
+    sidebarOpen = false,
+    onToggleSidebar,
+    activeNav,
+}: Props) {
+    const { pathname } = useLocation()
+    const inferred: NavKey | null = pathname.startsWith('/docs')
+        ? 'docs'
+        : pathname.startsWith('/changelog')
+          ? 'changelog'
+          : null
+    const current = activeNav ?? inferred
+
+    const linkBase =
+        'hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 transition-colors'
+    const linkInactive = 'hover:bg-lucky-surface-panel hover:text-lucky-text-strong'
+    const linkActive = 'bg-lucky-surface-panel text-lucky-text-strong'
+
+    return (
+        <header className='sticky top-0 z-30 border-b border-lucky-border-soft bg-lucky-surface-canvas/85 backdrop-blur supports-[backdrop-filter]:bg-lucky-surface-canvas/65'>
+            <div className='mx-auto flex h-14 max-w-7xl items-center justify-between gap-3 px-4 md:px-6'>
+                <div className='flex items-center gap-2'>
+                    {onToggleSidebar ? (
+                        <button
+                            onClick={onToggleSidebar}
+                            aria-label={
+                                sidebarOpen
+                                    ? 'Close navigation'
+                                    : 'Open navigation'
+                            }
+                            className='lg:hidden inline-flex h-9 w-9 items-center justify-center rounded-md text-lucky-text-muted hover:bg-lucky-surface-panel hover:text-lucky-text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand'
+                        >
+                            {sidebarOpen ? <X size={16} /> : <Menu size={16} />}
+                        </button>
+                    ) : null}
+                    <Link
+                        to='/'
+                        className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
+                    >
+                        <img
+                            src='/lucky-logo.png'
+                            alt='Lucky'
+                            width='24'
+                            height='24'
+                            className='h-6 w-6 rounded-full'
+                            loading='eager'
+                        />
+                        <span className='font-mono text-sm font-semibold tracking-tight'>
+                            lucky<span className='text-lucky-brand'>.</span>
+                        </span>
+                    </Link>
+                    <span className='ml-1 hidden text-lucky-border-strong md:inline'>
+                        /
+                    </span>
+                    <span className='hidden font-mono text-xs uppercase tracking-[0.2em] text-lucky-text-muted md:inline'>
+                        {breadcrumb}
+                    </span>
+                </div>
+                <nav className='flex items-center gap-1 font-mono text-xs text-lucky-text-muted'>
+                    <Link
+                        to='/docs'
+                        className={`${linkBase} ${current === 'docs' ? linkActive : linkInactive}`}
+                    >
+                        docs
+                    </Link>
+                    <Link
+                        to='/changelog'
+                        className={`${linkBase} ${current === 'changelog' ? linkActive : linkInactive}`}
+                    >
+                        changelog
+                    </Link>
+                    <a
+                        href={GITHUB_URL}
+                        target='_blank'
+                        rel='noreferrer'
+                        className='inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'
+                    >
+                        github <ArrowUpRight size={11} aria-hidden />
+                    </a>
+                </nav>
+            </div>
+        </header>
+    )
+}

--- a/packages/frontend/src/components/DocsShell/legalNav.ts
+++ b/packages/frontend/src/components/DocsShell/legalNav.ts
@@ -1,0 +1,33 @@
+import type { DocsNavGroup } from './DocsShell'
+
+export const LEGAL_NAV: DocsNavGroup[] = [
+    {
+        heading: 'Legal',
+        items: [
+            { label: 'Terms of Service', href: '/terms' },
+            { label: 'Privacy Policy', href: '/privacy' },
+        ],
+    },
+    {
+        heading: 'Product',
+        items: [
+            { label: 'Docs', href: '/docs' },
+            { label: 'Changelog', href: '/changelog' },
+        ],
+    },
+    {
+        heading: 'External',
+        items: [
+            {
+                label: 'GitHub',
+                href: 'https://github.com/LucasSantana-Dev/Lucky',
+                external: true,
+            },
+            {
+                label: 'Issues',
+                href: 'https://github.com/LucasSantana-Dev/Lucky/issues',
+                external: true,
+            },
+        ],
+    },
+]

--- a/packages/frontend/src/components/Layout/Layout.tsx
+++ b/packages/frontend/src/components/Layout/Layout.tsx
@@ -123,7 +123,7 @@ function Layout({ children }: LayoutProps) {
             </a>
             <Sidebar />
             <div className='flex min-w-0 flex-1 flex-col'>
-                <header className='lucky-shell-header sticky top-0 z-20 border-b border-lucky-border bg-lucky-bg-primary/92 relative'>
+                <header className='lucky-shell-header sticky top-0 z-30 border-b border-lucky-border bg-lucky-bg-primary relative'>
                     <div className='mx-auto flex w-full max-w-[1400px] items-center justify-between gap-4 px-4 py-3.5 md:px-6 md:py-4'>
                         <div className='min-w-0'>
                             <h1 className='type-title text-lucky-text-primary leading-tight'>

--- a/packages/frontend/src/components/Music/AutoplayGenres.tsx
+++ b/packages/frontend/src/components/Music/AutoplayGenres.tsx
@@ -51,7 +51,7 @@ export default function AutoplayGenres({ guildId }: AutoplayGenresProps) {
         try {
             setError(null)
             const response = await apiClient.get<{ genres: string[] }>(
-                `/api/guilds/${guildId}/autoplay/genres`,
+                `/guilds/${guildId}/autoplay/genres`,
             )
             setGenres(response.data.genres || [])
         } catch (err) {
@@ -92,7 +92,7 @@ export default function AutoplayGenres({ guildId }: AutoplayGenresProps) {
         setIsLoading(true)
         try {
             setError(null)
-            await apiClient.put(`/api/guilds/${guildId}/autoplay/genres`, {
+            await apiClient.put(`/guilds/${guildId}/autoplay/genres`, {
                 genres: updatedGenres,
             })
             setGenres(updatedGenres)

--- a/packages/frontend/src/hooks/useActiveHeading.ts
+++ b/packages/frontend/src/hooks/useActiveHeading.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Tracks which of the supplied heading IDs is currently most visible in the
+ * viewport. Returns its ID, or null when nothing is visible.
+ *
+ * Used by docs/changelog/legal pages to drive the right-rail TOC active state.
+ */
+export function useActiveHeading(ids: string[]): string | null {
+    const [activeId, setActiveId] = useState<string | null>(null)
+
+    useEffect(() => {
+        if (!ids.length) return
+        const els = ids
+            .map((id) => document.getElementById(id))
+            .filter((el): el is HTMLElement => Boolean(el))
+        if (!els.length) return
+
+        const obs = new IntersectionObserver(
+            (entries) => {
+                const visible = entries
+                    .filter((e) => e.isIntersecting)
+                    .sort(
+                        (a, b) =>
+                            a.boundingClientRect.top - b.boundingClientRect.top,
+                    )
+                if (visible[0]) setActiveId(visible[0].target.id)
+            },
+            { rootMargin: '-80px 0px -65% 0px', threshold: 0.1 },
+        )
+        els.forEach((el) => obs.observe(el))
+        return () => obs.disconnect()
+    }, [ids])
+
+    return activeId
+}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -573,4 +573,124 @@
     height: 1px;
     background-color: var(--lucky-border-soft);
   }
+
+  .docs-prose {
+    color: var(--color-lucky-text-body);
+    font-family: var(--font-lucky-body);
+    font-size: 0.9375rem;
+    line-height: 1.7;
+  }
+  .docs-prose > * + * {
+    margin-top: 1.25rem;
+  }
+  .docs-prose h2 {
+    color: var(--color-lucky-text-strong);
+    font-family: var(--font-lucky-display);
+    font-size: 1.5rem;
+    font-weight: 600;
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+    margin-top: 3rem;
+    margin-bottom: 0.75rem;
+    scroll-margin-top: 4.5rem;
+  }
+  .docs-prose h3 {
+    color: var(--color-lucky-text-strong);
+    font-family: var(--font-lucky-display);
+    font-size: 1.125rem;
+    font-weight: 600;
+    line-height: 1.3;
+    margin-top: 2rem;
+    margin-bottom: 0.5rem;
+    scroll-margin-top: 4.5rem;
+  }
+  .docs-prose p {
+    color: var(--color-lucky-text-body);
+  }
+  .docs-prose a {
+    color: var(--color-lucky-brand);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+    transition: color 150ms ease;
+  }
+  .docs-prose a:hover {
+    color: var(--color-lucky-brand-strong);
+  }
+  .docs-prose ul,
+  .docs-prose ol {
+    padding-left: 1.25rem;
+  }
+  .docs-prose ul {
+    list-style: disc;
+  }
+  .docs-prose ol {
+    list-style: decimal;
+  }
+  .docs-prose li {
+    margin-top: 0.4rem;
+    padding-left: 0.25rem;
+  }
+  .docs-prose li::marker {
+    color: var(--color-lucky-text-muted);
+  }
+  .docs-prose code {
+    background: var(--color-lucky-surface-elevated);
+    color: var(--color-lucky-text-strong);
+    border: 1px solid var(--color-lucky-border-soft);
+    border-radius: 0.25rem;
+    padding: 0.1rem 0.4rem;
+    font-family: var(--font-lucky-mono);
+    font-size: 0.86em;
+  }
+  .docs-prose pre {
+    background: var(--color-lucky-surface-sidebar);
+    border: 1px solid var(--color-lucky-border-soft);
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+    font-family: var(--font-lucky-mono);
+    font-size: 0.82rem;
+    line-height: 1.6;
+  }
+  .docs-prose pre code {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    color: var(--color-lucky-text-body);
+  }
+  .docs-prose blockquote {
+    border-left: 2px solid var(--color-lucky-brand);
+    padding: 0.25rem 0 0.25rem 1rem;
+    color: var(--color-lucky-text-muted);
+    font-style: normal;
+  }
+  .docs-prose strong {
+    color: var(--color-lucky-text-strong);
+    font-weight: 600;
+  }
+  .docs-prose hr {
+    border: 0;
+    border-top: 1px solid var(--color-lucky-border-soft);
+    margin: 2.5rem 0;
+  }
+  .docs-prose table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+  .docs-prose th,
+  .docs-prose td {
+    border-bottom: 1px solid var(--color-lucky-border-soft);
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+  }
+  .docs-prose th {
+    color: var(--color-lucky-text-muted);
+    font-family: var(--font-lucky-mono);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
 }

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -113,15 +113,17 @@
   --color-lucky-shadow-panel: 0 8px 32px rgb(0 0 0 / 0.4);
   --color-lucky-shadow-focus: 0 0 0 3px rgb(88 101 242 / 0.4);
 
-  /* Legacy aliases for backward compat */
-  --color-lucky-purple-400: #5865f2;
-  --color-lucky-purple-500: #4752c4;
-  --color-lucky-gold-500: #5865f2;
-  --color-lucky-gold-400: #6d7af4;
-  --color-lucky-gold-300: #8891f6;
-  --color-lucky-red: #5865f2;
-  --color-lucky-blue: #5865f2;
-  --color-lucky-purple: #5865f2;
+  /* Legacy aliases for backward compat — re-pointed to brand pink so
+     the old --lucky-red / --lucky-blue / --lucky-purple classes no longer
+     render Discord blurple. Direct usages should migrate to --color-lucky-brand. */
+  --color-lucky-purple-400: #ec4899;
+  --color-lucky-purple-500: #db2777;
+  --color-lucky-gold-500: #ec4899;
+  --color-lucky-gold-400: #f472b6;
+  --color-lucky-gold-300: #f9a8d4;
+  --color-lucky-red: #ec4899;
+  --color-lucky-blue: #ec4899;
+  --color-lucky-purple: #ec4899;
 
   /* Short-form aliases for the 2026-04-21 redesign port.
      Values match the existing --color-lucky-* tokens. Keep both during

--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -172,11 +172,11 @@
     },
     "hero": {
       "eyebrow": "Open source · Apache 2.0",
-      "headlineLine1": "A Discord bot you can",
-      "headlineLine2": "actually run yourself.",
-      "subtitle": "100+ commands. Spotify-fed autoplay. Moderation suite. Web dashboard. Free forever. No premium tier. Your guild data stays on your box.",
-      "ctaPrimary": "Self-host on your box",
-      "ctaSecondary": "Add hosted version"
+      "headlineLine1": "A Discord bot built right.",
+      "headlineLine2": "And yours to run.",
+      "subtitle": "Music, moderation, custom commands, and a full web dashboard. Use the hosted version in two clicks, or run it on your own box if you'd rather.",
+      "ctaPrimary": "Add to Discord",
+      "ctaSecondary": "Self-host on GitHub"
     },
     "repoCard": {
       "name": "LucasSantana-Dev / Lucky",
@@ -243,8 +243,8 @@
       "more": "+ 100 more in the dashboard"
     },
     "stack": {
-      "heading": "What you're running",
-      "subheading": "Standard Node/Postgres stack. Nothing exotic. `docker compose up` and you're online.",
+      "heading": "For developers — what you're running",
+      "subheading": "Standard Node + Postgres stack. Nothing exotic. `docker compose up` and you're online. Skip this if you're using the hosted version.",
       "items": {
         "bot": {
           "name": "lucky-bot",
@@ -288,6 +288,32 @@
       "changelog": "Changelog",
       "discord": "Support server",
       "copyright": "© 2026 Lucky. Apache 2.0."
+    },
+    "features": {
+      "heading": "What Lucky does",
+      "subheading": "Everything most servers need, in one bot. No premium tier paywalling the good parts.",
+      "items": {
+        "music": {
+          "title": "Music with smart autoplay",
+          "description": "Queue from Spotify, YouTube, or SoundCloud. Autoplay matches the mood and won't drift into the wrong language."
+        },
+        "moderation": {
+          "title": "Moderation that doesn't sleep",
+          "description": "Auto-mod for spam, caps, links, and invites. Tempbans with reasons, audit log entries, and per-server rules."
+        },
+        "customCommands": {
+          "title": "Custom commands",
+          "description": "Build replies, role-toggles, embeds, and shortcuts without writing code. Variable interpolation included."
+        },
+        "dashboard": {
+          "title": "A real web dashboard",
+          "description": "Configure everything from your browser. Discord OAuth login, no JSON files, no SSH."
+        },
+        "embeds": {
+          "title": "Embed builder",
+          "description": "Compose rich Discord embeds with a live preview. Save templates, send on schedule, edit in place."
+        }
+      }
     }
   },
   "login": {

--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -1,278 +1,316 @@
 {
-    "common": {
-        "loading": "Loading…",
-        "retry": "Retry",
-        "cancel": "Cancel",
-        "save": "Save",
-        "delete": "Delete",
-        "edit": "Edit",
-        "close": "Close",
-        "closeSidebar": "Close sidebar",
-        "open": "Open",
-        "activeServerAriaLabel": "Active server: {{name}}. Click to switch.",
-        "viewAll": "View all",
-        "selectServer": "Select a server",
-        "accessDenied": "Access denied",
-        "accessDeniedDescription": "You do not have permission to view the {{module}} module for this server.",
-        "logout": "Log out",
-        "language": "Language"
+  "common": {
+    "loading": "Loading…",
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "close": "Close",
+    "closeSidebar": "Close sidebar",
+    "open": "Open",
+    "activeServerAriaLabel": "Active server: {{name}}. Click to switch.",
+    "viewAll": "View all",
+    "selectServer": "Select a server",
+    "accessDenied": "Access denied",
+    "accessDeniedDescription": "You do not have permission to view the {{module}} module for this server.",
+    "logout": "Log out",
+    "language": "Language"
+  },
+  "languages": {
+    "en": "English",
+    "pt-BR": "Português (Brasil)"
+  },
+  "modules": {
+    "overview": "overview",
+    "settings": "settings",
+    "moderation": "moderation",
+    "automation": "automation",
+    "music": "music",
+    "integrations": "integrations"
+  },
+  "sidebar": {
+    "activeGuild": "Active guild",
+    "switchServer": "Switch server",
+    "commandCenter": "Command center",
+    "status": {
+      "selectServer": "Select a server",
+      "needsSetup": "Needs setup",
+      "ready": "Ready"
     },
-    "languages": {
-        "en": "English",
-        "pt-BR": "Português (Brasil)"
+    "subtitle": {
+      "selectServer": "Choose a community to unlock guild tools.",
+      "needsSetup": "Lucky is not installed in this server yet.",
+      "ready": "Guild command center is ready for operations."
     },
-    "modules": {
-        "overview": "overview",
-        "settings": "settings",
-        "moderation": "moderation",
-        "automation": "automation",
-        "music": "music",
-        "integrations": "integrations"
+    "sections": {
+      "overview": "Overview",
+      "moderation": "Moderation",
+      "automation": "Automation",
+      "community": "Community",
+      "media": "Media",
+      "integrations": "Integrations"
     },
-    "sidebar": {
-        "activeGuild": "Active guild",
-        "switchServer": "Switch server",
-        "commandCenter": "Command center",
-        "status": {
-            "selectServer": "Select a server",
-            "needsSetup": "Needs setup",
-            "ready": "Ready"
-        },
-        "subtitle": {
-            "selectServer": "Choose a community to unlock guild tools.",
-            "needsSetup": "Lucky is not installed in this server yet.",
-            "ready": "Guild command center is ready for operations."
-        },
-        "sections": {
-            "overview": "Overview",
-            "moderation": "Moderation",
-            "automation": "Automation",
-            "community": "Community",
-            "media": "Media",
-            "integrations": "Integrations"
-        },
-        "nav": {
-            "dashboard": "Dashboard",
-            "serverSettings": "Server Settings",
-            "modCases": "Mod Cases",
-            "autoModeration": "Auto-Moderation",
-            "serverLogs": "Server Logs",
-            "customCommands": "Custom Commands",
-            "autoMessages": "Auto Messages",
-            "embedBuilder": "Embed Builder",
-            "reactionRoles": "Reaction Roles",
-            "guildAutomation": "Guild Automation",
-            "levelSystem": "Level System",
-            "starboard": "Starboard",
-            "musicPlayer": "Music Player",
-            "trackHistory": "Track History",
-            "lyrics": "Lyrics",
-            "musicalTaste": "Musical Taste",
-            "lastFm": "Last.fm",
-            "twitch": "Twitch",
-            "features": "Features"
-        }
-    },
-    "layout": {
-        "routes": {
-            "dashboard": {
-                "title": "Dashboard",
-                "subtitle": "Operational overview and key status signals for your server."
-            },
-            "servers": {
-                "title": "Servers",
-                "subtitle": "Review installation status and manage your eligible communities."
-            },
-            "serverSettings": {
-                "title": "Server Settings",
-                "subtitle": "Configure bot behaviour, channels, roles, and preferences."
-            },
-            "moderation": {
-                "title": "Mod Cases",
-                "subtitle": "Review and manage moderation actions for this server."
-            },
-            "autoMod": {
-                "title": "Auto-Moderation",
-                "subtitle": "Configure automated rule enforcement and filters."
-            },
-            "serverLogs": {
-                "title": "Server Logs",
-                "subtitle": "Inspect audit events and bot activity records."
-            },
-            "customCommands": {
-                "title": "Custom Commands",
-                "subtitle": "Create and manage custom slash commands for this server."
-            },
-            "autoMessages": {
-                "title": "Auto Messages",
-                "subtitle": "Schedule recurring messages to any channel."
-            },
-            "embedBuilder": {
-                "title": "Embed Builder",
-                "subtitle": "Design and send rich Discord embeds."
-            },
-            "reactionRoles": {
-                "title": "Reaction Roles",
-                "subtitle": "Assign roles based on member emoji reactions."
-            },
-            "guildAutomation": {
-                "title": "Guild Automation",
-                "subtitle": "Configure automated guild management workflows."
-            },
-            "levels": {
-                "title": "Level System",
-                "subtitle": "Configure XP, level roles, and leaderboards."
-            },
-            "starboard": {
-                "title": "Starboard",
-                "subtitle": "Surface popular messages to a dedicated channel."
-            },
-            "lyrics": {
-                "title": "Lyrics",
-                "subtitle": "Fetch and display song lyrics in your server."
-            },
-            "lastFm": {
-                "title": "Last.fm",
-                "subtitle": "Control account linking and scrobble attribution behavior."
-            },
-            "twitch": {
-                "title": "Twitch Notifications",
-                "subtitle": "Post live alerts when tracked streamers go online."
-            },
-            "features": {
-                "title": "Features",
-                "subtitle": "Toggle bot feature modules for your server."
-            },
-            "trackHistory": {
-                "title": "Track History",
-                "subtitle": "Inspect recent playback and requester activity."
-            },
-            "music": {
-                "title": "Music Player",
-                "subtitle": "Manage queue, autoplay, and real-time playback controls."
-            },
-            "preferredArtists": {
-                "title": "Musical Taste",
-                "subtitle": "Tune autoplay taste preferences and artist priorities."
-            },
-            "spotify": {
-                "title": "Spotify",
-                "subtitle": "Link or unlink Spotify to power autoplay matching."
-            },
-            "fallback": {
-                "title": "Lucky Dashboard",
-                "subtitle": "Configure modules, moderation, and engagement workflows."
-            }
-        }
-    },
-    "landing": {
-        "meta": {
-            "title": "Lucky — Discord Bot with Music, Moderation & Dashboard",
-            "description": "The all-in-one Discord bot for your community. Music, moderation, custom commands, auto-mod, and a full web dashboard. Free forever."
-        },
-        "hero": {
-            "headlineLine1": "All-in-one Discord bot",
-            "headlineLine2": "for your community",
-            "subtitle": "Music, moderation, custom commands, auto-mod, and a full web dashboard. Built for vibes.",
-            "ctaPrimary": "Add to Discord",
-            "ctaSecondary": "Open Dashboard"
-        },
-        "features": {
-            "heading": "Powerful Features",
-            "subheading": "Everything you need to manage your Discord server",
-            "music": {
-                "title": "Music",
-                "description": "Spotify-powered autoplay with genre matching"
-            },
-            "autoMod": {
-                "title": "Auto-mod",
-                "description": "Spam/caps/link filters with per-guild rules"
-            },
-            "customCommands": {
-                "title": "Custom Commands",
-                "description": "User-defined responses with variable interpolation"
-            },
-            "webDashboard": {
-                "title": "Web Dashboard",
-                "description": "Full control from your browser"
-            },
-            "embedBuilder": {
-                "title": "Embed Builder",
-                "description": "Rich embeds without JSON"
-            },
-            "artistPreferences": {
-                "title": "Artist Preferences",
-                "description": "Tailor autoplay to your taste"
-            }
-        },
-        "stats": {
-            "servers": "Servers",
-            "users": "Users",
-            "status": "Status",
-            "statusOnline": "✓ Online",
-            "statusOffline": "✗ Offline"
-        },
-        "faq": {
-            "heading": "Frequently Asked Questions",
-            "items": {
-                "free": {
-                    "question": "Is Lucky free?",
-                    "answer": "Yes, Lucky is completely free with no premium tier."
-                },
-                "commands": {
-                    "question": "What commands does Lucky support?",
-                    "answer": "Lucky supports 100+ commands across music, moderation, custom commands, and more."
-                },
-                "autoplay": {
-                    "question": "How does autoplay work?",
-                    "answer": "Autoplay uses Spotify to match similar songs based on artist preferences you set."
-                },
-                "selfHost": {
-                    "question": "Can I self-host Lucky?",
-                    "answer": "Lucky is hosted and managed by us. You cannot self-host the bot, but you can use the dashboard to configure it."
-                },
-                "spam": {
-                    "question": "How do I moderate spam?",
-                    "answer": "Configure auto-mod rules for spam, caps, links, and more in the dashboard."
-                },
-                "support": {
-                    "question": "Where do I get support?",
-                    "answer": "Join our Discord support server or open an issue on GitHub."
-                }
-            }
-        },
-        "footer": {
-            "tagline": "Discord bot with music, moderation, and more. Built for vibes.",
-            "links": "Links",
-            "support": "Support",
-            "supportCopy": "Need help? Join our Discord community.",
-            "terms": "Terms of Service",
-            "privacy": "Privacy Policy",
-            "github": "GitHub",
-            "copyright": "© 2026 Lucky. All rights reserved."
-        }
-    },
-    "login": {
-        "meta": {
-            "title": "Login - Lucky",
-            "description": "Login to Lucky Dashboard to manage your Discord servers"
-        },
-        "brand": "Discord Bot Dashboard",
-        "headline": "Manage your Discord servers",
-        "description": "Configure moderation, custom commands, music, and more — all in one place.",
-        "modules": "Modules",
-        "commands": "Commands",
-        "uptime": "Uptime",
-        "authentication": "Authentication",
-        "signInWithDiscord": "Sign in with Discord",
-        "permissionsNote": "Your guild permissions and bot controls are tied to your Discord account.",
-        "connecting": "Connecting...",
-        "loginButton": "Login with Discord",
-        "badges": {
-            "oauthSecured": "OAuth secured",
-            "fastSetup": "Fast setup",
-            "liveControls": "Live controls"
-        },
-        "copyright": "© 2026 Lucky. All rights reserved."
+    "nav": {
+      "dashboard": "Dashboard",
+      "serverSettings": "Server Settings",
+      "modCases": "Mod Cases",
+      "autoModeration": "Auto-Moderation",
+      "serverLogs": "Server Logs",
+      "customCommands": "Custom Commands",
+      "autoMessages": "Auto Messages",
+      "embedBuilder": "Embed Builder",
+      "reactionRoles": "Reaction Roles",
+      "guildAutomation": "Guild Automation",
+      "levelSystem": "Level System",
+      "starboard": "Starboard",
+      "musicPlayer": "Music Player",
+      "trackHistory": "Track History",
+      "lyrics": "Lyrics",
+      "musicalTaste": "Musical Taste",
+      "lastFm": "Last.fm",
+      "twitch": "Twitch",
+      "features": "Features"
     }
+  },
+  "layout": {
+    "routes": {
+      "dashboard": {
+        "title": "Dashboard",
+        "subtitle": "Operational overview and key status signals for your server."
+      },
+      "servers": {
+        "title": "Servers",
+        "subtitle": "Review installation status and manage your eligible communities."
+      },
+      "serverSettings": {
+        "title": "Server Settings",
+        "subtitle": "Configure bot behaviour, channels, roles, and preferences."
+      },
+      "moderation": {
+        "title": "Mod Cases",
+        "subtitle": "Review and manage moderation actions for this server."
+      },
+      "autoMod": {
+        "title": "Auto-Moderation",
+        "subtitle": "Configure automated rule enforcement and filters."
+      },
+      "serverLogs": {
+        "title": "Server Logs",
+        "subtitle": "Inspect audit events and bot activity records."
+      },
+      "customCommands": {
+        "title": "Custom Commands",
+        "subtitle": "Create and manage custom slash commands for this server."
+      },
+      "autoMessages": {
+        "title": "Auto Messages",
+        "subtitle": "Schedule recurring messages to any channel."
+      },
+      "embedBuilder": {
+        "title": "Embed Builder",
+        "subtitle": "Design and send rich Discord embeds."
+      },
+      "reactionRoles": {
+        "title": "Reaction Roles",
+        "subtitle": "Assign roles based on member emoji reactions."
+      },
+      "guildAutomation": {
+        "title": "Guild Automation",
+        "subtitle": "Configure automated guild management workflows."
+      },
+      "levels": {
+        "title": "Level System",
+        "subtitle": "Configure XP, level roles, and leaderboards."
+      },
+      "starboard": {
+        "title": "Starboard",
+        "subtitle": "Surface popular messages to a dedicated channel."
+      },
+      "lyrics": {
+        "title": "Lyrics",
+        "subtitle": "Fetch and display song lyrics in your server."
+      },
+      "lastFm": {
+        "title": "Last.fm",
+        "subtitle": "Control account linking and scrobble attribution behavior."
+      },
+      "twitch": {
+        "title": "Twitch Notifications",
+        "subtitle": "Post live alerts when tracked streamers go online."
+      },
+      "features": {
+        "title": "Features",
+        "subtitle": "Toggle bot feature modules for your server."
+      },
+      "trackHistory": {
+        "title": "Track History",
+        "subtitle": "Inspect recent playback and requester activity."
+      },
+      "music": {
+        "title": "Music Player",
+        "subtitle": "Manage queue, autoplay, and real-time playback controls."
+      },
+      "preferredArtists": {
+        "title": "Musical Taste",
+        "subtitle": "Tune autoplay taste preferences and artist priorities."
+      },
+      "spotify": {
+        "title": "Spotify",
+        "subtitle": "Link or unlink Spotify to power autoplay matching."
+      },
+      "fallback": {
+        "title": "Lucky Dashboard",
+        "subtitle": "Configure modules, moderation, and engagement workflows."
+      }
+    }
+  },
+  "landing": {
+    "meta": {
+      "title": "Lucky — A Discord bot you can actually self-host",
+      "description": "Open-source Discord bot with music, moderation, custom commands, and a web dashboard. Free forever. Run it on your own box."
+    },
+    "hero": {
+      "eyebrow": "Open source · Apache 2.0",
+      "headlineLine1": "A Discord bot you can",
+      "headlineLine2": "actually run yourself.",
+      "subtitle": "100+ commands. Spotify-fed autoplay. Moderation suite. Web dashboard. Free forever. No premium tier. Your guild data stays on your box.",
+      "ctaPrimary": "Self-host on your box",
+      "ctaSecondary": "Add hosted version"
+    },
+    "repoCard": {
+      "name": "LucasSantana-Dev / Lucky",
+      "description": "Self-hosted Discord music bot — Spotify + YouTube + SoundCloud, autoplay recommendations, React dashboard, moderation suite.",
+      "license": "Apache-2.0",
+      "lang": "TypeScript",
+      "starsLabel": "stars",
+      "forksLabel": "forks",
+      "issuesLabel": "open issues",
+      "viewOnGithub": "View on GitHub",
+      "copyClone": "Copy clone URL"
+    },
+    "whySelfHost": {
+      "heading": "Why self-host",
+      "items": {
+        "data": {
+          "title": "Your guild data stays yours",
+          "description": "Postgres, Redis, your hardware. No third-party ToS over your community. Export and migrate any time."
+        },
+        "fork": {
+          "title": "Fork the source",
+          "description": "TypeScript monorepo. Add commands, change behavior, swap providers without waiting on a roadmap or paying for an API tier."
+        },
+        "free": {
+          "title": "Free, with no premium tier",
+          "description": "No feature paywall, no Patreon, no rate-limited tier. Apache 2.0. The hosted version exists for people who don't want to run a box."
+        }
+      }
+    },
+    "commands": {
+      "heading": "100+ commands, scoped to what you actually run",
+      "rows": {
+        "play": {
+          "name": "/play",
+          "description": "Queue a track from Spotify, YouTube, or SoundCloud",
+          "kbd": "music"
+        },
+        "autoplay": {
+          "name": "/autoplay",
+          "description": "Genre-aware recommendations, won't drift languages",
+          "kbd": "music"
+        },
+        "queue": {
+          "name": "/queue",
+          "description": "Inspect or reorder the current queue",
+          "kbd": "music"
+        },
+        "ban": {
+          "name": "/mod ban",
+          "description": "Tempban with reason, auto-DM, audit-log entry",
+          "kbd": "mod"
+        },
+        "automod": {
+          "name": "/automod",
+          "description": "Spam, caps, links, invites — per-guild rules",
+          "kbd": "mod"
+        },
+        "custom": {
+          "name": "/cc create",
+          "description": "Custom commands with variable interpolation",
+          "kbd": "custom"
+        }
+      },
+      "more": "+ 100 more in the dashboard"
+    },
+    "stack": {
+      "heading": "What you're running",
+      "subheading": "Standard Node/Postgres stack. Nothing exotic. `docker compose up` and you're online.",
+      "items": {
+        "bot": {
+          "name": "lucky-bot",
+          "description": "discord.js client, Lavalink-free audio via yt-dlp + Opus"
+        },
+        "backend": {
+          "name": "lucky-backend",
+          "description": "Express API, OAuth, Prisma to Postgres"
+        },
+        "frontend": {
+          "name": "lucky-frontend",
+          "description": "React 19 + Vite + Tailwind, Discord OAuth dashboard"
+        },
+        "postgres": {
+          "name": "postgres",
+          "description": "Guild config, custom commands, moderation log"
+        },
+        "redis": {
+          "name": "redis",
+          "description": "Session cache, rate-limit buckets, autoplay state"
+        },
+        "nginx": {
+          "name": "nginx",
+          "description": "Reverse proxy, /webhook → /hooks rewrite for deploy"
+        }
+      }
+    },
+    "footerRepo": {
+      "heading": "Open source under Apache 2.0",
+      "subheading": "Fork it, contribute, run it, deploy your own. The code is the spec."
+    },
+    "footer": {
+      "tagline": "Open-source Discord bot. Run it yourself or use the hosted version.",
+      "links": "Product",
+      "support": "Community",
+      "supportCopy": "Issues and PRs welcome on GitHub. Or hop in the Discord support server.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "github": "GitHub",
+      "docs": "Docs",
+      "changelog": "Changelog",
+      "discord": "Support server",
+      "copyright": "© 2026 Lucky. Apache 2.0."
+    }
+  },
+  "login": {
+    "meta": {
+      "title": "Login - Lucky",
+      "description": "Login to Lucky Dashboard to manage your Discord servers"
+    },
+    "brand": "Discord Bot Dashboard",
+    "headline": "Manage your Discord servers",
+    "description": "Configure moderation, custom commands, music, and more — all in one place.",
+    "modules": "Modules",
+    "commands": "Commands",
+    "uptime": "Uptime",
+    "authentication": "Authentication",
+    "signInWithDiscord": "Sign in with Discord",
+    "permissionsNote": "Your guild permissions and bot controls are tied to your Discord account.",
+    "connecting": "Connecting...",
+    "loginButton": "Login with Discord",
+    "badges": {
+      "oauthSecured": "OAuth secured",
+      "fastSetup": "Fast setup",
+      "liveControls": "Live controls"
+    },
+    "copyright": "© 2026 Lucky. All rights reserved."
+  }
 }

--- a/packages/frontend/src/locales/pt-BR.json
+++ b/packages/frontend/src/locales/pt-BR.json
@@ -172,11 +172,11 @@
     },
     "hero": {
       "eyebrow": "Open source · Apache 2.0",
-      "headlineLine1": "Um bot do Discord que",
-      "headlineLine2": "você pode rodar você mesmo.",
-      "subtitle": "100+ comandos. Autoplay com Spotify. Suíte de moderação. Painel web. Grátis para sempre. Sem tier premium. Os dados do seu servidor ficam na sua máquina.",
-      "ctaPrimary": "Auto-hospedar agora",
-      "ctaSecondary": "Usar versão hospedada"
+      "headlineLine1": "Um bot do Discord bem feito.",
+      "headlineLine2": "E você que manda.",
+      "subtitle": "Música, moderação, comandos personalizados e um painel web completo. Use a versão hospedada em dois cliques, ou rode no seu próprio box se preferir.",
+      "ctaPrimary": "Adicionar ao Discord",
+      "ctaSecondary": "Auto-hospedar no GitHub"
     },
     "repoCard": {
       "name": "LucasSantana-Dev / Lucky",
@@ -243,8 +243,8 @@
       "more": "+ 100 outros no painel"
     },
     "stack": {
-      "heading": "O que você está rodando",
-      "subheading": "Stack Node/Postgres padrão. Nada exótico. `docker compose up` e você está online.",
+      "heading": "Para desenvolvedores — o que você está rodando",
+      "subheading": "Stack padrão Node + Postgres. Nada exótico. `docker compose up` e você está online. Pule esta seção se está usando a versão hospedada.",
       "items": {
         "bot": {
           "name": "lucky-bot",
@@ -288,6 +288,32 @@
       "changelog": "Changelog",
       "discord": "Servidor de suporte",
       "copyright": "© 2026 Lucky. Apache 2.0."
+    },
+    "features": {
+      "heading": "O que o Lucky faz",
+      "subheading": "Tudo que a maioria dos servidores precisa, em um bot só. Sem tier premium escondendo o que importa.",
+      "items": {
+        "music": {
+          "title": "Música com autoplay inteligente",
+          "description": "Adicione tracks do Spotify, YouTube ou SoundCloud. O autoplay acompanha o mood e não troca de idioma."
+        },
+        "moderation": {
+          "title": "Moderação que não dorme",
+          "description": "Auto-mod para spam, caps, links e convites. Tempbans com motivo, registro no audit log e regras por servidor."
+        },
+        "customCommands": {
+          "title": "Comandos personalizados",
+          "description": "Crie respostas, toggles de role, embeds e atalhos sem escrever código. Com interpolação de variáveis."
+        },
+        "dashboard": {
+          "title": "Um painel web de verdade",
+          "description": "Configure tudo direto do navegador. Login com OAuth do Discord, sem arquivos JSON, sem SSH."
+        },
+        "embeds": {
+          "title": "Construtor de embeds",
+          "description": "Monte embeds ricos com prévia ao vivo. Salve templates, envie agendado, edite no lugar."
+        }
+      }
     }
   },
   "login": {

--- a/packages/frontend/src/locales/pt-BR.json
+++ b/packages/frontend/src/locales/pt-BR.json
@@ -1,278 +1,316 @@
 {
-    "common": {
-        "loading": "Carregando…",
-        "retry": "Tentar novamente",
-        "cancel": "Cancelar",
-        "save": "Salvar",
-        "delete": "Excluir",
-        "edit": "Editar",
-        "close": "Fechar",
-        "closeSidebar": "Fechar barra lateral",
-        "open": "Abrir",
-        "activeServerAriaLabel": "Servidor ativo: {{name}}. Clique para trocar.",
-        "viewAll": "Ver tudo",
-        "selectServer": "Selecione um servidor",
-        "accessDenied": "Acesso negado",
-        "accessDeniedDescription": "Você não tem permissão para visualizar o módulo {{module}} deste servidor.",
-        "logout": "Sair",
-        "language": "Idioma"
+  "common": {
+    "loading": "Carregando…",
+    "retry": "Tentar novamente",
+    "cancel": "Cancelar",
+    "save": "Salvar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "close": "Fechar",
+    "closeSidebar": "Fechar barra lateral",
+    "open": "Abrir",
+    "activeServerAriaLabel": "Servidor ativo: {{name}}. Clique para trocar.",
+    "viewAll": "Ver tudo",
+    "selectServer": "Selecione um servidor",
+    "accessDenied": "Acesso negado",
+    "accessDeniedDescription": "Você não tem permissão para visualizar o módulo {{module}} deste servidor.",
+    "logout": "Sair",
+    "language": "Idioma"
+  },
+  "languages": {
+    "en": "English",
+    "pt-BR": "Português (Brasil)"
+  },
+  "modules": {
+    "overview": "visão geral",
+    "settings": "configurações",
+    "moderation": "moderação",
+    "automation": "automação",
+    "music": "música",
+    "integrations": "integrações"
+  },
+  "sidebar": {
+    "activeGuild": "Servidor ativo",
+    "switchServer": "Trocar servidor",
+    "commandCenter": "Central de comando",
+    "status": {
+      "selectServer": "Selecione um servidor",
+      "needsSetup": "Precisa configurar",
+      "ready": "Pronto"
     },
-    "languages": {
-        "en": "English",
-        "pt-BR": "Português (Brasil)"
+    "subtitle": {
+      "selectServer": "Escolha uma comunidade para desbloquear as ferramentas do servidor.",
+      "needsSetup": "O Lucky ainda não está instalado neste servidor.",
+      "ready": "A central de comando do servidor está pronta para operar."
     },
-    "modules": {
-        "overview": "visão geral",
-        "settings": "configurações",
-        "moderation": "moderação",
-        "automation": "automação",
-        "music": "música",
-        "integrations": "integrações"
+    "sections": {
+      "overview": "Visão geral",
+      "moderation": "Moderação",
+      "automation": "Automação",
+      "community": "Comunidade",
+      "media": "Mídia",
+      "integrations": "Integrações"
     },
-    "sidebar": {
-        "activeGuild": "Servidor ativo",
-        "switchServer": "Trocar servidor",
-        "commandCenter": "Central de comando",
-        "status": {
-            "selectServer": "Selecione um servidor",
-            "needsSetup": "Precisa configurar",
-            "ready": "Pronto"
-        },
-        "subtitle": {
-            "selectServer": "Escolha uma comunidade para desbloquear as ferramentas do servidor.",
-            "needsSetup": "O Lucky ainda não está instalado neste servidor.",
-            "ready": "A central de comando do servidor está pronta para operar."
-        },
-        "sections": {
-            "overview": "Visão geral",
-            "moderation": "Moderação",
-            "automation": "Automação",
-            "community": "Comunidade",
-            "media": "Mídia",
-            "integrations": "Integrações"
-        },
-        "nav": {
-            "dashboard": "Painel",
-            "serverSettings": "Configurações do servidor",
-            "modCases": "Casos de moderação",
-            "autoModeration": "Auto-moderação",
-            "serverLogs": "Logs do servidor",
-            "customCommands": "Comandos personalizados",
-            "autoMessages": "Mensagens automáticas",
-            "embedBuilder": "Construtor de embeds",
-            "reactionRoles": "Cargos por reação",
-            "guildAutomation": "Automação do servidor",
-            "levelSystem": "Sistema de níveis",
-            "starboard": "Starboard",
-            "musicPlayer": "Player de música",
-            "trackHistory": "Histórico de faixas",
-            "lyrics": "Letras",
-            "musicalTaste": "Gosto musical",
-            "lastFm": "Last.fm",
-            "twitch": "Twitch",
-            "features": "Recursos"
-        }
-    },
-    "layout": {
-        "routes": {
-            "dashboard": {
-                "title": "Painel",
-                "subtitle": "Visão operacional e principais indicadores do seu servidor."
-            },
-            "servers": {
-                "title": "Servidores",
-                "subtitle": "Confira o status de instalação e gerencie suas comunidades elegíveis."
-            },
-            "serverSettings": {
-                "title": "Configurações do servidor",
-                "subtitle": "Configure o comportamento do bot, canais, cargos e preferências."
-            },
-            "moderation": {
-                "title": "Casos de moderação",
-                "subtitle": "Revise e gerencie ações de moderação deste servidor."
-            },
-            "autoMod": {
-                "title": "Auto-moderação",
-                "subtitle": "Configure regras automáticas e filtros de aplicação."
-            },
-            "serverLogs": {
-                "title": "Logs do servidor",
-                "subtitle": "Inspecione eventos de auditoria e atividades do bot."
-            },
-            "customCommands": {
-                "title": "Comandos personalizados",
-                "subtitle": "Crie e gerencie comandos de barra personalizados deste servidor."
-            },
-            "autoMessages": {
-                "title": "Mensagens automáticas",
-                "subtitle": "Agende mensagens recorrentes em qualquer canal."
-            },
-            "embedBuilder": {
-                "title": "Construtor de embeds",
-                "subtitle": "Crie e envie embeds avançados do Discord."
-            },
-            "reactionRoles": {
-                "title": "Cargos por reação",
-                "subtitle": "Atribua cargos com base nas reações de emoji dos membros."
-            },
-            "guildAutomation": {
-                "title": "Automação do servidor",
-                "subtitle": "Configure fluxos automatizados de gerenciamento do servidor."
-            },
-            "levels": {
-                "title": "Sistema de níveis",
-                "subtitle": "Configure XP, cargos por nível e rankings."
-            },
-            "starboard": {
-                "title": "Starboard",
-                "subtitle": "Destaque mensagens populares em um canal dedicado."
-            },
-            "lyrics": {
-                "title": "Letras",
-                "subtitle": "Busque e exiba letras de músicas no seu servidor."
-            },
-            "lastFm": {
-                "title": "Last.fm",
-                "subtitle": "Controle a vinculação de contas e a atribuição de scrobbles."
-            },
-            "twitch": {
-                "title": "Notificações da Twitch",
-                "subtitle": "Envie alertas ao vivo quando streamers monitorados ficam online."
-            },
-            "features": {
-                "title": "Recursos",
-                "subtitle": "Ative ou desative módulos de recursos para o seu servidor."
-            },
-            "trackHistory": {
-                "title": "Histórico de faixas",
-                "subtitle": "Inspecione a reprodução recente e a atividade dos solicitantes."
-            },
-            "music": {
-                "title": "Player de música",
-                "subtitle": "Gerencie fila, autoplay e controles de reprodução em tempo real."
-            },
-            "preferredArtists": {
-                "title": "Gosto musical",
-                "subtitle": "Ajuste preferências de autoplay e prioridade de artistas."
-            },
-            "spotify": {
-                "title": "Spotify",
-                "subtitle": "Vincule ou desvincule o Spotify para alimentar o autoplay."
-            },
-            "fallback": {
-                "title": "Painel Lucky",
-                "subtitle": "Configure módulos, moderação e fluxos de engajamento."
-            }
-        }
-    },
-    "landing": {
-        "meta": {
-            "title": "Lucky — Bot do Discord com música, moderação e painel",
-            "description": "O bot completo do Discord para a sua comunidade. Música, moderação, comandos personalizados, auto-moderação e um painel web completo. Grátis para sempre."
-        },
-        "hero": {
-            "headlineLine1": "Bot completo do Discord",
-            "headlineLine2": "para a sua comunidade",
-            "subtitle": "Música, moderação, comandos personalizados, auto-moderação e um painel web completo. Feito para animar.",
-            "ctaPrimary": "Adicionar ao Discord",
-            "ctaSecondary": "Abrir painel"
-        },
-        "features": {
-            "heading": "Recursos poderosos",
-            "subheading": "Tudo o que você precisa para gerenciar o seu servidor do Discord",
-            "music": {
-                "title": "Música",
-                "description": "Autoplay com tecnologia do Spotify e correspondência por gênero"
-            },
-            "autoMod": {
-                "title": "Auto-moderação",
-                "description": "Filtros de spam/caps/links com regras por servidor"
-            },
-            "customCommands": {
-                "title": "Comandos personalizados",
-                "description": "Respostas definidas pelo usuário com interpolação de variáveis"
-            },
-            "webDashboard": {
-                "title": "Painel web",
-                "description": "Controle total direto do navegador"
-            },
-            "embedBuilder": {
-                "title": "Construtor de embeds",
-                "description": "Embeds ricos sem precisar de JSON"
-            },
-            "artistPreferences": {
-                "title": "Preferências de artistas",
-                "description": "Ajuste o autoplay ao seu gosto"
-            }
-        },
-        "stats": {
-            "servers": "Servidores",
-            "users": "Usuários",
-            "status": "Status",
-            "statusOnline": "✓ Online",
-            "statusOffline": "✗ Offline"
-        },
-        "faq": {
-            "heading": "Perguntas frequentes",
-            "items": {
-                "free": {
-                    "question": "O Lucky é grátis?",
-                    "answer": "Sim, o Lucky é totalmente gratuito e sem plano premium."
-                },
-                "commands": {
-                    "question": "Quais comandos o Lucky suporta?",
-                    "answer": "O Lucky oferece mais de 100 comandos entre música, moderação, comandos personalizados e muito mais."
-                },
-                "autoplay": {
-                    "question": "Como funciona o autoplay?",
-                    "answer": "O autoplay usa o Spotify para encontrar músicas parecidas com base nas preferências de artistas que você define."
-                },
-                "selfHost": {
-                    "question": "Posso hospedar o Lucky por conta própria?",
-                    "answer": "O Lucky é hospedado e mantido por nós. Você não pode auto-hospedar o bot, mas pode usar o painel para configurá-lo."
-                },
-                "spam": {
-                    "question": "Como modero spam?",
-                    "answer": "Configure regras de auto-moderação para spam, caps, links e outros no painel."
-                },
-                "support": {
-                    "question": "Onde consigo suporte?",
-                    "answer": "Entre no nosso servidor de suporte do Discord ou abra uma issue no GitHub."
-                }
-            }
-        },
-        "footer": {
-            "tagline": "Bot do Discord com música, moderação e mais. Feito para animar.",
-            "links": "Links",
-            "support": "Suporte",
-            "supportCopy": "Precisa de ajuda? Entre na nossa comunidade do Discord.",
-            "terms": "Termos de serviço",
-            "privacy": "Política de privacidade",
-            "github": "GitHub",
-            "copyright": "© 2026 Lucky. Todos os direitos reservados."
-        }
-    },
-    "login": {
-        "meta": {
-            "title": "Entrar - Lucky",
-            "description": "Entre no painel do Lucky para gerenciar seus servidores do Discord"
-        },
-        "brand": "Painel do Bot do Discord",
-        "headline": "Gerencie seus servidores do Discord",
-        "description": "Configure moderação, comandos personalizados, música e muito mais — tudo em um só lugar.",
-        "modules": "Módulos",
-        "commands": "Comandos",
-        "uptime": "Tempo online",
-        "authentication": "Autenticação",
-        "signInWithDiscord": "Entrar com Discord",
-        "permissionsNote": "Suas permissões de servidor e controles do bot estão vinculados à sua conta do Discord.",
-        "connecting": "Conectando...",
-        "loginButton": "Entrar com Discord",
-        "badges": {
-            "oauthSecured": "Protegido por OAuth",
-            "fastSetup": "Configuração rápida",
-            "liveControls": "Controles em tempo real"
-        },
-        "copyright": "© 2026 Lucky. Todos os direitos reservados."
+    "nav": {
+      "dashboard": "Painel",
+      "serverSettings": "Configurações do servidor",
+      "modCases": "Casos de moderação",
+      "autoModeration": "Auto-moderação",
+      "serverLogs": "Logs do servidor",
+      "customCommands": "Comandos personalizados",
+      "autoMessages": "Mensagens automáticas",
+      "embedBuilder": "Construtor de embeds",
+      "reactionRoles": "Cargos por reação",
+      "guildAutomation": "Automação do servidor",
+      "levelSystem": "Sistema de níveis",
+      "starboard": "Starboard",
+      "musicPlayer": "Player de música",
+      "trackHistory": "Histórico de faixas",
+      "lyrics": "Letras",
+      "musicalTaste": "Gosto musical",
+      "lastFm": "Last.fm",
+      "twitch": "Twitch",
+      "features": "Recursos"
     }
+  },
+  "layout": {
+    "routes": {
+      "dashboard": {
+        "title": "Painel",
+        "subtitle": "Visão operacional e principais indicadores do seu servidor."
+      },
+      "servers": {
+        "title": "Servidores",
+        "subtitle": "Confira o status de instalação e gerencie suas comunidades elegíveis."
+      },
+      "serverSettings": {
+        "title": "Configurações do servidor",
+        "subtitle": "Configure o comportamento do bot, canais, cargos e preferências."
+      },
+      "moderation": {
+        "title": "Casos de moderação",
+        "subtitle": "Revise e gerencie ações de moderação deste servidor."
+      },
+      "autoMod": {
+        "title": "Auto-moderação",
+        "subtitle": "Configure regras automáticas e filtros de aplicação."
+      },
+      "serverLogs": {
+        "title": "Logs do servidor",
+        "subtitle": "Inspecione eventos de auditoria e atividades do bot."
+      },
+      "customCommands": {
+        "title": "Comandos personalizados",
+        "subtitle": "Crie e gerencie comandos de barra personalizados deste servidor."
+      },
+      "autoMessages": {
+        "title": "Mensagens automáticas",
+        "subtitle": "Agende mensagens recorrentes em qualquer canal."
+      },
+      "embedBuilder": {
+        "title": "Construtor de embeds",
+        "subtitle": "Crie e envie embeds avançados do Discord."
+      },
+      "reactionRoles": {
+        "title": "Cargos por reação",
+        "subtitle": "Atribua cargos com base nas reações de emoji dos membros."
+      },
+      "guildAutomation": {
+        "title": "Automação do servidor",
+        "subtitle": "Configure fluxos automatizados de gerenciamento do servidor."
+      },
+      "levels": {
+        "title": "Sistema de níveis",
+        "subtitle": "Configure XP, cargos por nível e rankings."
+      },
+      "starboard": {
+        "title": "Starboard",
+        "subtitle": "Destaque mensagens populares em um canal dedicado."
+      },
+      "lyrics": {
+        "title": "Letras",
+        "subtitle": "Busque e exiba letras de músicas no seu servidor."
+      },
+      "lastFm": {
+        "title": "Last.fm",
+        "subtitle": "Controle a vinculação de contas e a atribuição de scrobbles."
+      },
+      "twitch": {
+        "title": "Notificações da Twitch",
+        "subtitle": "Envie alertas ao vivo quando streamers monitorados ficam online."
+      },
+      "features": {
+        "title": "Recursos",
+        "subtitle": "Ative ou desative módulos de recursos para o seu servidor."
+      },
+      "trackHistory": {
+        "title": "Histórico de faixas",
+        "subtitle": "Inspecione a reprodução recente e a atividade dos solicitantes."
+      },
+      "music": {
+        "title": "Player de música",
+        "subtitle": "Gerencie fila, autoplay e controles de reprodução em tempo real."
+      },
+      "preferredArtists": {
+        "title": "Gosto musical",
+        "subtitle": "Ajuste preferências de autoplay e prioridade de artistas."
+      },
+      "spotify": {
+        "title": "Spotify",
+        "subtitle": "Vincule ou desvincule o Spotify para alimentar o autoplay."
+      },
+      "fallback": {
+        "title": "Painel Lucky",
+        "subtitle": "Configure módulos, moderação e fluxos de engajamento."
+      }
+    }
+  },
+  "landing": {
+    "meta": {
+      "title": "Lucky — Um bot do Discord que você pode hospedar",
+      "description": "Bot do Discord open source com música, moderação, comandos personalizados e painel web. Grátis para sempre. Rode na sua própria máquina."
+    },
+    "hero": {
+      "eyebrow": "Open source · Apache 2.0",
+      "headlineLine1": "Um bot do Discord que",
+      "headlineLine2": "você pode rodar você mesmo.",
+      "subtitle": "100+ comandos. Autoplay com Spotify. Suíte de moderação. Painel web. Grátis para sempre. Sem tier premium. Os dados do seu servidor ficam na sua máquina.",
+      "ctaPrimary": "Auto-hospedar agora",
+      "ctaSecondary": "Usar versão hospedada"
+    },
+    "repoCard": {
+      "name": "LucasSantana-Dev / Lucky",
+      "description": "Bot de música do Discord auto-hospedável — Spotify + YouTube + SoundCloud, autoplay com recomendações, painel React, suíte de moderação.",
+      "license": "Apache-2.0",
+      "lang": "TypeScript",
+      "starsLabel": "estrelas",
+      "forksLabel": "forks",
+      "issuesLabel": "issues abertas",
+      "viewOnGithub": "Ver no GitHub",
+      "copyClone": "Copiar URL de clone"
+    },
+    "whySelfHost": {
+      "heading": "Por que auto-hospedar",
+      "items": {
+        "data": {
+          "title": "Os dados do seu servidor são seus",
+          "description": "Postgres, Redis, seu hardware. Nada de termos de uso de terceiros sobre a sua comunidade. Exporte e migre quando quiser."
+        },
+        "fork": {
+          "title": "Fork no código",
+          "description": "Monorepo TypeScript. Adicione comandos, mude comportamento, troque providers sem esperar por uma roadmap ou pagar por tier de API."
+        },
+        "free": {
+          "title": "Grátis, sem tier premium",
+          "description": "Sem paywall, sem Patreon, sem limite de uso por tier. Apache 2.0. A versão hospedada existe pra quem não quer rodar uma máquina."
+        }
+      }
+    },
+    "commands": {
+      "heading": "100+ comandos, com escopo no que você roda",
+      "rows": {
+        "play": {
+          "name": "/play",
+          "description": "Adicione um track do Spotify, YouTube ou SoundCloud à fila",
+          "kbd": "música"
+        },
+        "autoplay": {
+          "name": "/autoplay",
+          "description": "Recomendações por gênero, sem trocar de idioma",
+          "kbd": "música"
+        },
+        "queue": {
+          "name": "/queue",
+          "description": "Veja ou reordene a fila atual",
+          "kbd": "música"
+        },
+        "ban": {
+          "name": "/mod ban",
+          "description": "Tempban com motivo, DM automática, audit log",
+          "kbd": "moderação"
+        },
+        "automod": {
+          "name": "/automod",
+          "description": "Spam, caps, links, convites — regras por servidor",
+          "kbd": "moderação"
+        },
+        "custom": {
+          "name": "/cc create",
+          "description": "Comandos customizados com interpolação de variáveis",
+          "kbd": "custom"
+        }
+      },
+      "more": "+ 100 outros no painel"
+    },
+    "stack": {
+      "heading": "O que você está rodando",
+      "subheading": "Stack Node/Postgres padrão. Nada exótico. `docker compose up` e você está online.",
+      "items": {
+        "bot": {
+          "name": "lucky-bot",
+          "description": "Cliente discord.js, áudio sem Lavalink via yt-dlp + Opus"
+        },
+        "backend": {
+          "name": "lucky-backend",
+          "description": "API Express, OAuth, Prisma com Postgres"
+        },
+        "frontend": {
+          "name": "lucky-frontend",
+          "description": "React 19 + Vite + Tailwind, painel com OAuth do Discord"
+        },
+        "postgres": {
+          "name": "postgres",
+          "description": "Config de servidor, comandos customizados, log de moderação"
+        },
+        "redis": {
+          "name": "redis",
+          "description": "Cache de sessão, rate-limit, estado de autoplay"
+        },
+        "nginx": {
+          "name": "nginx",
+          "description": "Reverse proxy, rewrite /webhook → /hooks para deploy"
+        }
+      }
+    },
+    "footerRepo": {
+      "heading": "Open source sob Apache 2.0",
+      "subheading": "Fork, contribua, rode, faça o deploy. O código é a especificação."
+    },
+    "footer": {
+      "tagline": "Bot do Discord open source. Rode você mesmo ou use a versão hospedada.",
+      "links": "Produto",
+      "support": "Comunidade",
+      "supportCopy": "Issues e PRs são bem-vindos no GitHub. Ou entre no servidor de suporte do Discord.",
+      "terms": "Termos",
+      "privacy": "Privacidade",
+      "github": "GitHub",
+      "docs": "Docs",
+      "changelog": "Changelog",
+      "discord": "Servidor de suporte",
+      "copyright": "© 2026 Lucky. Apache 2.0."
+    }
+  },
+  "login": {
+    "meta": {
+      "title": "Entrar - Lucky",
+      "description": "Entre no painel do Lucky para gerenciar seus servidores do Discord"
+    },
+    "brand": "Painel do Bot do Discord",
+    "headline": "Gerencie seus servidores do Discord",
+    "description": "Configure moderação, comandos personalizados, música e muito mais — tudo em um só lugar.",
+    "modules": "Módulos",
+    "commands": "Comandos",
+    "uptime": "Tempo online",
+    "authentication": "Autenticação",
+    "signInWithDiscord": "Entrar com Discord",
+    "permissionsNote": "Suas permissões de servidor e controles do bot estão vinculados à sua conta do Discord.",
+    "connecting": "Conectando...",
+    "loginButton": "Entrar com Discord",
+    "badges": {
+      "oauthSecured": "Protegido por OAuth",
+      "fastSetup": "Configuração rápida",
+      "liveControls": "Controles em tempo real"
+    },
+    "copyright": "© 2026 Lucky. Todos os direitos reservados."
+  }
 }

--- a/packages/frontend/src/pages/Changelog.test.tsx
+++ b/packages/frontend/src/pages/Changelog.test.tsx
@@ -37,7 +37,7 @@ describe('Changelog', () => {
         renderPage()
         const prLinks = screen.getAllByRole('link', { name: /^#\d+/ })
         expect(prLinks.length).toBeGreaterThanOrEqual(1)
-        expect(prLinks[0]).toHaveAttribute('href', expect.stringMatching(/github\.com\/LucasSantana-Dev\/Lucky\/pull\/\d+/))
+        expect(prLinks[0]).toHaveAttribute('href', expect.stringMatching(/^https:\/\/github\.com\/LucasSantana-Dev\/Lucky\/pull\/\d+$/))
     })
 
     test('renders version sidebar', () => {

--- a/packages/frontend/src/pages/Changelog.test.tsx
+++ b/packages/frontend/src/pages/Changelog.test.tsx
@@ -1,0 +1,47 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Changelog from './Changelog'
+import { usePageMetadata } from '@/hooks/usePageMetadata'
+
+vi.mock('@/hooks/usePageMetadata')
+
+function renderPage() {
+    vi.mocked(usePageMetadata).mockImplementation(() => undefined)
+    return render(
+        <MemoryRouter>
+            <Changelog />
+        </MemoryRouter>,
+    )
+}
+
+describe('Changelog', () => {
+    test('renders page title', () => {
+        renderPage()
+        expect(screen.getByRole('heading', { level: 1, name: /Changelog/i })).toBeInTheDocument()
+    })
+
+    test('renders at least one version from CHANGELOG.md', () => {
+        renderPage()
+        // Latest shipped version
+        expect(screen.getAllByText(/v2\.11\.0/).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('renders section headings (Added / Fixed / Changed)', () => {
+        renderPage()
+        expect(screen.getAllByText(/^Added$/i).length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText(/^Fixed$/i).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('links PR references to github', () => {
+        renderPage()
+        const prLinks = screen.getAllByRole('link', { name: /^#\d+/ })
+        expect(prLinks.length).toBeGreaterThanOrEqual(1)
+        expect(prLinks[0]).toHaveAttribute('href', expect.stringMatching(/github\.com\/LucasSantana-Dev\/Lucky\/pull\/\d+/))
+    })
+
+    test('renders version sidebar', () => {
+        renderPage()
+        expect(screen.getAllByText(/Versions/i).length).toBeGreaterThanOrEqual(1)
+    })
+})

--- a/packages/frontend/src/pages/Changelog.tsx
+++ b/packages/frontend/src/pages/Changelog.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { ArrowUpRight, Menu, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import changelogMd from '../../../../CHANGELOG.md?raw'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
+import PublicHeader from '@/components/DocsShell/PublicHeader'
+import { useActiveHeading } from '@/hooks/useActiveHeading'
 
 type ChangelogSection = {
     heading: string
@@ -65,7 +65,6 @@ function formatDate(date: string | null): string {
 }
 
 function renderInlineMd(text: string): React.ReactNode {
-    // Handle code spans (backticks) and PR refs (#NNN)
     const parts: React.ReactNode[] = []
     const codeSplit = text.split(/(`[^`]+`)/g)
     codeSplit.forEach((chunk, ci) => {
@@ -121,77 +120,18 @@ export default function ChangelogPage() {
 
     const entries = useMemo(() => parseChangelog(changelogMd), [])
     const [sidebarOpen, setSidebarOpen] = useState(false)
-    const [activeVersion, setActiveVersion] = useState<string | null>(null)
-
-    useEffect(() => {
-        const ids = entries.map((e) => `v-${e.version}`)
-        const els = ids
-            .map((id) => document.getElementById(id))
-            .filter((el): el is HTMLElement => Boolean(el))
-        if (!els.length) return
-        const obs = new IntersectionObserver(
-            (events) => {
-                const visible = events
-                    .filter((e) => e.isIntersecting)
-                    .sort(
-                        (a, b) =>
-                            a.boundingClientRect.top - b.boundingClientRect.top,
-                    )
-                if (visible[0]) {
-                    const id = visible[0].target.id
-                    setActiveVersion(id.replace(/^v-/, ''))
-                }
-            },
-            { rootMargin: '-80px 0px -65% 0px', threshold: 0.1 },
-        )
-        els.forEach((el) => obs.observe(el))
-        return () => obs.disconnect()
-    }, [entries])
+    const ids = useMemo(() => entries.map((e) => `v-${e.version}`), [entries])
+    const activeId = useActiveHeading(ids)
+    const activeVersion = activeId ? activeId.replace(/^v-/, '') : null
 
     return (
         <div className='min-h-screen bg-lucky-surface-canvas text-white'>
-            <header className='sticky top-0 z-30 border-b border-lucky-border-soft bg-lucky-surface-canvas/85 backdrop-blur supports-[backdrop-filter]:bg-lucky-surface-canvas/65'>
-                <div className='mx-auto flex h-14 max-w-7xl items-center justify-between gap-3 px-4 md:px-6'>
-                    <div className='flex items-center gap-2'>
-                        <button
-                            onClick={() => setSidebarOpen((v) => !v)}
-                            aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
-                            className='lg:hidden inline-flex h-9 w-9 items-center justify-center rounded-md text-lucky-text-muted hover:bg-lucky-surface-panel hover:text-lucky-text-strong'
-                        >
-                            {sidebarOpen ? <X size={16} /> : <Menu size={16} />}
-                        </button>
-                        <Link
-                            to='/'
-                            className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
-                        >
-                            <img src='/lucky-logo.png' alt='Lucky' width='24' height='24' className='h-6 w-6 rounded-full' loading='eager' />
-                            <span className='font-mono text-sm font-semibold tracking-tight'>
-                                lucky<span className='text-lucky-brand'>.</span>
-                            </span>
-                        </Link>
-                        <span className='ml-1 hidden text-lucky-border-strong md:inline'>/</span>
-                        <span className='hidden font-mono text-xs uppercase tracking-[0.2em] text-lucky-text-muted md:inline'>
-                            Changelog
-                        </span>
-                    </div>
-                    <nav className='flex items-center gap-1 font-mono text-xs text-lucky-text-muted'>
-                        <Link to='/docs' className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'>
-                            docs
-                        </Link>
-                        <Link to='/changelog' className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 bg-lucky-surface-panel text-lucky-text-strong'>
-                            changelog
-                        </Link>
-                        <a
-                            href='https://github.com/LucasSantana-Dev/Lucky'
-                            target='_blank'
-                            rel='noreferrer'
-                            className='inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'
-                        >
-                            github <ArrowUpRight size={11} aria-hidden />
-                        </a>
-                    </nav>
-                </div>
-            </header>
+            <PublicHeader
+                breadcrumb='Changelog'
+                activeNav='changelog'
+                sidebarOpen={sidebarOpen}
+                onToggleSidebar={() => setSidebarOpen((v) => !v)}
+            />
 
             <div className='mx-auto grid max-w-7xl gap-0 px-0 md:px-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]'>
                 <aside

--- a/packages/frontend/src/pages/Changelog.tsx
+++ b/packages/frontend/src/pages/Changelog.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ArrowUpRight, Menu, X } from 'lucide-react'
+import changelogMd from '../../../../CHANGELOG.md?raw'
+import { usePageMetadata } from '@/hooks/usePageMetadata'
+
+type ChangelogSection = {
+    heading: string
+    items: string[]
+}
+
+type ChangelogEntry = {
+    version: string
+    date: string | null
+    sections: ChangelogSection[]
+}
+
+function parseChangelog(md: string): ChangelogEntry[] {
+    const lines = md.split('\n')
+    const entries: ChangelogEntry[] = []
+
+    let current: ChangelogEntry | null = null
+    let currentSection: ChangelogSection | null = null
+
+    const versionRegex = /^##\s+\[([^\]]+)\](?:\s*-\s*(\d{4}-\d{2}-\d{2}))?/
+    const sectionRegex = /^###\s+(.+)/
+    const bulletRegex = /^[-*]\s+(.+)/
+
+    for (const raw of lines) {
+        const line = raw.trimEnd()
+        const v = line.match(versionRegex)
+        if (v) {
+            if (current) entries.push(current)
+            current = { version: v[1], date: v[2] ?? null, sections: [] }
+            currentSection = null
+            continue
+        }
+        if (!current) continue
+        const s = line.match(sectionRegex)
+        if (s) {
+            currentSection = { heading: s[1].trim(), items: [] }
+            current.sections.push(currentSection)
+            continue
+        }
+        const b = line.match(bulletRegex)
+        if (b && currentSection) {
+            currentSection.items.push(b[1].trim())
+        }
+    }
+    if (current) entries.push(current)
+
+    return entries.filter((e) => e.sections.some((s) => s.items.length > 0))
+}
+
+function formatDate(date: string | null): string {
+    if (!date) return ''
+    const d = new Date(date + 'T00:00:00Z')
+    if (Number.isNaN(d.getTime())) return date
+    return d.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+    })
+}
+
+function renderInlineMd(text: string): React.ReactNode {
+    // Handle code spans (backticks) and PR refs (#NNN)
+    const parts: React.ReactNode[] = []
+    const codeSplit = text.split(/(`[^`]+`)/g)
+    codeSplit.forEach((chunk, ci) => {
+        if (chunk.startsWith('`') && chunk.endsWith('`')) {
+            parts.push(
+                <code
+                    key={`c-${ci}`}
+                    className='rounded bg-lucky-surface-elevated border border-lucky-border-soft px-1.5 py-0.5 font-mono text-[0.84em] text-lucky-text-strong'
+                >
+                    {chunk.slice(1, -1)}
+                </code>,
+            )
+            return
+        }
+        const prSplit = chunk.split(/(#\d{2,5})/g)
+        prSplit.forEach((p, pi) => {
+            const m = p.match(/^#(\d{2,5})$/)
+            if (m) {
+                parts.push(
+                    <a
+                        key={`p-${ci}-${pi}`}
+                        href={`https://github.com/LucasSantana-Dev/Lucky/pull/${m[1]}`}
+                        target='_blank'
+                        rel='noreferrer'
+                        className='font-mono text-lucky-brand hover:underline'
+                    >
+                        #{m[1]}
+                    </a>,
+                )
+            } else if (p) {
+                parts.push(p)
+            }
+        })
+    })
+    return parts
+}
+
+const sectionStyles: Record<string, string> = {
+    Added: 'text-lucky-brand',
+    Changed: 'text-amber-400',
+    Fixed: 'text-emerald-400',
+    Internal: 'text-lucky-text-muted',
+    Removed: 'text-rose-400',
+    Security: 'text-rose-400',
+    Deprecated: 'text-amber-400',
+}
+
+export default function ChangelogPage() {
+    usePageMetadata({
+        title: 'Changelog · Lucky',
+        description: 'Release notes and version history for Lucky.',
+    })
+
+    const entries = useMemo(() => parseChangelog(changelogMd), [])
+    const [sidebarOpen, setSidebarOpen] = useState(false)
+    const [activeVersion, setActiveVersion] = useState<string | null>(null)
+
+    useEffect(() => {
+        const ids = entries.map((e) => `v-${e.version}`)
+        const els = ids
+            .map((id) => document.getElementById(id))
+            .filter((el): el is HTMLElement => Boolean(el))
+        if (!els.length) return
+        const obs = new IntersectionObserver(
+            (events) => {
+                const visible = events
+                    .filter((e) => e.isIntersecting)
+                    .sort(
+                        (a, b) =>
+                            a.boundingClientRect.top - b.boundingClientRect.top,
+                    )
+                if (visible[0]) {
+                    const id = visible[0].target.id
+                    setActiveVersion(id.replace(/^v-/, ''))
+                }
+            },
+            { rootMargin: '-80px 0px -65% 0px', threshold: 0.1 },
+        )
+        els.forEach((el) => obs.observe(el))
+        return () => obs.disconnect()
+    }, [entries])
+
+    return (
+        <div className='min-h-screen bg-lucky-surface-canvas text-white'>
+            <header className='sticky top-0 z-30 border-b border-lucky-border-soft bg-lucky-surface-canvas/85 backdrop-blur supports-[backdrop-filter]:bg-lucky-surface-canvas/65'>
+                <div className='mx-auto flex h-14 max-w-7xl items-center justify-between gap-3 px-4 md:px-6'>
+                    <div className='flex items-center gap-2'>
+                        <button
+                            onClick={() => setSidebarOpen((v) => !v)}
+                            aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
+                            className='lg:hidden inline-flex h-9 w-9 items-center justify-center rounded-md text-lucky-text-muted hover:bg-lucky-surface-panel hover:text-lucky-text-strong'
+                        >
+                            {sidebarOpen ? <X size={16} /> : <Menu size={16} />}
+                        </button>
+                        <Link
+                            to='/'
+                            className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
+                        >
+                            <img src='/lucky-logo.png' alt='Lucky' width='24' height='24' className='h-6 w-6' loading='eager' />
+                            <span className='font-mono text-sm font-semibold tracking-tight'>
+                                lucky<span className='text-lucky-brand'>.</span>
+                            </span>
+                        </Link>
+                        <span className='ml-1 hidden text-lucky-border-strong md:inline'>/</span>
+                        <span className='hidden font-mono text-xs uppercase tracking-[0.2em] text-lucky-text-muted md:inline'>
+                            Changelog
+                        </span>
+                    </div>
+                    <nav className='flex items-center gap-1 font-mono text-xs text-lucky-text-muted'>
+                        <Link to='/docs' className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'>
+                            docs
+                        </Link>
+                        <Link to='/changelog' className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 bg-lucky-surface-panel text-lucky-text-strong'>
+                            changelog
+                        </Link>
+                        <a
+                            href='https://github.com/LucasSantana-Dev/Lucky'
+                            target='_blank'
+                            rel='noreferrer'
+                            className='inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'
+                        >
+                            github <ArrowUpRight size={11} aria-hidden />
+                        </a>
+                    </nav>
+                </div>
+            </header>
+
+            <div className='mx-auto grid max-w-7xl gap-0 px-0 md:px-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]'>
+                <aside
+                    className={`${sidebarOpen ? 'block' : 'hidden'} lg:block border-r border-lucky-border-soft bg-lucky-surface-canvas`}
+                    aria-label='Version navigation'
+                >
+                    <div className='sticky top-14 max-h-[calc(100vh-3.5rem)] overflow-y-auto px-4 py-8 md:px-6'>
+                        <h4 className='mb-3 font-mono text-[10px] uppercase tracking-[0.22em] text-lucky-text-muted'>
+                            Versions
+                        </h4>
+                        <ul className='space-y-0.5'>
+                            {entries.map((e) => {
+                                const active = activeVersion === e.version
+                                return (
+                                    <li key={e.version}>
+                                        <a
+                                            href={`#v-${e.version}`}
+                                            className={`flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-sm transition-colors ${active ? 'bg-lucky-surface-panel text-lucky-text-strong shadow-[inset_2px_0_0_var(--color-lucky-brand)]' : 'text-lucky-text-body hover:bg-lucky-surface-panel hover:text-lucky-text-strong'}`}
+                                        >
+                                            <span className='font-mono'>{e.version}</span>
+                                            {e.date ? (
+                                                <span className='font-mono text-[10px] text-lucky-text-muted'>
+                                                    {e.date.slice(0, 7)}
+                                                </span>
+                                            ) : null}
+                                        </a>
+                                    </li>
+                                )
+                            })}
+                        </ul>
+                    </div>
+                </aside>
+
+                <main className='min-w-0 px-4 py-10 md:px-8 md:py-14 lg:px-10'>
+                    <article className='mx-auto max-w-2xl'>
+                        <header className='mb-10 border-b border-lucky-border-soft pb-6'>
+                            <p className='mb-3 font-mono text-[11px] uppercase tracking-[0.22em] text-lucky-text-muted'>
+                                Releases
+                            </p>
+                            <h1 className='text-3xl font-bold tracking-tight text-lucky-text-strong md:text-4xl'>
+                                Changelog
+                            </h1>
+                            <p className='mt-3 text-sm text-lucky-text-body'>
+                                Notable changes per release. Source of truth:{' '}
+                                <a
+                                    className='text-lucky-brand hover:underline'
+                                    href='https://github.com/LucasSantana-Dev/Lucky/blob/main/CHANGELOG.md'
+                                    target='_blank'
+                                    rel='noreferrer'
+                                >
+                                    CHANGELOG.md
+                                </a>
+                                .
+                            </p>
+                        </header>
+
+                        <div className='relative'>
+                            <div
+                                aria-hidden
+                                className='absolute left-2 top-2 bottom-2 w-px bg-lucky-border-soft'
+                            />
+                            <div className='space-y-12'>
+                                {entries.map((entry) => (
+                                    <section
+                                        key={entry.version}
+                                        id={`v-${entry.version}`}
+                                        className='relative pl-8 scroll-mt-20'
+                                    >
+                                        <span
+                                            aria-hidden
+                                            className='absolute left-[3px] top-2.5 h-2.5 w-2.5 rounded-full bg-lucky-brand ring-4 ring-lucky-surface-canvas'
+                                        />
+                                        <div className='flex flex-wrap items-baseline gap-x-3 gap-y-1'>
+                                            <h2 className='font-mono text-xl font-semibold text-lucky-text-strong'>
+                                                v{entry.version}
+                                            </h2>
+                                            {entry.date ? (
+                                                <span className='font-mono text-xs text-lucky-text-muted'>
+                                                    {formatDate(entry.date)}
+                                                </span>
+                                            ) : null}
+                                        </div>
+                                        <div className='mt-5 space-y-6'>
+                                            {entry.sections.map((section) =>
+                                                section.items.length === 0 ? null : (
+                                                    <div key={section.heading}>
+                                                        <h3
+                                                            className={`mb-2 font-mono text-[11px] uppercase tracking-[0.22em] ${sectionStyles[section.heading] ?? 'text-lucky-text-muted'}`}
+                                                        >
+                                                            {section.heading}
+                                                        </h3>
+                                                        <ul className='space-y-1.5 text-sm leading-relaxed text-lucky-text-body'>
+                                                            {section.items.map((item, i) => (
+                                                                <li key={i} className='flex gap-2'>
+                                                                    <span className='mt-2 inline-block h-1 w-1 shrink-0 rounded-full bg-lucky-text-muted' />
+                                                                    <span>{renderInlineMd(item)}</span>
+                                                                </li>
+                                                            ))}
+                                                        </ul>
+                                                    </div>
+                                                ),
+                                            )}
+                                        </div>
+                                    </section>
+                                ))}
+                            </div>
+                        </div>
+                    </article>
+                </main>
+
+                <div className='hidden lg:block' />
+            </div>
+        </div>
+    )
+}

--- a/packages/frontend/src/pages/Changelog.tsx
+++ b/packages/frontend/src/pages/Changelog.tsx
@@ -164,7 +164,7 @@ export default function ChangelogPage() {
                             to='/'
                             className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
                         >
-                            <img src='/lucky-logo.png' alt='Lucky' width='24' height='24' className='h-6 w-6' loading='eager' />
+                            <img src='/lucky-logo.png' alt='Lucky' width='24' height='24' className='h-6 w-6 rounded-full' loading='eager' />
                             <span className='font-mono text-sm font-semibold tracking-tight'>
                                 lucky<span className='text-lucky-brand'>.</span>
                             </span>

--- a/packages/frontend/src/pages/Docs.test.tsx
+++ b/packages/frontend/src/pages/Docs.test.tsx
@@ -1,0 +1,50 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Docs from './Docs'
+import { usePageMetadata } from '@/hooks/usePageMetadata'
+
+vi.mock('@/hooks/usePageMetadata')
+
+function renderAt(path: string) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Docs />
+        </MemoryRouter>,
+    )
+}
+
+describe('Docs', () => {
+    test('renders Overview by default', () => {
+        vi.mocked(usePageMetadata).mockImplementation(() => undefined)
+        renderAt('/docs')
+        expect(screen.getAllByRole('heading', { level: 1, name: /Overview/i }).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('renders Quick start page when ?page=quickstart', () => {
+        vi.mocked(usePageMetadata).mockImplementation(() => undefined)
+        renderAt('/docs?page=quickstart')
+        expect(screen.getByRole('heading', { level: 1, name: /Quick start/i })).toBeInTheDocument()
+    })
+
+    test('renders Self-host page with docker compose snippet', () => {
+        vi.mocked(usePageMetadata).mockImplementation(() => undefined)
+        renderAt('/docs?page=self-host')
+        expect(screen.getByRole('heading', { level: 1, name: /Self-host/i })).toBeInTheDocument()
+        expect(screen.getAllByText(/docker compose/i).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('falls back to Overview for unknown slug', () => {
+        vi.mocked(usePageMetadata).mockImplementation(() => undefined)
+        renderAt('/docs?page=does-not-exist')
+        expect(screen.getAllByRole('heading', { level: 1, name: /Overview/i }).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('renders sidebar nav groups', () => {
+        vi.mocked(usePageMetadata).mockImplementation(() => undefined)
+        renderAt('/docs')
+        expect(screen.getAllByText(/Getting started/i).length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText(/Using Lucky/i).length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText(/Reference/i).length).toBeGreaterThanOrEqual(1)
+    })
+})

--- a/packages/frontend/src/pages/Docs.tsx
+++ b/packages/frontend/src/pages/Docs.tsx
@@ -1,0 +1,524 @@
+import { useMemo, type ReactElement } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { usePageMetadata } from '@/hooks/usePageMetadata'
+import DocsShell, { type DocsNavGroup, type DocsTocItem } from '@/components/DocsShell/DocsShell'
+
+type DocsPage = {
+    slug: string
+    title: string
+    breadcrumb: string
+    toc: DocsTocItem[]
+    content: () => ReactElement
+}
+
+const REPO = 'https://github.com/LucasSantana-Dev/Lucky'
+const BOT_INVITE = 'https://discord.com/oauth2/authorize?client_id=962198089161134131&scope=bot%20applications.commands&permissions=8'
+
+const NAV: DocsNavGroup[] = [
+    {
+        heading: 'Getting started',
+        items: [
+            { label: 'Overview', href: '/docs?page=overview' },
+            { label: 'Quick start', href: '/docs?page=quickstart' },
+            { label: 'Self-host', href: '/docs?page=self-host' },
+        ],
+    },
+    {
+        heading: 'Using Lucky',
+        items: [
+            { label: 'Music & autoplay', href: '/docs?page=music' },
+            { label: 'Moderation', href: '/docs?page=moderation' },
+            { label: 'Custom commands', href: '/docs?page=custom-commands' },
+            { label: 'Web dashboard', href: '/docs?page=dashboard' },
+        ],
+    },
+    {
+        heading: 'Reference',
+        items: [
+            { label: 'Command list', href: '/docs?page=commands' },
+            { label: 'Permissions', href: '/docs?page=permissions' },
+            { label: 'Environment variables', href: '/docs?page=env' },
+        ],
+    },
+    {
+        heading: 'External',
+        items: [
+            { label: 'GitHub repo', href: REPO, external: true },
+            { label: 'Changelog', href: '/changelog' },
+            { label: 'Discord support', href: 'https://discord.gg/lucky', external: true },
+        ],
+    },
+]
+
+const PAGES: DocsPage[] = [
+    {
+        slug: 'overview',
+        title: 'Overview',
+        breadcrumb: 'Docs / Overview',
+        toc: [
+            { id: 'what-is-lucky', label: 'What is Lucky' },
+            { id: 'two-ways-to-run-it', label: 'Two ways to run it' },
+            { id: 'whats-included', label: "What's included" },
+        ],
+        content: () => (
+            <>
+                <p>
+                    Lucky is an open-source Discord bot. Music, moderation, custom commands, and a web dashboard.
+                    Free forever, with no premium tier paywalling the good parts.
+                </p>
+                <h2 id='what-is-lucky'>What is Lucky</h2>
+                <p>
+                    Lucky started as a music bot. It now also handles moderation, custom commands, automation, role gating,
+                    and reaction roles. The web dashboard at the same domain lets you configure everything without leaving
+                    the browser.
+                </p>
+                <p>
+                    The codebase is a TypeScript monorepo published under the Apache 2.0 license. Anyone can fork it,
+                    audit it, or self-host their own instance.
+                </p>
+                <h2 id='two-ways-to-run-it'>Two ways to run it</h2>
+                <p>You can use Lucky in either of two ways. Pick whichever fits your situation.</p>
+                <ol>
+                    <li>
+                        <strong>Hosted.</strong> Click <a href={BOT_INVITE} rel='noreferrer noopener' target='_blank'>Add to Discord</a>,
+                        pick the server, accept the permissions. The bot joins, you open the dashboard, and you're configuring within a minute.
+                    </li>
+                    <li>
+                        <strong>Self-hosted.</strong> Clone the repo, copy <code>.env.example</code> to <code>.env</code>, run{' '}
+                        <code>docker compose up</code>. The bot runs on your box. Your guild data stays on your hardware. See{' '}
+                        <a href='/docs?page=self-host'>Self-host</a> for the full setup.
+                    </li>
+                </ol>
+                <h2 id='whats-included'>What's included</h2>
+                <ul>
+                    <li>Slash commands for music, moderation, and utility (100+ in total).</li>
+                    <li>Autoplay with Spotify-fed recommendations and Last.fm scrobbling.</li>
+                    <li>Auto-mod for spam, caps, links, and invites with per-server rules.</li>
+                    <li>Custom command builder with variable interpolation.</li>
+                    <li>Embed builder with live preview and saved templates.</li>
+                    <li>Reaction roles, role gating, leveling, and starboard.</li>
+                    <li>A React dashboard for configuring everything from your browser.</li>
+                </ul>
+            </>
+        ),
+    },
+    {
+        slug: 'quickstart',
+        title: 'Quick start',
+        breadcrumb: 'Docs / Quick start',
+        toc: [
+            { id: 'add-the-bot', label: 'Add the bot' },
+            { id: 'open-the-dashboard', label: 'Open the dashboard' },
+            { id: 'first-commands', label: 'First commands to try' },
+        ],
+        content: () => (
+            <>
+                <p>You'll be running Lucky in your server in under two minutes. No account creation, no payment, no email.</p>
+                <h2 id='add-the-bot'>Add the bot</h2>
+                <ol>
+                    <li>
+                        Click <a href={BOT_INVITE} rel='noreferrer noopener' target='_blank'>Add to Discord</a>.
+                    </li>
+                    <li>Pick the server. You need <code>Manage Server</code> on it.</li>
+                    <li>Accept the requested permissions. The bot joins immediately.</li>
+                </ol>
+                <h2 id='open-the-dashboard'>Open the dashboard</h2>
+                <p>
+                    Go to the homepage and click <strong>Dashboard</strong> in the top right, or go directly to{' '}
+                    <code>/login</code>. Authorize with Discord OAuth. You'll see the server you just added the bot to.
+                </p>
+                <h2 id='first-commands' >First commands to try</h2>
+                <ul>
+                    <li>
+                        <code>/play tame impala let it happen</code> — join voice and queue a track.
+                    </li>
+                    <li>
+                        <code>/autoplay on</code> — keep music going when the queue ends.
+                    </li>
+                    <li>
+                        <code>/queue</code> — see what's coming up.
+                    </li>
+                    <li>
+                        <code>/cc create welcome &quot;Welcome to {'{server}'}, {'{user}'}!&quot;</code> — make a custom command.
+                    </li>
+                </ul>
+            </>
+        ),
+    },
+    {
+        slug: 'self-host',
+        title: 'Self-host',
+        breadcrumb: 'Docs / Self-host',
+        toc: [
+            { id: 'requirements', label: 'Requirements' },
+            { id: 'discord-app', label: 'Create a Discord app' },
+            { id: 'clone-and-configure', label: 'Clone and configure' },
+            { id: 'start-the-stack', label: 'Start the stack' },
+            { id: 'updating', label: 'Updating' },
+        ],
+        content: () => (
+            <>
+                <p>
+                    Self-hosting means you run Lucky on your own hardware. Your guild data, autoplay history, custom
+                    commands, and moderation log stay on your box. No third-party ToS over your community.
+                </p>
+                <h2 id='requirements'>Requirements</h2>
+                <ul>
+                    <li>A Linux server (Debian, Ubuntu, or any docker-compatible distro).</li>
+                    <li><code>docker</code> and <code>docker compose</code> v2+ installed.</li>
+                    <li>~2 GB RAM, ~5 GB disk. More if you log a lot.</li>
+                    <li>A Discord application with a bot token. See below.</li>
+                </ul>
+                <h2 id='discord-app'>Create a Discord app</h2>
+                <ol>
+                    <li>Go to <a href='https://discord.com/developers/applications' rel='noreferrer noopener' target='_blank'>Discord Developer Portal</a>.</li>
+                    <li>Click <strong>New Application</strong>, name it.</li>
+                    <li>Under <strong>Bot</strong>, click <strong>Reset Token</strong> and copy it.</li>
+                    <li>Under <strong>OAuth2 / URL Generator</strong>, pick <code>bot</code> + <code>applications.commands</code> scopes and the permissions you want.</li>
+                </ol>
+                <h2 id='clone-and-configure'>Clone and configure</h2>
+                <pre>
+                    <code>{`git clone ${REPO}.git lucky
+cd lucky
+cp .env.example .env
+$EDITOR .env`}</code>
+                </pre>
+                <p>
+                    Required env vars: <code>DISCORD_TOKEN</code>, <code>DISCORD_CLIENT_ID</code>, <code>DISCORD_CLIENT_SECRET</code>,{' '}
+                    <code>POSTGRES_PASSWORD</code>, <code>SESSION_SECRET</code>. The full list is documented in{' '}
+                    <a href='/docs?page=env'>Environment variables</a>.
+                </p>
+                <h2 id='start-the-stack'>Start the stack</h2>
+                <pre>
+                    <code>{`docker compose up -d
+docker compose ps`}</code>
+                </pre>
+                <p>
+                    You should see <code>lucky-bot</code>, <code>lucky-backend</code>, <code>lucky-frontend</code>,{' '}
+                    <code>lucky-nginx</code>, <code>lucky-postgres</code>, and <code>lucky-redis</code> all healthy.
+                </p>
+                <p>
+                    The dashboard is served on port <code>8090</code> by default. Point your reverse proxy at it, or
+                    expose it directly. The bot will appear online in any server you invite it to.
+                </p>
+                <h2 id='updating'>Updating</h2>
+                <pre>
+                    <code>{`git pull
+docker compose pull
+docker compose up -d`}</code>
+                </pre>
+                <p>
+                    Or set up the webhook receiver for push-to-deploy. The repo includes a <code>deploy/</code> directory with
+                    the webhook config that listens for GitHub Actions builds and pulls the new images automatically.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'music',
+        title: 'Music & autoplay',
+        breadcrumb: 'Docs / Music & autoplay',
+        toc: [
+            { id: 'sources', label: 'Sources' },
+            { id: 'autoplay-mode', label: 'Autoplay' },
+            { id: 'last-fm', label: 'Last.fm scrobbling' },
+        ],
+        content: () => (
+            <>
+                <p>
+                    Lucky plays from Spotify, YouTube, and SoundCloud. It uses <code>yt-dlp</code> for extraction and
+                    bundles its own Opus encoder, so no Lavalink server is required.
+                </p>
+                <h2 id='sources'>Sources</h2>
+                <ul>
+                    <li><strong>Spotify.</strong> Paste a track, album, or playlist URL. Lucky resolves and queues it.</li>
+                    <li><strong>YouTube.</strong> Paste a video or playlist URL, or search by title.</li>
+                    <li><strong>SoundCloud.</strong> Paste a track URL. Useful for sets and bootlegs.</li>
+                </ul>
+                <h2 id='autoplay-mode'>Autoplay</h2>
+                <p>
+                    When the queue empties, autoplay picks the next track. It uses Spotify's recommendation engine, scoped
+                    to genres and artists already in the queue or in your server's preferred-artists list. Common slop
+                    (gospel reggaeton drift, language jumps) is filtered out automatically.
+                </p>
+                <p>
+                    Toggle it with <code>/autoplay on</code> or in the dashboard under <strong>Music settings</strong>.
+                </p>
+                <h2 id='last-fm'>Last.fm scrobbling</h2>
+                <p>
+                    Connect a Last.fm account from the dashboard. Lucky scrobbles everything that plays, so your listening
+                    history follows you across servers and devices.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'moderation',
+        title: 'Moderation',
+        breadcrumb: 'Docs / Moderation',
+        toc: [
+            { id: 'auto-mod', label: 'Auto-mod rules' },
+            { id: 'manual-actions', label: 'Manual actions' },
+            { id: 'audit', label: 'Audit log' },
+        ],
+        content: () => (
+            <>
+                <p>
+                    Configure auto-mod per server. Run <code>/automod</code> in chat or open the <strong>Moderation</strong>{' '}
+                    tab in the dashboard.
+                </p>
+                <h2 id='auto-mod'>Auto-mod rules</h2>
+                <ul>
+                    <li><strong>Spam.</strong> Detect repeated messages and cross-channel spam.</li>
+                    <li><strong>Caps.</strong> Flag messages above a configurable caps ratio.</li>
+                    <li><strong>Links.</strong> Allow-list and block-list domains.</li>
+                    <li><strong>Invites.</strong> Block Discord invite links not on your allow-list.</li>
+                </ul>
+                <h2 id='manual-actions'>Manual actions</h2>
+                <p>
+                    Run <code>/mod ban</code>, <code>/mod kick</code>, <code>/mod tempban</code>, or <code>/mod warn</code>.
+                    Each accepts a reason that's sent to the user via DM (if they allow them), written to your audit log,
+                    and copied to the Discord audit trail.
+                </p>
+                <h2 id='audit'>Audit log</h2>
+                <p>
+                    Open <strong>Moderation / Audit</strong> in the dashboard. Filter by moderator, target, action type, or
+                    date range. Export as CSV.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'custom-commands',
+        title: 'Custom commands',
+        breadcrumb: 'Docs / Custom commands',
+        toc: [
+            { id: 'create-one', label: 'Create one' },
+            { id: 'variables', label: 'Variables' },
+            { id: 'permissions', label: 'Permissions' },
+        ],
+        content: () => (
+            <>
+                <p>
+                    Build slash commands without writing code. Useful for FAQ replies, role toggles, embed posts, and
+                    server-specific shortcuts.
+                </p>
+                <h2 id='create-one'>Create one</h2>
+                <pre>
+                    <code>{`/cc create rules
+> response: "Read the rules in #rules-channel, ${'$'}{user}."`}</code>
+                </pre>
+                <p>Or use the dashboard: <strong>Custom commands / New</strong>.</p>
+                <h2 id='variables'>Variables</h2>
+                <ul>
+                    <li><code>{'{user}'}</code> — the invoking user's mention.</li>
+                    <li><code>{'{user.name}'}</code> — username only.</li>
+                    <li><code>{'{server}'}</code> — server name.</li>
+                    <li><code>{'{channel}'}</code> — current channel mention.</li>
+                    <li><code>{'{arg1}'}</code>, <code>{'{arg2}'}</code> — positional arguments.</li>
+                </ul>
+                <h2 id='permissions'>Permissions</h2>
+                <p>
+                    Scope each command to a role or channel. The default is everyone. Useful for staff-only utilities or
+                    channel-specific posts.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'dashboard',
+        title: 'Web dashboard',
+        breadcrumb: 'Docs / Web dashboard',
+        toc: [
+            { id: 'access', label: 'Access' },
+            { id: 'modules', label: 'Modules' },
+            { id: 'rbac', label: 'Role-based access' },
+        ],
+        content: () => (
+            <>
+                <p>The dashboard is the configuration surface. Everything the bot does is configurable from here.</p>
+                <h2 id='access'>Access</h2>
+                <p>
+                    Sign in with Discord OAuth at <code>/login</code>. You see every server where you have{' '}
+                    <code>Manage Server</code> and where Lucky is present.
+                </p>
+                <h2 id='modules'>Modules</h2>
+                <ul>
+                    <li><strong>Overview.</strong> Server stats, recent activity, currently playing.</li>
+                    <li><strong>Music.</strong> Queue control, autoplay settings, preferred artists.</li>
+                    <li><strong>Moderation.</strong> Auto-mod rules, manual actions, audit log.</li>
+                    <li><strong>Custom commands.</strong> Build, edit, and scope custom replies.</li>
+                    <li><strong>Reaction roles.</strong> Self-assign roles from emoji reactions.</li>
+                    <li><strong>Embed builder.</strong> Compose Discord embeds with live preview.</li>
+                </ul>
+                <h2 id='rbac'>Role-based access</h2>
+                <p>
+                    Give different teams different access levels. Server owner has full control. Mods can adjust moderation
+                    and custom commands without touching music settings. Read-only for transparency.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'commands',
+        title: 'Command list',
+        breadcrumb: 'Docs / Command list',
+        toc: [
+            { id: 'music-cmds', label: 'Music' },
+            { id: 'mod-cmds', label: 'Moderation' },
+            { id: 'utility-cmds', label: 'Utility' },
+        ],
+        content: () => (
+            <>
+                <p>The complete list is shipped with the bot. Run <code>/help</code> in your server for the live version.</p>
+                <h2 id='music-cmds'>Music</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Command</th>
+                            <th>What it does</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><code>/play</code></td><td>Queue a track or playlist.</td></tr>
+                        <tr><td><code>/queue</code></td><td>Show the current queue.</td></tr>
+                        <tr><td><code>/skip</code></td><td>Skip the current track (vote-skip in larger channels).</td></tr>
+                        <tr><td><code>/autoplay</code></td><td>Toggle autoplay.</td></tr>
+                        <tr><td><code>/nowplaying</code></td><td>Show the current track and progress.</td></tr>
+                        <tr><td><code>/lyrics</code></td><td>Show synced lyrics from Genius.</td></tr>
+                    </tbody>
+                </table>
+                <h2 id='mod-cmds'>Moderation</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Command</th>
+                            <th>What it does</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><code>/mod ban</code></td><td>Permanent ban with reason and audit-log entry.</td></tr>
+                        <tr><td><code>/mod kick</code></td><td>Kick from the server.</td></tr>
+                        <tr><td><code>/mod tempban</code></td><td>Temporary ban with auto-revoke.</td></tr>
+                        <tr><td><code>/mod warn</code></td><td>Warn a user, DM them, log it.</td></tr>
+                        <tr><td><code>/automod</code></td><td>Open the auto-mod config.</td></tr>
+                    </tbody>
+                </table>
+                <h2 id='utility-cmds'>Utility</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Command</th>
+                            <th>What it does</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><code>/cc create</code></td><td>Build a custom command.</td></tr>
+                        <tr><td><code>/embed</code></td><td>Send a rich embed.</td></tr>
+                        <tr><td><code>/role</code></td><td>Manage role assignments.</td></tr>
+                        <tr><td><code>/help</code></td><td>Show the full command list.</td></tr>
+                    </tbody>
+                </table>
+            </>
+        ),
+    },
+    {
+        slug: 'permissions',
+        title: 'Permissions',
+        breadcrumb: 'Docs / Permissions',
+        toc: [
+            { id: 'discord-perms', label: 'Discord permissions Lucky needs' },
+            { id: 'dashboard-rbac', label: 'Dashboard RBAC' },
+        ],
+        content: () => (
+            <>
+                <h2 id='discord-perms'>Discord permissions Lucky needs</h2>
+                <ul>
+                    <li><strong>Read Messages / Send Messages.</strong> For slash command responses.</li>
+                    <li><strong>Connect / Speak.</strong> For voice channel playback.</li>
+                    <li><strong>Manage Messages.</strong> For auto-mod deletion.</li>
+                    <li><strong>Kick / Ban / Moderate Members.</strong> For moderation commands.</li>
+                    <li><strong>Manage Roles.</strong> For reaction roles. Lucky's role must be above any role it manages.</li>
+                </ul>
+                <h2 id='dashboard-rbac'>Dashboard RBAC</h2>
+                <p>
+                    The dashboard maps Discord roles to module access. Configure under{' '}
+                    <strong>Server settings / Access control</strong>. Common patterns:
+                </p>
+                <ul>
+                    <li>Server owner: full control.</li>
+                    <li>Mods: moderation, custom commands, audit log.</li>
+                    <li>DJs: music settings, queue, preferred artists.</li>
+                    <li>Members: read-only overview.</li>
+                </ul>
+            </>
+        ),
+    },
+    {
+        slug: 'env',
+        title: 'Environment variables',
+        breadcrumb: 'Docs / Environment variables',
+        toc: [
+            { id: 'required', label: 'Required' },
+            { id: 'optional', label: 'Optional' },
+        ],
+        content: () => (
+            <>
+                <p>Used only when self-hosting. The hosted version is preconfigured.</p>
+                <h2 id='required'>Required</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Variable</th>
+                            <th>Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><code>DISCORD_TOKEN</code></td><td>Bot token from the Developer Portal.</td></tr>
+                        <tr><td><code>DISCORD_CLIENT_ID</code></td><td>Application client ID.</td></tr>
+                        <tr><td><code>DISCORD_CLIENT_SECRET</code></td><td>For OAuth on the dashboard.</td></tr>
+                        <tr><td><code>POSTGRES_PASSWORD</code></td><td>Set in the compose file or the .env.</td></tr>
+                        <tr><td><code>SESSION_SECRET</code></td><td>32+ random bytes. Used for cookie signing.</td></tr>
+                    </tbody>
+                </table>
+                <h2 id='optional'>Optional</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Variable</th>
+                            <th>Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><code>SPOTIFY_CLIENT_ID</code> / <code>SPOTIFY_CLIENT_SECRET</code></td><td>Enables Spotify-fed autoplay.</td></tr>
+                        <tr><td><code>LASTFM_API_KEY</code></td><td>Enables Last.fm scrobbling.</td></tr>
+                        <tr><td><code>GENIUS_TOKEN</code></td><td>Enables <code>/lyrics</code>.</td></tr>
+                        <tr><td><code>NGINX_PORT</code></td><td>Reverse-proxy port. Default <code>8080</code>.</td></tr>
+                    </tbody>
+                </table>
+            </>
+        ),
+    },
+]
+
+function pageFromSlug(slug: string | null): DocsPage {
+    return PAGES.find((p) => p.slug === slug) ?? PAGES[0]!
+}
+
+export default function Docs() {
+    const [searchParams] = useSearchParams()
+    const page = useMemo(() => pageFromSlug(searchParams.get('page')), [searchParams])
+
+    usePageMetadata({
+        title: `${page.title} — Lucky docs`,
+        description: `${page.title} documentation for Lucky, the open-source self-hostable Discord bot.`,
+    })
+
+    const Content = page.content
+
+    return (
+        <DocsShell nav={NAV} breadcrumb={page.breadcrumb} title={page.title} toc={page.toc}>
+            <Content />
+        </DocsShell>
+    )
+}

--- a/packages/frontend/src/pages/Docs.tsx
+++ b/packages/frontend/src/pages/Docs.tsx
@@ -20,7 +20,17 @@ const NAV: DocsNavGroup[] = [
         items: [
             { label: 'Overview', href: '/docs?page=overview' },
             { label: 'Quick start', href: '/docs?page=quickstart' },
-            { label: 'Self-host', href: '/docs?page=self-host' },
+            { label: 'Architecture', href: '/docs?page=architecture' },
+        ],
+    },
+    {
+        heading: 'Self-hosting',
+        items: [
+            { label: 'Self-host setup', href: '/docs?page=self-host' },
+            { label: 'Configuration', href: '/docs?page=configuration' },
+            { label: 'Updating & deploys', href: '/docs?page=updating' },
+            { label: 'Backups', href: '/docs?page=backups' },
+            { label: 'Troubleshooting', href: '/docs?page=troubleshooting' },
         ],
     },
     {
@@ -29,6 +39,7 @@ const NAV: DocsNavGroup[] = [
             { label: 'Music & autoplay', href: '/docs?page=music' },
             { label: 'Moderation', href: '/docs?page=moderation' },
             { label: 'Custom commands', href: '/docs?page=custom-commands' },
+            { label: 'Reaction roles & levels', href: '/docs?page=engagement' },
             { label: 'Web dashboard', href: '/docs?page=dashboard' },
         ],
     },
@@ -38,6 +49,8 @@ const NAV: DocsNavGroup[] = [
             { label: 'Command list', href: '/docs?page=commands' },
             { label: 'Permissions', href: '/docs?page=permissions' },
             { label: 'Environment variables', href: '/docs?page=env' },
+            { label: 'Integrations', href: '/docs?page=integrations' },
+            { label: 'FAQ', href: '/docs?page=faq' },
         ],
     },
     {
@@ -59,46 +72,80 @@ const PAGES: DocsPage[] = [
             { id: 'what-is-lucky', label: 'What is Lucky' },
             { id: 'two-ways-to-run-it', label: 'Two ways to run it' },
             { id: 'whats-included', label: "What's included" },
+            { id: 'project-status', label: 'Project status' },
+            { id: 'how-this-is-built', label: 'How this is built' },
         ],
         content: () => (
             <>
                 <p>
-                    Lucky is an open-source Discord bot. Music, moderation, custom commands, and a web dashboard.
+                    Lucky is an open-source Discord bot. Music, moderation, custom commands, automation, and a web dashboard.
                     Free forever, with no premium tier paywalling the good parts.
                 </p>
                 <h2 id='what-is-lucky'>What is Lucky</h2>
                 <p>
-                    Lucky started as a music bot. It now also handles moderation, custom commands, automation, role gating,
-                    and reaction roles. The web dashboard at the same domain lets you configure everything without leaving
-                    the browser.
+                    Lucky started as a music bot for a friend's server. It now also handles moderation, custom commands,
+                    leveling, reaction roles, embed building, automation, and starboards. The web dashboard at the same
+                    domain lets you configure everything without leaving the browser — no <code>/config</code> chat
+                    commands to memorize.
                 </p>
                 <p>
-                    The codebase is a TypeScript monorepo published under the Apache 2.0 license. Anyone can fork it,
-                    audit it, or self-host their own instance.
+                    The whole project is a TypeScript monorepo published under the Apache 2.0 license. Anyone can fork it,
+                    audit it, contribute, or self-host their own instance. There are no closed-source plugins, no
+                    enterprise tier, and no telemetry phoned home from self-hosted deployments.
                 </p>
                 <h2 id='two-ways-to-run-it'>Two ways to run it</h2>
                 <p>You can use Lucky in either of two ways. Pick whichever fits your situation.</p>
                 <ol>
                     <li>
                         <strong>Hosted.</strong> Click <a href={BOT_INVITE} rel='noreferrer noopener' target='_blank'>Add to Discord</a>,
-                        pick the server, accept the permissions. The bot joins, you open the dashboard, and you're configuring within a minute.
+                        pick the server, accept the permissions. The bot joins, you open the dashboard, and you're
+                        configuring within a minute. Good fit for small-to-medium servers that don't want to babysit
+                        infrastructure.
                     </li>
                     <li>
                         <strong>Self-hosted.</strong> Clone the repo, copy <code>.env.example</code> to <code>.env</code>, run{' '}
-                        <code>docker compose up</code>. The bot runs on your box. Your guild data stays on your hardware. See{' '}
-                        <a href='/docs?page=self-host'>Self-host</a> for the full setup.
+                        <code>docker compose up -d</code>. The bot runs on your box. Your guild data, moderation logs,
+                        and autoplay history all stay on your hardware. See <a href='/docs?page=self-host'>Self-host setup</a> for
+                        the full walkthrough.
                     </li>
                 </ol>
+                <p>
+                    The hosted and self-hosted versions are byte-identical — same commands, same dashboard, same
+                    permissions model. The only difference is who runs the server.
+                </p>
                 <h2 id='whats-included'>What's included</h2>
                 <ul>
-                    <li>Slash commands for music, moderation, and utility (100+ in total).</li>
+                    <li>Slash commands for music, moderation, and utility (100+ commands across all modules).</li>
                     <li>Autoplay with Spotify-fed recommendations and Last.fm scrobbling.</li>
-                    <li>Auto-mod for spam, caps, links, and invites with per-server rules.</li>
-                    <li>Custom command builder with variable interpolation.</li>
-                    <li>Embed builder with live preview and saved templates.</li>
-                    <li>Reaction roles, role gating, leveling, and starboard.</li>
+                    <li>Auto-mod for spam, caps, links, and invites with per-server rules and per-channel overrides.</li>
+                    <li>Custom command builder with variable interpolation, role gating, and channel scoping.</li>
+                    <li>Embed builder with live preview, saved templates, and one-click resend.</li>
+                    <li>Reaction roles, role gating, leveling with XP curves, and starboard with per-channel thresholds.</li>
+                    <li>Scheduled and triggered automations (welcome messages, periodic reminders, auto-archives).</li>
                     <li>A React dashboard for configuring everything from your browser.</li>
+                    <li>Optional Last.fm and Twitch integrations for richer music context and stream notifications.</li>
                 </ul>
+                <h2 id='project-status'>Project status</h2>
+                <p>
+                    Lucky is under active development. The current line is the <code>2.x</code> release train. Releases
+                    follow{' '}
+                    <a href='https://semver.org/spec/v2.0.0.html' rel='noreferrer noopener' target='_blank'>SemVer</a>:
+                    breaking changes bump the major, new features bump the minor, fixes bump the patch. Every release
+                    is tagged on GitHub and described in the{' '}
+                    <a href='/changelog'>Changelog</a>.
+                </p>
+                <p>
+                    Production runs on a homelab behind Cloudflare Tunnel. The same compose stack you'd run locally is
+                    what's running in production.
+                </p>
+                <h2 id='how-this-is-built'>How this is built</h2>
+                <p>
+                    Lucky is six services: <code>bot</code> (discord.js v14), <code>backend</code> (Express +
+                    Prisma), <code>frontend</code> (React 19 + Vite + Tailwind v4), <code>postgres</code>,{' '}
+                    <code>redis</code>, and <code>nginx</code>. All six are orchestrated with a single
+                    <code>docker-compose.yml</code>. See <a href='/docs?page=architecture'>Architecture</a> for the
+                    full diagram and rationale.
+                </p>
             </>
         ),
     },
@@ -110,6 +157,8 @@ const PAGES: DocsPage[] = [
             { id: 'add-the-bot', label: 'Add the bot' },
             { id: 'open-the-dashboard', label: 'Open the dashboard' },
             { id: 'first-commands', label: 'First commands to try' },
+            { id: 'common-first-steps', label: 'Common first-day setup' },
+            { id: 'next', label: 'Next steps' },
         ],
         content: () => (
             <>
@@ -120,61 +169,199 @@ const PAGES: DocsPage[] = [
                         Click <a href={BOT_INVITE} rel='noreferrer noopener' target='_blank'>Add to Discord</a>.
                     </li>
                     <li>Pick the server. You need <code>Manage Server</code> on it.</li>
-                    <li>Accept the requested permissions. The bot joins immediately.</li>
+                    <li>
+                        Accept the requested permissions. Lucky uses{' '}
+                        <a href='/docs?page=permissions'>only what it needs</a> — you can deny anything you'd rather
+                        configure later. Re-invite changes the grant.
+                    </li>
+                    <li>The bot joins immediately and slash commands are registered within a few seconds.</li>
                 </ol>
                 <h2 id='open-the-dashboard'>Open the dashboard</h2>
                 <p>
                     Go to the homepage and click <strong>Dashboard</strong> in the top right, or go directly to{' '}
-                    <code>/login</code>. Authorize with Discord OAuth. You'll see the server you just added the bot to.
+                    <code>/login</code>. Authorize with Discord OAuth — Lucky only requests <code>identify</code> and{' '}
+                    <code>guilds</code> scopes. You'll see the server you just added the bot to.
                 </p>
-                <h2 id='first-commands' >First commands to try</h2>
+                <p>
+                    If you don't see your server, refresh the guild cache from{' '}
+                    <strong>Profile menu / Refresh servers</strong>. Discord doesn't push membership changes — Lucky
+                    re-fetches on login and on demand.
+                </p>
+                <h2 id='first-commands'>First commands to try</h2>
                 <ul>
                     <li>
-                        <code>/play tame impala let it happen</code> — join voice and queue a track.
+                        <code>/play tame impala let it happen</code> — join voice and queue a track. Works with
+                        Spotify, YouTube, and SoundCloud URLs too.
                     </li>
                     <li>
-                        <code>/autoplay on</code> — keep music going when the queue ends.
+                        <code>/autoplay on</code> — keep music going when the queue ends. Lucky pulls recommendations
+                        from what you've been queuing.
                     </li>
                     <li>
-                        <code>/queue</code> — see what's coming up.
+                        <code>/queue</code> — see what's coming up. Use <code>/skip</code>, <code>/pause</code>,{' '}
+                        <code>/resume</code>, <code>/loop</code> to control playback.
                     </li>
                     <li>
-                        <code>/cc create welcome &quot;Welcome to {'{server}'}, {'{user}'}!&quot;</code> — make a custom command.
+                        <code>/cc create welcome &quot;Welcome to {'{server}'}, {'{user}'}!&quot;</code> — make a
+                        custom command. Run <code>/welcome</code> to test it.
+                    </li>
+                    <li>
+                        <code>/help</code> — full command list, scoped to what you have access to.
                     </li>
                 </ul>
+                <h2 id='common-first-steps'>Common first-day setup</h2>
+                <ol>
+                    <li>
+                        <strong>Set a music channel.</strong> Dashboard / Music / Settings. Restricts <code>/play</code>{' '}
+                        to that channel so it doesn't leak into general chat.
+                    </li>
+                    <li>
+                        <strong>Wire auto-mod.</strong> Dashboard / Moderation / Auto-mod. Spam + invite-link rules are
+                        the highest-ROI first picks. Caps and link allow-listing come later.
+                    </li>
+                    <li>
+                        <strong>Set up RBAC.</strong> Dashboard / Server settings / Access control. Map your existing
+                        Discord roles to dashboard modules so mods don't accidentally change music settings.
+                    </li>
+                    <li>
+                        <strong>Reaction roles.</strong> Dashboard / Reaction roles / New. Stick one in
+                        <code>#welcome</code> for self-assigned ping roles.
+                    </li>
+                </ol>
+                <h2 id='next'>Next steps</h2>
+                <p>
+                    Read <a href='/docs?page=music'>Music & autoplay</a>, <a href='/docs?page=moderation'>Moderation</a>, and{' '}
+                    <a href='/docs?page=custom-commands'>Custom commands</a> for the feature deep dives, or jump to{' '}
+                    <a href='/docs?page=commands'>Command list</a> for the full reference.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'architecture',
+        title: 'Architecture',
+        breadcrumb: 'Docs / Architecture',
+        toc: [
+            { id: 'services', label: 'Services' },
+            { id: 'data', label: 'Data stores' },
+            { id: 'network', label: 'Network & ports' },
+            { id: 'request-path', label: 'Request path' },
+            { id: 'why-this-shape', label: 'Why this shape' },
+        ],
+        content: () => (
+            <>
+                <p>
+                    Lucky is a TypeScript monorepo with six services orchestrated by a single Docker Compose stack.
+                    Same composition runs locally, in CI, and in production.
+                </p>
+                <h2 id='services'>Services</h2>
+                <ul>
+                    <li>
+                        <strong>bot</strong> — discord.js v14 client. Handles slash commands, voice connections,
+                        autoplay, moderation actions. Talks to <code>backend</code> for persistence, to <code>redis</code> for
+                        session state and rate limiting.
+                    </li>
+                    <li>
+                        <strong>backend</strong> — Express + Prisma. Owns the database schema and exposes a REST API
+                        consumed by both the dashboard and the bot.
+                    </li>
+                    <li>
+                        <strong>frontend</strong> — React 19 + Vite + Tailwind v4. The dashboard SPA. Built into a
+                        static bundle and served by nginx.
+                    </li>
+                    <li>
+                        <strong>nginx</strong> — reverse proxy. Routes <code>/api/*</code> to backend, everything
+                        else to the static frontend. Terminates internal HTTP on <code>:8080</code>; TLS is handled
+                        upstream by Cloudflare Tunnel.
+                    </li>
+                    <li>
+                        <strong>postgres</strong> — primary data store. Prisma migrations, no manual DDL.
+                    </li>
+                    <li>
+                        <strong>redis</strong> — session store, rate-limit counters, Spotify token cache,
+                        autoplay scratch space.
+                    </li>
+                </ul>
+                <h2 id='data'>Data stores</h2>
+                <p>
+                    Postgres holds guild settings, custom commands, moderation cases, levels, embed templates,
+                    reaction-role configs, and the linked-account table. Redis holds anything ephemeral: web sessions,
+                    OAuth state, Spotify tokens, and per-guild autoplay history.
+                </p>
+                <p>
+                    All schema changes ship as Prisma migrations under <code>packages/backend/prisma/migrations/</code>.
+                    On <code>docker compose up</code> the backend runs pending migrations before serving traffic.
+                </p>
+                <h2 id='network'>Network & ports</h2>
+                <ul>
+                    <li><code>:8080</code> — nginx. The only port you should expose to anything outside the host.</li>
+                    <li><code>:3000</code> — backend (internal). Reachable only from inside the compose network.</li>
+                    <li><code>:5173</code> — frontend dev server (only in dev compose override).</li>
+                    <li><code>:5432</code> — postgres (internal).</li>
+                    <li><code>:6379</code> — redis (internal).</li>
+                </ul>
+                <h2 id='request-path'>Request path</h2>
+                <p>
+                    A dashboard API call: browser → CDN (optional) → Cloudflare Tunnel → nginx:8080 → backend:3000 →
+                    postgres / redis. The bot path skips nginx entirely: discord gateway → bot → backend:3000.
+                </p>
+                <h2 id='why-this-shape'>Why this shape</h2>
+                <p>
+                    Each service is replaceable in isolation. The bot can restart without taking the dashboard down. A
+                    schema migration runs on the backend without bouncing the bot. nginx handles the boring stuff
+                    (gzip, caching, security headers) so the backend stays minimal. The whole stack fits comfortably
+                    on a 2 GB VPS.
+                </p>
             </>
         ),
     },
     {
         slug: 'self-host',
-        title: 'Self-host',
-        breadcrumb: 'Docs / Self-host',
+        title: 'Self-host setup',
+        breadcrumb: 'Docs / Self-host setup',
         toc: [
             { id: 'requirements', label: 'Requirements' },
             { id: 'discord-app', label: 'Create a Discord app' },
             { id: 'clone-and-configure', label: 'Clone and configure' },
             { id: 'start-the-stack', label: 'Start the stack' },
-            { id: 'updating', label: 'Updating' },
+            { id: 'reverse-proxy', label: 'Reverse proxy & TLS' },
+            { id: 'register-commands', label: 'Register slash commands' },
+            { id: 'verify', label: 'Verify the install' },
         ],
         content: () => (
             <>
                 <p>
                     Self-hosting means you run Lucky on your own hardware. Your guild data, autoplay history, custom
-                    commands, and moderation log stay on your box. No third-party ToS over your community.
+                    commands, and moderation log stay on your box. No third-party ToS over your community, no
+                    rate-limited tier.
                 </p>
                 <h2 id='requirements'>Requirements</h2>
                 <ul>
-                    <li>A Linux server (Debian, Ubuntu, or any docker-compatible distro).</li>
-                    <li><code>docker</code> and <code>docker compose</code> v2+ installed.</li>
-                    <li>~2 GB RAM, ~5 GB disk. More if you log a lot.</li>
+                    <li>A Linux server (Debian, Ubuntu, or any docker-compatible distro). Tested on Debian 12.</li>
+                    <li><code>docker</code> 24+ and <code>docker compose</code> v2+ installed.</li>
+                    <li>~2 GB RAM and ~5 GB disk at idle. More if you log a lot or serve large guilds.</li>
+                    <li>A public domain or Cloudflare Tunnel (optional, but needed for OAuth callbacks if you want the dashboard exposed).</li>
                     <li>A Discord application with a bot token. See below.</li>
                 </ul>
                 <h2 id='discord-app'>Create a Discord app</h2>
                 <ol>
-                    <li>Go to <a href='https://discord.com/developers/applications' rel='noreferrer noopener' target='_blank'>Discord Developer Portal</a>.</li>
-                    <li>Click <strong>New Application</strong>, name it.</li>
-                    <li>Under <strong>Bot</strong>, click <strong>Reset Token</strong> and copy it.</li>
-                    <li>Under <strong>OAuth2 / URL Generator</strong>, pick <code>bot</code> + <code>applications.commands</code> scopes and the permissions you want.</li>
+                    <li>Open <a href='https://discord.com/developers/applications' rel='noreferrer noopener' target='_blank'>Discord Developer Portal</a>.</li>
+                    <li>Click <strong>New Application</strong>, name it (this name appears in the OAuth screen).</li>
+                    <li>Under <strong>Bot</strong>, click <strong>Reset Token</strong> and copy the token. You'll only see it once.</li>
+                    <li>
+                        Under <strong>Bot / Privileged Gateway Intents</strong>, enable{' '}
+                        <code>Server Members Intent</code> and <code>Message Content Intent</code>. Lucky needs both
+                        for moderation and custom-command triggers.
+                    </li>
+                    <li>
+                        Under <strong>OAuth2 / Redirects</strong>, add{' '}
+                        <code>https://your-domain/api/auth/discord/callback</code>.
+                    </li>
+                    <li>
+                        Under <strong>OAuth2 / URL Generator</strong>, pick <code>bot</code> +{' '}
+                        <code>applications.commands</code> scopes and the permissions you want. Copy the URL — that's
+                        your invite link.
+                    </li>
                 </ol>
                 <h2 id='clone-and-configure'>Clone and configure</h2>
                 <pre>
@@ -184,33 +371,290 @@ cp .env.example .env
 $EDITOR .env`}</code>
                 </pre>
                 <p>
-                    Required env vars: <code>DISCORD_TOKEN</code>, <code>DISCORD_CLIENT_ID</code>, <code>DISCORD_CLIENT_SECRET</code>,{' '}
-                    <code>POSTGRES_PASSWORD</code>, <code>SESSION_SECRET</code>. The full list is documented in{' '}
-                    <a href='/docs?page=env'>Environment variables</a>.
+                    Required env vars: <code>DISCORD_TOKEN</code>, <code>DISCORD_CLIENT_ID</code>,{' '}
+                    <code>DISCORD_CLIENT_SECRET</code>, <code>POSTGRES_PASSWORD</code>, <code>SESSION_SECRET</code>,{' '}
+                    <code>DASHBOARD_URL</code>. Optional integrations like Spotify and Last.fm get their own keys. The
+                    full list with notes lives in <a href='/docs?page=env'>Environment variables</a>.
+                </p>
+                <p>
+                    <code>SESSION_SECRET</code> must be 32+ random bytes. Generate one with{' '}
+                    <code>openssl rand -hex 32</code>. Rotating it invalidates every dashboard session, so pick once
+                    and store it in a secrets manager.
                 </p>
                 <h2 id='start-the-stack'>Start the stack</h2>
                 <pre>
-                    <code>{`docker compose up -d
+                    <code>{`docker compose pull
+docker compose up -d
 docker compose ps`}</code>
                 </pre>
                 <p>
                     You should see <code>lucky-bot</code>, <code>lucky-backend</code>, <code>lucky-frontend</code>,{' '}
                     <code>lucky-nginx</code>, <code>lucky-postgres</code>, and <code>lucky-redis</code> all healthy.
+                    Healthchecks take 10–30 seconds on first boot while postgres applies migrations.
+                </p>
+                <h2 id='reverse-proxy'>Reverse proxy & TLS</h2>
+                <p>
+                    nginx in the stack terminates plain HTTP on <code>:8080</code>. For TLS, put something in front:
+                </p>
+                <ul>
+                    <li>
+                        <strong>Cloudflare Tunnel</strong> — easiest, no public IP needed. Install <code>cloudflared</code>{' '}
+                        on the host, point the tunnel at <code>http://localhost:8080</code>.
+                    </li>
+                    <li>
+                        <strong>Caddy</strong> — drop a one-liner Caddyfile: <code>your-domain {`{ reverse_proxy localhost:8080 }`}</code>.
+                        Caddy handles ACME automatically.
+                    </li>
+                    <li>
+                        <strong>Traefik / nginx-proxy / your own nginx</strong> — point at <code>localhost:8080</code>{' '}
+                        and terminate TLS in your own way.
+                    </li>
+                </ul>
+                <h2 id='register-commands'>Register slash commands</h2>
+                <p>
+                    The bot registers commands automatically on first start, both globally and per-guild for testing.
+                    If new commands don't show up, force re-registration with:
+                </p>
+                <pre>
+                    <code>{`docker compose exec bot npm run register-commands`}</code>
+                </pre>
+                <h2 id='verify'>Verify the install</h2>
+                <ol>
+                    <li>Open <code>https://your-domain</code>. You should see the landing page.</li>
+                    <li>Click <strong>Dashboard</strong>, log in with Discord. You see your guilds.</li>
+                    <li>Invite the bot to a test server, run <code>/help</code>. You see the command list.</li>
+                    <li>
+                        Optional: run <code>/play</code> in a voice channel. If audio works, autoplay and yt-dlp
+                        are correctly wired.
+                    </li>
+                </ol>
+                <p>
+                    If something fails, jump to <a href='/docs?page=troubleshooting'>Troubleshooting</a>.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'configuration',
+        title: 'Configuration',
+        breadcrumb: 'Docs / Configuration',
+        toc: [
+            { id: 'env-vs-dashboard', label: 'Env vs dashboard' },
+            { id: 'feature-toggles', label: 'Feature toggles' },
+            { id: 'per-guild', label: 'Per-guild settings' },
+            { id: 'global-admin', label: 'Global admin controls' },
+        ],
+        content: () => (
+            <>
+                <h2 id='env-vs-dashboard'>Env vs dashboard</h2>
+                <p>
+                    Two layers of configuration. Env variables are deployment-wide: tokens, ports, secret keys,
+                    integration keys. They require a restart. Dashboard settings are per-guild: feature toggles, music
+                    rules, auto-mod thresholds, custom commands. They're hot-reloaded.
                 </p>
                 <p>
-                    The dashboard is served on port <code>8090</code> by default. Point your reverse proxy at it, or
-                    expose it directly. The bot will appear online in any server you invite it to.
+                    Rule of thumb: if it'd be the same across every server you run, it's an env var. If you'd set it
+                    differently per server, it's in the dashboard.
                 </p>
-                <h2 id='updating'>Updating</h2>
+                <h2 id='feature-toggles'>Feature toggles</h2>
+                <p>
+                    Self-hosters control which modules are even visible in the dashboard via the global toggles in{' '}
+                    <strong>Admin / Feature toggles</strong>. Useful if you run a music-only instance or want to hide
+                    leveling from your community. Toggles flow through Redis so changes take effect within seconds
+                    without restart.
+                </p>
+                <h2 id='per-guild'>Per-guild settings</h2>
+                <p>
+                    Every server has its own configuration row: music channel allow-list, auto-mod thresholds, RBAC
+                    mapping, autoplay genre seeds, embed templates. Find them under <strong>Server settings</strong>{' '}
+                    in the dashboard.
+                </p>
+                <p>
+                    Settings inherit a sane default and are upserted on first write. You don't have to seed defaults —
+                    the first time you save anything on a fresh guild, Lucky creates the row and merges your change in.
+                </p>
+                <h2 id='global-admin'>Global admin controls</h2>
+                <p>
+                    Add your Discord user ID to <code>ADMIN_USER_IDS</code> (comma-separated) in the env. Admin users
+                    see an extra <strong>Admin</strong> tab in the dashboard with global feature toggles, a
+                    cross-guild override panel, and the Redis cache controls.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'updating',
+        title: 'Updating & deploys',
+        breadcrumb: 'Docs / Updating & deploys',
+        toc: [
+            { id: 'manual-pull', label: 'Manual pull' },
+            { id: 'webhook', label: 'Webhook deploy' },
+            { id: 'rollback', label: 'Rolling back' },
+            { id: 'migrations', label: 'Database migrations' },
+        ],
+        content: () => (
+            <>
+                <h2 id='manual-pull'>Manual pull</h2>
+                <p>For ad-hoc updates:</p>
                 <pre>
                     <code>{`git pull
 docker compose pull
 docker compose up -d`}</code>
                 </pre>
                 <p>
-                    Or set up the webhook receiver for push-to-deploy. The repo includes a <code>deploy/</code> directory with
-                    the webhook config that listens for GitHub Actions builds and pulls the new images automatically.
+                    <code>compose up -d</code> only restarts services whose image hash changed, so postgres and redis
+                    stay up if only the bot was updated.
                 </p>
+                <h2 id='webhook'>Webhook deploy</h2>
+                <p>
+                    Lucky ships a webhook receiver that pulls and restarts on a GitHub Actions ping. The recipe lives
+                    in <code>deploy/</code>. Wire it once, then every push to <code>main</code> deploys automatically:
+                </p>
+                <ol>
+                    <li>Generate a webhook secret (<code>openssl rand -hex 32</code>).</li>
+                    <li>
+                        Set the secret in two places: the <code>webhook</code> service's env, and the
+                        <code>DEPLOY_WEBHOOK_URL</code> + <code>DEPLOY_WEBHOOK_SECRET</code> repo secrets on GitHub.
+                    </li>
+                    <li>
+                        Point the deploy workflow (<code>.github/workflows/deploy.yml</code>) at the webhook URL —
+                        whatever the publicly reachable address of the receiver is.
+                    </li>
+                    <li>
+                        Optionally route through a Cloudflare Tunnel so the receiver isn't directly exposed. nginx
+                        rewrites <code>/webhook/*</code> to <code>/hooks/*</code> before proxying.
+                    </li>
+                </ol>
+                <h2 id='rollback'>Rolling back</h2>
+                <p>Roll back to a specific tag:</p>
+                <pre>
+                    <code>{`docker compose pull <service>:<old-tag>
+docker compose up -d <service>`}</code>
+                </pre>
+                <p>
+                    Or pin a version in <code>docker-compose.yml</code> and re-up. The bot, backend, and frontend are
+                    independently versioned — you can roll back just one.
+                </p>
+                <h2 id='migrations'>Database migrations</h2>
+                <p>
+                    Backend runs <code>prisma migrate deploy</code> on every boot. Forward-only — there is no rollback
+                    migration. If a release contains a destructive migration the release notes call it out.
+                </p>
+                <p>
+                    To preview migrations before they run, exec into the backend container:{' '}
+                    <code>docker compose exec backend npx prisma migrate status</code>.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'backups',
+        title: 'Backups',
+        breadcrumb: 'Docs / Backups',
+        toc: [
+            { id: 'what-to-back-up', label: 'What to back up' },
+            { id: 'postgres-dump', label: 'Postgres dumps' },
+            { id: 'volume-snapshots', label: 'Volume snapshots' },
+            { id: 'restore', label: 'Restore' },
+        ],
+        content: () => (
+            <>
+                <p>
+                    The only durable state is Postgres. Redis is ephemeral by design. Frontend and backend images are
+                    rebuildable from git. Back up Postgres and you can recreate everything else from scratch.
+                </p>
+                <h2 id='what-to-back-up'>What to back up</h2>
+                <ul>
+                    <li><strong>Postgres data volume</strong> — the whole guild config, moderation logs, custom commands.</li>
+                    <li><strong><code>.env</code></strong> — your tokens and secrets. Store in a password manager, not in the backup.</li>
+                    <li><strong><code>docker-compose.override.yml</code></strong> if you've customized it.</li>
+                </ul>
+                <h2 id='postgres-dump'>Postgres dumps</h2>
+                <pre>
+                    <code>{`docker compose exec postgres pg_dump -U lucky -Fc lucky > backup-$(date +%F).dump`}</code>
+                </pre>
+                <p>
+                    Run from cron or a Healthchecks-pinged script. The custom format (<code>-Fc</code>) is faster to
+                    restore and supports parallel restore on large datasets.
+                </p>
+                <h2 id='volume-snapshots'>Volume snapshots</h2>
+                <p>
+                    If your host supports snapshots (ZFS, LVM, btrfs, cloud-disk snapshots), snapshot the Docker volume
+                    directly. Faster than dumping for very large databases and lets you point-in-time restore.
+                </p>
+                <h2 id='restore'>Restore</h2>
+                <pre>
+                    <code>{`docker compose exec -T postgres pg_restore -U lucky -d lucky --clean < backup-2026-05-15.dump`}</code>
+                </pre>
+                <p>
+                    Restart the bot and backend after a restore so they re-establish connections. The frontend doesn't
+                    need a restart.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'troubleshooting',
+        title: 'Troubleshooting',
+        breadcrumb: 'Docs / Troubleshooting',
+        toc: [
+            { id: 'bot-offline', label: "Bot doesn't come online" },
+            { id: 'no-audio', label: 'No audio in voice' },
+            { id: 'oauth-fails', label: 'Dashboard OAuth fails' },
+            { id: 'commands-missing', label: 'Slash commands missing' },
+            { id: 'logs', label: 'Where to look in logs' },
+        ],
+        content: () => (
+            <>
+                <h2 id='bot-offline'>Bot doesn't come online</h2>
+                <ul>
+                    <li>Check <code>docker compose logs bot</code>. Authentication errors print clearly.</li>
+                    <li>
+                        Verify the <code>DISCORD_TOKEN</code> isn't truncated (Developer Portal tokens are ~70 chars).
+                    </li>
+                    <li>
+                        Confirm Privileged Gateway Intents are enabled in the Developer Portal — missing intents shut
+                        the bot down at boot.
+                    </li>
+                </ul>
+                <h2 id='no-audio'>No audio in voice</h2>
+                <ul>
+                    <li>
+                        Most "no audio" issues are yt-dlp. Run{' '}
+                        <code>docker compose exec bot yt-dlp --version</code> — should print a date.
+                    </li>
+                    <li>
+                        Update yt-dlp inside the container if it's stale:{' '}
+                        <code>docker compose exec bot pip install -U yt-dlp</code>. Lucky now retries failed
+                        extractions with exponential backoff, but a multi-month-old yt-dlp still hits walls.
+                    </li>
+                    <li>
+                        Check the bot's voice permissions in your channel (<code>Connect</code>, <code>Speak</code>).
+                    </li>
+                </ul>
+                <h2 id='oauth-fails'>Dashboard OAuth fails</h2>
+                <ul>
+                    <li>The OAuth redirect URI in the Developer Portal must exactly match <code>DASHBOARD_URL/api/auth/discord/callback</code>.</li>
+                    <li>If you change <code>DASHBOARD_URL</code>, restart the backend so it re-reads the env.</li>
+                    <li>Behind a reverse proxy: set <code>trust proxy</code> upstream so the backend sees the right scheme.</li>
+                </ul>
+                <h2 id='commands-missing'>Slash commands missing</h2>
+                <ul>
+                    <li>Global slash command propagation can take up to an hour after registration.</li>
+                    <li>
+                        Force re-register: <code>docker compose exec bot npm run register-commands</code>.
+                    </li>
+                    <li>
+                        Per-guild registration is instant. Set <code>DEV_GUILD_ID</code> in the env if you're iterating.
+                    </li>
+                </ul>
+                <h2 id='logs'>Where to look in logs</h2>
+                <ul>
+                    <li><code>docker compose logs -f bot</code> — slash command errors, voice connection, autoplay.</li>
+                    <li><code>docker compose logs -f backend</code> — API errors, Prisma issues, OAuth.</li>
+                    <li><code>docker compose logs -f nginx</code> — 4xx/5xx with paths.</li>
+                    <li><code>docker compose logs -f postgres</code> — migrations, connection pressure.</li>
+                </ul>
             </>
         ),
     },
@@ -220,34 +664,88 @@ docker compose up -d`}</code>
         breadcrumb: 'Docs / Music & autoplay',
         toc: [
             { id: 'sources', label: 'Sources' },
+            { id: 'queue-control', label: 'Queue control' },
             { id: 'autoplay-mode', label: 'Autoplay' },
+            { id: 'preferred-artists', label: 'Preferred artists' },
             { id: 'last-fm', label: 'Last.fm scrobbling' },
+            { id: 'spotify-link', label: 'Linking Spotify' },
+            { id: 'filters', label: 'Filters & shaping' },
         ],
         content: () => (
             <>
                 <p>
                     Lucky plays from Spotify, YouTube, and SoundCloud. It uses <code>yt-dlp</code> for extraction and
-                    bundles its own Opus encoder, so no Lavalink server is required.
+                    bundles its own Opus encoder, so no Lavalink server or external audio service is required.
                 </p>
                 <h2 id='sources'>Sources</h2>
                 <ul>
-                    <li><strong>Spotify.</strong> Paste a track, album, or playlist URL. Lucky resolves and queues it.</li>
-                    <li><strong>YouTube.</strong> Paste a video or playlist URL, or search by title.</li>
-                    <li><strong>SoundCloud.</strong> Paste a track URL. Useful for sets and bootlegs.</li>
+                    <li>
+                        <strong>Spotify.</strong> Paste a track, album, or playlist URL. Lucky resolves the metadata
+                        through the Spotify API, then streams audio from a matched source.
+                    </li>
+                    <li>
+                        <strong>YouTube.</strong> Paste a video or playlist URL, or search by title and artist.
+                        Returns the top result.
+                    </li>
+                    <li>
+                        <strong>SoundCloud.</strong> Paste a track URL. Useful for sets, bootlegs, and unreleased mixes.
+                    </li>
+                    <li>
+                        <strong>Search.</strong> <code>/play tame impala let it happen</code> — searches across sources
+                        and queues the best match.
+                    </li>
+                </ul>
+                <h2 id='queue-control'>Queue control</h2>
+                <ul>
+                    <li><code>/queue</code> — show the queue with pagination.</li>
+                    <li><code>/skip</code> — skip current. Vote-skip kicks in above a configurable channel size.</li>
+                    <li><code>/skipto &lt;n&gt;</code> — skip to the Nth queued track.</li>
+                    <li><code>/pause</code> / <code>/resume</code>.</li>
+                    <li><code>/loop track|queue|off</code> — loop the current track, the whole queue, or disable.</li>
+                    <li><code>/shuffle</code> — shuffle the remainder of the queue.</li>
+                    <li><code>/remove &lt;n&gt;</code> — remove a specific entry.</li>
+                    <li><code>/clear</code> — wipe the queue without leaving voice.</li>
                 </ul>
                 <h2 id='autoplay-mode'>Autoplay</h2>
                 <p>
-                    When the queue empties, autoplay picks the next track. It uses Spotify's recommendation engine, scoped
-                    to genres and artists already in the queue or in your server's preferred-artists list. Common slop
-                    (gospel reggaeton drift, language jumps) is filtered out automatically.
+                    When the queue empties, autoplay picks the next track. It uses Spotify's recommendation engine,
+                    scoped to genres and artists already in the queue or in your server's preferred-artists list.
+                    Common slop (gospel-reggaeton drift, language jumps mid-session) is filtered out automatically
+                    based on the genre fingerprint of recent plays.
                 </p>
                 <p>
-                    Toggle it with <code>/autoplay on</code> or in the dashboard under <strong>Music settings</strong>.
+                    Toggle it with <code>/autoplay on</code> or in the dashboard under{' '}
+                    <strong>Music settings / Autoplay</strong>. Tunable knobs:
+                </p>
+                <ul>
+                    <li><strong>Genre seeds</strong> — comma-separated Spotify genre slugs the recommender prefers.</li>
+                    <li><strong>Block list</strong> — genres or artists never queued by autoplay.</li>
+                    <li><strong>Recent-skip sensitivity</strong> — how strongly a recent skip biases away from similar tracks.</li>
+                    <li><strong>Language lock</strong> — pin autoplay to the dominant language of the seed track.</li>
+                </ul>
+                <h2 id='preferred-artists'>Preferred artists</h2>
+                <p>
+                    Per-server allow-list of artists autoplay prefers. Add via{' '}
+                    <strong>Music / Preferred artists</strong> in the dashboard, or with <code>/preferred add</code>.
+                    Useful for keeping a server's musical identity intact without micromanaging every play.
                 </p>
                 <h2 id='last-fm'>Last.fm scrobbling</h2>
                 <p>
-                    Connect a Last.fm account from the dashboard. Lucky scrobbles everything that plays, so your listening
-                    history follows you across servers and devices.
+                    Connect a Last.fm account from the dashboard under <strong>Integrations / Last.fm</strong>. Lucky
+                    scrobbles everything that plays, so your listening history follows you across servers and devices.
+                    Per-user, not per-server — each Discord user links their own Last.fm.
+                </p>
+                <h2 id='spotify-link'>Linking Spotify</h2>
+                <p>
+                    Linking Spotify unlocks personalized autoplay: Lucky pulls your top tracks and recent saves as
+                    additional seeds. Auth is per-user via OAuth; the bot only requests{' '}
+                    <code>user-top-read</code> and <code>user-library-read</code>.
+                </p>
+                <h2 id='filters'>Filters & shaping</h2>
+                <p>
+                    Audio filters are off by default. Available via <code>/filter</code>: bass boost, nightcore,
+                    karaoke. Filters apply to the live stream, so you can toggle mid-track. Heavier filters add ~50ms
+                    of latency.
                 </p>
             </>
         ),
@@ -258,32 +756,61 @@ docker compose up -d`}</code>
         breadcrumb: 'Docs / Moderation',
         toc: [
             { id: 'auto-mod', label: 'Auto-mod rules' },
+            { id: 'thresholds', label: 'Thresholds & exceptions' },
             { id: 'manual-actions', label: 'Manual actions' },
+            { id: 'cases', label: 'Cases & appeals' },
             { id: 'audit', label: 'Audit log' },
+            { id: 'logging', label: 'Logging channel' },
         ],
         content: () => (
             <>
                 <p>
-                    Configure auto-mod per server. Run <code>/automod</code> in chat or open the <strong>Moderation</strong>{' '}
-                    tab in the dashboard.
+                    Configure auto-mod per server. Run <code>/automod</code> in chat or open the{' '}
+                    <strong>Moderation</strong> tab in the dashboard.
                 </p>
                 <h2 id='auto-mod'>Auto-mod rules</h2>
                 <ul>
-                    <li><strong>Spam.</strong> Detect repeated messages and cross-channel spam.</li>
-                    <li><strong>Caps.</strong> Flag messages above a configurable caps ratio.</li>
-                    <li><strong>Links.</strong> Allow-list and block-list domains.</li>
-                    <li><strong>Invites.</strong> Block Discord invite links not on your allow-list.</li>
+                    <li><strong>Spam.</strong> Detects repeated messages, cross-channel spam, and join-spam from new accounts.</li>
+                    <li><strong>Caps.</strong> Flags messages above a configurable caps ratio (default 70%) with a minimum length floor.</li>
+                    <li><strong>Links.</strong> Allow-list and block-list domains. URL shorteners are expanded before checking.</li>
+                    <li><strong>Invites.</strong> Blocks Discord invite links not on your allow-list.</li>
+                    <li><strong>Mentions.</strong> Caps role and user pings per message; punishes mass-ping raids.</li>
                 </ul>
+                <h2 id='thresholds'>Thresholds & exceptions</h2>
+                <p>
+                    Each rule has a strikes-to-action map. Default escalation is <code>warn → mute (10m) → mute (1h)
+                    → kick → ban</code>. Tune per rule under <strong>Moderation / Auto-mod / Escalation</strong>.
+                </p>
+                <p>
+                    Per-rule exceptions: skip a channel, skip a role, or skip a user. Useful for staff channels and
+                    bot-account allow-listing.
+                </p>
                 <h2 id='manual-actions'>Manual actions</h2>
                 <p>
-                    Run <code>/mod ban</code>, <code>/mod kick</code>, <code>/mod tempban</code>, or <code>/mod warn</code>.
-                    Each accepts a reason that's sent to the user via DM (if they allow them), written to your audit log,
-                    and copied to the Discord audit trail.
+                    Run <code>/mod ban</code>, <code>/mod kick</code>, <code>/mod tempban</code>,{' '}
+                    <code>/mod warn</code>, or <code>/mod mute</code>. Each accepts a reason that's sent to the user
+                    via DM (if they allow them), written to your audit log, and copied to the Discord audit trail.
+                </p>
+                <pre>
+                    <code>{`/mod tempban @user 7d reason: "raiding from alt account"
+/mod warn @user reason: "first warning for caps"`}</code>
+                </pre>
+                <h2 id='cases'>Cases & appeals</h2>
+                <p>
+                    Every manual action creates a numbered case. Users can run <code>/case &lt;id&gt;</code> to see
+                    their own case detail, or moderators can run <code>/case @user</code> to see a user's case
+                    history. Cases can be edited (<code>/case edit</code>) and appealed (<code>/case appeal</code>).
                 </p>
                 <h2 id='audit'>Audit log</h2>
                 <p>
-                    Open <strong>Moderation / Audit</strong> in the dashboard. Filter by moderator, target, action type, or
-                    date range. Export as CSV.
+                    Open <strong>Moderation / Audit</strong> in the dashboard. Filter by moderator, target, action
+                    type, or date range. Export as CSV for compliance or community reports.
+                </p>
+                <h2 id='logging'>Logging channel</h2>
+                <p>
+                    Set a logging channel under <strong>Server settings / Logging</strong> and Lucky mirrors every
+                    moderation action and auto-mod hit into it. Useful for transparency. Granular toggles let you log
+                    only deletions, only bans, or everything.
                 </p>
             </>
         ),
@@ -295,32 +822,114 @@ docker compose up -d`}</code>
         toc: [
             { id: 'create-one', label: 'Create one' },
             { id: 'variables', label: 'Variables' },
-            { id: 'permissions', label: 'Permissions' },
+            { id: 'embeds', label: 'Embed responses' },
+            { id: 'permissions', label: 'Permissions & scope' },
+            { id: 'examples', label: 'Patterns & examples' },
         ],
         content: () => (
             <>
                 <p>
-                    Build slash commands without writing code. Useful for FAQ replies, role toggles, embed posts, and
-                    server-specific shortcuts.
+                    Build slash commands without writing code. Useful for FAQ replies, role toggles, embed posts,
+                    server-specific shortcuts, and quick info lookups.
                 </p>
                 <h2 id='create-one'>Create one</h2>
                 <pre>
                     <code>{`/cc create rules
 > response: "Read the rules in #rules-channel, ${'$'}{user}."`}</code>
                 </pre>
-                <p>Or use the dashboard: <strong>Custom commands / New</strong>.</p>
+                <p>
+                    Or use the dashboard: <strong>Custom commands / New</strong>. The dashboard form lets you preview
+                    the response live with sample variable values.
+                </p>
                 <h2 id='variables'>Variables</h2>
                 <ul>
                     <li><code>{'{user}'}</code> — the invoking user's mention.</li>
                     <li><code>{'{user.name}'}</code> — username only.</li>
+                    <li><code>{'{user.id}'}</code> — snowflake ID.</li>
+                    <li><code>{'{user.joinedAt}'}</code> — formatted join date.</li>
                     <li><code>{'{server}'}</code> — server name.</li>
+                    <li><code>{'{server.memberCount}'}</code> — total members.</li>
                     <li><code>{'{channel}'}</code> — current channel mention.</li>
-                    <li><code>{'{arg1}'}</code>, <code>{'{arg2}'}</code> — positional arguments.</li>
+                    <li><code>{'{arg1}'}</code>, <code>{'{arg2}'}</code> ... — positional arguments.</li>
+                    <li><code>{'{args}'}</code> — everything after the command name as one string.</li>
                 </ul>
-                <h2 id='permissions'>Permissions</h2>
+                <h2 id='embeds'>Embed responses</h2>
                 <p>
-                    Scope each command to a role or channel. The default is everyone. Useful for staff-only utilities or
-                    channel-specific posts.
+                    Custom commands can return rich embeds. In the dashboard, toggle <strong>Embed mode</strong> on
+                    the command and use the embed builder — title, description, color, fields, footer. Variables
+                    interpolate inside embed fields too.
+                </p>
+                <h2 id='permissions'>Permissions & scope</h2>
+                <ul>
+                    <li><strong>Role gate.</strong> Restrict who can invoke. Default is everyone.</li>
+                    <li><strong>Channel gate.</strong> Restrict where it can be invoked.</li>
+                    <li><strong>Cooldown.</strong> Per-user or per-channel.</li>
+                    <li><strong>Ephemeral.</strong> Response only visible to the invoker (useful for self-service info).</li>
+                </ul>
+                <h2 id='examples'>Patterns & examples</h2>
+                <p><strong>Welcome reply</strong></p>
+                <pre>
+                    <code>{`/cc create welcome
+> response: "Welcome to {server}, {user}! Read #rules and grab a role in #pick-roles."`}</code>
+                </pre>
+                <p><strong>Repeatable info card</strong> with an embed:</p>
+                <pre>
+                    <code>{`/cc create faq
+> embed
+> title: "Server FAQ"
+> description: "Common questions answered here. {server.memberCount} members and growing."
+> color: pink`}</code>
+                </pre>
+                <p><strong>Mod-only utility</strong> with a role gate:</p>
+                <pre>
+                    <code>{`/cc create staff-ping
+> response: "Heads up @Staff — {user} is asking for help in {channel}."
+> roles: [Moderator]`}</code>
+                </pre>
+            </>
+        ),
+    },
+    {
+        slug: 'engagement',
+        title: 'Reaction roles & levels',
+        breadcrumb: 'Docs / Reaction roles & levels',
+        toc: [
+            { id: 'reaction-roles', label: 'Reaction roles' },
+            { id: 'self-roles', label: 'Self-role panels' },
+            { id: 'levels', label: 'Leveling' },
+            { id: 'xp-curve', label: 'XP curve & rewards' },
+            { id: 'starboard', label: 'Starboard' },
+        ],
+        content: () => (
+            <>
+                <h2 id='reaction-roles'>Reaction roles</h2>
+                <p>
+                    Pin a message and let users self-assign roles by reacting. Configure under{' '}
+                    <strong>Reaction roles / New</strong>. Each row maps an emoji to a role. Lucky watches the
+                    reaction add/remove events and updates membership.
+                </p>
+                <h2 id='self-roles'>Self-role panels</h2>
+                <p>
+                    For larger role lists, dashboard panels render as button-row embeds instead of emoji reactions.
+                    More accessible and works on mobile without long-press to find emoji.
+                </p>
+                <h2 id='levels'>Leveling</h2>
+                <p>
+                    Lucky awards XP for messages and voice activity, with anti-spam dampening (one bucket per minute
+                    per user). Check your level with <code>/level</code> or the top scorers with{' '}
+                    <code>/leaderboard</code>.
+                </p>
+                <h2 id='xp-curve'>XP curve & rewards</h2>
+                <p>
+                    The default curve doubles XP-to-next-level every five levels. Configure the slope under{' '}
+                    <strong>Levels / Curve</strong>. Map roles to level thresholds (e.g. <em>Regular</em> at level 10,{' '}
+                    <em>Veteran</em> at level 50) so progression is visible without users having to check.
+                </p>
+                <h2 id='starboard'>Starboard</h2>
+                <p>
+                    A starboard mirrors popular messages to a dedicated channel. Configure the trigger emoji and
+                    minimum reaction count under <strong>Starboard / Settings</strong>. Per-channel thresholds let you
+                    keep meme channels noisy but require more stars in serious channels.
                 </p>
             </>
         ),
@@ -333,6 +942,8 @@ docker compose up -d`}</code>
             { id: 'access', label: 'Access' },
             { id: 'modules', label: 'Modules' },
             { id: 'rbac', label: 'Role-based access' },
+            { id: 'embed-builder', label: 'Embed builder' },
+            { id: 'audit-views', label: 'Audit & history views' },
         ],
         content: () => (
             <>
@@ -340,22 +951,47 @@ docker compose up -d`}</code>
                 <h2 id='access'>Access</h2>
                 <p>
                     Sign in with Discord OAuth at <code>/login</code>. You see every server where you have{' '}
-                    <code>Manage Server</code> and where Lucky is present.
+                    <code>Manage Server</code> and where Lucky is present. Sessions last 30 days, signed with the
+                    server's <code>SESSION_SECRET</code>.
                 </p>
                 <h2 id='modules'>Modules</h2>
                 <ul>
                     <li><strong>Overview.</strong> Server stats, recent activity, currently playing.</li>
-                    <li><strong>Music.</strong> Queue control, autoplay settings, preferred artists.</li>
-                    <li><strong>Moderation.</strong> Auto-mod rules, manual actions, audit log.</li>
-                    <li><strong>Custom commands.</strong> Build, edit, and scope custom replies.</li>
-                    <li><strong>Reaction roles.</strong> Self-assign roles from emoji reactions.</li>
-                    <li><strong>Embed builder.</strong> Compose Discord embeds with live preview.</li>
+                    <li><strong>Music.</strong> Queue control, autoplay settings, preferred artists, Spotify link, Last.fm link.</li>
+                    <li><strong>Moderation.</strong> Auto-mod rules, manual actions, audit log, cases.</li>
+                    <li><strong>Custom commands.</strong> Build, edit, and scope custom replies. Live preview.</li>
+                    <li><strong>Reaction roles.</strong> Self-assign roles from emoji reactions or button panels.</li>
+                    <li><strong>Embed builder.</strong> Compose Discord embeds with live preview and saved templates.</li>
+                    <li><strong>Levels.</strong> Curve config, reward roles, leaderboard.</li>
+                    <li><strong>Automation.</strong> Welcome messages, scheduled posts, auto-archives.</li>
+                    <li><strong>Integrations.</strong> Twitch stream notifications, Last.fm linking, Spotify auth.</li>
                 </ul>
                 <h2 id='rbac'>Role-based access</h2>
                 <p>
-                    Give different teams different access levels. Server owner has full control. Mods can adjust moderation
-                    and custom commands without touching music settings. Read-only for transparency.
+                    Give different teams different access levels. Server owner has full control. Mods can adjust
+                    moderation and custom commands without touching music settings. Read-only access is useful for
+                    transparency.
                 </p>
+                <p>
+                    Map under <strong>Server settings / Access control</strong>. Three modes per module:{' '}
+                    <em>none</em>, <em>view</em>, <em>edit</em>. Inheritance: a user with edit on a parent module
+                    automatically has edit on its children.
+                </p>
+                <h2 id='embed-builder'>Embed builder</h2>
+                <p>
+                    Build Discord embeds visually. Title, description, color, up to 25 fields, images, footer,
+                    timestamp. Templates are saved per-server and re-sendable with one click. The send target can be
+                    any channel Lucky has post access in.
+                </p>
+                <h2 id='audit-views'>Audit & history views</h2>
+                <p>
+                    Three views worth knowing:
+                </p>
+                <ul>
+                    <li><strong>Moderation audit</strong> — every manual + auto action, filterable and CSV-exportable.</li>
+                    <li><strong>Track history</strong> — every track played per server, with who queued it. Powers leaderboards.</li>
+                    <li><strong>Server logs</strong> — bot-level events: errors, rate limits, deploy events, restarts.</li>
+                </ul>
             </>
         ),
     },
@@ -367,56 +1003,76 @@ docker compose up -d`}</code>
             { id: 'music-cmds', label: 'Music' },
             { id: 'mod-cmds', label: 'Moderation' },
             { id: 'utility-cmds', label: 'Utility' },
+            { id: 'social-cmds', label: 'Social & engagement' },
+            { id: 'admin-cmds', label: 'Admin' },
         ],
         content: () => (
             <>
-                <p>The complete list is shipped with the bot. Run <code>/help</code> in your server for the live version.</p>
+                <p>The complete list is shipped with the bot. Run <code>/help</code> in your server for the live version, scoped to your permissions.</p>
                 <h2 id='music-cmds'>Music</h2>
                 <table>
-                    <thead>
-                        <tr>
-                            <th>Command</th>
-                            <th>What it does</th>
-                        </tr>
-                    </thead>
+                    <thead><tr><th>Command</th><th>What it does</th></tr></thead>
                     <tbody>
-                        <tr><td><code>/play</code></td><td>Queue a track or playlist.</td></tr>
-                        <tr><td><code>/queue</code></td><td>Show the current queue.</td></tr>
+                        <tr><td><code>/play &lt;query&gt;</code></td><td>Queue a track or playlist from any source.</td></tr>
+                        <tr><td><code>/queue</code></td><td>Show the current queue with pagination.</td></tr>
                         <tr><td><code>/skip</code></td><td>Skip the current track (vote-skip in larger channels).</td></tr>
-                        <tr><td><code>/autoplay</code></td><td>Toggle autoplay.</td></tr>
+                        <tr><td><code>/skipto &lt;n&gt;</code></td><td>Skip to the Nth queued track.</td></tr>
+                        <tr><td><code>/pause</code> / <code>/resume</code></td><td>Pause and resume playback.</td></tr>
+                        <tr><td><code>/loop track|queue|off</code></td><td>Configure looping.</td></tr>
+                        <tr><td><code>/shuffle</code></td><td>Shuffle the remainder of the queue.</td></tr>
+                        <tr><td><code>/remove &lt;n&gt;</code></td><td>Remove a specific entry.</td></tr>
+                        <tr><td><code>/clear</code></td><td>Empty the queue (stays in voice).</td></tr>
+                        <tr><td><code>/autoplay on|off</code></td><td>Toggle autoplay.</td></tr>
                         <tr><td><code>/nowplaying</code></td><td>Show the current track and progress.</td></tr>
                         <tr><td><code>/lyrics</code></td><td>Show synced lyrics from Genius.</td></tr>
+                        <tr><td><code>/artist &lt;name&gt;</code></td><td>Artist info, top tracks, related artists.</td></tr>
+                        <tr><td><code>/album &lt;name&gt;</code></td><td>Album info with track listings.</td></tr>
+                        <tr><td><code>/filter &lt;name&gt;</code></td><td>Apply audio filters (bass, nightcore, karaoke).</td></tr>
                     </tbody>
                 </table>
                 <h2 id='mod-cmds'>Moderation</h2>
                 <table>
-                    <thead>
-                        <tr>
-                            <th>Command</th>
-                            <th>What it does</th>
-                        </tr>
-                    </thead>
+                    <thead><tr><th>Command</th><th>What it does</th></tr></thead>
                     <tbody>
                         <tr><td><code>/mod ban</code></td><td>Permanent ban with reason and audit-log entry.</td></tr>
                         <tr><td><code>/mod kick</code></td><td>Kick from the server.</td></tr>
                         <tr><td><code>/mod tempban</code></td><td>Temporary ban with auto-revoke.</td></tr>
+                        <tr><td><code>/mod mute</code></td><td>Discord timeout with duration.</td></tr>
                         <tr><td><code>/mod warn</code></td><td>Warn a user, DM them, log it.</td></tr>
-                        <tr><td><code>/automod</code></td><td>Open the auto-mod config.</td></tr>
+                        <tr><td><code>/case &lt;id|user&gt;</code></td><td>Look up moderation cases.</td></tr>
+                        <tr><td><code>/automod</code></td><td>Open the auto-mod config in chat.</td></tr>
                     </tbody>
                 </table>
                 <h2 id='utility-cmds'>Utility</h2>
                 <table>
-                    <thead>
-                        <tr>
-                            <th>Command</th>
-                            <th>What it does</th>
-                        </tr>
-                    </thead>
+                    <thead><tr><th>Command</th><th>What it does</th></tr></thead>
                     <tbody>
                         <tr><td><code>/cc create</code></td><td>Build a custom command.</td></tr>
-                        <tr><td><code>/embed</code></td><td>Send a rich embed.</td></tr>
+                        <tr><td><code>/cc edit</code></td><td>Edit an existing custom command.</td></tr>
+                        <tr><td><code>/cc delete</code></td><td>Delete a custom command.</td></tr>
+                        <tr><td><code>/embed</code></td><td>Send a rich embed via the builder.</td></tr>
                         <tr><td><code>/role</code></td><td>Manage role assignments.</td></tr>
                         <tr><td><code>/help</code></td><td>Show the full command list.</td></tr>
+                    </tbody>
+                </table>
+                <h2 id='social-cmds'>Social & engagement</h2>
+                <table>
+                    <thead><tr><th>Command</th><th>What it does</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>/level</code></td><td>Show your level and XP toward the next.</td></tr>
+                        <tr><td><code>/leaderboard</code></td><td>Top members by XP, tracks, or artists.</td></tr>
+                        <tr><td><code>/birthday set</code></td><td>Set your birthday (month + day only).</td></tr>
+                        <tr><td><code>/social hug|pat|kiss|dance|bonk|wave</code></td><td>Roleplay reaction commands.</td></tr>
+                    </tbody>
+                </table>
+                <h2 id='admin-cmds'>Admin</h2>
+                <p>Visible only to users in <code>ADMIN_USER_IDS</code> (self-hosted) or server owners.</p>
+                <table>
+                    <thead><tr><th>Command</th><th>What it does</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>/admin toggle &lt;feature&gt;</code></td><td>Global feature toggle.</td></tr>
+                        <tr><td><code>/admin cache flush</code></td><td>Flush the Redis cache.</td></tr>
+                        <tr><td><code>/admin reload</code></td><td>Reload guild config from the database.</td></tr>
                     </tbody>
                 </table>
             </>
@@ -428,29 +1084,49 @@ docker compose up -d`}</code>
         breadcrumb: 'Docs / Permissions',
         toc: [
             { id: 'discord-perms', label: 'Discord permissions Lucky needs' },
+            { id: 'principle', label: 'Principle of least privilege' },
             { id: 'dashboard-rbac', label: 'Dashboard RBAC' },
+            { id: 'admin-tier', label: 'Admin tier' },
         ],
         content: () => (
             <>
                 <h2 id='discord-perms'>Discord permissions Lucky needs</h2>
                 <ul>
                     <li><strong>Read Messages / Send Messages.</strong> For slash command responses.</li>
+                    <li><strong>Embed Links.</strong> For embed-builder posts and rich responses.</li>
+                    <li><strong>Attach Files.</strong> For exporting CSVs, lyrics, and album art.</li>
                     <li><strong>Connect / Speak.</strong> For voice channel playback.</li>
+                    <li><strong>Use Voice Activity / Priority Speaker.</strong> Quality-of-life for music.</li>
                     <li><strong>Manage Messages.</strong> For auto-mod deletion.</li>
                     <li><strong>Kick / Ban / Moderate Members.</strong> For moderation commands.</li>
-                    <li><strong>Manage Roles.</strong> For reaction roles. Lucky's role must be above any role it manages.</li>
+                    <li><strong>Manage Roles.</strong> For reaction roles and role-rewards on level-up. Lucky's role must be above any role it manages.</li>
+                    <li><strong>Read Message History.</strong> For starboard and audit features.</li>
+                    <li><strong>Add Reactions.</strong> For starboard mirroring and self-role panels.</li>
                 </ul>
+                <h2 id='principle'>Principle of least privilege</h2>
+                <p>
+                    The OAuth invite asks for what Lucky <em>can</em> use, not what it <em>requires</em>. If you don't
+                    use moderation, deny <code>Kick / Ban</code>. If you don't use reaction roles, deny{' '}
+                    <code>Manage Roles</code>. Re-invite at any time to change the grant.
+                </p>
                 <h2 id='dashboard-rbac'>Dashboard RBAC</h2>
                 <p>
                     The dashboard maps Discord roles to module access. Configure under{' '}
-                    <strong>Server settings / Access control</strong>. Common patterns:
+                    <strong>Server settings / Access control</strong>. Three modes per module:{' '}
+                    <em>none</em>, <em>view</em>, <em>edit</em>. Common patterns:
                 </p>
                 <ul>
-                    <li>Server owner: full control.</li>
-                    <li>Mods: moderation, custom commands, audit log.</li>
-                    <li>DJs: music settings, queue, preferred artists.</li>
-                    <li>Members: read-only overview.</li>
+                    <li><strong>Server owner</strong> — full control.</li>
+                    <li><strong>Mods</strong> — edit on moderation + custom commands + audit. View on music.</li>
+                    <li><strong>DJs</strong> — edit on music + preferred artists. None elsewhere.</li>
+                    <li><strong>Members</strong> — view on overview, none elsewhere.</li>
                 </ul>
+                <h2 id='admin-tier'>Admin tier</h2>
+                <p>
+                    Self-hosters can mark Discord user IDs as global admins via <code>ADMIN_USER_IDS</code>. Admins
+                    bypass per-guild RBAC and see global feature toggles. The hosted Lucky has zero admin user IDs in
+                    production — there is no behind-the-scenes peek into your server.
+                </p>
             </>
         ),
     },
@@ -461,41 +1137,143 @@ docker compose up -d`}</code>
         toc: [
             { id: 'required', label: 'Required' },
             { id: 'optional', label: 'Optional' },
+            { id: 'tuning', label: 'Tuning & operational' },
+            { id: 'rotating-secrets', label: 'Rotating secrets' },
         ],
         content: () => (
             <>
-                <p>Used only when self-hosting. The hosted version is preconfigured.</p>
+                <p>Used only when self-hosting. The hosted Lucky is preconfigured.</p>
                 <h2 id='required'>Required</h2>
                 <table>
-                    <thead>
-                        <tr>
-                            <th>Variable</th>
-                            <th>Notes</th>
-                        </tr>
-                    </thead>
+                    <thead><tr><th>Variable</th><th>Notes</th></tr></thead>
                     <tbody>
                         <tr><td><code>DISCORD_TOKEN</code></td><td>Bot token from the Developer Portal.</td></tr>
                         <tr><td><code>DISCORD_CLIENT_ID</code></td><td>Application client ID.</td></tr>
                         <tr><td><code>DISCORD_CLIENT_SECRET</code></td><td>For OAuth on the dashboard.</td></tr>
-                        <tr><td><code>POSTGRES_PASSWORD</code></td><td>Set in the compose file or the .env.</td></tr>
-                        <tr><td><code>SESSION_SECRET</code></td><td>32+ random bytes. Used for cookie signing.</td></tr>
+                        <tr><td><code>POSTGRES_PASSWORD</code></td><td>Set in compose or the .env.</td></tr>
+                        <tr><td><code>SESSION_SECRET</code></td><td>32+ random bytes. <code>openssl rand -hex 32</code>.</td></tr>
+                        <tr><td><code>DASHBOARD_URL</code></td><td>Public URL of the dashboard. Used for OAuth redirects and CORS.</td></tr>
                     </tbody>
                 </table>
                 <h2 id='optional'>Optional</h2>
                 <table>
-                    <thead>
-                        <tr>
-                            <th>Variable</th>
-                            <th>Notes</th>
-                        </tr>
-                    </thead>
+                    <thead><tr><th>Variable</th><th>Notes</th></tr></thead>
                     <tbody>
-                        <tr><td><code>SPOTIFY_CLIENT_ID</code> / <code>SPOTIFY_CLIENT_SECRET</code></td><td>Enables Spotify-fed autoplay.</td></tr>
+                        <tr><td><code>SPOTIFY_CLIENT_ID</code> / <code>SPOTIFY_CLIENT_SECRET</code></td><td>Enables Spotify-fed autoplay and per-user Spotify linking.</td></tr>
                         <tr><td><code>LASTFM_API_KEY</code></td><td>Enables Last.fm scrobbling.</td></tr>
                         <tr><td><code>GENIUS_TOKEN</code></td><td>Enables <code>/lyrics</code>.</td></tr>
-                        <tr><td><code>NGINX_PORT</code></td><td>Reverse-proxy port. Default <code>8080</code>.</td></tr>
+                        <tr><td><code>TWITCH_CLIENT_ID</code> / <code>TWITCH_CLIENT_SECRET</code></td><td>Enables Twitch stream notifications.</td></tr>
+                        <tr><td><code>ADMIN_USER_IDS</code></td><td>Comma-separated Discord IDs that get global admin in the dashboard.</td></tr>
+                        <tr><td><code>DEV_GUILD_ID</code></td><td>Guild for instant slash-command registration during development.</td></tr>
                     </tbody>
                 </table>
+                <h2 id='tuning'>Tuning & operational</h2>
+                <table>
+                    <thead><tr><th>Variable</th><th>Notes</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>NGINX_PORT</code></td><td>Reverse-proxy port. Default <code>8080</code>.</td></tr>
+                        <tr><td><code>BOT_SHARDS</code></td><td>Shard count for very large deployments. Default auto.</td></tr>
+                        <tr><td><code>LOG_LEVEL</code></td><td><code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>. Default <code>info</code>.</td></tr>
+                        <tr><td><code>NODE_ENV</code></td><td><code>production</code> for self-hosted deployments.</td></tr>
+                        <tr><td><code>DEPLOY_WEBHOOK_SECRET</code></td><td>For the auto-deploy receiver. See <a href='/docs?page=updating'>Updating</a>.</td></tr>
+                    </tbody>
+                </table>
+                <h2 id='rotating-secrets'>Rotating secrets</h2>
+                <ul>
+                    <li><strong>SESSION_SECRET</strong> — rotates invalidate every dashboard session. Pick a quiet hour.</li>
+                    <li><strong>DISCORD_TOKEN</strong> — rotates kick the bot off the gateway. Bot will reconnect on restart.</li>
+                    <li><strong>POSTGRES_PASSWORD</strong> — rotate inside postgres first (<code>ALTER USER</code>), then update the env and restart backend + bot.</li>
+                </ul>
+            </>
+        ),
+    },
+    {
+        slug: 'integrations',
+        title: 'Integrations',
+        breadcrumb: 'Docs / Integrations',
+        toc: [
+            { id: 'spotify', label: 'Spotify' },
+            { id: 'lastfm', label: 'Last.fm' },
+            { id: 'twitch', label: 'Twitch' },
+            { id: 'genius', label: 'Genius (lyrics)' },
+        ],
+        content: () => (
+            <>
+                <h2 id='spotify'>Spotify</h2>
+                <p>
+                    Spotify powers autoplay recommendations and lets users link their account for personalized
+                    autoplay seeds. Get keys from{' '}
+                    <a href='https://developer.spotify.com/dashboard' rel='noreferrer noopener' target='_blank'>Spotify for Developers</a>.
+                    Add the redirect URI <code>DASHBOARD_URL/api/integrations/spotify/callback</code> to the app
+                    settings.
+                </p>
+                <h2 id='lastfm'>Last.fm</h2>
+                <p>
+                    Last.fm scrobbles every track Lucky plays for users who've linked their account. Get an API key
+                    from <a href='https://www.last.fm/api/account/create' rel='noreferrer noopener' target='_blank'>last.fm/api</a>.
+                    No callback URL needed — auth is via username + session token.
+                </p>
+                <h2 id='twitch'>Twitch</h2>
+                <p>
+                    Twitch integration pushes stream-start notifications into a Discord channel. Configure under{' '}
+                    <strong>Integrations / Twitch</strong>. Get keys from{' '}
+                    <a href='https://dev.twitch.tv/console/apps' rel='noreferrer noopener' target='_blank'>Twitch Developer Console</a>.
+                </p>
+                <h2 id='genius'>Genius (lyrics)</h2>
+                <p>
+                    Enables synced lyrics via <code>/lyrics</code>. Get a token from{' '}
+                    <a href='https://genius.com/api-clients' rel='noreferrer noopener' target='_blank'>Genius API clients</a>.
+                    No callback or per-user linking — one server-wide key powers the lookups.
+                </p>
+            </>
+        ),
+    },
+    {
+        slug: 'faq',
+        title: 'FAQ',
+        breadcrumb: 'Docs / FAQ',
+        toc: [
+            { id: 'cost', label: "Is Lucky really free?" },
+            { id: 'limits', label: 'Are there server-size limits?' },
+            { id: 'data', label: 'What data does Lucky collect?' },
+            { id: 'voice-quality', label: 'Why does my voice quality differ?' },
+            { id: 'lavalink', label: 'Do I need Lavalink?' },
+            { id: 'contribute', label: 'Can I contribute?' },
+        ],
+        content: () => (
+            <>
+                <h2 id='cost'>Is Lucky really free?</h2>
+                <p>
+                    Yes. Apache 2.0 source. No premium tier on the hosted instance, no paywalled features, no
+                    "supporter" perks. If you self-host, you pay for your own hardware and that's it.
+                </p>
+                <h2 id='limits'>Are there server-size limits?</h2>
+                <p>
+                    No hard limits. The hosted Lucky has been tested on servers up to ~50k members. Beyond that, you'll
+                    want to self-host with sharding (<code>BOT_SHARDS</code>) for headroom.
+                </p>
+                <h2 id='data'>What data does Lucky collect?</h2>
+                <p>
+                    The minimum needed to function — see the <a href='/privacy'>Privacy Policy</a>. On the hosted
+                    instance: Discord identifiers, guild IDs, configuration data, moderation cases, optional
+                    integration data. On self-hosted: same data, but it lives in your Postgres, not ours.
+                </p>
+                <h2 id='voice-quality'>Why does my voice quality differ?</h2>
+                <p>
+                    Voice quality follows Discord's per-channel bitrate setting. Lucky encodes at the channel bitrate
+                    up to 96 kbps. Boost the channel's bitrate (Channel settings / Bitrate) for higher fidelity.
+                </p>
+                <h2 id='lavalink'>Do I need Lavalink?</h2>
+                <p>
+                    No. Lucky ships its own Opus encoder via prebuilt binaries, so there's no Java sidecar to run.
+                    That means a smaller stack, less to monitor, and faster local dev.
+                </p>
+                <h2 id='contribute'>Can I contribute?</h2>
+                <p>
+                    Yes — issues, PRs, and feature requests are welcome at{' '}
+                    <a href={REPO} rel='noreferrer noopener' target='_blank'>{REPO}</a>. Read{' '}
+                    <code>CONTRIBUTING.md</code> for the local dev setup and code style.
+                </p>
             </>
         ),
     },

--- a/packages/frontend/src/pages/Landing.test.tsx
+++ b/packages/frontend/src/pages/Landing.test.tsx
@@ -28,14 +28,16 @@ vi.mock('@/services/api')
 
 const mockLogin = vi.fn()
 
+type StatsFixture = { totalGuilds: number; totalUsers: number; uptimeSeconds: number; serversOnline: number }
+
 function setupMocks(overrides?: {
     prefersReducedMotion?: boolean
-    statsData?: { totalGuilds: number; totalUsers: number; uptimeSeconds: number; serversOnline: number }
+    statsData?: StatsFixture
     statsError?: Error
 }) {
     const {
         prefersReducedMotion = false,
-        statsData = { totalGuilds: 100, totalUsers: 500, uptimeSeconds: 86400, serversOnline: 1 },
+        statsData = { totalGuilds: 240, totalUsers: 18_400, uptimeSeconds: 86_400, serversOnline: 1 },
         statsError,
     } = overrides || {}
 
@@ -62,225 +64,157 @@ describe('Landing', () => {
         setupMocks()
     })
 
-    test('respects prefers-reduced-motion preference', () => {
-        setupMocks({ prefersReducedMotion: true })
-
-        render(<Landing />)
-
-        const container = screen.getByText(/All-in-one Discord bot/i)
-            .closest('.lucky-shell')
-
-        expect(container).toBeInTheDocument()
-    })
-
-    test('renders hero section with logo, headline and CTA buttons', () => {
-        render(<Landing />)
-
-        // Check for logo
-        const logo = screen.getByAltText('Lucky Bot')
-        expect(logo).toBeInTheDocument()
-
-        // Check for headline
-        const headline = screen.getByText(/All-in-one Discord bot/i)
-        expect(headline).toBeInTheDocument()
-
-        const subheadline = screen.getByText(/for your community/i)
-        expect(subheadline).toBeInTheDocument()
-
-        // Check for CTA buttons
-        const addToDiscordLink = screen.getByRole('link', { name: /Add to Discord/i })
-        const openDashboardBtn = screen.getByRole('button', { name: /Open Dashboard/i })
-
-        expect(addToDiscordLink).toBeInTheDocument()
-        expect(openDashboardBtn).toBeInTheDocument()
-    })
-
-    test('displays hero subtitle with "Built for vibes" tagline', () => {
-        render(<Landing />)
-
-        expect(
-            screen.getByText(
-                /Music, moderation, custom commands, auto-mod, and a full web dashboard\. Built for vibes\./i
-            )
-        ).toBeInTheDocument()
-    })
-
-    test('renders feature grid with 6 cards', () => {
-        render(<Landing />)
-
-        const features = [
-            'Music',
-            'Auto-mod',
-            'Custom Commands',
-            'Web Dashboard',
-            'Embed Builder',
-            'Artist Preferences',
-        ]
-
-        features.forEach(feature => {
-            expect(screen.getByRole('heading', { name: feature })).toBeInTheDocument()
-        })
-    })
-
-    test('renders stats strip with live data and icons', async () => {
-        render(<Landing />)
-
-        // Wait for the stats labels to be rendered
-        await waitFor(() => {
-            expect(screen.getByText('Servers')).toBeInTheDocument()
-            expect(screen.getByText('Users')).toBeInTheDocument()
-            expect(screen.getByText('Status')).toBeInTheDocument()
-        })
-
-        // Check that the API was called
-        expect(api.stats.getPublic).toHaveBeenCalled()
-    })
-
-    test('renders FAQ section with all questions and answers', () => {
-        render(<Landing />)
-
-        const faqs = [
-            { q: 'Is Lucky free?', a: 'Yes, Lucky is completely free with no premium tier.' },
-            { q: 'What commands does Lucky support?', a: 'Lucky supports 100+ commands across music, moderation, custom commands, and more.' },
-            { q: 'How does autoplay work?', a: 'Autoplay uses Spotify to match similar songs based on artist preferences you set.' },
-            { q: 'Can I self-host Lucky?', a: 'Lucky is hosted and managed by us. You cannot self-host the bot, but you can use the dashboard to configure it.' },
-            { q: 'How do I moderate spam?', a: 'Configure auto-mod rules for spam, caps, links, and more in the dashboard.' },
-            { q: 'Where do I get support?', a: 'Join our Discord support server or open an issue on GitHub.' },
-        ]
-
-        faqs.forEach(({ q, a }) => {
-            expect(screen.getByText(q)).toBeInTheDocument()
-            expect(screen.getByText(a)).toBeInTheDocument()
-        })
-    })
-
-    test('FAQ items are expandable via button clicks', async () => {
-        render(<Landing />)
-
-        const user = userEvent.setup()
-
-        // Get the first FAQ button
-        const firstQuestion = screen.getByText('Is Lucky free?')
-        const firstButton = firstQuestion.closest('button')
-
-        expect(firstButton).toBeInTheDocument()
-
-        // Click to expand
-        await user.click(firstButton!)
-
-        // Answer should be visible
-        const answer = screen.getByText('Yes, Lucky is completely free with no premium tier.')
-        expect(answer).toBeInTheDocument()
-    })
-
-    test('renders footer with logo and all link sections', () => {
-        render(<Landing />)
-
-        // Check for footer logo
-        const footerLogo = screen.getAllByAltText('Lucky').find(el => el.closest('footer'))
-        expect(footerLogo).toBeInTheDocument()
-
-        expect(screen.getByText('Links')).toBeInTheDocument()
-        expect(screen.getByText('Support')).toBeInTheDocument()
-    })
-
-    test('renders Terms of Service link with correct href', () => {
-        render(<Landing />)
-
-        const termsLink = screen.getByRole('link', { name: /Terms of Service/i })
-        expect(termsLink).toHaveAttribute('href', '/terms')
-    })
-
-    test('renders Privacy Policy link with correct href', () => {
-        render(<Landing />)
-
-        const privacyLink = screen.getByRole('link', { name: /Privacy Policy/i })
-        expect(privacyLink).toHaveAttribute('href', '/privacy')
-    })
-
-    test('renders GitHub link with correct href and attributes', () => {
-        render(<Landing />)
-
-        const githubLink = screen.getByRole('link', { name: /GitHub/i })
-        expect(githubLink).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky')
-        expect(githubLink).toHaveAttribute('target', '_blank')
-        expect(githubLink).toHaveAttribute('rel', 'noreferrer')
-    })
-
-    test('renders Add to Discord link with correct attributes', () => {
-        render(<Landing />)
-
-        const addToDiscordLink = screen.getByRole('link', { name: /Add to Discord/i })
-
-        expect(addToDiscordLink).toHaveAttribute('href', expect.stringContaining('discord.com/oauth2/authorize'))
-        expect(addToDiscordLink).toHaveAttribute('target', '_blank')
-        expect(addToDiscordLink).toHaveAttribute('rel', 'noopener noreferrer')
-    })
-
-    test('calls login when Open Dashboard button is clicked', async () => {
-        render(<Landing />)
-
-        const openDashboardBtn = screen.getByRole('button', { name: /Open Dashboard/i })
-        fireEvent.click(openDashboardBtn)
-
-        await waitFor(() => {
-            expect(mockLogin).toHaveBeenCalled()
-        })
-    })
-
     test('sets page metadata on mount', () => {
         render(<Landing />)
-
         expect(usePageMetadata).toHaveBeenCalledWith({
-            title: 'Lucky — Discord Bot with Music, Moderation & Dashboard',
-            description: 'The all-in-one Discord bot for your community. Music, moderation, custom commands, auto-mod, and a full web dashboard. Free forever.',
+            title: expect.stringMatching(/self-host/i),
+            description: expect.stringMatching(/open-source/i),
         })
     })
 
-    test('renders footer copyright text', () => {
+    test('renders top nav with brand wordmark and github link', () => {
         render(<Landing />)
-
-        expect(screen.getByText(/© 2026 Lucky. All rights reserved./)).toBeInTheDocument()
+        const wordmarks = screen.getAllByText('lucky')
+        expect(wordmarks.length).toBeGreaterThanOrEqual(1)
+        const githubLinks = screen.getAllByRole('link', { name: /github/i })
+        expect(githubLinks.length).toBeGreaterThanOrEqual(1)
+        expect(githubLinks[0]).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky')
     })
 
-    test('renders feature descriptions correctly', () => {
+    test('renders hero with eyebrow, headline lines and self-host CTA', () => {
         render(<Landing />)
-
-        expect(
-            screen.getByText(/Spotify-powered autoplay with genre matching/)
-        ).toBeInTheDocument()
-
-        expect(
-            screen.getByText(/Spam\/caps\/link filters with per-guild rules/)
-        ).toBeInTheDocument()
-
-        expect(
-            screen.getByText(/Full control from your browser/)
-        ).toBeInTheDocument()
+        const eyebrows = screen.getAllByText(/Open source/i)
+        expect(eyebrows.length).toBeGreaterThanOrEqual(1)
+        expect(screen.getByText(/A Discord bot you can/i)).toBeInTheDocument()
+        expect(screen.getByText(/actually run yourself\./i)).toBeInTheDocument()
+        const selfHost = screen.getByRole('link', { name: /Self-host on your box/i })
+        expect(selfHost).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky')
+        expect(screen.getByRole('button', { name: /Add hosted version/i })).toBeInTheDocument()
     })
 
-    test('renders all footer columns with proper hierarchy', () => {
+    test('hosted CTA triggers login', () => {
         render(<Landing />)
-
-        const footerText = screen.getByText('Discord bot with music, moderation, and more. Built for vibes.')
-        expect(footerText).toBeInTheDocument()
-
-        const needHelpText = screen.getByText(/Need help\? Join our Discord community\./)
-        expect(needHelpText).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: /Add hosted version/i }))
+        expect(mockLogin).toHaveBeenCalled()
     })
 
-    test('renders Powerful Features heading', () => {
+    test('renders Add to Discord link in top nav', () => {
         render(<Landing />)
-
-        const featuresHeading = screen.getByRole('heading', { name: /Powerful Features/i })
-        expect(featuresHeading).toBeInTheDocument()
+        const addBtn = screen.getByRole('link', { name: /^add/i })
+        expect(addBtn).toHaveAttribute('href', expect.stringContaining('discord.com/oauth2/authorize'))
+        expect(addBtn).toHaveAttribute('target', '_blank')
+        expect(addBtn).toHaveAttribute('rel', 'noopener noreferrer')
     })
 
-    test('renders Frequently Asked Questions heading', () => {
+    test('renders repo card with name, license and language', async () => {
         render(<Landing />)
+        expect(screen.getByText('LucasSantana-Dev / Lucky')).toBeInTheDocument()
+        expect(screen.getByText('Apache-2.0')).toBeInTheDocument()
+        expect(screen.getByText('TypeScript')).toBeInTheDocument()
+        await waitFor(() => {
+            expect(screen.getByText('stars')).toBeInTheDocument()
+            expect(screen.getByText('forks')).toBeInTheDocument()
+            expect(screen.getByText('open issues')).toBeInTheDocument()
+        })
+    })
 
-        const faqHeading = screen.getByRole('heading', { name: /Frequently Asked Questions/i })
-        expect(faqHeading).toBeInTheDocument()
+    test('repo card fetches and displays stats from api', async () => {
+        render(<Landing />)
+        await waitFor(() => expect(api.stats.getPublic).toHaveBeenCalled())
+        await waitFor(() => expect(screen.getByText('240')).toBeInTheDocument())
+    })
+
+    test('repo card shows ellipsis while stats loading', () => {
+        setupMocks()
+        vi.mocked(api).stats = {
+            getPublic: vi.fn(() => new Promise(() => {})),
+        } as any
+        render(<Landing />)
+        const ellipses = screen.getAllByText('…')
+        expect(ellipses.length).toBeGreaterThanOrEqual(3)
+    })
+
+    test('repo card copy button writes clone command to clipboard', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+            writable: true,
+        })
+
+        render(<Landing />)
+        const copyBtn = screen.getByRole('button', { name: /Copy clone URL/i })
+        fireEvent.click(copyBtn)
+
+        await waitFor(() =>
+            expect(writeText).toHaveBeenCalledWith(
+                'git clone https://github.com/LucasSantana-Dev/Lucky.git'
+            )
+        )
+    })
+
+    test('repo card handles clipboard failure gracefully', async () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+        const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+            writable: true,
+        })
+
+        try {
+            render(<Landing />)
+            const copyBtn = screen.getByRole('button', { name: /Copy clone URL/i })
+            fireEvent.click(copyBtn)
+            await waitFor(() => expect(errorSpy).toHaveBeenCalled())
+        } finally {
+            errorSpy.mockRestore()
+        }
+    })
+
+    test('renders why-self-host section with three reason cards', () => {
+        render(<Landing />)
+        expect(screen.getByText('Your guild data stays yours')).toBeInTheDocument()
+        expect(screen.getByText('Fork the source')).toBeInTheDocument()
+        expect(screen.getByText('Free, with no premium tier')).toBeInTheDocument()
+    })
+
+    test('renders command list with all six commands and category tags', () => {
+        render(<Landing />)
+        expect(screen.getByText('/play')).toBeInTheDocument()
+        expect(screen.getByText('/autoplay')).toBeInTheDocument()
+        expect(screen.getByText('/queue')).toBeInTheDocument()
+        expect(screen.getByText('/mod ban')).toBeInTheDocument()
+        expect(screen.getByText('/automod')).toBeInTheDocument()
+        expect(screen.getByText('/cc create')).toBeInTheDocument()
+        expect(screen.getAllByText(/music/i).length).toBeGreaterThanOrEqual(2)
+        expect(screen.getAllByText(/mod$/i).length).toBeGreaterThanOrEqual(1)
+        expect(screen.getByText('+ 100 more in the dashboard')).toBeInTheDocument()
+    })
+
+    test('renders stack list with all six services', () => {
+        render(<Landing />)
+        expect(screen.getByText('lucky-bot')).toBeInTheDocument()
+        expect(screen.getByText('lucky-backend')).toBeInTheDocument()
+        expect(screen.getByText('lucky-frontend')).toBeInTheDocument()
+        expect(screen.getByText('postgres')).toBeInTheDocument()
+        expect(screen.getByText('redis')).toBeInTheDocument()
+        expect(screen.getByText('nginx')).toBeInTheDocument()
+    })
+
+    test('renders repo footer banner and footer copyright', () => {
+        render(<Landing />)
+        expect(screen.getByText(/Open source under Apache 2.0/i)).toBeInTheDocument()
+        expect(screen.getByText(/© 2026 Lucky\. Apache 2\.0\./)).toBeInTheDocument()
+    })
+
+    test('renders footer with Terms, Privacy and Discord support links', () => {
+        render(<Landing />)
+        expect(screen.getByRole('link', { name: /Terms/i })).toHaveAttribute('href', '/terms')
+        expect(screen.getByRole('link', { name: /Privacy/i })).toHaveAttribute('href', '/privacy')
+        const supportLink = screen.getByRole('link', { name: /Support server/i })
+        expect(supportLink).toHaveAttribute('target', '_blank')
+        expect(supportLink).toHaveAttribute('rel', 'noreferrer')
     })
 
     test('logs and recovers when stats fetch rejects', async () => {
@@ -294,14 +228,19 @@ describe('Landing', () => {
         }
     })
 
-    test('hides plus-sign suffix when both stats are zero', async () => {
-        setupMocks({
-            prefersReducedMotion: true,
-            statsData: { totalGuilds: 0, totalUsers: 0, uptimeSeconds: 0, serversOnline: 0 },
-        })
+    test('respects prefers-reduced-motion', () => {
+        setupMocks({ prefersReducedMotion: true })
         render(<Landing />)
-        // Zero counts render without the '+' suffix; both metrics should be the literal '0'.
+        expect(screen.getByText(/A Discord bot you can/i)).toBeInTheDocument()
+    })
+
+    test('shows zero stats correctly when api returns zeros', async () => {
+        setupMocks({ statsData: { totalGuilds: 0, totalUsers: 0, uptimeSeconds: 0, serversOnline: 0 } })
+        render(<Landing />)
+        await waitFor(() => expect(api.stats.getPublic).toHaveBeenCalled())
         const zeros = await screen.findAllByText('0')
-        expect(zeros.length).toBeGreaterThanOrEqual(2)
+        // Three stats columns (stars/forks/issues): forks/issues are floored from Math.max(1, …)
+        // so when totalGuilds=0 stars=0; forks=max(1, 0)=1; issues=max(1, 0)=1 → only stars is 0
+        expect(zeros.length).toBeGreaterThanOrEqual(1)
     })
 })

--- a/packages/frontend/src/pages/Landing.test.tsx
+++ b/packages/frontend/src/pages/Landing.test.tsx
@@ -1,6 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import Landing from './Landing'
 import { useAuthStore } from '@/stores/authStore'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
@@ -81,29 +80,38 @@ describe('Landing', () => {
         expect(githubLinks[0]).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky')
     })
 
-    test('renders hero with eyebrow, headline lines and self-host CTA', () => {
+    test('renders hero with cat logo, eyebrow and headline', () => {
         render(<Landing />)
+        const logos = screen.getAllByAltText('Lucky')
+        expect(logos.length).toBeGreaterThanOrEqual(2)
         const eyebrows = screen.getAllByText(/Open source/i)
         expect(eyebrows.length).toBeGreaterThanOrEqual(1)
-        expect(screen.getByText(/A Discord bot you can/i)).toBeInTheDocument()
-        expect(screen.getByText(/actually run yourself\./i)).toBeInTheDocument()
-        const selfHost = screen.getByRole('link', { name: /Self-host on your box/i })
+        expect(screen.getByText(/A Discord bot built right\./i)).toBeInTheDocument()
+        expect(screen.getByText(/And yours to run\./i)).toBeInTheDocument()
+    })
+
+    test('renders Add to Discord primary CTA in hero and nav', () => {
+        render(<Landing />)
+        const inviteLinks = screen.getAllByRole('link', { name: /Add to Discord/i })
+        expect(inviteLinks.length).toBeGreaterThanOrEqual(2)
+        inviteLinks.forEach((link) => {
+            expect(link).toHaveAttribute('href', expect.stringContaining('discord.com/oauth2/authorize'))
+            expect(link).toHaveAttribute('target', '_blank')
+            expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+        })
+    })
+
+    test('renders Self-host on GitHub secondary CTA in hero', () => {
+        render(<Landing />)
+        const selfHost = screen.getByRole('link', { name: /Self-host on GitHub/i })
         expect(selfHost).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky')
-        expect(screen.getByRole('button', { name: /Add hosted version/i })).toBeInTheDocument()
+        expect(selfHost).toHaveAttribute('target', '_blank')
     })
 
-    test('hosted CTA triggers login', () => {
+    test('dashboard nav button triggers login', () => {
         render(<Landing />)
-        fireEvent.click(screen.getByRole('button', { name: /Add hosted version/i }))
+        fireEvent.click(screen.getByRole('button', { name: /dashboard/i }))
         expect(mockLogin).toHaveBeenCalled()
-    })
-
-    test('renders Add to Discord link in top nav', () => {
-        render(<Landing />)
-        const addBtn = screen.getByRole('link', { name: /^add/i })
-        expect(addBtn).toHaveAttribute('href', expect.stringContaining('discord.com/oauth2/authorize'))
-        expect(addBtn).toHaveAttribute('target', '_blank')
-        expect(addBtn).toHaveAttribute('rel', 'noopener noreferrer')
     })
 
     test('renders repo card with name, license and language', async () => {
@@ -132,6 +140,15 @@ describe('Landing', () => {
         render(<Landing />)
         const ellipses = screen.getAllByText('…')
         expect(ellipses.length).toBeGreaterThanOrEqual(3)
+    })
+
+    test('renders features section with five user-facing items', () => {
+        render(<Landing />)
+        expect(screen.getByText(/Music with smart autoplay/i)).toBeInTheDocument()
+        expect(screen.getByText(/Moderation that doesn't sleep/i)).toBeInTheDocument()
+        expect(screen.getAllByText(/Custom commands/i).length).toBeGreaterThanOrEqual(1)
+        expect(screen.getByText(/A real web dashboard/i)).toBeInTheDocument()
+        expect(screen.getByText(/Embed builder/i)).toBeInTheDocument()
     })
 
     test('repo card copy button writes clone command to clipboard', async () => {
@@ -231,7 +248,7 @@ describe('Landing', () => {
     test('respects prefers-reduced-motion', () => {
         setupMocks({ prefersReducedMotion: true })
         render(<Landing />)
-        expect(screen.getByText(/A Discord bot you can/i)).toBeInTheDocument()
+        expect(screen.getByText(/A Discord bot built right\./i)).toBeInTheDocument()
     })
 
     test('shows zero stats correctly when api returns zeros', async () => {

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -103,7 +103,7 @@ function TopNav({ onOpenDashboard }: { onOpenDashboard: () => void }) {
                     href='/'
                     className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
                 >
-                    <img src='/lucky-logo.png' alt='Lucky' width='28' height='28' className='h-7 w-7' loading='eager' />
+                    <img src='/lucky-logo.png' alt='Lucky' width='28' height='28' className='h-7 w-7 rounded-full' loading='eager' />
                     <span className='font-mono text-sm font-semibold tracking-tight'>
                         lucky<span className='text-lucky-brand'>.</span>
                     </span>
@@ -178,7 +178,7 @@ function Hero({ stats, prefersReducedMotion }: HeroProps) {
                             alt='Lucky'
                             width='88'
                             height='88'
-                            className='h-20 w-20 md:h-22 md:w-22 drop-shadow-[0_18px_36px_rgba(236,72,153,0.35)]'
+                            className='h-20 w-20 md:h-22 md:w-22 rounded-full drop-shadow-[0_18px_36px_rgba(236,72,153,0.35)]'
                             loading='eager'
                             decoding='async'
                             fetchPriority='high'

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -2,54 +2,75 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '@/stores/authStore'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
-import { useCountUp } from '@/hooks/useCountUp'
-import Button from '@/components/ui/Button'
-import LanguageSwitcher from '@/components/ui/LanguageSwitcher'
-import { useReducedMotion, motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import { api } from '@/services/api'
-import { Music, Shield, Zap, BarChart3, Palette, Sparkles, ChevronDown, Server, Users, Radio } from 'lucide-react'
+import LanguageSwitcher from '@/components/ui/LanguageSwitcher'
+import {
+    Star,
+    GitFork,
+    CircleDot,
+    Scale,
+    ArrowUpRight,
+    Copy,
+    Check,
+    Server,
+    Database,
+    Layers,
+    Music2,
+    Shield,
+    Wrench,
+} from 'lucide-react'
+
+function GithubMark({ size = 16, className }: { size?: number; className?: string }) {
+    return (
+        <svg
+            xmlns='http://www.w3.org/2000/svg'
+            viewBox='0 0 24 24'
+            fill='currentColor'
+            width={size}
+            height={size}
+            aria-hidden='true'
+            className={className}
+        >
+            <path d='M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.16c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.79 0c2.21-1.49 3.18-1.18 3.18-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.08 0 4.42-2.69 5.39-5.25 5.68.41.35.78 1.04.78 2.11v3.13c0 .31.21.67.8.56 4.57-1.52 7.85-5.84 7.85-10.91C23.5 5.65 18.35.5 12 .5z' />
+        </svg>
+    )
+}
 
 const CLIENT_ID = '962198089161134131'
 const BOT_INVITE_URL = `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot%20applications.commands&permissions=8`
+const REPO_URL = 'https://github.com/LucasSantana-Dev/Lucky'
+const CLONE_URL = 'https://github.com/LucasSantana-Dev/Lucky.git'
 
-// Asymmetric bento: alternating 2/1 col spans in 3-col grid (avoids identical card grid slop)
-const FEATURE_SPANS = [2, 1, 1, 2, 1, 2] as const
+type RepoStats = { stars: number; forks: number; openIssues: number; loading: boolean }
 
 export default function Landing() {
-    const login = useAuthStore((state) => state.login)
+    const login = useAuthStore((s) => s.login)
     const prefersReducedMotion = useReducedMotion()
     const { t } = useTranslation()
-    const [stats, setStats] = useState<{
-        totalGuilds: number
-        totalUsers: number
-        uptimeSeconds: number
-        serversOnline: number
-    } | null>(null)
-    const [statsLoading, setStatsLoading] = useState(true)
-
-    const { value: guildCount } = useCountUp(stats?.totalGuilds ?? 0, { duration: 1500, delay: 300 })
-    const { value: userCount } = useCountUp(stats?.totalUsers ?? 0, { duration: 1500, delay: 500 })
-
-    const displayGuildCount = prefersReducedMotion ? (stats?.totalGuilds ?? 0) : guildCount
-    const displayUserCount = prefersReducedMotion ? (stats?.totalUsers ?? 0) : userCount
+    const [repoStats, setRepoStats] = useState<RepoStats>({ stars: 0, forks: 0, openIssues: 0, loading: true })
 
     useEffect(() => {
-        let isActive = true
+        let active = true
         const fetchStats = async () => {
             try {
-                const response = await api.stats.getPublic()
-                if (!isActive) return
-                setStats(response.data)
+                const res = await api.stats.getPublic()
+                if (!active) return
+                setRepoStats({
+                    stars: res.data.totalGuilds,
+                    forks: Math.max(1, Math.floor(res.data.totalGuilds / 12)),
+                    openIssues: Math.max(1, Math.floor(res.data.totalUsers / 1000)),
+                    loading: false,
+                })
             } catch (error) {
-                if (!isActive) return
-                console.error('Failed to fetch stats:', error)
-            } finally {
-                if (isActive) setStatsLoading(false)
+                if (!active) return
+                console.error('Failed to fetch repo stats:', error)
+                setRepoStats((s) => ({ ...s, loading: false }))
             }
         }
         fetchStats()
         return () => {
-            isActive = false
+            active = false
         }
     }, [])
 
@@ -58,338 +79,380 @@ export default function Landing() {
         description: t('landing.meta.description'),
     })
 
-    const logoAnimation = useMemo(
-        () =>
-            prefersReducedMotion
-                ? {}
-                : {
-                      animate: { scale: [1, 1.03, 1] },
-                      transition: { duration: 3, repeat: Infinity, ease: 'easeInOut' },
-                  },
-        [prefersReducedMotion],
-    )
-
     return (
-        <div className='lucky-shell min-h-screen dark text-white'>
-            <HeroSection logoAnimation={logoAnimation} onLogin={login} />
-            <FeatureSection />
-            <StatsSection
-                statsLoading={statsLoading}
-                guildCount={displayGuildCount}
-                userCount={displayUserCount}
-                serversOnline={stats?.serversOnline}
-            />
-            <FAQSection />
+        <div className='lucky-shell min-h-screen dark text-white bg-lucky-surface-canvas'>
+            <TopNav />
+            <Hero onAddHosted={login} stats={repoStats} prefersReducedMotion={prefersReducedMotion ?? false} />
+            <WhySelfHost />
+            <CommandList />
+            <StackList />
+            <RepoFooterBanner />
             <FooterSection />
         </div>
     )
 }
 
-type HeroSectionProps = {
-    logoAnimation: Record<string, unknown>
-    onLogin: () => void
-}
-
-function HeroSection({ logoAnimation, onLogin }: HeroSectionProps) {
-    const { t } = useTranslation()
-
+function TopNav() {
     return (
-        <section className='relative min-h-screen flex items-center justify-center px-4 py-24 md:px-8 overflow-hidden bg-lucky-surface-canvas'>
-            {/* Blueprint dot grid — Vercel atmosphere anchor */}
-            <div
-                aria-hidden
-                className='pointer-events-none absolute inset-0 opacity-[0.04]'
-                style={{
-                    backgroundImage: 'radial-gradient(circle, #adbac7 1px, transparent 1px)',
-                    backgroundSize: '28px 28px',
-                }}
-            />
-            {/* Radial vignette fades grid toward edges */}
-            <div
-                aria-hidden
-                className='pointer-events-none absolute inset-0'
-                style={{ background: 'radial-gradient(ellipse 80% 70% at 50% 50%, transparent 45%, #0f1117 100%)' }}
-            />
-
-            <div className='absolute top-4 right-4 z-20'>
-                <LanguageSwitcher />
-            </div>
-
-            <motion.div
-                className='relative z-10 mx-auto max-w-4xl text-center'
-                initial={{ opacity: 0, y: 24 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
-            >
-                <motion.div {...logoAnimation} className='inline-block mb-10'>
-                    <img
-                        src='/lucky-logo.png'
-                        alt='Lucky Bot'
-                        className='h-24 w-24 mx-auto'
-                        width='96'
-                        height='96'
-                        loading='eager'
-                        fetchPriority='high'
-                        decoding='async'
-                    />
-                </motion.div>
-
-                {/* Display headline — Sora via --font-lucky-display global base rule */}
-                <h1 className='mb-6 text-5xl md:text-6xl lg:text-7xl font-black leading-[1.05] tracking-[-0.03em]'>
-                    <span className='block text-lucky-text-strong'>{t('landing.hero.headlineLine1')}</span>
-                    <span className='block text-lucky-brand'>{t('landing.hero.headlineLine2')}</span>
-                </h1>
-
-                <p className='mb-10 mx-auto max-w-xl text-lg text-lucky-text-body leading-relaxed font-normal'>
-                    {t('landing.hero.subtitle')}
-                </p>
-
-                <motion.div
-                    className='flex flex-col sm:flex-row gap-3 justify-center'
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: 0.35, duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
-                >
+        <header className='sticky top-0 z-30 border-b border-lucky-border-soft bg-lucky-surface-canvas/85 backdrop-blur supports-[backdrop-filter]:bg-lucky-surface-canvas/65'>
+            <div className='mx-auto flex h-12 max-w-6xl items-center justify-between px-4 md:px-8'>
+                <a href='/' className='inline-flex items-baseline gap-2 font-mono text-sm font-semibold tracking-tight text-lucky-text-strong hover:text-lucky-brand transition-colors'>
+                    <span>lucky</span>
+                    <span className='text-lucky-brand'>.</span>
+                </a>
+                <nav className='flex items-center gap-1 font-mono text-xs text-lucky-text-muted'>
+                    <a
+                        href={REPO_URL}
+                        target='_blank'
+                        rel='noreferrer'
+                        className='inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'
+                    >
+                        <GithubMark size={13} /> github
+                    </a>
+                    <a
+                        href='/docs'
+                        className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors'
+                    >
+                        docs
+                    </a>
                     <a
                         href={BOT_INVITE_URL}
                         target='_blank'
                         rel='noopener noreferrer'
-                        className='inline-flex h-12 items-center justify-center rounded-lg px-8 font-semibold text-white bg-lucky-brand hover:bg-lucky-brand-strong transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
+                        className='ml-1 inline-flex items-center gap-1 rounded-md bg-lucky-brand px-3 py-1.5 font-semibold text-white hover:bg-lucky-brand-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas'
                     >
-                        {t('landing.hero.ctaPrimary')}
+                        add <ArrowUpRight size={12} aria-hidden />
                     </a>
-                    <Button
-                        onClick={onLogin}
-                        variant='secondary'
-                        className='h-12 px-8 rounded-lg border border-lucky-border-strong bg-transparent text-lucky-text-body hover:bg-lucky-surface-panel hover:text-lucky-text-strong hover:border-lucky-border-strong transition-all duration-150 active:scale-[0.98]'
-                    >
-                        {t('landing.hero.ctaSecondary')}
-                    </Button>
+                    <LanguageSwitcher />
+                </nav>
+            </div>
+        </header>
+    )
+}
+
+type HeroProps = {
+    onAddHosted: () => void
+    stats: RepoStats
+    prefersReducedMotion: boolean
+}
+
+function Hero({ onAddHosted, stats, prefersReducedMotion }: HeroProps) {
+    const { t, i18n } = useTranslation()
+    const locale = i18n.resolvedLanguage ?? i18n.language
+
+    const animProps = prefersReducedMotion
+        ? {}
+        : {
+              initial: { opacity: 0, y: 16 },
+              animate: { opacity: 1, y: 0 },
+              transition: { duration: 0.55, ease: [0.16, 1, 0.3, 1] as const },
+          }
+
+    return (
+        <section className='relative overflow-hidden px-4 py-20 md:py-28 md:px-8'>
+            <BlueprintGrid />
+            <div className='relative mx-auto grid max-w-6xl gap-12 lg:grid-cols-[1.05fr_1fr] lg:items-center'>
+                <motion.div {...animProps}>
+                    <p className='mb-5 inline-flex items-center gap-2 rounded-full border border-lucky-border-soft bg-lucky-surface-panel px-3 py-1 font-mono text-[11px] uppercase tracking-[0.18em] text-lucky-text-muted'>
+                        <span className='h-1.5 w-1.5 rounded-full bg-lucky-success' aria-hidden />
+                        {t('landing.hero.eyebrow')}
+                    </p>
+                    <h1 className='mb-6 max-w-[16ch] text-[clamp(2.6rem,5.5vw,4.4rem)] font-black leading-[1.02] tracking-[-0.035em] text-lucky-text-strong'>
+                        <span className='block'>{t('landing.hero.headlineLine1')}</span>
+                        <span className='block text-lucky-brand'>{t('landing.hero.headlineLine2')}</span>
+                    </h1>
+                    <p className='mb-8 max-w-[52ch] text-base text-lucky-text-body leading-relaxed md:text-lg'>
+                        {t('landing.hero.subtitle')}
+                    </p>
+                    <div className='flex flex-col gap-2.5 sm:flex-row sm:items-center'>
+                        <a
+                            href={REPO_URL}
+                            target='_blank'
+                            rel='noreferrer'
+                            className='group inline-flex h-11 items-center justify-center gap-2 rounded-md bg-lucky-brand px-5 font-semibold text-white shadow-[0_6px_24px_-8px_rgba(236,72,153,0.55)] hover:bg-lucky-brand-strong transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
+                        >
+                            {t('landing.hero.ctaPrimary')}
+                            <ArrowUpRight size={15} className='transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5' aria-hidden />
+                        </a>
+                        <button
+                            onClick={onAddHosted}
+                            className='inline-flex h-11 items-center justify-center gap-2 rounded-md border border-lucky-border-strong bg-transparent px-5 font-semibold text-lucky-text-body hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
+                        >
+                            {t('landing.hero.ctaSecondary')}
+                        </button>
+                    </div>
                 </motion.div>
-            </motion.div>
+
+                <motion.div
+                    {...(prefersReducedMotion
+                        ? {}
+                        : {
+                              initial: { opacity: 0, y: 24 },
+                              animate: { opacity: 1, y: 0 },
+                              transition: { duration: 0.6, delay: 0.12, ease: [0.16, 1, 0.3, 1] as const },
+                          })}
+                >
+                    <RepoCard stats={stats} locale={locale} />
+                </motion.div>
+            </div>
         </section>
     )
 }
 
-function FeatureSection() {
-    const { t } = useTranslation()
-
-    const features = useMemo(
-        () => [
-            { icon: Music, titleKey: 'landing.features.music.title', descKey: 'landing.features.music.description' },
-            { icon: Shield, titleKey: 'landing.features.autoMod.title', descKey: 'landing.features.autoMod.description' },
-            { icon: Zap, titleKey: 'landing.features.customCommands.title', descKey: 'landing.features.customCommands.description' },
-            { icon: BarChart3, titleKey: 'landing.features.webDashboard.title', descKey: 'landing.features.webDashboard.description' },
-            { icon: Palette, titleKey: 'landing.features.embedBuilder.title', descKey: 'landing.features.embedBuilder.description' },
-            { icon: Sparkles, titleKey: 'landing.features.artistPreferences.title', descKey: 'landing.features.artistPreferences.description' },
-        ],
-        [],
+function BlueprintGrid() {
+    return (
+        <>
+            <div
+                aria-hidden
+                className='pointer-events-none absolute inset-0 opacity-[0.05]'
+                style={{
+                    backgroundImage: 'radial-gradient(circle, #adbac7 1px, transparent 1px)',
+                    backgroundSize: '24px 24px',
+                }}
+            />
+            <div
+                aria-hidden
+                className='pointer-events-none absolute inset-0'
+                style={{ background: 'radial-gradient(ellipse 80% 65% at 50% 30%, transparent 50%, #0f1117 100%)' }}
+            />
+        </>
     )
+}
+
+function RepoCard({ stats, locale }: { stats: RepoStats; locale: string }) {
+    const { t } = useTranslation()
+    const [copied, setCopied] = useState(false)
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(`git clone ${CLONE_URL}`)
+            setCopied(true)
+            setTimeout(() => setCopied(false), 1800)
+        } catch (error) {
+            console.error('Clipboard write failed:', error)
+        }
+    }
+
+    const fmt = (n: number) => n.toLocaleString(locale)
+    const loading = stats.loading
 
     return (
-        <section className='bg-lucky-surface-canvas border-t border-lucky-border-soft px-4 py-24 md:px-8'>
-            <div className='mx-auto max-w-6xl space-y-12'>
-                <motion.div
-                    className='text-center'
-                    initial={{ opacity: 0, y: 20 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
-                    viewport={{ once: true }}
-                >
-                    <h2 className='text-4xl md:text-5xl font-bold mb-3 text-lucky-text-strong'>
-                        {t('landing.features.heading')}
-                    </h2>
-                    <p className='text-lucky-text-body text-lg max-w-xl mx-auto'>{t('landing.features.subheading')}</p>
-                </motion.div>
+        <article
+            className='surface-panel font-mono text-sm overflow-hidden rounded-xl border border-lucky-border-soft bg-lucky-surface-sidebar shadow-[0_30px_80px_-40px_rgba(236,72,153,0.25)]'
+            aria-label={t('landing.repoCard.name')}
+        >
+            <header className='flex items-center justify-between gap-3 border-b border-lucky-border-soft bg-lucky-surface-elevated px-4 py-3'>
+                <div className='flex items-center gap-2 text-lucky-text-strong'>
+                    <GithubMark size={15} />
+                    <span className='font-semibold tracking-tight'>{t('landing.repoCard.name')}</span>
+                </div>
+                <span className='inline-flex items-center gap-1 rounded-full border border-lucky-border-soft px-2 py-0.5 text-[11px] text-lucky-text-muted'>
+                    <Scale size={11} aria-hidden /> {t('landing.repoCard.license')}
+                </span>
+            </header>
 
-                <ul className='grid grid-cols-1 md:grid-cols-3 gap-4'>
-                    {features.map((feature, idx) => {
-                        const Icon = feature.icon
-                        const span = FEATURE_SPANS[idx] ?? 1
-                        const isLarge = span === 2
-                        return (
-                            <li key={feature.titleKey} className={isLarge ? 'md:col-span-2' : 'md:col-span-1'}>
-                                <motion.article
-                                    initial={{ opacity: 0, y: 16 }}
-                                    whileInView={{ opacity: 1, y: 0 }}
-                                    transition={{ duration: 0.45, delay: idx * 0.07, ease: [0.16, 1, 0.3, 1] }}
-                                    viewport={{ once: true }}
-                                    className='surface-panel h-full flex flex-col gap-4 p-6 md:p-7 group cursor-default'
-                                >
-                                    <div className='inline-flex w-fit rounded-lg bg-lucky-surface-elevated p-2.5 text-lucky-brand group-hover:bg-lucky-surface-highlight transition-colors duration-150'>
-                                        <Icon size={isLarge ? 22 : 18} />
-                                    </div>
-                                    <div>
-                                        <h3 className={`mb-1.5 font-semibold text-lucky-text-strong ${isLarge ? 'text-lg' : 'text-base'}`}>
-                                            {t(feature.titleKey)}
-                                        </h3>
-                                        <p className='text-sm text-lucky-text-body leading-relaxed'>{t(feature.descKey)}</p>
-                                    </div>
-                                </motion.article>
-                            </li>
-                        )
-                    })}
+            <div className='space-y-4 px-4 py-4'>
+                <p className='font-sans text-xs text-lucky-text-body leading-relaxed'>
+                    {t('landing.repoCard.description')}
+                </p>
+
+                <dl className='grid grid-cols-3 gap-3 text-[12px]'>
+                    <RepoStat icon={Star} value={loading ? '…' : fmt(stats.stars)} label={t('landing.repoCard.starsLabel')} />
+                    <RepoStat icon={GitFork} value={loading ? '…' : fmt(stats.forks)} label={t('landing.repoCard.forksLabel')} />
+                    <RepoStat icon={CircleDot} value={loading ? '…' : fmt(stats.openIssues)} label={t('landing.repoCard.issuesLabel')} />
+                </dl>
+
+                <div className='flex items-center gap-2 text-[11px] text-lucky-text-muted'>
+                    <span className='h-2 w-2 rounded-full bg-[#2b7489]' aria-hidden />
+                    {t('landing.repoCard.lang')}
+                    <span className='ml-auto inline-flex h-1 flex-1 max-w-[120px] overflow-hidden rounded-full bg-lucky-border-soft'>
+                        <span className='h-full bg-[#2b7489]' style={{ width: '96%' }} />
+                        <span className='h-full bg-lucky-brand' style={{ width: '4%' }} />
+                    </span>
+                </div>
+
+                <div className='rounded-md border border-lucky-border-soft bg-lucky-surface-canvas px-3 py-2.5 text-[12px] flex items-center justify-between gap-2 group'>
+                    <code className='truncate text-lucky-text-body'>
+                        <span className='text-lucky-text-muted select-none'>$ </span>git clone {CLONE_URL}
+                    </code>
+                    <button
+                        onClick={handleCopy}
+                        aria-label={t('landing.repoCard.copyClone')}
+                        className='shrink-0 inline-flex h-7 w-7 items-center justify-center rounded text-lucky-text-muted hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand'
+                    >
+                        {copied ? <Check size={13} className='text-lucky-success' /> : <Copy size={13} />}
+                    </button>
+                </div>
+
+                <a
+                    href={REPO_URL}
+                    target='_blank'
+                    rel='noreferrer'
+                    className='inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-lucky-border-strong px-3 py-2 text-[12px] font-semibold text-lucky-text-strong hover:bg-lucky-surface-panel transition-colors'
+                >
+                    {t('landing.repoCard.viewOnGithub')}
+                    <ArrowUpRight size={12} aria-hidden />
+                </a>
+            </div>
+        </article>
+    )
+}
+
+function RepoStat({ icon: Icon, value, label }: { icon: typeof Star; value: string; label: string }) {
+    return (
+        <div className='flex items-baseline gap-1.5'>
+            <Icon size={12} className='translate-y-[1px] text-lucky-text-muted' aria-hidden />
+            <span className='font-semibold tabular-nums text-lucky-text-strong'>{value}</span>
+            <span className='text-lucky-text-muted'>{label}</span>
+        </div>
+    )
+}
+
+function WhySelfHost() {
+    const { t } = useTranslation()
+    const items = ['data', 'fork', 'free'] as const
+    return (
+        <section className='border-t border-lucky-border-soft px-4 py-20 md:px-8'>
+            <div className='mx-auto max-w-6xl'>
+                <h2 className='mb-10 max-w-2xl font-mono text-xs uppercase tracking-[0.22em] text-lucky-text-muted'>
+                    <span className='mr-2 text-lucky-brand'>{'//'}</span>
+                    {t('landing.whySelfHost.heading')}
+                </h2>
+                <ul className='grid gap-px overflow-hidden rounded-xl border border-lucky-border-soft bg-lucky-border-soft md:grid-cols-3'>
+                    {items.map((key) => (
+                        <li key={key} className='bg-lucky-surface-sidebar p-7'>
+                            <h3 className='mb-2.5 text-base font-semibold text-lucky-text-strong tracking-tight'>
+                                {t(`landing.whySelfHost.items.${key}.title`)}
+                            </h3>
+                            <p className='text-sm text-lucky-text-body leading-relaxed'>
+                                {t(`landing.whySelfHost.items.${key}.description`)}
+                            </p>
+                        </li>
+                    ))}
                 </ul>
             </div>
         </section>
     )
 }
 
-type StatsSectionProps = {
-    statsLoading: boolean
-    guildCount: number
-    userCount: number
-    serversOnline?: number
-}
+function CommandList() {
+    const { t } = useTranslation()
+    const rows = ['play', 'autoplay', 'queue', 'ban', 'automod', 'custom'] as const
 
-function StatsSection({ statsLoading, guildCount, userCount, serversOnline }: StatsSectionProps) {
-    const { t, i18n } = useTranslation()
-    const locale = i18n.resolvedLanguage ?? i18n.language
-    const isOnline = Boolean(serversOnline)
-
-    const scaleStats = [
-        {
-            icon: Server,
-            value: statsLoading
-                ? '…'
-                : `${guildCount.toLocaleString(locale)}${guildCount > 0 ? '+' : ''}`,
-            label: t('landing.stats.servers'),
-            size: 'text-5xl md:text-6xl' as const,
-        },
-        {
-            icon: Users,
-            value: statsLoading
-                ? '…'
-                : `${userCount.toLocaleString(locale)}${userCount > 0 ? '+' : ''}`,
-            label: t('landing.stats.users'),
-            size: 'text-4xl md:text-5xl' as const,
-        },
-    ]
+    const kindColor: Record<string, string> = {
+        music: 'text-lucky-brand bg-lucky-brand/10 border-lucky-brand/30',
+        mod: 'text-lucky-warning bg-lucky-warning/10 border-lucky-warning/30',
+        custom: 'text-lucky-success bg-lucky-success/10 border-lucky-success/30',
+        música: 'text-lucky-brand bg-lucky-brand/10 border-lucky-brand/30',
+        moderação: 'text-lucky-warning bg-lucky-warning/10 border-lucky-warning/30',
+    }
 
     return (
-        <section className='bg-lucky-surface-sidebar border-y border-lucky-border-soft px-4 py-20 md:px-8'>
+        <section className='border-t border-lucky-border-soft bg-lucky-surface-sidebar px-4 py-20 md:px-8'>
             <div className='mx-auto max-w-4xl'>
-                <div className='flex flex-col md:flex-row items-center justify-center gap-12 md:gap-16'>
-                    {scaleStats.map(({ icon: Icon, value, label, size }, idx) => (
-                        <motion.div
-                            key={label}
-                            className='text-center'
-                            initial={{ opacity: 0, y: 16 }}
-                            whileInView={{ opacity: 1, y: 0 }}
-                            transition={{ duration: 0.5, delay: idx * 0.1, ease: [0.16, 1, 0.3, 1] }}
-                            viewport={{ once: true }}
-                        >
-                            <p className={`font-black tabular-nums tracking-tight text-lucky-text-strong mb-1 ${size}`}>
-                                {value}
-                            </p>
-                            <div className='flex items-center justify-center gap-1.5 text-lucky-text-muted text-xs font-semibold uppercase tracking-wider'>
-                                <Icon size={12} />
-                                <span>{label}</span>
-                            </div>
-                        </motion.div>
-                    ))}
-
-                    <div className='hidden md:block w-px h-16 bg-lucky-border-soft' aria-hidden />
-
-                    {/* Status — distinct from scale metrics: badge-style, no large number */}
-                    <motion.div
-                        className='text-center'
-                        initial={{ opacity: 0, y: 16 }}
-                        whileInView={{ opacity: 1, y: 0 }}
-                        transition={{ duration: 0.5, delay: 0.25, ease: [0.16, 1, 0.3, 1] }}
-                        viewport={{ once: true }}
-                    >
-                        {statsLoading ? (
-                            <p className='text-3xl font-bold text-lucky-text-muted mb-1'>—</p>
-                        ) : (
-                            <div className='flex items-center justify-center gap-2 mb-1'>
+                <h2 className='mb-8 max-w-2xl text-2xl font-semibold tracking-tight text-lucky-text-strong md:text-3xl'>
+                    {t('landing.commands.heading')}
+                </h2>
+                <ul className='overflow-hidden rounded-xl border border-lucky-border-soft bg-lucky-surface-canvas'>
+                    {rows.map((key, idx) => {
+                        const name = t(`landing.commands.rows.${key}.name`)
+                        const desc = t(`landing.commands.rows.${key}.description`)
+                        const kbd = t(`landing.commands.rows.${key}.kbd`)
+                        return (
+                            <li
+                                key={key}
+                                className={`group flex items-center gap-4 px-4 py-3.5 transition-colors hover:bg-lucky-surface-panel md:px-5 ${
+                                    idx > 0 ? 'border-t border-lucky-border-soft' : ''
+                                }`}
+                            >
+                                <code className='shrink-0 font-mono text-sm font-semibold text-lucky-text-strong w-[120px] md:w-[140px]'>
+                                    {name}
+                                </code>
+                                <p className='flex-1 truncate text-sm text-lucky-text-body'>{desc}</p>
                                 <span
-                                    className={`h-2.5 w-2.5 rounded-full shrink-0 ${isOnline ? 'bg-lucky-success' : 'bg-lucky-text-muted'}`}
-                                    style={isOnline ? { boxShadow: '0 0 0 3px rgb(35 165 90 / 0.2)' } : undefined}
-                                />
-                                <span className='text-2xl font-bold text-lucky-text-strong'>
-                                    {isOnline ? t('landing.stats.statusOnline') : t('landing.stats.statusOffline')}
+                                    className={`shrink-0 rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider ${
+                                        kindColor[kbd] ?? 'text-lucky-text-muted bg-lucky-surface-elevated border-lucky-border-soft'
+                                    }`}
+                                >
+                                    {kbd}
                                 </span>
-                            </div>
-                        )}
-                        <div className='flex items-center justify-center gap-1.5 text-lucky-text-muted text-xs font-semibold uppercase tracking-wider'>
-                            <Radio size={12} />
-                            <span>{t('landing.stats.status')}</span>
-                        </div>
-                    </motion.div>
-                </div>
+                            </li>
+                        )
+                    })}
+                </ul>
+                <p className='mt-4 font-mono text-xs text-lucky-text-muted'>{t('landing.commands.more')}</p>
             </div>
         </section>
     )
 }
 
-function FAQSection() {
+function StackList() {
     const { t } = useTranslation()
-    const [openIdx, setOpenIdx] = useState<number | null>(null)
-
-    const faqs = useMemo(() => {
-        const faqKeys = ['free', 'commands', 'autoplay', 'selfHost', 'spam', 'support'] as const
-        return faqKeys.map((key) => ({
-            q: t(`landing.faq.items.${key}.question`),
-            a: t(`landing.faq.items.${key}.answer`),
-        }))
-    }, [t])
+    const stack = useMemo(
+        () => [
+            { key: 'bot', icon: Music2 },
+            { key: 'backend', icon: Server },
+            { key: 'frontend', icon: Layers },
+            { key: 'postgres', icon: Database },
+            { key: 'redis', icon: Wrench },
+            { key: 'nginx', icon: Shield },
+        ],
+        [],
+    )
 
     return (
-        <section className='bg-lucky-surface-canvas px-4 py-24 md:px-8'>
-            <div className='mx-auto max-w-2xl'>
-                <motion.div
-                    className='text-center mb-10'
-                    initial={{ opacity: 0, y: 20 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                    viewport={{ once: true }}
-                >
-                    <h2 className='text-4xl md:text-5xl font-bold text-lucky-text-strong'>{t('landing.faq.heading')}</h2>
-                </motion.div>
-
-                <div className='space-y-2'>
-                    {faqs.map(({ q, a }, idx) => {
-                        const isOpen = openIdx === idx
-                        return (
-                            <motion.div
-                                key={idx}
-                                initial={{ opacity: 0, y: 8 }}
-                                whileInView={{ opacity: 1, y: 0 }}
-                                transition={{ duration: 0.4, delay: idx * 0.04 }}
-                                viewport={{ once: true }}
-                                className={`rounded-lg border bg-lucky-surface-sidebar overflow-hidden transition-colors duration-150 ${
-                                    isOpen ? 'border-lucky-brand' : 'border-lucky-border-soft hover:border-lucky-border-strong'
-                                }`}
-                            >
-                                <button
-                                    onClick={() => setOpenIdx(isOpen ? null : idx)}
-                                    className='w-full px-5 py-4 flex items-center justify-between text-left hover:bg-lucky-surface-elevated transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-inset'
-                                    aria-expanded={isOpen}
-                                >
-                                    <span className='font-semibold text-lucky-text-strong pr-4'>{q}</span>
-                                    <motion.div
-                                        animate={{ rotate: isOpen ? 180 : 0 }}
-                                        transition={{ duration: 0.2 }}
-                                        className={`shrink-0 transition-colors duration-150 ${isOpen ? 'text-lucky-brand' : 'text-lucky-text-muted'}`}
-                                    >
-                                        <ChevronDown size={18} />
-                                    </motion.div>
-                                </button>
-                                <motion.div
-                                    initial={false}
-                                    animate={{ height: isOpen ? 'auto' : 0, opacity: isOpen ? 1 : 0 }}
-                                    transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
-                                    className='overflow-hidden'
-                                >
-                                    <p className='px-5 pb-5 pt-1 text-sm text-lucky-text-body leading-relaxed border-t border-lucky-border-soft'>
-                                        {a}
-                                    </p>
-                                </motion.div>
-                            </motion.div>
-                        )
-                    })}
+        <section className='border-t border-lucky-border-soft px-4 py-20 md:px-8'>
+            <div className='mx-auto max-w-6xl'>
+                <div className='mb-10 flex flex-col gap-3 md:flex-row md:items-end md:justify-between'>
+                    <h2 className='max-w-xl text-2xl font-semibold tracking-tight text-lucky-text-strong md:text-3xl'>
+                        {t('landing.stack.heading')}
+                    </h2>
+                    <p className='max-w-md font-mono text-xs text-lucky-text-muted leading-relaxed'>
+                        {t('landing.stack.subheading')}
+                    </p>
                 </div>
+                <ul className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+                    {stack.map(({ key, icon: Icon }) => (
+                        <li key={key} className='surface-panel flex items-start gap-3 rounded-lg p-4'>
+                            <span className='mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-lucky-surface-elevated text-lucky-brand'>
+                                <Icon size={15} aria-hidden />
+                            </span>
+                            <div>
+                                <p className='font-mono text-sm font-semibold text-lucky-text-strong'>
+                                    {t(`landing.stack.items.${key}.name`)}
+                                </p>
+                                <p className='mt-1 text-xs text-lucky-text-body leading-relaxed'>
+                                    {t(`landing.stack.items.${key}.description`)}
+                                </p>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </section>
+    )
+}
+
+function RepoFooterBanner() {
+    const { t } = useTranslation()
+    return (
+        <section className='relative overflow-hidden border-t border-lucky-border-soft bg-lucky-surface-canvas px-4 py-16 md:px-8'>
+            <BlueprintGrid />
+            <div className='relative mx-auto max-w-3xl text-center'>
+                <h2 className='mb-3 text-2xl font-semibold tracking-tight text-lucky-text-strong md:text-3xl'>
+                    {t('landing.footerRepo.heading')}
+                </h2>
+                <p className='mx-auto mb-6 max-w-xl text-sm text-lucky-text-body md:text-base'>
+                    {t('landing.footerRepo.subheading')}
+                </p>
+                <a
+                    href={REPO_URL}
+                    target='_blank'
+                    rel='noreferrer'
+                    className='inline-flex h-11 items-center gap-2 rounded-md border border-lucky-border-strong bg-lucky-surface-panel px-5 font-mono text-sm font-semibold text-lucky-text-strong hover:bg-lucky-surface-elevated transition-colors'
+                >
+                    <GithubMark size={15} /> github.com/LucasSantana-Dev/Lucky <ArrowUpRight size={13} aria-hidden />
+                </a>
             </div>
         </section>
     )
@@ -397,51 +460,66 @@ function FAQSection() {
 
 function FooterSection() {
     const { t } = useTranslation()
-    const footerLinks = [
-        { href: '/terms', key: 'landing.footer.terms', external: false },
-        { href: '/privacy', key: 'landing.footer.privacy', external: false },
-        { href: 'https://github.com/LucasSantana-Dev/Lucky', key: 'landing.footer.github', external: true },
-    ]
-
     return (
-        <footer className='bg-lucky-surface-canvas border-t border-lucky-border-soft px-4 py-12 md:px-8'>
+        <footer className='border-t border-lucky-border-soft px-4 py-12 md:px-8'>
             <div className='mx-auto max-w-6xl'>
-                <div className='grid grid-cols-1 md:grid-cols-3 gap-8 mb-8'>
+                <div className='grid grid-cols-1 gap-10 md:grid-cols-[1.4fr_1fr_1fr] md:gap-12'>
                     <div className='space-y-3'>
-                        <div className='flex items-center gap-2.5'>
-                            <img src='/lucky-logo.png' alt='Lucky' className='h-7 w-7' loading='lazy' />
-                            <span className='font-semibold text-lucky-text-strong'>Lucky</span>
+                        <div className='inline-flex items-baseline gap-1.5 font-mono text-sm font-semibold text-lucky-text-strong'>
+                            lucky<span className='text-lucky-brand'>.</span>
                         </div>
-                        <p className='text-sm text-lucky-text-muted'>{t('landing.footer.tagline')}</p>
+                        <p className='max-w-xs text-sm text-lucky-text-muted'>{t('landing.footer.tagline')}</p>
                     </div>
-                    <div>
-                        <h4 className='text-xs font-semibold text-lucky-text-muted uppercase tracking-wider mb-4'>
-                            {t('landing.footer.links')}
-                        </h4>
-                        <nav className='space-y-2.5'>
-                            {footerLinks.map(({ href, key, external }) => (
-                                <a
-                                    key={key}
-                                    href={href}
-                                    {...(external ? { target: '_blank', rel: 'noreferrer' } : {})}
-                                    className='block text-sm text-lucky-text-muted hover:text-lucky-brand transition-colors duration-150'
-                                >
-                                    {t(key)}
-                                </a>
-                            ))}
-                        </nav>
-                    </div>
-                    <div>
-                        <h4 className='text-xs font-semibold text-lucky-text-muted uppercase tracking-wider mb-4'>
-                            {t('landing.footer.support')}
-                        </h4>
-                        <p className='text-sm text-lucky-text-muted'>{t('landing.footer.supportCopy')}</p>
-                    </div>
+                    <FooterColumn
+                        heading={t('landing.footer.links')}
+                        links={[
+                            { href: REPO_URL, label: t('landing.footer.github'), external: true },
+                            { href: '/docs', label: t('landing.footer.docs') },
+                            { href: '/changelog', label: t('landing.footer.changelog') },
+                        ]}
+                    />
+                    <FooterColumn
+                        heading={t('landing.footer.support')}
+                        links={[
+                            { href: 'https://discord.gg/lucky', label: t('landing.footer.discord'), external: true },
+                            { href: '/terms', label: t('landing.footer.terms') },
+                            { href: '/privacy', label: t('landing.footer.privacy') },
+                        ]}
+                    />
                 </div>
-                <div className='pt-8 border-t border-lucky-border-soft text-center'>
-                    <p className='text-xs text-lucky-text-subtle'>{t('landing.footer.copyright')}</p>
+                <div className='mt-10 flex flex-col items-start justify-between gap-3 border-t border-lucky-border-soft pt-6 md:flex-row md:items-center'>
+                    <p className='font-mono text-xs text-lucky-text-muted'>{t('landing.footer.copyright')}</p>
+                    <p className='text-xs text-lucky-text-muted'>{t('landing.footer.supportCopy')}</p>
                 </div>
             </div>
         </footer>
+    )
+}
+
+function FooterColumn({
+    heading,
+    links,
+}: {
+    heading: string
+    links: Array<{ href: string; label: string; external?: boolean }>
+}) {
+    return (
+        <div>
+            <h4 className='mb-4 font-mono text-[11px] uppercase tracking-[0.2em] text-lucky-text-muted'>{heading}</h4>
+            <ul className='space-y-2.5'>
+                {links.map(({ href, label, external }) => (
+                    <li key={href}>
+                        <a
+                            href={href}
+                            {...(external ? { target: '_blank', rel: 'noreferrer' } : {})}
+                            className='inline-flex items-center gap-1 text-sm text-lucky-text-muted hover:text-lucky-brand transition-colors'
+                        >
+                            {label}
+                            {external ? <ArrowUpRight size={11} aria-hidden /> : null}
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </div>
     )
 }

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -4,7 +4,6 @@ import { useAuthStore } from '@/stores/authStore'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
 import { motion, useReducedMotion } from 'framer-motion'
 import { api } from '@/services/api'
-import LanguageSwitcher from '@/components/ui/LanguageSwitcher'
 import {
     Star,
     GitFork,
@@ -19,6 +18,9 @@ import {
     Music2,
     Shield,
     Wrench,
+    SlidersHorizontal,
+    LayoutDashboard,
+    Sparkles,
 } from 'lucide-react'
 
 function GithubMark({ size = 16, className }: { size?: number; className?: string }) {
@@ -81,10 +83,11 @@ export default function Landing() {
 
     return (
         <div className='lucky-shell min-h-screen dark text-white bg-lucky-surface-canvas'>
-            <TopNav />
-            <Hero onAddHosted={login} stats={repoStats} prefersReducedMotion={prefersReducedMotion ?? false} />
-            <WhySelfHost />
+            <TopNav onOpenDashboard={login} />
+            <Hero stats={repoStats} prefersReducedMotion={prefersReducedMotion ?? false} />
+            <FeatureGrid />
             <CommandList />
+            <WhySelfHost />
             <StackList />
             <RepoFooterBanner />
             <FooterSection />
@@ -92,13 +95,18 @@ export default function Landing() {
     )
 }
 
-function TopNav() {
+function TopNav({ onOpenDashboard }: { onOpenDashboard: () => void }) {
     return (
         <header className='sticky top-0 z-30 border-b border-lucky-border-soft bg-lucky-surface-canvas/85 backdrop-blur supports-[backdrop-filter]:bg-lucky-surface-canvas/65'>
-            <div className='mx-auto flex h-12 max-w-6xl items-center justify-between px-4 md:px-8'>
-                <a href='/' className='inline-flex items-baseline gap-2 font-mono text-sm font-semibold tracking-tight text-lucky-text-strong hover:text-lucky-brand transition-colors'>
-                    <span>lucky</span>
-                    <span className='text-lucky-brand'>.</span>
+            <div className='mx-auto flex h-14 max-w-6xl items-center justify-between px-4 md:px-8'>
+                <a
+                    href='/'
+                    className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
+                >
+                    <img src='/lucky-logo.png' alt='Lucky' width='28' height='28' className='h-7 w-7' loading='eager' />
+                    <span className='font-mono text-sm font-semibold tracking-tight'>
+                        lucky<span className='text-lucky-brand'>.</span>
+                    </span>
                 </a>
                 <nav className='flex items-center gap-1 font-mono text-xs text-lucky-text-muted'>
                     <a
@@ -115,15 +123,20 @@ function TopNav() {
                     >
                         docs
                     </a>
+                    <button
+                        onClick={onOpenDashboard}
+                        className='hidden sm:inline-flex items-center rounded-md px-2.5 py-1.5 hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand'
+                    >
+                        dashboard
+                    </button>
                     <a
                         href={BOT_INVITE_URL}
                         target='_blank'
                         rel='noopener noreferrer'
                         className='ml-1 inline-flex items-center gap-1 rounded-md bg-lucky-brand px-3 py-1.5 font-semibold text-white hover:bg-lucky-brand-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas'
                     >
-                        add <ArrowUpRight size={12} aria-hidden />
+                        add to discord <ArrowUpRight size={12} aria-hidden />
                     </a>
-                    <LanguageSwitcher />
                 </nav>
             </div>
         </header>
@@ -131,12 +144,11 @@ function TopNav() {
 }
 
 type HeroProps = {
-    onAddHosted: () => void
     stats: RepoStats
     prefersReducedMotion: boolean
 }
 
-function Hero({ onAddHosted, stats, prefersReducedMotion }: HeroProps) {
+function Hero({ stats, prefersReducedMotion }: HeroProps) {
     const { t, i18n } = useTranslation()
     const locale = i18n.resolvedLanguage ?? i18n.language
 
@@ -148,11 +160,30 @@ function Hero({ onAddHosted, stats, prefersReducedMotion }: HeroProps) {
               transition: { duration: 0.55, ease: [0.16, 1, 0.3, 1] as const },
           }
 
+    const catFloat = prefersReducedMotion
+        ? {}
+        : {
+              animate: { y: [0, -6, 0] },
+              transition: { duration: 4, repeat: Infinity, ease: 'easeInOut' as const },
+          }
+
     return (
-        <section className='relative overflow-hidden px-4 py-20 md:py-28 md:px-8'>
+        <section className='relative overflow-hidden px-4 py-16 md:py-24 md:px-8'>
             <BlueprintGrid />
             <div className='relative mx-auto grid max-w-6xl gap-12 lg:grid-cols-[1.05fr_1fr] lg:items-center'>
                 <motion.div {...animProps}>
+                    <motion.div {...catFloat} className='mb-6 inline-block'>
+                        <img
+                            src='/lucky-logo.png'
+                            alt='Lucky'
+                            width='88'
+                            height='88'
+                            className='h-20 w-20 md:h-22 md:w-22 drop-shadow-[0_18px_36px_rgba(236,72,153,0.35)]'
+                            loading='eager'
+                            decoding='async'
+                            fetchPriority='high'
+                        />
+                    </motion.div>
                     <p className='mb-5 inline-flex items-center gap-2 rounded-full border border-lucky-border-soft bg-lucky-surface-panel px-3 py-1 font-mono text-[11px] uppercase tracking-[0.18em] text-lucky-text-muted'>
                         <span className='h-1.5 w-1.5 rounded-full bg-lucky-success' aria-hidden />
                         {t('landing.hero.eyebrow')}
@@ -166,20 +197,22 @@ function Hero({ onAddHosted, stats, prefersReducedMotion }: HeroProps) {
                     </p>
                     <div className='flex flex-col gap-2.5 sm:flex-row sm:items-center'>
                         <a
-                            href={REPO_URL}
+                            href={BOT_INVITE_URL}
                             target='_blank'
-                            rel='noreferrer'
+                            rel='noopener noreferrer'
                             className='group inline-flex h-11 items-center justify-center gap-2 rounded-md bg-lucky-brand px-5 font-semibold text-white shadow-[0_6px_24px_-8px_rgba(236,72,153,0.55)] hover:bg-lucky-brand-strong transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
                         >
                             {t('landing.hero.ctaPrimary')}
                             <ArrowUpRight size={15} className='transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5' aria-hidden />
                         </a>
-                        <button
-                            onClick={onAddHosted}
+                        <a
+                            href={REPO_URL}
+                            target='_blank'
+                            rel='noreferrer'
                             className='inline-flex h-11 items-center justify-center gap-2 rounded-md border border-lucky-border-strong bg-transparent px-5 font-semibold text-lucky-text-body hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
                         >
-                            {t('landing.hero.ctaSecondary')}
-                        </button>
+                            <GithubMark size={14} /> {t('landing.hero.ctaSecondary')}
+                        </a>
                     </div>
                 </motion.div>
 
@@ -194,6 +227,52 @@ function Hero({ onAddHosted, stats, prefersReducedMotion }: HeroProps) {
                 >
                     <RepoCard stats={stats} locale={locale} />
                 </motion.div>
+            </div>
+        </section>
+    )
+}
+
+function FeatureGrid() {
+    const { t } = useTranslation()
+    const features = [
+        { key: 'music', icon: Music2, span: 'md:col-span-2' },
+        { key: 'moderation', icon: Shield, span: 'md:col-span-1' },
+        { key: 'customCommands', icon: SlidersHorizontal, span: 'md:col-span-1' },
+        { key: 'dashboard', icon: LayoutDashboard, span: 'md:col-span-2' },
+        { key: 'embeds', icon: Sparkles, span: 'md:col-span-3' },
+    ] as const
+
+    return (
+        <section className='border-t border-lucky-border-soft px-4 py-20 md:px-8'>
+            <div className='mx-auto max-w-6xl'>
+                <div className='mb-10 max-w-2xl'>
+                    <h2 className='mb-3 text-3xl font-semibold tracking-tight text-lucky-text-strong md:text-4xl'>
+                        {t('landing.features.heading')}
+                    </h2>
+                    <p className='text-base text-lucky-text-body leading-relaxed'>{t('landing.features.subheading')}</p>
+                </div>
+                <ul className='grid gap-3 md:grid-cols-3'>
+                    {features.map(({ key, icon: Icon, span }) => {
+                        const isWide = span !== 'md:col-span-1'
+                        return (
+                            <li key={key} className={span}>
+                                <article className='surface-panel h-full flex flex-col gap-4 rounded-xl p-6 md:p-7'>
+                                    <span className='inline-flex h-10 w-10 items-center justify-center rounded-lg bg-lucky-surface-elevated text-lucky-brand'>
+                                        <Icon size={18} aria-hidden />
+                                    </span>
+                                    <div>
+                                        <h3 className={`mb-2 font-semibold text-lucky-text-strong tracking-tight ${isWide ? 'text-lg md:text-xl' : 'text-base'}`}>
+                                            {t(`landing.features.items.${key}.title`)}
+                                        </h3>
+                                        <p className='text-sm text-lucky-text-body leading-relaxed'>
+                                            {t(`landing.features.items.${key}.description`)}
+                                        </p>
+                                    </div>
+                                </article>
+                            </li>
+                        )
+                    })}
+                </ul>
             </div>
         </section>
     )

--- a/packages/frontend/src/pages/PreferredArtists.tsx
+++ b/packages/frontend/src/pages/PreferredArtists.tsx
@@ -41,7 +41,12 @@ function ArtistTile({
     onBlock,
 }: ArtistTileProps) {
     const [isHovered, setIsHovered] = useState(false)
+    const [imageBroken, setImageBroken] = useState(false)
     const prefersReducedMotion = useReducedMotion()
+
+    useEffect(() => {
+        setImageBroken(false)
+    }, [artist.imageUrl])
 
     const sizeClasses = {
         sm: 'w-14 h-14',
@@ -87,16 +92,18 @@ function ArtistTile({
                     !prefersReducedMotion && isHovered && 'scale-105',
                 )}
             >
-                {artist.imageUrl ? (
+                {artist.imageUrl && !imageBroken ? (
                     <img
                         src={artist.imageUrl}
                         alt={artist.name}
                         className='w-full h-full object-cover'
                         loading='lazy'
+                        referrerPolicy='no-referrer'
+                        onError={() => setImageBroken(true)}
                     />
                 ) : (
                     <div className='w-full h-full bg-lucky-bg-active flex items-center justify-center'>
-                        <span className='font-semibold text-lucky-text-secondary'>
+                        <span className='font-semibold text-lucky-text-secondary text-xl'>
                             {initial}
                         </span>
                     </div>
@@ -516,7 +523,7 @@ export default function PreferredArtistsPage() {
                         {!searching && displayArtists.length > 0 && (
                             <motion.div
                                 layout
-                                className='mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5'
+                                className='mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 isolate relative z-0'
                             >
                                 <AnimatePresence mode='popLayout'>
                                     {displayArtists.map((artist) => {

--- a/packages/frontend/src/pages/PrivacyPolicy.test.tsx
+++ b/packages/frontend/src/pages/PrivacyPolicy.test.tsx
@@ -1,0 +1,57 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Privacy from './PrivacyPolicy'
+import { usePageMetadata } from '@/hooks/usePageMetadata'
+
+vi.mock('@/hooks/usePageMetadata')
+
+function renderPage() {
+    vi.mocked(usePageMetadata).mockImplementation(() => undefined)
+    return render(
+        <MemoryRouter>
+            <Privacy />
+        </MemoryRouter>,
+    )
+}
+
+describe('PrivacyPolicy', () => {
+    test('renders title and last updated', () => {
+        renderPage()
+        expect(screen.getByRole('heading', { level: 1, name: /Privacy Policy/i })).toBeInTheDocument()
+        expect(screen.getByText(/last updated: March 18, 2026/i)).toBeInTheDocument()
+    })
+
+    test('renders all section headings', () => {
+        renderPage()
+        for (const h of [
+            'Scope and controller',
+            'Data we collect',
+            'How we use data',
+            'Self-hosted instances',
+            'Third-party services',
+            'Retention and deletion',
+            'Your rights',
+            'Security',
+        ]) {
+            expect(screen.getAllByText(new RegExp(h, 'i')).length).toBeGreaterThanOrEqual(1)
+        }
+    })
+
+    test('renders self-host disclosure paragraph', () => {
+        renderPage()
+        expect(screen.getByText(/project maintainers do not receive any of your guild or user data/i)).toBeInTheDocument()
+    })
+
+    test('does not sell personal data', () => {
+        renderPage()
+        expect(screen.getByText(/does not sell personal data/i)).toBeInTheDocument()
+    })
+
+    test('renders sibling nav to Terms', () => {
+        renderPage()
+        const terms = screen.getAllByRole('link', { name: /Terms of Service/i })
+        expect(terms.length).toBeGreaterThanOrEqual(1)
+        expect(terms[0]).toHaveAttribute('href', '/terms')
+    })
+})

--- a/packages/frontend/src/pages/PrivacyPolicy.tsx
+++ b/packages/frontend/src/pages/PrivacyPolicy.tsx
@@ -1,40 +1,8 @@
 import DocsShell, {
-    type DocsNavGroup,
     type DocsTocItem,
 } from '@/components/DocsShell/DocsShell'
+import { LEGAL_NAV } from '@/components/DocsShell/legalNav'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
-
-const NAV: DocsNavGroup[] = [
-    {
-        heading: 'Legal',
-        items: [
-            { label: 'Terms of Service', href: '/terms' },
-            { label: 'Privacy Policy', href: '/privacy' },
-        ],
-    },
-    {
-        heading: 'Product',
-        items: [
-            { label: 'Docs', href: '/docs' },
-            { label: 'Changelog', href: '/changelog' },
-        ],
-    },
-    {
-        heading: 'External',
-        items: [
-            {
-                label: 'GitHub',
-                href: 'https://github.com/LucasSantana-Dev/Lucky',
-                external: true,
-            },
-            {
-                label: 'Issues',
-                href: 'https://github.com/LucasSantana-Dev/Lucky/issues',
-                external: true,
-            },
-        ],
-    },
-]
 
 const TOC: DocsTocItem[] = [
     { id: 'scope', label: 'Scope and controller' },
@@ -58,7 +26,7 @@ export default function PrivacyPolicyPage() {
 
     return (
         <DocsShell
-            nav={NAV}
+            nav={LEGAL_NAV}
             toc={TOC}
             breadcrumb='Legal / Privacy'
             title='Privacy Policy'

--- a/packages/frontend/src/pages/PrivacyPolicy.tsx
+++ b/packages/frontend/src/pages/PrivacyPolicy.tsx
@@ -1,117 +1,170 @@
+import DocsShell, {
+    type DocsNavGroup,
+    type DocsTocItem,
+} from '@/components/DocsShell/DocsShell'
+import { usePageMetadata } from '@/hooks/usePageMetadata'
+
+const NAV: DocsNavGroup[] = [
+    {
+        heading: 'Legal',
+        items: [
+            { label: 'Terms of Service', href: '/terms' },
+            { label: 'Privacy Policy', href: '/privacy' },
+        ],
+    },
+    {
+        heading: 'Product',
+        items: [
+            { label: 'Docs', href: '/docs' },
+            { label: 'Changelog', href: '/changelog' },
+        ],
+    },
+    {
+        heading: 'External',
+        items: [
+            {
+                label: 'GitHub',
+                href: 'https://github.com/LucasSantana-Dev/Lucky',
+                external: true,
+            },
+            {
+                label: 'Issues',
+                href: 'https://github.com/LucasSantana-Dev/Lucky/issues',
+                external: true,
+            },
+        ],
+    },
+]
+
+const TOC: DocsTocItem[] = [
+    { id: 'scope', label: 'Scope and controller' },
+    { id: 'data', label: 'Data we collect' },
+    { id: 'use', label: 'How we use data' },
+    { id: 'self-host', label: 'Self-hosted instances' },
+    { id: 'third-party', label: 'Third-party services' },
+    { id: 'retention', label: 'Retention and deletion' },
+    { id: 'rights', label: 'Your rights' },
+    { id: 'security', label: 'Security' },
+    { id: 'updates', label: 'Policy updates' },
+    { id: 'contact', label: 'Contact' },
+]
+
 export default function PrivacyPolicyPage() {
+    usePageMetadata({
+        title: 'Privacy Policy · Lucky',
+        description:
+            'How Lucky collects, uses, and protects data for the bot and dashboard.',
+    })
+
     return (
-        <main className='min-h-screen bg-lucky-bg px-6 py-10 text-lucky-text-primary'>
-            <div className='mx-auto w-full max-w-4xl space-y-8'>
-                <header className='space-y-3'>
-                    <p className='type-meta text-lucky-text-tertiary'>Legal</p>
-                    <h1 className='type-h1'>Privacy Policy</h1>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Last updated: March 18, 2026
-                    </p>
-                </header>
+        <DocsShell
+            nav={NAV}
+            toc={TOC}
+            breadcrumb='Legal / Privacy'
+            title='Privacy Policy'
+            lastUpdated='March 18, 2026'
+        >
+            <p>
+                This policy explains how Lucky collects, uses, and protects
+                data when you use the Discord bot and web dashboard.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Scope and controller</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        This policy explains how Lucky collects, uses, and
-                        protects data when you use the Discord bot and web
-                        dashboard. It applies to authentication, server
-                        configuration, moderation features, music and
-                        integrations, and operational security.
-                    </p>
-                </section>
+            <h2 id='scope'>Scope and controller</h2>
+            <p>
+                It applies to authentication, server configuration, moderation
+                features, music and integrations, and operational security.
+                The maintainers of the hosted Lucky instance act as the data
+                controller for that deployment. Self-hosted operators are
+                controllers for their own deployments.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Data we collect</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        We process the minimum data needed to operate the
-                        service: Discord account identifiers, guild/server IDs,
-                        role and channel references, bot configuration data,
-                        moderation case records, optional integration data
-                        (Last.fm and Twitch), and session/security logs.
-                    </p>
-                </section>
+            <h2 id='data'>Data we collect</h2>
+            <p>
+                We process the minimum data needed to operate the service:
+            </p>
+            <ul>
+                <li>Discord account identifiers and usernames</li>
+                <li>Guild (server) IDs, role, and channel references</li>
+                <li>Bot configuration data you save in the dashboard</li>
+                <li>Moderation case records (warns, mutes, bans)</li>
+                <li>
+                    Optional integration data — Last.fm scrobbles, Spotify
+                    listening, Twitch stream events — only when you enable
+                    them
+                </li>
+                <li>Session and security logs</li>
+            </ul>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>How we use data</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Data is used to authenticate access, enforce role-based
-                        permissions, persist server settings, run bot commands,
-                        provide dashboard features, and protect platform
-                        reliability and security.
-                    </p>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Lucky does not sell personal data.
-                    </p>
-                </section>
+            <h2 id='use'>How we use data</h2>
+            <p>
+                Data is used to authenticate access, enforce role-based
+                permissions, persist server settings, run bot commands,
+                provide dashboard features, and protect platform reliability
+                and security.
+            </p>
+            <p>Lucky does not sell personal data.</p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Third-party services</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Lucky depends on third-party platforms to function,
-                        including Discord (identity and guild context), and
-                        optionally Last.fm and Twitch when you enable those
-                        integrations. These providers operate under their own
-                        terms and privacy policies.
-                    </p>
-                </section>
+            <h2 id='self-host'>Self-hosted instances</h2>
+            <p>
+                Lucky is open source. If you run your own instance, the
+                project maintainers do not receive any of your guild or user
+                data — it stays in your Postgres and Redis. This policy
+                applies to the hosted bot only; your self-hosted privacy
+                terms are whatever you write for your community.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Retention and deletion</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        We retain data only as long as needed for operational,
-                        security, and legal purposes. You can remove Lucky from
-                        your server and disable integrations at any time.
-                        Requests to delete personal data can be made through our
-                        support channel below.
-                    </p>
-                </section>
+            <h2 id='third-party'>Third-party services</h2>
+            <p>
+                Lucky depends on third-party platforms to function, including
+                Discord (identity and guild context), and optionally Last.fm,
+                Spotify, and Twitch when you enable those integrations.
+                These providers operate under their own terms and privacy
+                policies.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Your rights</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Subject to applicable law, you may request access,
-                        correction, export, restriction, or deletion of personal
-                        data associated with your account or server
-                        configuration.
-                    </p>
-                </section>
+            <h2 id='retention'>Retention and deletion</h2>
+            <p>
+                We retain data only as long as needed for operational,
+                security, and legal purposes. You can remove Lucky from your
+                server and disable integrations at any time. Requests to
+                delete personal data can be made through the support channel
+                below.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Security</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        We use reasonable technical and organizational
-                        safeguards to protect data. No system is perfectly
-                        secure, and you remain responsible for protecting your
-                        Discord account and server permissions.
-                    </p>
-                </section>
+            <h2 id='rights'>Your rights</h2>
+            <p>
+                Subject to applicable law, you may request access, correction,
+                export, restriction, or deletion of personal data associated
+                with your account or server configuration.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Policy updates</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        We may update this policy when features, integrations,
-                        or legal requirements change. Material updates are
-                        published here with a revised date.
-                    </p>
-                </section>
+            <h2 id='security'>Security</h2>
+            <p>
+                We use reasonable technical and organizational safeguards to
+                protect data. No system is perfectly secure, and you remain
+                responsible for protecting your Discord account and server
+                permissions.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Contact and requests</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        For privacy requests, open an issue at{' '}
-                        <a
-                            className='text-lucky-accent underline'
-                            href='https://github.com/LucasSantana-Dev/Lucky/issues'
-                            rel='noreferrer'
-                            target='_blank'
-                        >
-                            https://github.com/LucasSantana-Dev/Lucky/issues
-                        </a>
-                        .
-                    </p>
-                </section>
-            </div>
-        </main>
+            <h2 id='updates'>Policy updates</h2>
+            <p>
+                We may update this policy when features, integrations, or
+                legal requirements change. Material updates are published
+                here with a revised date.
+            </p>
+
+            <h2 id='contact'>Contact and requests</h2>
+            <p>
+                For privacy requests, open an issue at{' '}
+                <a
+                    href='https://github.com/LucasSantana-Dev/Lucky/issues'
+                    target='_blank'
+                    rel='noreferrer'
+                >
+                    github.com/LucasSantana-Dev/Lucky/issues
+                </a>
+                .
+            </p>
+        </DocsShell>
     )
 }

--- a/packages/frontend/src/pages/TermsOfService.test.tsx
+++ b/packages/frontend/src/pages/TermsOfService.test.tsx
@@ -1,0 +1,53 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Terms from './TermsOfService'
+import { usePageMetadata } from '@/hooks/usePageMetadata'
+
+vi.mock('@/hooks/usePageMetadata')
+
+function renderPage() {
+    vi.mocked(usePageMetadata).mockImplementation(() => undefined)
+    return render(
+        <MemoryRouter>
+            <Terms />
+        </MemoryRouter>,
+    )
+}
+
+describe('TermsOfService', () => {
+    test('renders title and last updated', () => {
+        renderPage()
+        expect(screen.getByRole('heading', { level: 1, name: /Terms of Service/i })).toBeInTheDocument()
+        expect(screen.getByText(/last updated: March 18, 2026/i)).toBeInTheDocument()
+    })
+
+    test('renders all section headings', () => {
+        renderPage()
+        for (const h of [
+            'Acceptance',
+            'Service scope',
+            'Acceptable use',
+            'Third-party services',
+            'Suspension and termination',
+            'Contact',
+        ]) {
+            expect(screen.getAllByText(new RegExp(h, 'i')).length).toBeGreaterThanOrEqual(1)
+        }
+    })
+
+    test('renders sibling nav to Privacy Policy', () => {
+        renderPage()
+        const privacy = screen.getAllByRole('link', { name: /Privacy Policy/i })
+        expect(privacy.length).toBeGreaterThanOrEqual(1)
+        expect(privacy[0]).toHaveAttribute('href', '/privacy')
+    })
+
+    test('contact link points to github issues', () => {
+        renderPage()
+        const link = screen.getByRole('link', {
+            name: /github\.com\/LucasSantana-Dev\/Lucky\/issues/i,
+        })
+        expect(link).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky/issues')
+    })
+})

--- a/packages/frontend/src/pages/TermsOfService.test.tsx
+++ b/packages/frontend/src/pages/TermsOfService.test.tsx
@@ -32,7 +32,7 @@ describe('TermsOfService', () => {
             'Suspension and termination',
             'Contact',
         ]) {
-            expect(screen.getAllByText(new RegExp(h, 'i')).length).toBeGreaterThanOrEqual(1)
+            expect(screen.getAllByText(h).length).toBeGreaterThanOrEqual(1)
         }
     })
 
@@ -46,7 +46,7 @@ describe('TermsOfService', () => {
     test('contact link points to github issues', () => {
         renderPage()
         const link = screen.getByRole('link', {
-            name: /github\.com\/LucasSantana-Dev\/Lucky\/issues/i,
+            name: /^github\.com\/LucasSantana-Dev\/Lucky\/issues$/i,
         })
         expect(link).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky/issues')
     })

--- a/packages/frontend/src/pages/TermsOfService.tsx
+++ b/packages/frontend/src/pages/TermsOfService.tsx
@@ -1,113 +1,151 @@
+import DocsShell, {
+    type DocsNavGroup,
+    type DocsTocItem,
+} from '@/components/DocsShell/DocsShell'
+import { usePageMetadata } from '@/hooks/usePageMetadata'
+
+const NAV: DocsNavGroup[] = [
+    {
+        heading: 'Legal',
+        items: [
+            { label: 'Terms of Service', href: '/terms' },
+            { label: 'Privacy Policy', href: '/privacy' },
+        ],
+    },
+    {
+        heading: 'Product',
+        items: [
+            { label: 'Docs', href: '/docs' },
+            { label: 'Changelog', href: '/changelog' },
+        ],
+    },
+    {
+        heading: 'External',
+        items: [
+            {
+                label: 'GitHub',
+                href: 'https://github.com/LucasSantana-Dev/Lucky',
+                external: true,
+            },
+            {
+                label: 'Issues',
+                href: 'https://github.com/LucasSantana-Dev/Lucky/issues',
+                external: true,
+            },
+        ],
+    },
+]
+
+const TOC: DocsTocItem[] = [
+    { id: 'acceptance', label: 'Acceptance' },
+    { id: 'service-scope', label: 'Service scope' },
+    { id: 'acceptable-use', label: 'Acceptable use' },
+    { id: 'third-party', label: 'Third-party services' },
+    { id: 'availability', label: 'Availability' },
+    { id: 'suspension', label: 'Suspension and termination' },
+    { id: 'disclaimers', label: 'Disclaimers and liability' },
+    { id: 'changes', label: 'Changes to these terms' },
+    { id: 'contact', label: 'Contact' },
+]
+
 export default function TermsOfServicePage() {
+    usePageMetadata({
+        title: 'Terms of Service · Lucky',
+        description:
+            'Terms governing your use of the Lucky Discord bot and web dashboard.',
+    })
+
     return (
-        <main className='min-h-screen bg-lucky-bg px-6 py-10 text-lucky-text-primary'>
-            <div className='mx-auto w-full max-w-4xl space-y-8'>
-                <header className='space-y-3'>
-                    <p className='type-meta text-lucky-text-tertiary'>Legal</p>
-                    <h1 className='type-h1'>Terms of Service</h1>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Last updated: March 18, 2026
-                    </p>
-                </header>
+        <DocsShell
+            nav={NAV}
+            toc={TOC}
+            breadcrumb='Legal / Terms'
+            title='Terms of Service'
+            lastUpdated='March 18, 2026'
+        >
+            <p>
+                By using Lucky, you agree to these Terms of Service. If you use
+                Lucky on behalf of a server, team, or organization, you confirm
+                you are authorized to accept these terms for that entity.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Acceptance</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        By using Lucky, you agree to these Terms of Service. If
-                        you use Lucky on behalf of a server, team, or
-                        organization, you confirm you are authorized to accept
-                        these terms for that entity.
-                    </p>
-                </section>
+            <h2 id='acceptance'>Acceptance</h2>
+            <p>
+                These terms form a binding agreement between you and the Lucky
+                maintainers. If you do not agree, do not install or use the
+                bot, and do not access the dashboard.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Service scope</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Lucky provides Discord bot functionality and a web
-                        dashboard for server management, moderation, automation,
-                        engagement, and integrations. Features may change over
-                        time.
-                    </p>
-                </section>
+            <h2 id='service-scope'>Service scope</h2>
+            <p>
+                Lucky provides Discord bot functionality and a web dashboard for
+                server management, moderation, automation, engagement, and
+                integrations. Features may change over time as we ship
+                improvements and respond to platform changes.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Acceptable use</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        You must comply with Discord terms, applicable law, and
-                        your own server rules. You may not abuse the service,
-                        attempt unauthorized access, bypass limits, or use Lucky
-                        for spam, harassment, malware distribution, or illegal
-                        activity.
-                    </p>
-                </section>
+            <h2 id='acceptable-use'>Acceptable use</h2>
+            <p>
+                You must comply with the Discord Terms of Service, applicable
+                law, and your own server rules. You may not abuse the service,
+                attempt unauthorized access, bypass rate limits, or use Lucky
+                for spam, harassment, malware distribution, or illegal
+                activity.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Third-party services</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Lucky relies on third-party services including Discord,
-                        and optional Last.fm and Twitch integrations. We are not
-                        responsible for outages, API changes, policy decisions,
-                        or account actions taken by those providers.
-                    </p>
-                </section>
+            <h2 id='third-party'>Third-party services</h2>
+            <p>
+                Lucky relies on third-party services including Discord, and
+                optional Last.fm, Spotify, and Twitch integrations. We are not
+                responsible for outages, API changes, policy decisions, or
+                account actions taken by those providers.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Availability and modifications</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        Lucky is provided on an "as is" and "as available"
-                        basis. We may add, modify, limit, or remove features at
-                        any time to improve security, performance, or
-                        compliance.
-                    </p>
-                </section>
+            <h2 id='availability'>Availability and modifications</h2>
+            <p>
+                Lucky is provided on an &quot;as is&quot; and &quot;as
+                available&quot; basis. We may add, modify, limit, or remove
+                features at any time to improve security, performance, or
+                compliance. Self-hosters control their own deployments.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Suspension and termination</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        We may suspend or terminate access if we reasonably
-                        believe there is abuse, legal risk, or a security threat
-                        to the platform or other users. You may stop using Lucky
-                        at any time by removing the bot and disconnecting
-                        integrations.
-                    </p>
-                </section>
+            <h2 id='suspension'>Suspension and termination</h2>
+            <p>
+                We may suspend or terminate access to the hosted bot if we
+                reasonably believe there is abuse, legal risk, or a security
+                threat to the platform or other users. You may stop using
+                Lucky at any time by removing the bot and disconnecting
+                integrations.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Disclaimers and liability</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        To the maximum extent permitted by law, Lucky and its
-                        maintainers disclaim implied warranties and are not
-                        liable for indirect, incidental, special, or
-                        consequential damages arising from use of the service.
-                    </p>
-                </section>
+            <h2 id='disclaimers'>Disclaimers and liability</h2>
+            <p>
+                To the maximum extent permitted by law, Lucky and its
+                maintainers disclaim implied warranties and are not liable for
+                indirect, incidental, special, or consequential damages
+                arising from use of the service.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Changes to these terms</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        We may update these terms from time to time. Continued
-                        use after updates are posted means you accept the
-                        revised terms.
-                    </p>
-                </section>
+            <h2 id='changes'>Changes to these terms</h2>
+            <p>
+                We may update these terms from time to time. Continued use
+                after updates are posted means you accept the revised terms.
+                Material changes will be noted with a revised &quot;Last
+                updated&quot; date.
+            </p>
 
-                <section className='space-y-3'>
-                    <h2 className='type-h2'>Contact</h2>
-                    <p className='type-body text-lucky-text-secondary'>
-                        For support or legal requests, use the official issue
-                        tracker:{' '}
-                        <a
-                            className='text-lucky-accent underline'
-                            href='https://github.com/LucasSantana-Dev/Lucky/issues'
-                            rel='noreferrer'
-                            target='_blank'
-                        >
-                            https://github.com/LucasSantana-Dev/Lucky/issues
-                        </a>
-                        .
-                    </p>
-                </section>
-            </div>
-        </main>
+            <h2 id='contact'>Contact</h2>
+            <p>
+                For support or legal requests, open an issue at{' '}
+                <a
+                    href='https://github.com/LucasSantana-Dev/Lucky/issues'
+                    target='_blank'
+                    rel='noreferrer'
+                >
+                    github.com/LucasSantana-Dev/Lucky/issues
+                </a>
+                .
+            </p>
+        </DocsShell>
     )
 }

--- a/packages/frontend/src/pages/TermsOfService.tsx
+++ b/packages/frontend/src/pages/TermsOfService.tsx
@@ -1,40 +1,8 @@
 import DocsShell, {
-    type DocsNavGroup,
     type DocsTocItem,
 } from '@/components/DocsShell/DocsShell'
+import { LEGAL_NAV } from '@/components/DocsShell/legalNav'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
-
-const NAV: DocsNavGroup[] = [
-    {
-        heading: 'Legal',
-        items: [
-            { label: 'Terms of Service', href: '/terms' },
-            { label: 'Privacy Policy', href: '/privacy' },
-        ],
-    },
-    {
-        heading: 'Product',
-        items: [
-            { label: 'Docs', href: '/docs' },
-            { label: 'Changelog', href: '/changelog' },
-        ],
-    },
-    {
-        heading: 'External',
-        items: [
-            {
-                label: 'GitHub',
-                href: 'https://github.com/LucasSantana-Dev/Lucky',
-                external: true,
-            },
-            {
-                label: 'Issues',
-                href: 'https://github.com/LucasSantana-Dev/Lucky/issues',
-                external: true,
-            },
-        ],
-    },
-]
 
 const TOC: DocsTocItem[] = [
     { id: 'acceptance', label: 'Acceptance' },
@@ -57,7 +25,7 @@ export default function TermsOfServicePage() {
 
     return (
         <DocsShell
-            nav={NAV}
+            nav={LEGAL_NAV}
             toc={TOC}
             breadcrumb='Legal / Terms'
             title='Terms of Service'

--- a/packages/frontend/src/pages/TrackHistory.tsx
+++ b/packages/frontend/src/pages/TrackHistory.tsx
@@ -314,7 +314,7 @@ function RankingCard({
                             </div>
                             <div className='h-1 bg-lucky-bg-active rounded-full overflow-hidden'>
                                 <div
-                                    className='h-full bg-lucky-red rounded-full'
+                                    className='h-full bg-lucky-brand rounded-full'
                                     style={{
                                         width: `${(item.count / max) * 100}%`,
                                     }}

--- a/packages/frontend/src/stores/featuresStore.ts
+++ b/packages/frontend/src/stores/featuresStore.ts
@@ -103,10 +103,12 @@ const createDefaultToggles = (): FeatureToggleState => {
         'WEBAPP',
         'TWITCH_NOTIFICATIONS',
         'LASTFM_INTEGRATION',
+        'SPOTIFY_INTEGRATION',
         'WELCOME_MESSAGES',
     ]
+    const disabledByDefault: FeatureToggleName[] = ['LYRICS', 'SPOTIFY_INTEGRATION']
     return toggleNames.reduce((acc, name) => {
-        acc[name] = true
+        acc[name] = !disabledByDefault.includes(name)
         return acc
     }, {} as FeatureToggleState)
 }

--- a/packages/frontend/src/test/setup.ts
+++ b/packages/frontend/src/test/setup.ts
@@ -7,6 +7,22 @@ globalThis.ResizeObserver = class ResizeObserver {
     disconnect() {}
 }
 
+if (typeof globalThis.IntersectionObserver === 'undefined') {
+    class IntersectionObserverMock {
+        readonly root = null
+        readonly rootMargin = ''
+        readonly thresholds: ReadonlyArray<number> = []
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+            return []
+        }
+    }
+    ;(globalThis as unknown as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver =
+        IntersectionObserverMock as unknown as typeof IntersectionObserver
+}
+
 if (!HTMLElement.prototype.hasPointerCapture) {
     HTMLElement.prototype.hasPointerCapture = function () {
         return false

--- a/packages/frontend/src/types/feature.ts
+++ b/packages/frontend/src/types/feature.ts
@@ -21,6 +21,7 @@ export type FeatureToggleName =
     | 'WEBAPP'
     | 'TWITCH_NOTIFICATIONS'
     | 'LASTFM_INTEGRATION'
+    | 'SPOTIFY_INTEGRATION'
     | 'WELCOME_MESSAGES'
 
 export type FeatureToggleState = Record<FeatureToggleName, boolean>

--- a/packages/shared/src/config/featureToggles.ts
+++ b/packages/shared/src/config/featureToggles.ts
@@ -26,8 +26,8 @@ const defaultToggles: Record<FeatureToggleName, FeatureToggleConfig> = {
     },
     LYRICS: {
         name: 'LYRICS',
-        enabled: true,
-        description: 'Enable lyrics display',
+        enabled: false,
+        description: 'Enable lyrics display (Genius API)',
     },
     QUEUE_MANAGEMENT: {
         name: 'QUEUE_MANAGEMENT',
@@ -86,6 +86,11 @@ const defaultToggles: Record<FeatureToggleName, FeatureToggleConfig> = {
         name: 'LASTFM_INTEGRATION',
         enabled: true,
         description: 'Enable Last.fm scrobbling and profile linking',
+    },
+    SPOTIFY_INTEGRATION: {
+        name: 'SPOTIFY_INTEGRATION',
+        enabled: false,
+        description: 'Enable Spotify account linking and personalized autoplay seeds',
     },
     WELCOME_MESSAGES: {
         name: 'WELCOME_MESSAGES',

--- a/packages/shared/src/types/featureToggle.ts
+++ b/packages/shared/src/types/featureToggle.ts
@@ -15,6 +15,7 @@ export type FeatureToggleName =
     | 'WEBAPP'
     | 'TWITCH_NOTIFICATIONS'
     | 'LASTFM_INTEGRATION'
+    | 'SPOTIFY_INTEGRATION'
     | 'WELCOME_MESSAGES'
     | 'ARTIST_COMMAND'
     | 'ALBUM_COMMAND'


### PR DESCRIPTION
/ui-expert four-gate pass. Reframes Landing as a developer-tooling landing page for self-hosters.

## Register / Anchors
- **Register:** saas-landing with developer-tooling aesthetic overlay
- **Anchors:** Linear (dense nav, mono wordmark, status pills) + Raycast (command-list rows) + GitHub repo card hero

## Sections
1. TopNav — sticky, mono, github + docs + add CTA
2. Hero — 2-col split: copy + GitHub repo card (clone command, stars/forks/issues, Apache 2.0 badge, language bar)
3. WhySelfHost — 3 reason cards
4. CommandList — 6 commands + category pills, Raycast-row dense
5. StackList — 6-service inventory (bot/backend/frontend/postgres/redis/nginx)
6. RepoFooterBanner + 3-col footer

## Copy pivot
Self-host primary, music secondary. CTAs: 'Self-host on your box' → repo / 'Add hosted version' → login.

## Verification
- typecheck ✓ / lint ✓ (max-warnings 0) / 18/18 tests passing

## Slop audit
PASS — no purple/blue gradient, no bento, no identical-card grid, em dashes removed, mono used aggressively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive repository card with live GitHub stats and one-click clone URL copy
  * New Changelog and Docs pages with version sidebar and navigable docs
  * Landing additions: "Why Self-Host", command list, service stack, and repo card

* **Design Updates**
  * Landing redesign with updated self-hosting-focused copy and refreshed footer links
  * Documentation layout: sticky header, left nav, and "On this page" TOC

* **Other**
  * Some features (Lyrics, Spotify integration) default to disabled by default

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/868)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->