### PR TITLE
feat(ci): trivy image-scan on docker-publish (Phase A — audit only)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,6 +30,9 @@ jobs:
         permissions:
             contents: read
             packages: write
+            # Required by github/codeql-action/upload-sarif so trivy findings
+            # land in the repo's Code Scanning tab. See ADR 2026-05-16.
+            security-events: write
 
         strategy:
             matrix:
@@ -90,3 +93,33 @@ jobs:
                 # the GitHub owner's case (LucasSantana-Dev), so normalize here.
                 IMAGE="$(printf '%s' "${{ env.IMAGE_PREFIX }}-${{ matrix.service }}" | tr '[:upper:]' '[:lower:]')"
                 docker run --rm "$IMAGE:${{ steps.meta.outputs.version }}" yt-dlp --version
+
+            # Phase A of the image-scan rollout (ADR 2026-05-16). Runs against
+            # the freshly-pushed image — audit-only, exit-code 0, never blocks
+            # CI. Findings land in the Code Scanning tab via SARIF upload, one
+            # category per service so matrix runs don't overwrite each other.
+            # Phase B will tighten to severity HIGH,CRITICAL + exit-code 1
+            # after 2 weeks of clean audits.
+            - name: Normalize image ref
+              id: imgref
+              run: |
+                IMAGE="$(printf '%s' "${{ env.IMAGE_PREFIX }}-${{ matrix.service }}" | tr '[:upper:]' '[:lower:]')"
+                echo "ref=${IMAGE}:${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+            - name: Trivy image scan (audit-only)
+              uses: aquasecurity/trivy-action@0.36.0
+              with:
+                  image-ref: ${{ steps.imgref.outputs.ref }}
+                  format: sarif
+                  output: trivy-image-${{ matrix.service }}.sarif
+                  severity: MEDIUM,HIGH,CRITICAL
+                  ignore-unfixed: true
+                  exit-code: '0'
+                  vuln-type: os,library
+
+            - name: Upload Trivy SARIF
+              if: always()
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                  sarif_file: trivy-image-${{ matrix.service }}.sarif
+                  category: trivy-image-${{ matrix.service }}


### PR DESCRIPTION
## Summary

Implements **Phase A** of the rollout from ADR \`docs/decisions/2026-05-16-trivy-image-scan-vs-snyk-in-ci.md\` (PR #882).

Adds a Trivy image-scan step to \`.github/workflows/docker-publish.yml\` that runs against each freshly-pushed image (bot / backend / frontend / nginx). Audit-only — findings land in the repo's Code Scanning tab as SARIF, **never blocks CI**.

## Config (Phase A)

\`\`\`yaml
severity: MEDIUM,HIGH,CRITICAL
ignore-unfixed: true
exit-code: '0'         # audit-only
vuln-type: os,library  # OS packages + language deps
\`\`\`

One SARIF upload per service (\`category: trivy-image-<service>\`) so the four matrix runs don't overwrite each other.

## What this catches that the existing org-reusable Trivy doesn't

| Existing org reusable | This PR |
|---|---|
| \`scan-type: fs\` (filesystem only) | \`scan-type: image\` (built image) |
| Misses base-image OS CVEs | Catches Alpine/Debian package CVEs (the class that hit PR #881) |
| Filesystem-only IaC + config | Image-layer + lang deps |

## Phase B (≥ 2 weeks from now, after baseline clean)

Will tighten to:
- \`severity: HIGH,CRITICAL\`
- \`exit-code: '1'\` — blocks publication on critical findings
- Restructure to load-then-scan-then-push so a critical finding actually prevents the image from reaching ghcr.

Tracked in ADR's "Revisit when" + memory \`project_security_scan_policy_2026-05-16.md\`.

## What does NOT change

- Org reusable \`quality.yml\` Trivy job stays \`scan-type: fs\`
- No Snyk CLI added to CI
- Snyk GitHub App continues providing dashboard monitoring

## Permissions

Adds \`security-events: write\` to the job (required for \`upload-sarif\`). No new secrets.

## Test plan

- [ ] CI passes on this PR (workflow change only; nothing actually fires until a publish event triggers \`docker-publish.yml\`)
- [ ] On next \`push: main\` event: workflow runs, 4 Trivy scans complete, SARIF uploads to Code Scanning tab
- [ ] After PR #881 + this PR + a publish: Snyk dashboard's Lucky row drops from 4C / 16H to ≤ 1C tail (whatever remains in non-nginx images)