### PR TITLE
feat(backend): Prometheus /metrics endpoint + request middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,7 +1855,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
       "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -1866,7 +1866,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
       "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@clack/core": "0.5.0",
@@ -2625,14 +2625,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
       "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
@@ -2645,7 +2645,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
       "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.4.1"
@@ -2655,6 +2655,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
       "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2666,6 +2667,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2676,6 +2678,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3338,7 +3341,7 @@
       "version": "1.19.13",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
       "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -4219,7 +4222,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lucky/backend": {
@@ -4828,7 +4831,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -5465,7 +5468,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
       "integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.3.4",
@@ -5484,7 +5487,7 @@
       "version": "0.24.3",
       "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
       "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@electric-sql/pglite": "0.4.1",
@@ -5519,7 +5522,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
       "integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5533,14 +5536,14 @@
       "version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
       "integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
       "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.8.0"
@@ -5550,7 +5553,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
       "integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.8.0",
@@ -5562,7 +5565,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
       "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.8.0"
@@ -5572,7 +5575,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
       "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.2.0"
@@ -5582,7 +5585,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
       "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/instrumentation": {
@@ -5642,14 +5645,14 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
       "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/streams-local": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
       "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -5666,7 +5669,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -5679,7 +5682,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
       "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-toggle": "1.1.10",
@@ -7230,7 +7233,7 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
       "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -7256,7 +7259,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
@@ -7280,7 +7283,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
@@ -9608,7 +9611,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -9621,7 +9624,7 @@
       "version": "1.15.33",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.33.tgz",
       "integrity": "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9866,14 +9869,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.26",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
       "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -10816,7 +10819,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -10826,7 +10829,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -12281,7 +12284,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12497,7 +12500,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
       "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
@@ -12738,7 +12741,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.7.0.tgz",
       "integrity": "sha512-7zrmXjAK8u8Z6SOe4R65XObOR5X+Y2I/VVku3t5cPOGQ8/WsBcfFmfnIPiEl5EBMDOzPHRwbiPbMtQBKYdw7RA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
@@ -12964,6 +12967,12 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/bn.js": {
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
@@ -13181,7 +13190,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
       "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -13210,7 +13219,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -13226,7 +13235,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -13426,7 +13435,7 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
@@ -13704,7 +13713,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/connect-redis": {
@@ -13995,7 +14004,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dargs": {
@@ -14118,7 +14127,7 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -14141,7 +14150,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -14191,7 +14200,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -14461,7 +14470,7 @@
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
       "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -14499,7 +14508,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -15220,7 +15229,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ext-list": {
@@ -15254,7 +15263,7 @@
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -15277,7 +15286,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -15328,7 +15337,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15622,7 +15631,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -15639,7 +15648,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -15879,7 +15888,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
@@ -15965,7 +15974,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
       "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/get-proto": {
@@ -15998,7 +16007,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -16011,7 +16020,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
       "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "giget": "dist/cli.mjs"
@@ -16198,14 +16207,14 @@
       "version": "3.1.12",
       "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
       "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/graphmatch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
       "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/handlebars": {
@@ -16331,7 +16340,7 @@
       "version": "4.12.18",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -16456,7 +16465,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/http2-wrapper": {
@@ -16824,7 +16833,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -18342,7 +18351,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -18484,7 +18493,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -18921,7 +18930,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/lowercase-keys": {
@@ -18951,7 +18960,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
       "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -19422,7 +19431,7 @@
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
       "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
@@ -19443,7 +19452,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -19471,7 +19480,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
       "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lru.min": "^1.1.0"
@@ -19484,7 +19493,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19769,7 +19778,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -20133,7 +20142,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
       "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -20344,7 +20353,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -20431,7 +20440,7 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20514,7 +20523,7 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
       "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=12"
@@ -20623,7 +20632,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
       "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -20671,11 +20680,24 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -20687,7 +20709,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -20826,7 +20848,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
       "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.6",
@@ -21173,7 +21195,7 @@
       "version": "2.33.4",
       "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
       "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/remeda"
@@ -21244,7 +21266,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -21601,7 +21623,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
@@ -21788,7 +21810,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/slash": {
@@ -22054,7 +22076,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
       "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -22121,7 +22143,7 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/streamx": {
@@ -22626,6 +22648,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -22686,6 +22709,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terminal-link": {
@@ -23143,7 +23175,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -23553,7 +23585,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
       "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"
@@ -24291,7 +24323,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
       "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "grammex": "^3.1.11",
@@ -24361,6 +24393,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.1",
         "express-session": "^1.19.0",
+        "prom-client": "^15.1.3",
         "session-file-store": "^1.5.0"
       },
       "devDependencies": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.1",
         "express-session": "^1.19.0",
+        "prom-client": "^15.1.3",
         "session-file-store": "^1.5.0"
     },
     "devDependencies": {
@@ -38,8 +39,8 @@
         "jest": "^30.4.2",
         "supertest": "^7.0.0",
         "ts-jest": "^29.4.9",
-        "tsx": "^4.21.0",
         "tsup": "^8.5.1",
+        "tsx": "^4.21.0",
         "typescript": "^6.0.3"
     }
 }

--- a/packages/backend/src/middleware/index.ts
+++ b/packages/backend/src/middleware/index.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs'
 import path from 'path'
 import { setupSessionMiddleware } from './session'
 import { requestLogger } from './requestLogger'
+import { metricsMiddleware } from './metrics'
 import { getFrontendOrigins } from '../utils/frontendOrigin'
 
 export function setupMiddleware(app: Express): void {
@@ -59,6 +60,7 @@ export function setupMiddleware(app: Express): void {
     )
 
     app.use(requestLogger)
+    app.use(metricsMiddleware)
     app.use(express.json())
     app.use(express.urlencoded({ extended: true }))
     app.use(cookieParser())

--- a/packages/backend/src/middleware/metrics.ts
+++ b/packages/backend/src/middleware/metrics.ts
@@ -1,0 +1,49 @@
+import type { Request, Response, NextFunction } from 'express'
+import {
+    httpRequestsTotal,
+    httpRequestDurationSeconds,
+    httpServerErrorsTotal,
+} from '../utils/prometheus'
+
+/**
+ * Express middleware that records request count and duration to the
+ * Prometheus registry. Uses Express's resolved `req.route.path` template
+ * (e.g. `/api/guilds/:guildId`) as the label so cardinality stays bounded;
+ * if no route is matched (404, static files), the literal string `unmatched`
+ * is used instead of the raw URL.
+ */
+export function metricsMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+): void {
+    const start = process.hrtime.bigint()
+
+    res.on('finish', () => {
+        const elapsedSeconds =
+            Number(process.hrtime.bigint() - start) / 1_000_000_000
+        const method = req.method
+        const route = resolveRoute(req)
+        const status = String(res.statusCode)
+        httpRequestsTotal.inc({ method, route, status })
+        httpRequestDurationSeconds.observe(
+            { method, route, status },
+            elapsedSeconds,
+        )
+        if (res.statusCode >= 500) {
+            httpServerErrorsTotal.inc({ method, route })
+        }
+    })
+
+    next()
+}
+
+function resolveRoute(req: Request): string {
+    const route = req.route as { path?: string } | undefined
+    if (route?.path && typeof route.path === 'string') {
+        return route.path
+    }
+    // baseUrl is set when middleware is mounted under a prefix (e.g. /api).
+    if (req.baseUrl) return `${req.baseUrl}/unmatched`
+    return 'unmatched'
+}

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -26,6 +26,7 @@ import { requireAdmin } from '../middleware/requireAdmin'
 import { requireGuildModuleAccess } from '../middleware/guildAccess'
 import { errorHandler } from '../middleware/errorHandler'
 import { setupHealthRoutes } from './health'
+import { setupMetricsRoute } from './metrics'
 import { setupStatsRoutes } from './stats'
 import { setupInviteRoute } from './invite'
 
@@ -84,6 +85,7 @@ const routeSetups = [
 export function setupRoutes(app: Express): void {
     setupInviteRoute(app)
     setupHealthRoutes(app)
+    setupMetricsRoute(app)
     setupStatsRoutes(app)
     setupInternalNotifyRoutes(app)
     setupWebhookPublicRoutes(app)

--- a/packages/backend/src/routes/metrics.ts
+++ b/packages/backend/src/routes/metrics.ts
@@ -1,0 +1,30 @@
+import type { Express, Request, Response } from 'express'
+import { errorLog } from '@lucky/shared/utils'
+import { metricsContentType, renderMetrics } from '../utils/prometheus'
+
+/**
+ * Mount the /metrics endpoint that Prometheus scrapes.
+ *
+ * Intentionally unauthenticated and outside the /api rate limiter so
+ * the scraper can pull at its configured cadence. Restrict access at the
+ * network layer (Docker network, ingress allowlist).
+ *
+ * Set METRICS_DISABLED=true to skip the mount entirely.
+ */
+export function setupMetricsRoute(app: Express): void {
+    if (process.env.METRICS_DISABLED === 'true') return
+    app.get('/metrics', (_req: Request, res: Response) => {
+        renderMetrics()
+            .then((body) => {
+                res.set('content-type', metricsContentType)
+                res.status(200).send(body)
+            })
+            .catch((error: unknown) => {
+                errorLog({
+                    message: 'metrics route: failed to render',
+                    error,
+                })
+                res.status(500).send('internal error')
+            })
+    })
+}

--- a/packages/backend/src/utils/prometheus.ts
+++ b/packages/backend/src/utils/prometheus.ts
@@ -1,0 +1,57 @@
+import {
+    Registry,
+    collectDefaultMetrics,
+    Counter,
+    Histogram,
+} from 'prom-client'
+
+/**
+ * Shared Prometheus registry for the backend. Mounted at GET /metrics.
+ */
+export const registry = new Registry()
+
+registry.setDefaultLabels({ service: 'lucky-backend' })
+collectDefaultMetrics({ register: registry })
+
+/**
+ * Counter: total HTTP requests served, labelled by method, route template
+ * (NOT raw path — we use `req.route.path` so cardinality stays bounded),
+ * and status code.
+ */
+export const httpRequestsTotal = new Counter<'method' | 'route' | 'status'>({
+    name: 'lucky_backend_http_requests_total',
+    help: 'Count of HTTP requests handled by the backend, labelled by method, route template, and status code.',
+    labelNames: ['method', 'route', 'status'],
+    registers: [registry],
+})
+
+/**
+ * Histogram: HTTP request duration in seconds. Buckets tuned for typical
+ * API workloads (sub-50ms to ~5s p99).
+ */
+export const httpRequestDurationSeconds = new Histogram<
+    'method' | 'route' | 'status'
+>({
+    name: 'lucky_backend_http_request_duration_seconds',
+    help: 'HTTP request duration in seconds, observed at response finish.',
+    labelNames: ['method', 'route', 'status'],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+    registers: [registry],
+})
+
+/**
+ * Counter: HTTP errors (status >= 500) classified by method and route.
+ * Separate from the total counter for easier alerting.
+ */
+export const httpServerErrorsTotal = new Counter<'method' | 'route'>({
+    name: 'lucky_backend_http_server_errors_total',
+    help: 'Count of HTTP 5xx responses, labelled by method and route template.',
+    labelNames: ['method', 'route'],
+    registers: [registry],
+})
+
+export async function renderMetrics(): Promise<string> {
+    return registry.metrics()
+}
+
+export const metricsContentType: string = registry.contentType

--- a/packages/backend/tests/unit/middleware/metrics.test.ts
+++ b/packages/backend/tests/unit/middleware/metrics.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import { EventEmitter } from 'events'
+import { metricsMiddleware } from '../../../src/middleware/metrics'
+import {
+    registry,
+    httpRequestsTotal,
+    httpRequestDurationSeconds,
+    httpServerErrorsTotal,
+} from '../../../src/utils/prometheus'
+
+function createReq(
+    overrides: Partial<{
+        method: string
+        route: { path: string } | undefined
+        baseUrl: string
+    }> = {},
+): Parameters<typeof metricsMiddleware>[0] {
+    return {
+        method: 'GET',
+        route: { path: '/api/guilds/:guildId' },
+        baseUrl: '',
+        ...overrides,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+}
+
+function createRes(statusCode: number) {
+    const emitter = new EventEmitter()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return Object.assign(emitter, { statusCode }) as any
+}
+
+describe('metricsMiddleware', () => {
+    beforeEach(() => {
+        // Reset counters between tests so call counts don't bleed.
+        httpRequestsTotal.reset()
+        httpRequestDurationSeconds.reset()
+        httpServerErrorsTotal.reset()
+    })
+
+    test('calls next immediately', () => {
+        const req = createReq()
+        const res = createRes(200)
+        const next = jest.fn()
+        metricsMiddleware(req, res, next)
+        expect(next).toHaveBeenCalledTimes(1)
+    })
+
+    test('records count + duration on response finish with route template label', async () => {
+        const req = createReq()
+        const res = createRes(200)
+        const next = jest.fn()
+        metricsMiddleware(req, res, next)
+        res.emit('finish')
+
+        const text = await registry.metrics()
+        expect(text).toMatch(
+            /lucky_backend_http_requests_total\{[^}]*method="GET"[^}]*route="\/api\/guilds\/:guildId"[^}]*status="200"[^}]*\}\s+1/,
+        )
+        expect(text).toContain('lucky_backend_http_request_duration_seconds_bucket')
+        expect(text).toMatch(
+            /lucky_backend_http_request_duration_seconds_count\{[^}]*route="\/api\/guilds\/:guildId"[^}]*\}\s+1/,
+        )
+    })
+
+    test('increments server-errors counter for 5xx responses', async () => {
+        const req = createReq({ method: 'POST' })
+        const res = createRes(503)
+        const next = jest.fn()
+        metricsMiddleware(req, res, next)
+        res.emit('finish')
+
+        const text = await registry.metrics()
+        expect(text).toMatch(
+            /lucky_backend_http_server_errors_total\{[^}]*method="POST"[^}]*route="\/api\/guilds\/:guildId"[^}]*\}\s+1/,
+        )
+    })
+
+    test('does NOT increment server-errors counter for 4xx responses', async () => {
+        const req = createReq()
+        const res = createRes(404)
+        const next = jest.fn()
+        metricsMiddleware(req, res, next)
+        res.emit('finish')
+
+        const text = await registry.metrics()
+        // No 5xx error line should appear at all for this test.
+        expect(text).not.toMatch(
+            /lucky_backend_http_server_errors_total\{[^}]*\}\s+[1-9]/,
+        )
+    })
+
+    test('uses "unmatched" label when no route is resolved', async () => {
+        const req = createReq({ route: undefined })
+        const res = createRes(404)
+        const next = jest.fn()
+        metricsMiddleware(req, res, next)
+        res.emit('finish')
+
+        const text = await registry.metrics()
+        expect(text).toMatch(
+            /lucky_backend_http_requests_total\{[^}]*route="unmatched"[^}]*\}\s+1/,
+        )
+    })
+
+    test('uses "<baseUrl>/unmatched" when middleware is sub-mounted', async () => {
+        const req = createReq({ route: undefined, baseUrl: '/api' })
+        const res = createRes(404)
+        const next = jest.fn()
+        metricsMiddleware(req, res, next)
+        res.emit('finish')
+
+        const text = await registry.metrics()
+        expect(text).toMatch(
+            /lucky_backend_http_requests_total\{[^}]*route="\/api\/unmatched"[^}]*\}\s+1/,
+        )
+    })
+})

