### PR TITLE
chore(docs): wire up AI-doc policy enforcement (gitignore + pre-commit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,14 @@ cloudflared/config.yml
 # Local Claude Code spec scratch + worktrees (not part of repo)
 .wt-specs/
 worktrees/
+
+# AI-generated docs / generator outputs — see
+# docs/decisions/2026-05-15-no-ai-generated-docs-in-tracked-state.md.
+# Exact filenames only (no broad wildcards that would catch human-authored guides).
+.context/
+packages/bot/TEST_MAP.md
+docs/IMPLEMENTATION_STATUS.md
+docs/LOVABLE_PROMPT.md
+docs/FRONTEND_AI_STUDIO_CONTEXT.md
+**/LIBRARY_RECOMMENDATIONS.md
+**/CODE_EXAMPLES.md

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,21 @@
+# Reject AI-generated / generator-output docs landing in tracked state.
+# Policy: docs/decisions/2026-05-15-no-ai-generated-docs-in-tracked-state.md
+# Bypass (audited): git commit --no-verify
+
+# --diff-filter=ACMR: Added, Copied, Modified, Renamed.
+# Deletions (D) are fine — that's how this policy was rolled out.
+denied="$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(\.context/|packages/bot/TEST_MAP\.md$|docs/(IMPLEMENTATION_STATUS|LOVABLE_PROMPT|FRONTEND_AI_STUDIO_CONTEXT)\.md$|.*/(LIBRARY_RECOMMENDATIONS|CODE_EXAMPLES)\.md$)' || true)"
+
+if [ -n "$denied" ]; then
+    echo "✗ pre-commit: refusing to commit AI-generated docs:" >&2
+    echo "$denied" | sed 's/^/    /' >&2
+    echo "" >&2
+    echo "  Policy: docs/decisions/2026-05-15-no-ai-generated-docs-in-tracked-state.md" >&2
+    echo "  Options:" >&2
+    echo "    1. Convert to docs/runbooks/ entry with explicit ownership." >&2
+    echo "    2. Move outside the repo (~/notes, scratch dir)." >&2
+    echo "    3. git commit --no-verify  (escape hatch; document why in the message)" >&2
+    exit 1
+fi
+
 npx lint-staged


### PR DESCRIPTION
## Summary

Follow-up to #879. That PR landed the deletions + ADR but I forgot to stage the enforcement files — only the ADR was actually committed. The ADR documents the policy as machine-enforced, but without these two files it's only advisory.

This PR adds the missing pieces:

- \`.gitignore\` — exact-filename patterns for known generator outputs (no broad wildcards per the critic's review on #879):
  - \`.context/\`
  - \`packages/bot/TEST_MAP.md\`
  - \`docs/{IMPLEMENTATION_STATUS,LOVABLE_PROMPT,FRONTEND_AI_STUDIO_CONTEXT}.md\`
  - \`**/LIBRARY_RECOMMENDATIONS.md\`, \`**/CODE_EXAMPLES.md\`
- \`.husky/pre-commit\` — rejects \`ACMR\`-staged paths matching the deny list, points at the ADR, documents \`--no-verify\` as the audited escape hatch

Self-tested locally: \`echo test > docs/IMPLEMENTATION_STATUS.md && git add -f docs/IMPLEMENTATION_STATUS.md && .husky/pre-commit\` → exit 1.

## Policy

See \`docs/decisions/2026-05-15-no-ai-generated-docs-in-tracked-state.md\` (landed in #879).

## Test plan

- [ ] CI passes
- [ ] After merge: hook self-test still passes (verify locally after \`git pull\`)