### PR TITLE
ci(madge): audit-only circular-deps gate (#871 PR 4)

### DIFF
--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -1,0 +1,56 @@
+name: Circular Deps (madge)
+
+on:
+    push:
+        branches: ['release/**', main]
+    pull_request:
+        branches: ['release/**', main]
+
+# Audit-only gate. Reports madge cycle counts in PR logs without
+# failing the build. Promote to a hard gate (remove `continue-on-error`
+# and add `exit 1` when count > baseline) after #871 PR 3 lands and the
+# Cluster C autoplay/queue cycles are resolved.
+#
+# See docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md.
+
+permissions:
+    contents: read
+
+jobs:
+    circular:
+        name: madge / packages/bot
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+
+            - name: Install madge
+              run: npm install --no-save madge@^7
+
+            - name: Run madge --circular on packages/bot/src
+              run: |
+                  set +e
+                  npx madge --circular --extensions ts packages/bot/src \
+                      | tee madge-bot.txt
+                  COUNT=$(grep -cE '^[0-9]+\)' madge-bot.txt || echo 0)
+                  echo "bot_cycles=$COUNT" >> "$GITHUB_OUTPUT"
+                  echo "## madge circular deps — packages/bot/src" >> "$GITHUB_STEP_SUMMARY"
+                  echo "" >> "$GITHUB_STEP_SUMMARY"
+                  echo "**Cycle count:** $COUNT" >> "$GITHUB_STEP_SUMMARY"
+                  echo "" >> "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+                  cat madge-bot.txt >> "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+              id: madge
+
+            - name: Upload madge report
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: madge-report
+                  path: madge-bot.txt
+                  retention-days: 14


### PR DESCRIPTION
## Summary

PR 4 of 4 for #871. Adds an audit-only `madge --circular` workflow for `packages/bot/src` that runs on every PR + push targeting `release/**` and `main`.

- Reports cycle count + full report to the GitHub Actions job summary
- Uploads the raw report as a 14-day artifact
- `continue-on-error: true` keeps it from blocking merges while Cluster C is still open (current baseline: 10 cycles)

## Promotion path

When #871 PR 3 (Cluster C autoplay/queue) lands and the count reaches the agreed baseline (0 for runtime cycles, 1 for the persistent type-only `types/CustomClient` cycle), follow up to:

1. Remove `continue-on-error: true`
2. Add `if [ \"\$COUNT\" -gt 1 ]; then exit 1; fi` after the count export
3. Make it a required check in branch protection

## Refs

- Issue: #871
- ADR: `docs/decisions/2026-05-16-next-refactor-target-bot-circular-deps.md`
- Stacked after: #885, #886
- Predecessor of: PR 3 (Cluster C, three-man-team)

## Test plan

- [ ] CI green
- [ ] Job summary on this PR shows cycle count (expect 10)
- [ ] Artifact uploaded