### PR TITLE
refactor(bot): break trivial circular deps (Cluster A partial + D)

### DIFF
--- a/packages/bot/src/functions/download/utils/downloadVideo.ts
+++ b/packages/bot/src/functions/download/utils/downloadVideo.ts
@@ -1,1 +1,0 @@
-export type * from './downloadVideo'

--- a/packages/bot/src/functions/download/utils/ytDlpUtils/downloader.ts
+++ b/packages/bot/src/functions/download/utils/ytDlpUtils/downloader.ts
@@ -1,1 +1,0 @@
-export type * from './downloader'

--- a/packages/bot/src/types/CommandData.ts
+++ b/packages/bot/src/types/CommandData.ts
@@ -3,7 +3,7 @@ import type {
     SlashCommandSubcommandsOnlyBuilder,
     SlashCommandOptionsOnlyBuilder,
 } from '@discordjs/builders'
-import type { CustomClient } from './index'
+import type { CustomClient } from './CustomClient'
 import type { ChatInputCommandInteraction } from 'discord.js'
 
 export type TCommandData =

--- a/packages/bot/src/types/CustomClient.ts
+++ b/packages/bot/src/types/CustomClient.ts
@@ -1,0 +1,33 @@
+import type {
+    ChatInputCommandInteraction,
+    Client,
+    Collection,
+} from 'discord.js'
+import type { Player } from 'discord-player'
+import type Command from '../models/Command'
+
+// Extracted from `./index` so consumers can import `CustomClient`
+// without round-tripping through the barrel. See
+// docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md.
+// NOTE: a type-only cycle through `models/Command → types/CommandData`
+// persists at the module-graph level (madge cycle 1 of the original
+// list); it is `import type` only and erased by tsc, so it has no
+// runtime effect. A structural break was attempted but cascades into
+// `Collection<string, Command>` consumers (help.ts) that expect the
+// real class. Deferred to a follow-up PR once Cluster C lands and the
+// command-loader contracts can be revisited together.
+export type CustomClient = Client & {
+    commands: Collection<string, Command>
+    player: Player
+    cooldowns: Collection<string, number>
+    redis?: unknown
+    metrics?: unknown
+    tracer?: unknown
+    token?: string
+    clientId?: string
+}
+
+export type CommandType = {
+    data: unknown
+    execute: (_interaction: ChatInputCommandInteraction) => Promise<void>
+}

--- a/packages/bot/src/types/QueueMetadata.ts
+++ b/packages/bot/src/types/QueueMetadata.ts
@@ -1,5 +1,5 @@
 import type { TextChannel, User } from 'discord.js'
-import type { CustomClient } from './index'
+import type { CustomClient } from './CustomClient'
 
 export interface QueueMetadata {
     channel?: TextChannel | null

--- a/packages/bot/src/types/index.ts
+++ b/packages/bot/src/types/index.ts
@@ -1,25 +1,8 @@
-import type {
-    Client,
-    Collection,
-    ChatInputCommandInteraction,
-} from 'discord.js'
-import type { Player } from 'discord-player'
-import type Command from '../models/Command'
+// Pure barrel — re-exports only. Concrete type declarations live in
+// sibling modules so importers can target them directly without
+// round-tripping through this file. See
+// docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md
+// (fixed madge cycles 1-2).
 
-export type CustomClient = Client & {
-    commands: Collection<string, Command>
-    player: Player
-    cooldowns: Collection<string, number>
-    redis?: unknown
-    metrics?: unknown
-    tracer?: unknown
-    token?: string
-    clientId?: string
-}
-
-export type CommandType = {
-    data: unknown
-    execute: (_interaction: ChatInputCommandInteraction) => Promise<void>
-}
-
+export type { CommandType, CustomClient } from './CustomClient'
 export type { QueueMetadata } from './QueueMetadata'


### PR DESCRIPTION
## Summary

PR 1 of 4 from the \`/refactor-pipeline\` plan for #871 ([ADR](docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md)).

**Madge baseline:** 15 cycles. **After this PR:** 12 cycles.

## Fixes

### Cluster D — dead self-cycle barrels (cycles 14, 15)

Two files were one-liners doing \`export type * from './<self>'\`. With both \`./<name>.ts\` AND a \`./<name>/\` directory present, TypeScript resolved to the file → infinite self-import. **Zero external callers** (verified by grep). Pure dead code.

- Deleted: \`packages/bot/src/functions/download/utils/downloadVideo.ts\`
- Deleted: \`packages/bot/src/functions/download/utils/ytDlpUtils/downloader.ts\`

### Cluster A (partial) — extract CustomClient from types barrel

- **New file:** \`packages/bot/src/types/CustomClient.ts\` holds the \`CustomClient\` + \`CommandType\` declarations.
- \`types/index.ts\` becomes a pure re-export barrel (no inline declarations).
- \`types/CommandData.ts\` + \`types/QueueMetadata.ts\` import \`CustomClient\` from \`./CustomClient\` directly, eliminating the back-edge through \`./index\`.

Fixes cycle 2 (\`types/index.ts → QueueMetadata → types/index.ts\`).

## What's deferred

Original cycle 1 (\`types/index.ts → models/Command → types/CommandData → types/index.ts\`) is now \`types/CustomClient.ts → models/Command → types/CommandData → types/CustomClient.ts\` — same shape, same files. **\`import type\` only**, erased by tsc, no runtime effect.

A structural-type break (replacing \`Collection<string, Command>\` with a \`CommandLike\` shape) was attempted but cascades into \`help.ts\` and similar consumers that expect the real \`Command\` class. Cleaner to revisit alongside the command-loader contracts in a later PR (likely bundled with Cluster C's autoplay/queue refactor).

Documented in a code comment on \`types/CustomClient.ts\` so future readers know it's intentional.

## Caller impact

**None.** All existing \`import { CustomClient } from '.../types'\` paths still resolve through the barrel re-export.

## Validation

- \`npx madge --circular packages/bot/src\` → **12** (was 15)
- \`npx tsc --noEmit\` clean (no new errors; pre-existing prom-client typecheck issue is from PR #873 and unrelated)

## Test plan

- [ ] CI passes (tsc + jest)
- [ ] Manual: bot startup unaffected (types-only change)

## Next

PR 2 — Cluster B (monitoring telemetry: 2 cycles around \`SimplifiedTelemetry\`).