### PR TITLE
fix(ci): unblock postinstall scripts hitting GitHub API rate limit

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     quality:
-        uses: LucasSantana-Dev/.github/.github/workflows/quality.yml@39ebcddcd62666b363e0cc240e6547a805ba92e5
+        uses: LucasSantana-Dev/.github/.github/workflows/quality.yml@bd9e2443160b4ddefd9756ac794787269e09cde4
         with:
             node-version: '22'
             has-dockerfile: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
                   cache: 'npm'
 
             - name: Install dependencies
+              # Authenticate postinstall scripts that hit GitHub releases
+              # (e.g. youtube-dl-exec) so shared-runner IPs don't hit the
+              # 60 req/hr unauthenticated cap. See #874.
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  YOUTUBE_DL_SKIP_DOWNLOAD: 'true'
               run: npm ci
 
             - name: Build project


### PR DESCRIPTION
## Summary

Fixes #874 by:

1. **Bumping the pinned ref of the org reusable \`quality.yml\`** to the merge commit of [LucasSantana-Dev/.github#2](https://github.com/LucasSantana-Dev/.github/pull/2). That PR adds \`GITHUB_TOKEN\` + \`YOUTUBE_DL_SKIP_DOWNLOAD=true\` to the install step in the \`lint\` and \`deadcode\` jobs, eliminating the 60 req/hr unauthenticated cap that's been failing PRs since the observability rollout started.

2. **Applying the same env vars to local \`release.yml\`** for parity. Release builds don't strictly need the yt-dlp binary, so skipping the fetch is harmless.

## Why this scope

| Workflow | npm ci flags | Status |
|---|---|---|
| \`ci.yml\` | \`--legacy-peer-deps --ignore-scripts\` | already safe |
| \`sonarcloud.yml\` | \`--legacy-peer-deps --ignore-scripts\` | already safe |
| \`bundle-size.yml\` | runs postinstall | already sets both env vars |
| \`release.yml\` | bare \`npm ci\` | **fixed here** |
| reusable \`quality.yml\` | runs postinstall | **fixed via SHA bump** |

## Closes

- #874

## Unblocks

- PR #873 (bot observability metrics)
- PR #875 (backend observability)
- PR #876 (frontend Sentry)
- PR #877 (paired Lucky-side network for homelab #135)

## Test plan

- [ ] \`quality / Lint\` passes on this PR's first run
- [ ] After merge: re-run failed \`quality / Lint\` on #873 / #875 / #876 — they should pass without retry