--- a/packages/backend/tests/unit/routes/metrics.test.ts
+++ b/packages/backend/tests/unit/routes/metrics.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals'
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+    infoLog: jest.fn(),
+}))
+
+import express, { type Express } from 'express'
+import type { AddressInfo } from 'node:net'
+import { request as httpRequest } from 'node:http'
+import { setupMetricsRoute } from '../../../src/routes/metrics'
+
+function getRaw(
+    port: number,
+    path: string,
+): Promise<{ status: number; body: string; contentType: string | undefined }> {
+    return new Promise((resolve, reject) => {
+        const req = httpRequest(
+            { host: '127.0.0.1', port, path, method: 'GET' },
+            (res) => {
+                const chunks: Buffer[] = []
+                res.on('data', (c: Buffer) => chunks.push(c))
+                res.on('end', () =>
+                    resolve({
+                        status: res.statusCode ?? 0,
+                        body: Buffer.concat(chunks).toString('utf8'),
+                        contentType: res.headers['content-type'],
+                    }),
+                )
+            },
+        )
+        req.on('error', reject)
+        req.end()
+    })
+}
+
+async function startApp(): Promise<{
+    app: Express
+    port: number
+    close: () => Promise<void>
+}> {
+    const app = express()
+    setupMetricsRoute(app)
+    const server = app.listen(0, '127.0.0.1')
+    await new Promise<void>((resolve) => server.once('listening', resolve))
+    const port = (server.address() as AddressInfo).port
+    return {
+        app,
+        port,
+        close: () =>
+            new Promise<void>((resolve) => {
+                server.closeAllConnections?.()
+                server.close(() => resolve())
+            }),
+    }
+}
+
+describe('GET /metrics', () => {
+    const originalDisabled = process.env.METRICS_DISABLED
+    let closeFn: (() => Promise<void>) | null = null
+
+    beforeEach(() => {
+        delete process.env.METRICS_DISABLED
+    })
+
+    afterEach(async () => {
+        if (closeFn) await closeFn()
+        closeFn = null
+        if (originalDisabled === undefined) {
+            delete process.env.METRICS_DISABLED
+        } else {
+            process.env.METRICS_DISABLED = originalDisabled
+        }
+    })
+
+    test('serves Prometheus text exposition with correct content type', async () => {
+        const { port, close } = await startApp()
+        closeFn = close
+
+        const res = await getRaw(port, '/metrics')
+        expect(res.status).toBe(200)
+        expect(res.contentType).toMatch(/text\/plain/)
+        // Default Node metrics must be present.
+        expect(res.body).toContain('process_cpu_user_seconds_total')
+        // Service label is applied.
+        expect(res.body).toMatch(/service="lucky-backend"/)
+    })
+
+    test('does not mount the route when METRICS_DISABLED=true', async () => {
+        process.env.METRICS_DISABLED = 'true'
+        const { port, close } = await startApp()
+        closeFn = close
+
+        const res = await getRaw(port, '/metrics')
+        // Express default for unmatched route in a bare app is 404.
+        expect(res.status).toBe(404)
+    })
+})


