### PR TITLE
chore(docker): join bot+backend to shared lucky-monitoring network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,10 @@ services:
             - ./logs:/app/logs
         networks:
             - lucky-network
+            # Shared monitoring network so the homelab Prometheus
+            # container can scrape /metrics on port 9091 without
+            # exposing it on the host. See homelab PR #135.
+            - lucky-monitoring
         logging:
             driver: "json-file"
             options:
@@ -160,6 +164,10 @@ services:
             WEBAPP_BACKEND_URL: ${WEBAPP_BACKEND_URL:-}
         networks:
             - lucky-network
+            # Shared monitoring network so the homelab Prometheus
+            # container can scrape /metrics on the backend without
+            # exposing it on the host. See homelab PR #135.
+            - lucky-monitoring
         logging:
             driver: "json-file"
             options:
@@ -259,4 +267,10 @@ volumes:
 
 networks:
     lucky-network:
+        driver: bridge
+    # External network shared with the homelab monitoring stack
+    # (Prometheus, Grafana). Lucky owns/creates it; homelab joins it
+    # as `external: true`. See homelab PR #135.
+    lucky-monitoring:
+        name: lucky-monitoring
         driver: bridge


### PR DESCRIPTION
## Summary

Adds the `lucky-monitoring` Docker network and joins both `bot` and `backend` services to it, so the homelab Prometheus container can scrape:

- `lucky-bot:9091/metrics` (added in #873)
- `lucky-backend:5000/metrics` (added in #875)

…without exposing those ports to the host.

Lucky owns/creates the network; homelab joins it as `external: true` in `compose/monitoring.yml` (homelab PR #135).

## Why this PR exists separately

PR #135 in the homelab repo declares `lucky-monitoring` as an **external** network. Without this Lucky-side change, the homelab stack would fail to start (network does not exist) and the new `LuckyBotDown` / `LuckyBackendDown` alerts would fire immediately on deploy because the scrape targets would not be DNS-resolvable.

## Deploy order

1. Merge this PR (creates the network on the Lucky compose project on next deploy)
2. Redeploy Lucky → `docker network ls` shows `lucky-monitoring`
3. Merge homelab #135
4. Redeploy homelab monitoring stack → Prometheus container joins the existing network
5. Verify in Grafana that `up{job=~"lucky-.*"} == 1`

## Test plan

- [ ] CI passes (lint / Docker build / compose validate)
- [ ] After deploy: `docker network inspect lucky-monitoring` shows both `lucky-bot` and `lucky-backend` attached
- [ ] After homelab redeploy: Prometheus target page shows both Lucky targets as `UP`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration to enable monitoring infrastructure connections for bot and backend services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->