### PR TITLE
refactor(bot): break monitoring telemetry cycles (#871 PR 2)

### DIFF
--- a/packages/bot/src/utils/monitoring/SimplifiedTelemetry.ts
+++ b/packages/bot/src/utils/monitoring/SimplifiedTelemetry.ts
@@ -1,145 +1,36 @@
 /**
- * Simplified telemetry system without OpenTelemetry dependency
+ * Simplified telemetry system without OpenTelemetry dependency.
+ *
+ * Class implementations + singletons live in `./clients`; interfaces
+ * live in `./telemetryTypes`. This file is now a thin facade for span
+ * creation + the public re-export surface kept for backwards
+ * compatibility with consumers that imported everything from here
+ * (`SimplifiedTelemetryWrapper`, `telemetry`, `health`, `metrics`).
+ *
+ * See docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md
+ * for the cycle-break rationale.
  */
 
 import type { ChatInputCommandInteraction, Interaction } from 'discord.js'
 import type { CustomClient } from '../../types'
-import { infoLog, errorLog, debugLog } from '@lucky/shared/utils'
 
-export interface TelemetrySpan {
-    setAttributes: (attrs: Record<string, string>) => void
-    setAttribute: (key: string, value: string) => void
-    setStatus: (status: { code: number; message?: string }) => void
-    end: () => void
-    recordException: (error: Error) => void
-}
+export type {
+    TelemetrySpan,
+    TelemetryTracer,
+    MetricsClient,
+    HealthCheckClient,
+} from './telemetryTypes'
 
-export interface TelemetryTracer {
-    startSpan: (name: string) => TelemetrySpan
-}
+import type { TelemetrySpan } from './telemetryTypes'
 
-export interface MetricsClient {
-    commandExecutions: { inc: (labels: Record<string, string>) => void }
-    commandDuration: {
-        observe: (labels: Record<string, string>, value: number) => void
-    }
-    interactions: { inc: (labels: Record<string, string>) => void }
-    musicActions: { inc: (labels: Record<string, string>) => void }
-    errors: { inc: (labels: Record<string, string>) => void }
-}
+export {
+    simplifiedTracer,
+    simplifiedMetrics,
+    simplifiedHealthCheck,
+} from './clients'
 
-export interface HealthCheckClient {
-    isHealthy: () => boolean
-}
+import { simplifiedTracer } from './clients'
 
-// Simplified span implementation
-class SimplifiedSpan implements TelemetrySpan {
-    private readonly name: string
-    private readonly startTime: number
-    private attributes: Record<string, string> = {}
-    private status: { code: number; message?: string } = { code: 1 }
-    private ended = false
-
-    constructor(name: string) {
-        this.name = name
-        this.startTime = Date.now()
-        debugLog({ message: `Started span: ${name}` })
-    }
-
-    setAttributes(attrs: Record<string, string>): void {
-        this.attributes = { ...this.attributes, ...attrs }
-    }
-
-    setAttribute(key: string, value: string): void {
-        this.attributes[key] = value
-    }
-
-    setStatus(status: { code: number; message?: string }): void {
-        this.status = status
-    }
-
-    end(): void {
-        if (this.ended) return
-
-        const duration = Date.now() - this.startTime
-        this.ended = true
-
-        debugLog({
-            message: `Ended span: ${this.name}`,
-            data: {
-                duration,
-                status: this.status.code,
-                attributes: this.attributes,
-            },
-        })
-    }
-
-    recordException(error: Error): void {
-        errorLog({
-            message: `Exception in span: ${this.name}`,
-            error,
-            data: this.attributes,
-        })
-        this.setStatus({ code: 2, message: error.message })
-    }
-}
-
-// Simplified tracer implementation
-class SimplifiedTracer implements TelemetryTracer {
-    startSpan(name: string): TelemetrySpan {
-        return new SimplifiedSpan(name)
-    }
-}
-
-// Simplified metrics client
-class SimplifiedMetricsClient implements MetricsClient {
-    commandExecutions = {
-        inc: (labels: Record<string, string>) => {
-            infoLog({ message: 'Command execution', data: labels })
-        },
-    }
-
-    commandDuration = {
-        observe: (labels: Record<string, string>, value: number) => {
-            debugLog({
-                message: 'Command duration',
-                data: { ...labels, duration: value },
-            })
-        },
-    }
-
-    interactions = {
-        inc: (labels: Record<string, string>) => {
-            infoLog({ message: 'Interaction', data: labels })
-        },
-    }
-
-    musicActions = {
-        inc: (labels: Record<string, string>) => {
-            infoLog({ message: 'Music action', data: labels })
-        },
-    }
-
-    errors = {
-        inc: (labels: Record<string, string>) => {
-            errorLog({ message: 'Error metric', data: labels })
-        },
-    }
-}
-
-// Simplified health check client
-class SimplifiedHealthCheckClient implements HealthCheckClient {
-    isHealthy(): boolean {
-        return true // Simplified - always healthy
-    }
-}
-
-// Export singleton instances
-export const simplifiedTracer = new SimplifiedTracer()
-export const simplifiedMetrics = new SimplifiedMetricsClient()
-export const simplifiedHealthCheck = new SimplifiedHealthCheckClient()
-
-// Telemetry functions
 export function createCommandSpan(
     interaction: ChatInputCommandInteraction,
     _client: CustomClient,
@@ -173,17 +64,16 @@ export function createInteractionSpan(
 }
 
 export function markSpanSuccess(span: TelemetrySpan): void {
-    span.setStatus({ code: 1 }) // OK
+    span.setStatus({ code: 1 })
     span.end()
 }
 
 export function markSpanError(span: TelemetrySpan, error: Error): void {
-    span.setStatus({ code: 2, message: error.message }) // ERROR
+    span.setStatus({ code: 2, message: error.message })
     span.recordException(error)
     span.end()
 }
 
-// Metrics recording functions exported from ./telemetryMetrics.ts
 export {
     recordCommandMetric,
     recordInteractionMetric,
@@ -191,7 +81,6 @@ export {
     recordErrorMetric,
 } from './telemetryMetrics'
 
-// Health check functions exported from ./healthChecks.ts
 export {
     checkRedisHealth,
     checkDatabaseHealth,

--- a/packages/bot/src/utils/monitoring/clients.ts
+++ b/packages/bot/src/utils/monitoring/clients.ts
@@ -1,0 +1,122 @@
+/**
+ * Singleton client instances for the simplified telemetry system.
+ *
+ * Extracted from `./SimplifiedTelemetry` to break the runtime cycles
+ * `SimplifiedTelemetry ↔ healthChecks` and `SimplifiedTelemetry ↔
+ * telemetryMetrics` (madge cycles 3, 4 of the original list). See
+ * docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md.
+ *
+ * Interfaces live in `./telemetryTypes` so this module has no
+ * dependency on `./SimplifiedTelemetry`.
+ */
+
+import { infoLog, errorLog, debugLog } from '@lucky/shared/utils'
+import type {
+    TelemetrySpan,
+    TelemetryTracer,
+    MetricsClient,
+    HealthCheckClient,
+} from './telemetryTypes'
+
+class SimplifiedSpan implements TelemetrySpan {
+    private readonly name: string
+    private readonly startTime: number
+    private attributes: Record<string, string> = {}
+    private status: { code: number; message?: string } = { code: 1 }
+    private ended = false
+
+    constructor(name: string) {
+        this.name = name
+        this.startTime = Date.now()
+        debugLog({ message: `Started span: ${name}` })
+    }
+
+    setAttributes(attrs: Record<string, string>): void {
+        this.attributes = { ...this.attributes, ...attrs }
+    }
+
+    setAttribute(key: string, value: string): void {
+        this.attributes[key] = value
+    }
+
+    setStatus(status: { code: number; message?: string }): void {
+        this.status = status
+    }
+
+    end(): void {
+        if (this.ended) return
+
+        const duration = Date.now() - this.startTime
+        this.ended = true
+
+        debugLog({
+            message: `Ended span: ${this.name}`,
+            data: {
+                duration,
+                status: this.status.code,
+                attributes: this.attributes,
+            },
+        })
+    }
+
+    recordException(error: Error): void {
+        errorLog({
+            message: `Exception in span: ${this.name}`,
+            error,
+            data: this.attributes,
+        })
+        this.setStatus({ code: 2, message: error.message })
+    }
+}
+
+class SimplifiedTracer implements TelemetryTracer {
+    startSpan(name: string): TelemetrySpan {
+        return new SimplifiedSpan(name)
+    }
+}
+
+class SimplifiedMetricsClient implements MetricsClient {
+    commandExecutions = {
+        inc: (labels: Record<string, string>) => {
+            infoLog({ message: 'Command execution', data: labels })
+        },
+    }
+
+    commandDuration = {
+        observe: (labels: Record<string, string>, value: number) => {
+            debugLog({
+                message: 'Command duration',
+                data: { ...labels, duration: value },
+            })
+        },
+    }
+
+    interactions = {
+        inc: (labels: Record<string, string>) => {
+            infoLog({ message: 'Interaction', data: labels })
+        },
+    }
+
+    musicActions = {
+        inc: (labels: Record<string, string>) => {
+            infoLog({ message: 'Music action', data: labels })
+        },
+    }
+
+    errors = {
+        inc: (labels: Record<string, string>) => {
+            errorLog({ message: 'Error metric', data: labels })
+        },
+    }
+}
+
+class SimplifiedHealthCheckClient implements HealthCheckClient {
+    isHealthy(): boolean {
+        return true
+    }
+}
+
+export const simplifiedTracer: TelemetryTracer = new SimplifiedTracer()
+export const simplifiedMetrics: MetricsClient = new SimplifiedMetricsClient()
+export const simplifiedHealthCheck: HealthCheckClient =
+    new SimplifiedHealthCheckClient()

--- a/packages/bot/src/utils/monitoring/healthChecks.ts
+++ b/packages/bot/src/utils/monitoring/healthChecks.ts
@@ -1,5 +1,5 @@
 import type { CustomClient } from '../../types'
-import { simplifiedHealthCheck } from './SimplifiedTelemetry'
+import { simplifiedHealthCheck } from './clients'
 
 export function checkRedisHealth(_client: CustomClient): boolean {
     if (!_client.redis) return false

--- a/packages/bot/src/utils/monitoring/telemetryMetrics.ts
+++ b/packages/bot/src/utils/monitoring/telemetryMetrics.ts
@@ -1,5 +1,5 @@
 import type { CustomClient } from '../../types'
-import { simplifiedMetrics } from './SimplifiedTelemetry'
+import { simplifiedMetrics } from './clients'
 
 export function recordCommandMetric(
     client: CustomClient,

--- a/packages/bot/src/utils/monitoring/telemetryTypes.ts
+++ b/packages/bot/src/utils/monitoring/telemetryTypes.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared types for the simplified telemetry system.
+ *
+ * Extracted so `./clients` can implement these interfaces without
+ * depending on `./SimplifiedTelemetry`, which would re-introduce the
+ * runtime cycle this refactor removes. See
+ * docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md.
+ */
+
+export interface TelemetrySpan {
+    setAttributes: (attrs: Record<string, string>) => void
+    setAttribute: (key: string, value: string) => void
+    setStatus: (status: { code: number; message?: string }) => void
+    end: () => void
+    recordException: (error: Error) => void
+}
+
+export interface TelemetryTracer {
+    startSpan: (name: string) => TelemetrySpan
+}
+
+export interface MetricsClient {
+    commandExecutions: { inc: (labels: Record<string, string>) => void }
+    commandDuration: {
+        observe: (labels: Record<string, string>, value: number) => void
+    }
+    interactions: { inc: (labels: Record<string, string>) => void }
+    musicActions: { inc: (labels: Record<string, string>) => void }
+    errors: { inc: (labels: Record<string, string>) => void }
+}
+
+export interface HealthCheckClient {
+    isHealthy: () => boolean
+}


### PR DESCRIPTION
## Summary

PR 2 of 4 for #871. Breaks the two `SimplifiedTelemetry ↔ healthChecks` and `SimplifiedTelemetry ↔ telemetryMetrics` runtime cycles (Cluster B in the plan).

- Extracts singletons + classes into `packages/bot/src/utils/monitoring/clients.ts`
- Extracts shared interfaces into `packages/bot/src/utils/monitoring/telemetryTypes.ts`
- `SimplifiedTelemetry.ts` keeps its public re-export surface for backwards compatibility with `SimplifiedTelemetryWrapper`, `telemetry`, `health`, `metrics`

## Validation

- madge cycles: **12 → 10** (Cluster B done)
- `npx tsc --noEmit`: clean (one pre-existing `prom-client` error, unrelated)
- Jest monitoring/telemetry/health: 39 passed

## Refs

- Issue: #871
- ADR: `docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md`
- Plan: `.claude/plans/2026-05-16-bot-circular-deps.md` (Phase 2)
- Stacked after: #885 (Cluster A + D)
- Next: PR 3 (Cluster C, autoplay ↔ queue, three-man-team)

## Test plan

- [x] madge cycle count drops by 2
- [x] tsc clean (modulo pre-existing prom-client)
- [x] monitoring/telemetry/health tests pass
- [ ] CI green