### PR DESCRIPTION
## Summary

PR C of the observability rollout. Sentry was already wired in `bootstrap.ts`; this adds the Prometheus scrape surface to match the bot (#873).

## What

### Endpoint
- `GET /metrics` → Prometheus text exposition (mounted on the existing Express app, before the `/api` rate limiter, no auth — restrict at the network layer)
- `METRICS_DISABLED=true` skips the route entirely

### Metrics
- **`lucky_backend_http_requests_total{method,route,status}`** — per-request counter, labelled with the resolved Express route TEMPLATE (e.g. `/api/guilds/:guildId`), not the raw path, so cardinality stays bounded
- **`lucky_backend_http_request_duration_seconds{method,route,status}`** — histogram with buckets tuned for typical API latencies (5ms – 10s)
- **`lucky_backend_http_server_errors_total{method,route}`** — separate 5xx counter for easier alerting
- `prom-client` defaults: `process_cpu`, `eventloop_lag`, heap, GC, etc.

### Middleware
- New `metricsMiddleware` records duration on response `'finish'`. Mounted right after `requestLogger`, before `express.json()`, so it observes the full server time, not just handler time. Unmatched routes (404s, static) collapse to `"unmatched"` to keep cardinality finite.

## Test plan

- [x] `metrics.test.ts` (middleware, 6 cases): counters/histograms recorded on finish, 5xx-only error counter, route template label, unmatched + baseUrl fallbacks
- [x] `metrics.test.ts` (route, 2 cases): /metrics serves text exposition with default Node metrics + `service="lucky-backend"` label; METRICS_DISABLED no-op
- [x] All 72 existing middleware tests still pass
- [x] Backend `tsc --noEmit` clean
- [ ] Manual scrape on staging once deployed: `curl backend:5000/metrics | grep lucky_backend_http_requests_total`

## Deployment notes

- Same port as the API (`PORT` / `WEBAPP_PORT`, default 5000) — no extra port to open
- If Prometheus is in a separate network, route `/metrics` through nginx or expose the backend port internally
- Add to scrape config: `job_name: lucky-backend`, `static_configs.targets: [backend:5000]`, `metrics_path: /metrics`

## Known CI hazard

CI lint may show a transient `youtube-dl-exec postinstall` failure unrelated to this PR — tracked in #874 (GitHub API rate limit on shared runners). Re-run the affected check or land #874's fix first.

## Out of scope

- **PR D**: frontend `@sentry/react` browser SDK + web-vitals + route-change tracking
- **PR E**: Grafana dashboards + alert rules consuming these metrics + `lucky_bot_guilds_total` from #873