### PR TITLE
fix(security): apk upgrade nginx-alpine base on build to patch CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,6 +173,12 @@ CMD ["node", "packages/backend/dist/index.js"]
 # Replaces the former standalone Dockerfile.frontend.
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS production-frontend
 
+# Patch Alpine OS packages to current Alpine 3.21 package index versions.
+# See Dockerfile.nginx for context (same base image, same CVE exposure).
+USER root
+RUN apk upgrade --no-cache && rm -rf /var/cache/apk/*
+USER nginx
+
 COPY --from=build-frontend /app/packages/frontend/dist /usr/share/nginx/html
 COPY nginx/frontend.conf /etc/nginx/conf.d/default.conf
 

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -2,6 +2,15 @@
 # publishing maps host 8080 → container 8080.
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 
+# Patch Alpine OS packages (openssl, libxml2, libpng, expat, etc.) to
+# their current versions in the Alpine 3.21 package index. The upstream
+# nginx-unprivileged:1.27-alpine tag rebuilds infrequently, so its OS
+# packages drift behind published CVE fixes. Snyk Critical+High audit
+# 2026-05-15: 3C + 11H, all OS-layer.
+USER root
+RUN apk upgrade --no-cache && rm -rf /var/cache/apk/*
+USER nginx
+
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 8080


### PR DESCRIPTION
## Summary

Patches 3 critical + 11 high CVEs surfaced by the Snyk audit (2026-05-15) on \`lucky-nginx\` and \`lucky-frontend\` images. Both use \`nginxinc/nginx-unprivileged:1.27-alpine\` and share the same exposure.

| Sev | CVSS | Package | Current → Fixed |
|---|---|---|---|
| **C** | 9.8 | openssl | 3.3.3-r0 → 3.3.7-r0 (CVE-2026-31789) |
| **C** | 9.1 | libxml2 | 2.13.4-r6 → 2.13.9-r0 (OOB Read) |
| **C** | 9.1 | libxml2 | 2.13.4-r6 → 2.13.9-r0 (Pointer Dereference) |
| H | 8.1 | openssl | + CVE-2026-28387 |
| H | 8.1 | libpng | 1.6.47-r0 → 1.6.55-r0 (Heap overflow) |
| H | 7.8 | libpng | 1.6.47-r0 → 1.6.54-r0 (OOB Read) |
| H | 7.8 | expat | 2.7.0-r0 → 2.7.4-r0 (Integer overflow) |
| H | 7.5 | openssl | × 4 CVEs (CVE-2026-28388/89/90, CVE-2025-69421) |
| H | 7.5 | libxml2 | × 2 CVEs (OOB Write + Pointer Dereference) |
| H | 7.1 | libpng | OOB Read |

## Fix

Adds \`apk upgrade --no-cache\` after the FROM in both nginx stages. Pulls current Alpine 3.21 package versions on every build without changing the upstream tag.

Pattern is standard for Alpine images that don't have frequent upstream rebuilds. Hadolint DL3002 (no root user) is already ignored by the org reusable workflow, so the temporary \`USER root\` → \`apk\` → \`USER nginx\` switch is lint-clean.

## Why now

Dashboard surfaced this when I installed \`snyk\` CLI earlier today. The org reusable Trivy job (\`scan-type: fs, exit-code: 0\`) was missing these because (a) fs-scan doesn't inspect built images, (b) exit-code 0 means findings never block CI. Decision on Trivy-vs-Snyk is queued (task #27 in this session).

## Test plan

- [ ] CI passes (hadolint, build)
- [ ] After merge: docker-publish rebuilds → Snyk GitHub App re-scans \`lucky-nginx\` and \`lucky-frontend\` → expect 3C/11H → 0C/0H
- [ ] Image size delta within ~5MB (apk upgrade is small)