### PR TITLE
feat(shared): Guild Automation Module Executor seam + AutoMessages pilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,8 @@ docs/LOVABLE_PROMPT.md
 docs/FRONTEND_AI_STUDIO_CONTEXT.md
 **/LIBRARY_RECOMMENDATIONS.md
 **/CODE_EXAMPLES.md
+
+# graphify knowledge-graph build artifacts (graph.json, GRAPH_REPORT.md, cache/, manifest.json, cost.json).
+# Rebuild with `/graphify --update`; do not track.
+graphify-out/
+

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,208 @@
+# Lucky
+
+Self-hosted Discord music + moderation bot with a React dashboard. TypeScript monorepo (`packages/bot`, `packages/backend`, `packages/frontend`, `packages/shared`). This glossary defines the canonical vocabulary used across code, issues, PRs, and ADRs.
+
+## Language
+
+### Tenancy
+
+**Guild**:
+A Discord server. The primary tenancy unit — settings, sessions, feature toggles, moderation cases, and music state all scope to one Guild.
+_Avoid_: Server, workspace.
+
+**Member**:
+A User as they exist _inside a specific Guild_. Carries Guild-scoped state (XP, role grants, birthday).
+_Avoid_: User-in-server, guild-member.
+
+**User**:
+A Discord account, identified by a stable Discord user ID. Spans Guilds.
+_Avoid_: Player, account, customer.
+
+### Music (runtime)
+
+**Track**:
+A single playable music item with metadata — title, author, duration, url, thumbnail, source. Provider-agnostic at the type level; the `source` field names the upstream.
+_Avoid_: Song, video, media, item.
+
+**Source**:
+The upstream provider that supplies a Track's audio stream: `youtube`, `spotify`, `soundcloud`, `attachment`, `virtual`. Stored as a string on TrackMetadata.
+_Avoid_: Engine, provider, backend. **Note:** the same field name `source` is also (incorrectly) used inside `RecommendationBasis` to identify Candidate Sources — see "Flagged ambiguities" below.
+
+**Search Engine**:
+The discord-player `QueryType` used to _search_ for a Track — `QueryType.YOUTUBE_SEARCH`, `QueryType.SPOTIFY_SEARCH`, `QueryType.AUTO`, etc. Distinct from Source: the Spotify Search Engine can yield a Track whose Source is YouTube (Spotify metadata is matched against a YouTube stream). Referenced via the `searchEngine` / `preferredEngine` field.
+_Avoid_: Engine alone (ambiguous), extractor (reserve for the lower-level discord-player extractor plugins like `ytdlpExtractor`).
+
+**Queue**:
+The ordered list of Tracks for one Guild's active playback. The first item is the currently-playing Track; the rest play in order. One Queue per Guild at a time.
+_Avoid_: Playlist (reserved for user-saved collections, if/when introduced), list.
+
+**Player**:
+The per-Guild runtime playback state — voice connection, current Track, Queue, volume, repeat mode, paused/playing flag. Lives in memory; persisted snapshots are called **Sessions**. Canonical access path from a `guildId` is `resolveGuildQueue(client, guildId)` in `packages/bot/src/utils/music/queueResolver.ts`; calling `client.player.nodes.get(guildId)` directly is blocked by a guardrail test. See `docs/decisions/2026-05-19-queue-resolver-defensive-fallback-chain.md`.
+_Avoid_: Voice client, audio player. Don't reach into `discord-player` APIs directly — use the resolver.
+
+**Session** / **GuildSession**:
+A persisted snapshot of a Player's state (current track, queue position, volume, repeat mode, full queue JSON) for one Guild. Used to save/restore playback across bot restarts or `/session` commands.
+_Avoid_: Saved queue, playlist.
+
+### Music (autoplay + recommendations)
+
+**Autoplay**:
+The Player behavior that keeps playback continuous when the user-queued Tracks run out. Off by default; toggled per Guild. Implemented by the pipeline in `packages/bot/src/utils/music/autoplay/`.
+_Avoid_: Continuous play, radio mode, auto-queue.
+
+**Autoplay Candidate** (or **Candidate**):
+A Track proposed for Autoplay selection. Flows through the pipeline: collected from one or more Sources, scored, diversity-filtered, then dequeued for play.
+_Avoid_: Suggestion, next-up.
+
+**Candidate Source**:
+Where Autoplay Candidates come from — the _recommender_ dimension, distinct from the audio Source. Lucky has these: **Recommendation Engine** (vector-similarity over TrackHistory), **Last.fm Seeder** (`lastfm-similar`, `lastfm-genre-fallback`, `lastfm`), **Spotify Recommender** (`spotify-rec`), and fallbacks (`artist-fallback`, `genre`, preference-based `virtual` tracks). Carried on `RecommendationBasis.source` — see "Flagged ambiguities".
+_Avoid_: Provider, supplier, "source" without the "Candidate" qualifier.
+
+**Recommendation Engine**:
+The vector-similarity scorer in `packages/bot/src/services/musicRecommendation/`. Computes track similarity over a Guild's TrackHistory plus user feedback. Produces scored Recommendations; **one** of the Candidate Sources Autoplay consumes — not the autoplay system itself.
+_Avoid_: Recommender (when ambiguous), suggestion service.
+
+**Recommendation** (Prisma model):
+A persisted candidate with algorithm tag and feedback signal. Stores the Engine's output and user thumbs-up/down for re-ranking.
+_Avoid_: Suggestion record.
+
+**TrackHistory** (Prisma model):
+Per-Guild record of every Track that played, with timestamps and source. The substrate the Recommendation Engine learns from.
+_Avoid_: Play log, listen log.
+
+### Guild configuration
+
+**Guild Automation**:
+The declarative Guild-configuration-as-data subsystem. A Guild's intended state (channels, roles, settings) is captured as a JSON **Manifest**; **Runs** apply the Manifest to live Discord state; **Drift** records divergence between Manifest and observed state per module. NOT an umbrella for Autoplay / AutoMod / AutoMessage / AutoRole — those are _features_, this is _config reconciliation_.
+_Avoid_: Guild-as-code, GitOps-for-Guilds, sync, provisioning. Don't say "automation" as a generic term meaning "any Auto-\* feature".
+
+**Manifest**:
+The JSON spec declaring a Guild's intended configuration. Versioned; one per Guild. Owned by `GuildAutomationManifest`. Includes module ownership (which subsystems a Manifest claims) and last-captured-state for diff baselines.
+_Avoid_: Config, spec, template (overloaded with EmbedTemplate), schema.
+
+**Drift**:
+The diff between a Manifest's declared state and the currently observed Guild state, scoped to one module. Severity-rated. Owned by `GuildAutomationDrift`.
+_Avoid_: Diff (use Drift in Guild-Automation context), divergence.
+
+**Run** (Guild Automation Run):
+A single apply attempt of a Manifest: list of operations, protected-operation list, summary, diagnostics, status. Owned by `GuildAutomationRun`. Always qualify "Run" when ambiguous with general use. Runs are **partial-success-tolerant**: if one Module Executor fails mid-Run, succeeded executors' changes stay live and the next Run's Diff reconciles. No reverse-op rollback.
+_Avoid_: Apply, execution, job.
+
+**Module Executor**:
+The seam responsible for one Manifest module's reconciliation. Exposes three methods over its module section: `capture(ctx)` (read live state), `diff(live, manifest)` (compute changes), `apply(diff, ctx)` (perform writes + prune stale). Lives in `shared/src/services/guildAutomation/`. One Module Executor per Manifest module type: **Roles Executor**, **Channels Executor**, **Onboarding Executor**, **Moderation Executor** (covers both `automod` and `moderationSettings` sub-sections), **AutoMessages Executor**, **ReactionRoles Executor**, **CommandAccess Executor**.
+_Avoid_: Module service, module handler, applier. The word "Executor" is reserved for this seam — don't reuse it for `GuildAutomationRun` itself.
+
+**Discord Write Adapter**:
+The lower seam that hides bot-vs-backend differences in how Discord writes are performed. Module Executors depend on a `DiscordWriteAdapter` interface; bot provides a `DiscordJsAdapter` (uses the in-process `discord.js` Client), backend provides a `DiscordRestAdapter` (uses `fetch` + bot token). Means executors are pure logic and unit-testable by mocking the adapter — no real Discord client in tests.
+_Avoid_: Discord client, Discord port. "Adapter" matches the existing language in the codebase.
+
+**Capture / Diff / Apply**:
+The three canonical phases of a Module Executor. **Capture** reads live Discord/DB state into a typed `LiveState`. **Diff** compares LiveState against the Manifest section to produce a `Diff` (operations to perform + stale resources to prune). **Apply** executes the Diff and returns a Module Result. Drift detection is a side-product of Capture+Diff (no separate code path).
+_Avoid_: Plan/apply, read/diff/write — use these exact verbs in code and docs.
+
+### Moderation
+
+**Moderation Action**:
+A manual moderator action taken against a Member: `warn`, `mute`, `unmute`, `kick`, `ban`, `unban`, `lockdown` (channel), `slowmode` (channel), `purge` (messages). Each Action that targets a Member produces a Moderation Case.
+_Avoid_: Punishment, sanction, discipline.
+
+**Moderation Case**:
+The persisted record of one Moderation Action — case number, type, reason, duration (for timed actions), expiry, active flag, and full appeal trail. Owned by `ModerationCase`. Cases are per-Guild and per-target-User; case numbers are dense within a Guild.
+_Avoid_: Incident, ticket, infraction.
+
+**AutoMod**:
+The _automatic_ enforcement subsystem, distinct from Moderation. Driven by per-Guild `AutoModSettings` and runs on every incoming message — no moderator in the loop. Does not (currently) create Moderation Cases.
+_Avoid_: Auto-moderation (use as one word), filters, automod-bot.
+
+**AutoMod Rule**:
+One configured check category inside AutoMod: `spam`, `caps`, `links`, `invites`, `words`. Each Rule has its own enabled flag, threshold(s), and exemption lists on `AutoModSettings`.
+_Avoid_: Filter, policy.
+
+### Engagement
+
+**XP** (Experience Points):
+A Member's progress score within a Guild. Earned per message with a per-Member cooldown. Configured per-Guild on `LevelConfig`. Stored on `MemberXP` keyed by `(guildId, userId)`.
+_Avoid_: Points, score, karma.
+
+**Level**:
+A discrete tier derived from a Member's XP. Tiers are Guild-scoped; thresholds come from `LevelConfig`. The Member-Level pair is materialised on `MemberXP.level`.
+_Avoid_: Rank, tier (in writing about leveling specifically).
+
+**Level Reward**:
+A rule that grants a specific role to a Member when they reach a given Level in a Guild. One `LevelReward` per `(guildId, level)`. Triggers a Role Grant when satisfied.
+_Avoid_: Role unlock, perk.
+
+**Starboard**:
+A designated Channel where messages that receive a configured emoji react-count get cross-posted. Per-Guild config (channel, emoji, threshold, self-star allowed) on `StarboardConfig`.
+_Avoid_: Pinboard, hall of fame.
+
+**Starboard Entry**:
+The persisted record of one cross-posted message — original `messageId`, `authorId`, current `starCount`, and the mirrored `starboardMsgId` (the message in the Starboard channel).
+_Avoid_: Star, pin.
+
+### Role granting
+
+**Role Grant**:
+The umbrella concept for "the bot gave a Member a role". Multiple mechanisms produce Role Grants: AutoRole (on join), Level Reward (on level-up), Reaction Role (on emoji react to a designated message), and integration triggers (Twitch, etc.). `GuildRoleGrant` is the audit substrate: which `module` granted which `roleId` with which `mode`.
+_Avoid_: Role assignment (overloaded with Discord's own role-assignment UI), role award.
+
+**AutoRole**:
+A rule that grants a role to a new Member when they join the Guild, optionally after a delay. Owned by `AutoRole`. Produces a Role Grant on apply.
+_Avoid_: Welcome role (often used informally; reserve for an AutoRole tagged as welcome-purpose only).
+
+**Reaction Role**:
+A role granted (or removed) when a Member reacts with a specific emoji to a designated message. Owned by `ReactionRoleMapping` (one mapping per emoji) bound to a `ReactionRoleMessage` (the source message).
+_Avoid_: Self-assign role, react-for-role (informal).
+
+**Role Exclusion**:
+A _rule_, not a grant: when role X is granted to a Member, role Y must be removed from them. Owned by `RoleExclusion`. Applied during the Role Grant flow.
+_Avoid_: Mutual exclusion (use the term, but bind it to roles), conflict.
+
+### Integrations
+
+**Integration**:
+The umbrella concept for any binding between Lucky and an external service. Two sub-patterns: Account Link (User-scoped credentials) and Event Subscription (Guild-scoped external watcher). Does _not_ include operational dependencies like Sentry, Cloudflare Tunnel, or the Discord API itself — those are infrastructure.
+_Avoid_: Connection, plugin, extension.
+
+**Account Link**:
+A per-User credential binding to an external service. Keyed by `discordId` (the Discord user ID), not by Guild. Stores whatever the external service needs to act on the User's behalf (Last.fm `sessionKey`, Spotify OAuth tokens). Powers personalised features like scrobbling and the Spotify Recommender Candidate Source. Naming convention: `*Link` Prisma models.
+_Avoid_: User integration, account binding (use "Account Link"), OAuth grant (an Account Link may _contain_ OAuth tokens, but not every Link is OAuth — Last.fm uses session keys).
+
+**Last.fm Link**:
+One Account Link instance: a User's Last.fm session key plus their Last.fm username. Owned by `LastFmLink`. Used by the scrobbling pipeline and as a signal source for the Last.fm Seeder Candidate Source.
+_Avoid_: Last.fm account, scrobbler binding.
+
+**Spotify Link**:
+One Account Link instance: a User's Spotify OAuth tokens (access / refresh / expiry) plus their Spotify ID. Owned by `SpotifyLink`. Used by Spotify-data commands (e.g. `/artist`, `/album`) and as the auth context for the Spotify Recommender Candidate Source.
+_Avoid_: Spotify account, Spotify OAuth.
+
+**Event Subscription**:
+A per-Guild subscription that watches an external resource and posts into a Discord channel when an event fires. One-way (external → Discord). Naming convention: `*Notification` Prisma models.
+_Avoid_: Webhook (reserve for inbound HTTP), feed, subscription alone (ambiguous with `GuildSubscription`).
+
+**Twitch Notification**:
+One Event Subscription instance: a Guild watches a Twitch streamer (`twitchUserId` + `twitchLogin`) and posts a message to `discordChannelId` when the stream goes live. Owned by `TwitchNotification`.
+_Avoid_: Twitch alert, stream notification (informal; use "Twitch Notification" when discussing the model or feature specifically).
+
+## Example dialogue
+
+> **Dev:** Autoplay broke for Server 12345 — keeps picking the same artist.
+>
+> **Domain expert:** Which Candidate Source is it pulling from? If the Recommendation Engine is the only one returning candidates and TrackHistory is thin, the Diversity selector won't have much to work with.
+>
+> **Dev:** All three Sources are firing, but Spotify Recommender is dominating the candidate pool.
+>
+> **Domain expert:** That's a scoring issue, not an Autoplay-vs-Recommendation issue. Look at `candidateScorer.ts` — the weights between Sources are tunable. Don't go editing the Recommendation Engine itself.
+
+## Flagged ambiguities
+
+**`source` field is overloaded.** Today it carries two distinct meanings depending on the object it lives on:
+
+- On `TrackMetadata` and `Track`: the **audio Source** (`'youtube' | 'spotify' | 'soundcloud' | 'attachment' | 'virtual'`).
+- On `RecommendationBasis` (autoplay pipeline): the **Candidate Source** (`'spotify-rec' | 'lastfm-similar' | 'lastfm-genre-fallback' | 'lastfm' | 'artist-fallback' | 'genre'`).
+
+When writing new code, prefer renaming the `RecommendationBasis.source` field to `candidateSource` (or `recommender`) to remove the clash. Until then: in prose, always qualify ("audio Source" vs "Candidate Source") and never refer to either as bare "source".
+
+**`engine` field on TrackMetadata is near-dead.** Used in exactly one path (`engine: 'preferences'` on virtual tracks). Don't propagate it. The runtime concept is **Search Engine** (`QueryType`), passed as `searchEngine` / `preferredEngine` to `player.search()`. Plan to drop `TrackMetadata.engine` when the virtual-track path is refactored.
+
+**`UserPreferences` / `UserArtistPreference` are settings, not Integrations.** They live in the User domain but carry no external-service binding. Don't list them alongside Account Links or Event Subscriptions in docs or PR titles.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,41 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+Single-context repo. ADRs live in **`docs/decisions/`** (not the conventional `docs/adr/`) to match the existing `/adr-write` workflow.
+
+```
+/
+├── CONTEXT.md                    ← not yet created; proceed silently if absent
+├── docs/
+│   ├── decisions/                ← ADRs live here
+│   │   └── YYYY-MM-DD-<slug>.md
+│   ├── specs/                    ← /adt-specs-spec-new output
+│   ├── plans/                    ← /plan output
+│   └── references/
+├── packages/                     ← bot, backend, frontend, shared
+└── ...
+```
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root (if it exists).
+- **`docs/decisions/`** — read ADRs that touch the area you're about to work in. Filter by date and slug.
+
+If `CONTEXT.md` doesn't exist, **proceed silently**. Don't flag its absence; don't suggest creating it upfront. The producer skill (`/grill-with-docs`) creates it lazily when terms or decisions actually get resolved.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR in `docs/decisions/`, surface it explicitly rather than silently overriding:
+
+> _Contradicts `docs/decisions/2026-05-16-dependabot-batch-handling-policy.md` — but worth reopening because…_
+
+Recent ADRs (as of 2026-05-19) cover: dependabot batch policy, no-AI-generated docs, security-scan policy, Docker decisions trio, token optimization, deploy target, refactor target selection, autoplay integration tests, branch strategy, bot test suite cleanup. Check `docs/decisions/` for the current set before assuming a decision is unmade.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,27 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `LucasSantana-Dev/Lucky`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Repo is inferred from `git remote -v` — `gh` picks it up automatically when run inside the clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Repo-specific notes
+
+- The `/backlog` skill already creates issues with `cat:*` category labels (`cat:bug`, `cat:feature`, `cat:refactor`, `cat:tech-debt`, `cat:perf`, `cat:test`, `cat:docs`, `cat:security`) and a `backlog-skill` marker. Triage labels (see `triage-labels.md`) are orthogonal — apply both when appropriate.
+- Area labels (`bot`, `backend`, `frontend`, `shared`, `infra`, `ci`, `database`, `music`, `moderation`, `dx`) and size labels (`size/xs|s|m|l|xl`) are available; apply them when creating issues so existing dashboards and filters keep working.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,24 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's GitHub issue tracker.
+
+| Canonical role    | Label in this repo | Meaning                                  |
+| ----------------- | ------------------ | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`     | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`       | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`  | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`  | Requires human implementation            |
+| `wontfix`         | `wontfix`          | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+## Relationship to other labels in this repo
+
+These triage labels are **orthogonal** to:
+
+- **Category labels** (`cat:bug`, `cat:feature`, `cat:refactor`, `cat:tech-debt`, `cat:perf`, `cat:test`, `cat:docs`, `cat:security`) — what _kind_ of work
+- **Area labels** (`bot`, `backend`, `frontend`, `shared`, `infra`, `ci`, `database`, `music`, `moderation`, `dx`) — _where_ in the codebase
+- **Size labels** (`size/xs|s|m|l|xl`) — _how big_
+- **`backlog-skill`** — created by `/backlog`
+
+Triage labels answer _what's the next action and who owns it_. Apply alongside the others.

--- a/docs/decisions/2026-05-19-automod-does-not-create-moderation-cases.md
+++ b/docs/decisions/2026-05-19-automod-does-not-create-moderation-cases.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+date: 2026-05-19
+---
+
+# AutoMod actions do not create Moderation Cases
+
+AutoMod runs without a moderator in the loop and currently does not write to `ModerationCase`. Manual Moderation Actions (warn / mute / kick / ban / lockdown / slowmode / purge) write a `ModerationCase` row with case number, reason, duration, and an appeal trail; AutoMod hits do not.
+
+This is deliberate, not a missing feature. AutoMod handles high-volume, low-judgement enforcement (spam, caps, banned-words, link blocks) where every triggered action would inflate the Case table and dilute the appeal flow, which is designed around moderator-reviewable decisions.
+
+## Considered options
+
+- **Unified Cases for AutoMod and manual Moderation.** Rejected: floods the case audit trail with low-signal automatic hits, makes appeals less meaningful, and forces appeal-flow UX on enforcement decisions where appeal isn't appropriate.
+- **Separate "AutoMod Hit" table mirroring Cases.** Rejected for now: no current consumer needs that data shape. AutoMod logs are sufficient for tuning rules; Sentry covers operational visibility.
+- **Status quo: AutoMod writes nothing case-shaped.** Accepted.
+
+## Consequences
+
+- A moderator looking at a Member's `cases` history will not see AutoMod-triggered actions. If that becomes a real gap, surface it via a separate AutoMod-hit log rather than fusing the tables.
+- "Member case count" metrics reflect _moderator-issued_ actions only; this is the correct baseline for moderation-load dashboards but must be disclosed in any user-facing transparency report.
+- Reversing this decision later means a schema migration (either add fields to `ModerationCase` to disambiguate source, or introduce a separate `AutoModHit` table) plus rework of the appeal UI to handle the AutoMod path.

--- a/docs/decisions/2026-05-19-guild-automation-module-executors.md
+++ b/docs/decisions/2026-05-19-guild-automation-module-executors.md
@@ -1,0 +1,112 @@
+---
+status: accepted
+date: 2026-05-19
+revisit_after: after-pilot-executor
+---
+
+# Guild Automation reconciles via Module Executors with a Capture / Diff / Apply seam in shared
+
+`packages/backend/src/services/GuildAutomationExecutionService.ts` is a 1238-LOC class that reconciles 7 Manifest modules (Roles, Channels, Onboarding, Moderation, AutoMessages, ReactionRoles, CommandAccess) against live Discord + DB state. A parallel bot-side path lives at `packages/bot/src/utils/guildAutomation/` (`captureGuildState.ts`, `diff.ts`, `applyPlan.ts`) — duplicating much of the same logic with a different Discord write path (`discord.js` Client instead of REST).
+
+We will extract per-module **Module Executors** behind a `Capture / Diff / Apply` seam in `packages/shared/src/services/guildAutomation/`, with a lower `DiscordWriteAdapter` seam so bot and backend both consume the shared executors. Runs remain partial-success-tolerant and reconcile on the next Run via existing `GuildAutomationDrift`.
+
+## Context
+
+- `GuildAutomationExecutionService` mixes Discord REST infra, ID remapping across modules, per-module apply, stale pruning, and Run-record bookkeeping. Deletion test: removing any single module's logic still requires touching this one file.
+- Bot has a separate apply path (`packages/bot/src/utils/guildAutomation/applyPlan.ts`, 329 LOC) for the same Manifest. Plan-building logic is duplicated; only the Discord write mechanism differs.
+- Drift is already a first-class concept: `GuildAutomationDrift` Prisma model exists, `lastCapturedState` lives on `GuildAutomationManifest`, and `bot/utils/guildAutomation/diff.ts` computes diffs. The capture/diff/apply triplet is implicitly present already — just scattered.
+- Tests of any single module (e.g. AutoMessages) currently require mocking infra for all 6 other modules because they all live in one class.
+
+## Decision
+
+Four locked design choices:
+
+1. **Cut line.** Orchestrator owns Discord REST infra (`discordFetch`, `getBotToken`), cross-module ID remapping (`remap*Section`), `GuildAutomationRun` bookkeeping, and parity-checklist defaults. Each **Module Executor** owns Capture, Diff, Apply, and stale-pruning for its module only.
+2. **Seam shape.** **Capture / Diff / Apply** triplet. Each Module Executor exposes:
+    - `capture(ctx) → LiveState<T>` — reads live Discord/DB state into a typed shape.
+    - `diff(live, manifest) → Diff<T>` — computes operations + stale set.
+    - `apply(diff, ctx) → ModuleResult<T>` — executes operations, prunes stale, returns result.
+3. **Location.** Executors live in `packages/shared/src/services/guildAutomation/`. They depend on a `DiscordWriteAdapter` interface (also in shared). Bot provides `DiscordJsAdapter` (in-process `discord.js` Client). Backend provides `DiscordRestAdapter` (`fetch` + bot token). This collapses the duplicated bot/backend apply paths.
+4. **Rollback.** Partial-success + reconcile-on-next-Run. No reverse-op log. If executor N fails, executors 1..N−1 stay live; the next Run's Capture+Diff reconciles. Matches the existing `GuildAutomationRun` schema (`operations`, `protectedOperations`, `error`).
+
+**Enumeration:** seven Module Executors, one per Manifest module section:
+
+| Executor               | Manifest section                                       | Write target                                                     |
+| ---------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
+| Roles Executor         | `roles`                                                | Discord REST/Client (create/edit/delete + ID remap source)       |
+| Channels Executor      | `channels`                                             | Discord REST/Client                                              |
+| Onboarding Executor    | `onboarding`                                           | Discord REST/Client (mostly read, rare writes)                   |
+| Moderation Executor    | `moderation.automod` + `moderation.moderationSettings` | DB (`updateModerationSettings`, `autoModService.updateSettings`) |
+| AutoMessages Executor  | `automessages`                                         | DB + Discord channel ID resolution                               |
+| ReactionRoles Executor | `reactionroles`                                        | DB (`reactionRolesService`)                                      |
+| CommandAccess Executor | `commandaccess`                                        | DB (`guildRoleAccessService`)                                    |
+
+## Considered options
+
+### Cut line
+
+- **A. Orchestrator: infra + remap + run; Executor: apply + prune + drift (accepted).** Clean separation of cross-cutting concerns from per-module concerns.
+- **B. Thin orchestrator + fat executors.** Rejected: forces each executor to carry its own Discord REST adapter, duplicating infra across 7 places.
+- **C. Fat orchestrator + thin executors.** Rejected: executors become pure-data Module descriptors with logic still centralized — weakest seam, smallest payoff, and `One adapter = hypothetical seam` problem (one impl of each executor type means no real seam).
+
+### Seam shape
+
+- **A. Apply-only.** Rejected: loses native drift integration and pre-apply preview. Closest to current code but smallest refactor benefit.
+- **B. Plan + Apply (two-phase).** Considered. Simpler than the triplet but doesn't natively produce a Drift; `GuildAutomationDrift` would remain a separate code path.
+- **C. Capture / Diff / Apply triplet (accepted).** Aligns with existing `GuildAutomationDrift` model, `lastCapturedState` field, and the bot-side `captureGuildState.ts`/`diff.ts`/`applyPlan.ts` split. Drift detection becomes a side-product of normal flow.
+- **D. Hybrid (apply-only for onboarding, plan+apply for others).** Rejected: two interface kinds for one seam adds learning cost without clear win.
+
+### Location
+
+- **A. `shared/src/services/guildAutomation/` + `DiscordWriteAdapter` (accepted).** Both packages consume the same executors. Solves the bot↔backend duplication that would otherwise need a separate follow-up ADR.
+- **B. `backend/src/services/guildAutomation/` only.** Rejected: leaves the bot-side `applyPlan.ts` duplication in place. Future-us would re-litigate this immediately.
+- **C. Promote `bot/src/utils/guildAutomation/`.** Rejected outright. Violates the architecture invariant in `docs/ARCHITECTURE.md`: backend depends only on shared, not on bot.
+
+### Rollback
+
+- **A. Partial-success + reconcile (accepted).** Matches the existing `GuildAutomationRun.operations` / `protectedOperations` / `error` schema. Drift becomes visible via `GuildAutomationDrift` and the next Run converges.
+- **B. All-or-nothing rollback.** Rejected: doubles per-executor surface (each must emit reverse-ops), and Discord API doesn't cleanly reverse some operations (permission edits, onboarding mutations).
+- **C. Idempotent retry only.** Rejected: no rollback path means broken intermediate state is user-visible in the Guild between Runs.
+- **D. Hybrid best-effort revert per failing executor.** Rejected for the initial design — adds complexity without justification; revisit if partial-success data shows users frequently stuck on a half-applied state.
+
+## Consequences
+
+**Positive:**
+
+- Each Module Executor is unit-testable by mocking only the `DiscordWriteAdapter`. No real Discord client needed in tests.
+- Bot↔backend duplication collapses; `bot/src/utils/guildAutomation/applyPlan.ts` becomes a thin caller of the shared executors via `DiscordJsAdapter`.
+- New module types (e.g. a future "Voice Channels" or "Slowmode Policy" module) add one Executor file, not edits in two packages.
+- Drift detection is automatic: Capture + Diff produces a Drift result that the orchestrator can persist to `GuildAutomationDrift` without separate code.
+- Locality: each module's logic lives in one file under `shared/src/services/guildAutomation/<module>Executor.ts`.
+
+**Negative:**
+
+- Migration cost is real: 1238 LOC backend class + 329 LOC bot apply + scattered diff/capture/remap utilities all rewire. Expect ≥4 PRs to land safely.
+- `DiscordWriteAdapter` interface must be designed carefully — wrong methods leak Discord internals to executors anyway.
+- Cross-cutting infra (auth tokens, retry policies) must stay outside executors and inside the adapters/orchestrator; risk of accidentally re-introducing the monolith inside one Executor.
+
+**Neutral:**
+
+- `GuildAutomationRun` schema unchanged. `GuildAutomationDrift` schema unchanged. `GuildAutomationManifest.lastCapturedState` semantics unchanged.
+
+## Implementation plan (pilot-first)
+
+1. **Pilot Executor.** Pick the simplest write path — likely **AutoMessages Executor** (DB-only, no Discord REST) — and implement it in `shared/src/services/guildAutomation/autoMessagesExecutor.ts`. Define `ModuleExecutor<T>` and `DiscordWriteAdapter` interfaces. Backend orchestrator calls this Executor; old code path stays for the other 6 modules.
+2. **Bot consumer.** Wire bot to call the AutoMessages Executor through `DiscordJsAdapter`. Delete the duplicated automessages logic in `bot/src/utils/guildAutomation/applyPlan.ts`. This is the first cross-package consumption — proves the location works.
+3. **Migrate remaining 6 Executors** one PR per Executor, easiest first: Moderation (DB-only) → ReactionRoles → CommandAccess → Onboarding (mostly read) → Channels → Roles (most complex; ID remap-heavy).
+4. **Decommission the monolith.** Once all 7 executors are migrated, delete `GuildAutomationExecutionService` and the duplicated bot apply path. Verify the guardrail test in `bot/utils/guildAutomation/` is updated to enforce "no Manifest reconciliation outside `shared/services/guildAutomation/`".
+
+## Revisit when
+
+- **After the pilot Executor PR lands** — re-open this ADR with concrete evidence on whether the seam shape held up. Adjust before migrating the other 6.
+- The pilot reveals that `DiscordWriteAdapter` needs to leak so much Discord state that executors end up adapter-coupled anyway.
+- A new Manifest module type would naturally fit a different shape (e.g. requires multi-phase commit, transactions across DB + Discord).
+- Production data on `GuildAutomationDrift` shows partial-success Runs cause user-visible degradation that argues for option D (best-effort revert).
+- Lucky adopts a different Discord library (currently `discord.js` v14) — would force a `DiscordWriteAdapter` redesign and is a natural moment to reconsider.
+
+## Cross-references
+
+- `CONTEXT.md` — see entries: **Guild Automation**, **Manifest**, **Drift**, **Run**, **Module Executor**, **Discord Write Adapter**, **Capture / Diff / Apply**.
+- `docs/ARCHITECTURE.md` — confirms the `backend → shared` dependency direction and `bot → shared` direction that make this design legal.
+- `docs/decisions/2026-05-19-automod-does-not-create-moderation-cases.md` — confirms the Moderation Executor covers `automod` + `moderationSettings` sub-sections without bridging to `ModerationCase`.
+- This ADR was produced via `/improve-codebase-architecture` grilling on Lucky's `packages/` graph (2026-05-19 session) — the candidate ranked #2 (worst friction) of seven deepening opportunities surfaced.

--- a/docs/decisions/2026-05-19-queue-resolver-defensive-fallback-chain.md
+++ b/docs/decisions/2026-05-19-queue-resolver-defensive-fallback-chain.md
@@ -1,0 +1,62 @@
+---
+status: accepted
+date: 2026-05-19
+revisit_after: 2026-06-02
+---
+
+# Queue resolver keeps its 6-path defensive fallback chain (for now)
+
+`packages/bot/src/utils/music/queueResolver.ts` exposes `resolveGuildQueue(client, guildId)` — the single chokepoint (enforced by a guardrail test) for fetching a discord-player `GuildQueue` from a guild ID. It tries six paths in order: `nodes.get → queues.get → nodes.resolve → nodes.cache.get → cache scan by queue.id → cache scan by metadata.guild.id`. 34 production call sites and 257 LOC of tests depend on this shape.
+
+We are **keeping all six paths** pending production telemetry. We will revisit on **2026-06-02** with 14 days of source-distribution data; if the top three paths cover >99% of calls, we prune. Otherwise we leave the chain intact.
+
+## Considered options
+
+- **A — Status quo (accepted).** Keep all 6 paths and the guardrail. Cost: ~25–30h/year of upgrade-friction on every discord-player bump. Defensible because each path landed in response to a real production incident (PR #167, PR #364).
+- **B — Prune to top 3** (`nodes.get → queues.get → cache scan by guild`). **Deferred.** Plausibly correct but requires production data to confirm `nodes.resolve` + `nodes.cache.get` + `cache scan by id` are dead. Pruning speculatively risks reintroducing #364's regression.
+- **C — Adapter layer (`PlayerPort` interface).** Rejected. The resolver is already the adapter; adding another layer over a single-target bot is indirection without payback.
+- **D — Wait for upstream fix in discord-player.** Rejected. Months-out timeline; zero current value.
+- **E — Cache-scan-only.** Rejected. Loses the fast paths; degrades on large caches.
+
+## Decision
+
+Stay on **Option A**, **and** ship observability + gap-fixes immediately so the next decision can be data-driven:
+
+1. **Instrument** every `resolveGuildQueue` call with a `queue_resolution_source` tag (Sentry/Langfuse) carrying the resolved `source` value or `miss`.
+2. **Expand the guardrail test** (`queueResolver.guard.spec.ts`) so its `TARGET_DIRECTORIES` covers `src/functions/music/autoplay` and `src/services/musicRecommendation`, not just slash commands and webMusic.
+3. **Reorder cache scans**: prefer `metadata.guild.id` match (current path 6) over `queue.id` match (current path 5). Guild membership is more authoritative than a numeric queue identifier; the current order is a multi-guild correctness foot-gun in corrupted-cache scenarios.
+4. **Document `nodes.resolve` semantics** with a one-line comment grounded in the discord-player v7.2 changelog (lazy-init vs. redundant-with-`get`).
+5. **Add a CI canary** that re-runs `queueResolver.spec.ts` against the pinned discord-player version on every PR, failing on any semver-major bump until the resolver is re-verified against the new API.
+
+## Consequences
+
+**Positive:**
+
+- The next revisit (2026-06-02) is data-driven, not opinion-driven.
+- The guardrail expansion closes a real gap (autoplay and recommendation paths can currently bypass the resolver).
+- The reordered cache scans remove a latent multi-guild correctness risk.
+- The canary catches discord-player API drift before production.
+
+**Negative:**
+
+- Six paths and 257 LOC of tests remain on the maintenance ledger for at least 14 more days.
+- The instrumentation adds one tag per `resolveGuildQueue` call (~34 sites × call frequency); negligible Sentry/Langfuse volume impact for a bot of Lucky's scale.
+
+**Neutral:**
+
+- No change to public API; no change to call-site contracts.
+
+## Revisit when
+
+- **2026-06-02** with 14 days of telemetry — primary trigger.
+- discord-player v8 ships or v7.x announces a breaking change to `GuildNodeManager`.
+- A new `resolveGuildQueue`-related incident lands in production (would validate the fallback chain's value and push the revisit out).
+- Production data shows any single path accounting for >99% of resolutions (would justify aggressive pruning to that one).
+- The guardrail test fires on a real PR (would prove the expanded `TARGET_DIRECTORIES` is doing its job).
+
+## Cross-references
+
+- PR #167 (2026-03-11) — created the resolver and the original 5-path chain.
+- PR #364 (2026-03-25) — added path 6 (`metadata.guild.id` scan).
+- `CONTEXT.md` — see the **Player** glossary entry; `resolveGuildQueue` is the canonical access path from `guildId` to in-memory Player.
+- Critic review (2026-05-19, this session) — surfaced the observability gap, guardrail-coverage gap, scan-ordering risk, and canary-CI opportunity. Without that critique this would have been a less rigorous "leave it alone" non-decision.

--- a/packages/shared/src/services/guildAutomation/autoMessagesExecutor.spec.ts
+++ b/packages/shared/src/services/guildAutomation/autoMessagesExecutor.spec.ts
@@ -1,0 +1,150 @@
+import { createAutoMessagesExecutor } from './autoMessagesExecutor'
+
+type ServiceRow = {
+    id: string
+    channelId: string | null
+    message: string | null
+    enabled: boolean
+} | null
+
+function makeService(
+    overrides: Partial<{
+        welcome: ServiceRow
+        leave: ServiceRow
+    }> = {},
+) {
+    return {
+        getWelcomeMessage: jest
+            .fn<Promise<ServiceRow>, [string]>()
+            .mockResolvedValue(overrides.welcome ?? null),
+        getLeaveMessage: jest
+            .fn<Promise<ServiceRow>, [string]>()
+            .mockResolvedValue(overrides.leave ?? null),
+        createMessage: jest
+            .fn<
+                Promise<{ id: string }>,
+                [
+                    string,
+                    'welcome' | 'leave',
+                    { message: string },
+                    { channelId?: string } | undefined,
+                ]
+            >()
+            .mockImplementation((_g, type) =>
+                Promise.resolve({ id: `new-${type}` }),
+            ),
+        updateMessage: jest
+            .fn<Promise<void>, [string, Record<string, unknown>]>()
+            .mockResolvedValue(undefined),
+    }
+}
+
+describe('autoMessagesExecutor', () => {
+    it('Apply creates welcome and leave when neither exists', async () => {
+        const service = makeService()
+        const executor = createAutoMessagesExecutor({
+            autoMessageService: service,
+        })
+        const ctx = { guildId: 'guild-1' }
+
+        const live = await executor.capture(ctx)
+        const diff = executor.diff(live, {
+            welcome: { message: 'Hi', channelId: '1' },
+            leave: { message: 'Bye', channelId: '2' },
+        })
+        const result = await executor.apply(diff, ctx)
+
+        expect(service.createMessage).toHaveBeenCalledTimes(2)
+        expect(service.createMessage).toHaveBeenCalledWith(
+            'guild-1',
+            'welcome',
+            { message: 'Hi' },
+            { channelId: '1' },
+        )
+        expect(service.createMessage).toHaveBeenCalledWith(
+            'guild-1',
+            'leave',
+            { message: 'Bye' },
+            { channelId: '2' },
+        )
+        expect(service.updateMessage).not.toHaveBeenCalled()
+        expect(result.applied).toEqual([
+            { type: 'welcome', action: 'create' },
+            { type: 'leave', action: 'create' },
+        ])
+    })
+
+    it('Apply updates welcome when row already exists; leaves leave untouched when manifest omits it', async () => {
+        const service = makeService({
+            welcome: {
+                id: 'welcome-row',
+                channelId: 'old-1',
+                message: 'old hi',
+                enabled: true,
+            },
+        })
+        const executor = createAutoMessagesExecutor({
+            autoMessageService: service,
+        })
+        const ctx = { guildId: 'guild-1' }
+
+        const live = await executor.capture(ctx)
+        const diff = executor.diff(live, {
+            welcome: { message: 'new hi', channelId: 'new-1', enabled: false },
+        })
+        const result = await executor.apply(diff, ctx)
+
+        expect(service.createMessage).not.toHaveBeenCalled()
+        expect(service.updateMessage).toHaveBeenCalledTimes(1)
+        expect(service.updateMessage).toHaveBeenCalledWith('welcome-row', {
+            message: 'new hi',
+            channelId: 'new-1',
+            enabled: false,
+        })
+        expect(result.applied).toEqual([
+            { type: 'welcome', action: 'update' },
+            { type: 'leave', action: 'noop' },
+        ])
+    })
+
+    it('Apply is noop when manifest payload has no message (matches monolith skip-on-empty behavior)', async () => {
+        const service = makeService()
+        const executor = createAutoMessagesExecutor({
+            autoMessageService: service,
+        })
+        const ctx = { guildId: 'guild-1' }
+
+        const live = await executor.capture(ctx)
+        const diff = executor.diff(live, {
+            welcome: { channelId: '1' }, // no message — should be noop
+            leave: {},
+        })
+        const result = await executor.apply(diff, ctx)
+
+        expect(service.createMessage).not.toHaveBeenCalled()
+        expect(service.updateMessage).not.toHaveBeenCalled()
+        expect(result.applied).toEqual([
+            { type: 'welcome', action: 'noop' },
+            { type: 'leave', action: 'noop' },
+        ])
+    })
+
+    it('Apply is noop when manifest section is empty', async () => {
+        const service = makeService()
+        const executor = createAutoMessagesExecutor({
+            autoMessageService: service,
+        })
+        const ctx = { guildId: 'guild-1' }
+
+        const live = await executor.capture(ctx)
+        const diff = executor.diff(live, {})
+        const result = await executor.apply(diff, ctx)
+
+        expect(service.createMessage).not.toHaveBeenCalled()
+        expect(service.updateMessage).not.toHaveBeenCalled()
+        expect(result.applied).toEqual([
+            { type: 'welcome', action: 'noop' },
+            { type: 'leave', action: 'noop' },
+        ])
+    })
+})

--- a/packages/shared/src/services/guildAutomation/autoMessagesExecutor.ts
+++ b/packages/shared/src/services/guildAutomation/autoMessagesExecutor.ts
@@ -1,0 +1,145 @@
+type AutoMessageType = 'welcome' | 'leave'
+
+type AutoMessageSnapshot = {
+    id: string
+    channelId: string | null
+    message: string | null
+    enabled: boolean
+} | null
+
+export type AutoMessagesLiveState = {
+    welcome: AutoMessageSnapshot
+    leave: AutoMessageSnapshot
+}
+
+export type AutoMessagesManifestSection = {
+    welcome?: { enabled?: boolean; channelId?: string; message?: string }
+    leave?: { enabled?: boolean; channelId?: string; message?: string }
+}
+
+export type AutoMessagesDiffOp =
+    | {
+          kind: 'create'
+          type: AutoMessageType
+          message: string
+          channelId?: string
+      }
+    | {
+          kind: 'update'
+          type: AutoMessageType
+          id: string
+          message?: string
+          channelId?: string
+          enabled?: boolean
+      }
+    | { kind: 'noop'; type: AutoMessageType }
+
+export type AutoMessagesDiff = { ops: AutoMessagesDiffOp[] }
+
+export type AutoMessagesResult = {
+    applied: Array<{
+        type: AutoMessageType
+        action: 'create' | 'update' | 'noop'
+    }>
+}
+
+export type ExecutorContext = { guildId: string }
+
+export type AutoMessagesPort = {
+    getWelcomeMessage(guildId: string): Promise<AutoMessageSnapshot>
+    getLeaveMessage(guildId: string): Promise<AutoMessageSnapshot>
+    createMessage(
+        guildId: string,
+        type: AutoMessageType,
+        data: { message: string },
+        options?: { channelId?: string },
+    ): Promise<{ id: string }>
+    updateMessage(
+        id: string,
+        data: {
+            message?: string
+            channelId?: string
+            enabled?: boolean
+        },
+    ): Promise<unknown>
+}
+
+export function createAutoMessagesExecutor(deps: {
+    autoMessageService: AutoMessagesPort
+}) {
+    const svc = deps.autoMessageService
+    const MODULE_TYPES: readonly AutoMessageType[] = ['welcome', 'leave']
+
+    return {
+        async capture(ctx: ExecutorContext): Promise<AutoMessagesLiveState> {
+            const [welcome, leave] = await Promise.all([
+                svc.getWelcomeMessage(ctx.guildId),
+                svc.getLeaveMessage(ctx.guildId),
+            ])
+            return { welcome, leave }
+        },
+
+        diff(
+            live: AutoMessagesLiveState,
+            section: AutoMessagesManifestSection,
+        ): AutoMessagesDiff {
+            const ops: AutoMessagesDiffOp[] = []
+            for (const type of MODULE_TYPES) {
+                const want = section[type]
+                const have = live[type]
+                if (!want?.message) {
+                    ops.push({ kind: 'noop', type })
+                    continue
+                }
+                if (!have) {
+                    ops.push({
+                        kind: 'create',
+                        type,
+                        message: want.message,
+                        channelId: want.channelId,
+                    })
+                    continue
+                }
+                ops.push({
+                    kind: 'update',
+                    type,
+                    id: have.id,
+                    message: want.message,
+                    channelId: want.channelId,
+                    enabled: want.enabled,
+                })
+            }
+            return { ops }
+        },
+
+        async apply(
+            diff: AutoMessagesDiff,
+            ctx: ExecutorContext,
+        ): Promise<AutoMessagesResult> {
+            const applied: AutoMessagesResult['applied'] = []
+            for (const op of diff.ops) {
+                if (op.kind === 'create') {
+                    await svc.createMessage(
+                        ctx.guildId,
+                        op.type,
+                        { message: op.message },
+                        { channelId: op.channelId },
+                    )
+                    applied.push({ type: op.type, action: 'create' })
+                    continue
+                }
+                if (op.kind === 'update') {
+                    await svc.updateMessage(op.id, {
+                        message: op.message,
+                        channelId: op.channelId,
+                        enabled: op.enabled,
+                    })
+                    applied.push({ type: op.type, action: 'update' })
+                    continue
+                }
+                applied.push({ type: op.type, action: 'noop' })
+            }
+            return { applied }
+        },
+    }
+}


### PR DESCRIPTION
## Summary

Two-commit branch: foundational architecture docs + first concrete implementation of the new Module Executor seam for Guild Automation.

### `docs(architecture)` commit
- **CONTEXT.md** — project-wide domain glossary (Guild, Member, User, Track, Source, Search Engine, Queue, Player, Session, Autoplay, Candidate Source, Recommendation Engine, TrackHistory, Moderation Action, Moderation Case, AutoMod, AutoMod Rule, Guild Automation, Manifest, Drift, Run, XP, Level, Role Grant, AutoRole, Reaction Role, Account Link, Event Subscription, plus the three new Module Executor terms). Flags two known ambiguities: `source` field overload across `TrackMetadata` vs `RecommendationBasis`, and the dead `engine` field on `TrackMetadata`.
- **3 ADRs** under `docs/decisions/`:
  - `2026-05-19-automod-does-not-create-moderation-cases.md` — locks the deliberate split between AutoMod auto-enforcement and the appeal-flow-bearing `ModerationCase` audit trail.
  - `2026-05-19-queue-resolver-defensive-fallback-chain.md` — keeps the six-path `resolveGuildQueue` fallback chain pending 14 days of `queue_resolution_source` Sentry telemetry; ships observability + guardrail expansion + cache-scan reorder + discord-player canary CI as part of the same pilot. Revisit 2026-06-02.
  - `2026-05-19-guild-automation-module-executors.md` — replaces the 1238-LOC `GuildAutomationExecutionService` + the duplicated `bot/utils/guildAutomation/applyPlan.ts` with seven per-module **Module Executors** behind a **Capture / Diff / Apply** seam in `packages/shared/src/services/guildAutomation/`, plus a lower **`DiscordWriteAdapter`** seam (bot `DiscordJsAdapter`, backend `DiscordRestAdapter`). Partial-success rollback via existing `GuildAutomationDrift`.
- **`docs/agents/`** (3 files) — `issue-tracker.md`, `triage-labels.md`, `domain.md` capture the matt-pocock skill configs so downstream skills (`to-issues`, `triage`, `improve-codebase-architecture`, etc.) read the right vocabulary.
- **`.gitignore`** — adds `graphify-out/` (knowledge-graph build artifacts; rebuild with `/graphify --update`).

### `feat(shared)` commit
First concrete Module Executor implementing the seam shape from the ADR: **AutoMessages Module Executor** (DB-only, no Discord REST, simplest module to validate the shape).

- `packages/shared/src/services/guildAutomation/autoMessagesExecutor.ts`
  - Exposes a port-style `AutoMessagesPort` decoupled from `AutoMessageService` (avoids the full Prisma row leaking through `Pick<Service>`).
  - `capture(ctx)` reads welcome + leave rows in parallel.
  - `diff(live, section)` is pure; emits `create | update | noop` per type. Monolith-parity behavior: empty `section[type]` or missing `message` → `noop` (matches the existing `if (!payload?.message) return` in `upsertAutoMessage`).
  - `apply(diff, ctx)` walks ops via the port, returns applied actions for `GuildAutomationRun.operations`.
- `packages/shared/src/services/guildAutomation/autoMessagesExecutor.spec.ts` — 4 tests covering create both, update existing + manifest-absent leave, noop-on-empty-message, noop-on-empty-section.

## Why

Came out of `/improve-codebase-architecture` walking `packages/`:
- `GuildAutomationExecutionService` (1238 LOC, 7 module types entangled) was the worst single-file friction.
- A parallel apply path in `packages/bot/src/utils/guildAutomation/applyPlan.ts` duplicates plan-building logic.
- Tests of any single module currently need mocks for 6 unrelated module types.

Then `/grill-with-docs` resolved the domain vocabulary, `/research-and-decide` (with `critic` agent challenge) locked the four design choices, and `/adt-tdd` proved the seam shape on AutoMessages.

## Not in this PR (per ADR pilot plan)

- Adapter wrapping the real `AutoMessageService` → `AutoMessagesPort`
- Export from `shared/src/services/guildAutomation/index.ts`
- Backend orchestrator swap (`GuildAutomationExecutionService.upsertAutoMessage` → call this executor)
- Bot consumer wire-up + deletion of `applyPlan.ts` automessages logic
- Remaining 6 Module Executors (Moderation, ReactionRoles, CommandAccess, Onboarding, Channels, Roles) — one per follow-up PR per the ADR's sequencing

## Test plan

- [x] `packages/shared/src/services/guildAutomation/autoMessagesExecutor.spec.ts` — 4/4 passing locally
- [ ] Org-wide reusable quality workflow (lint, knip, semgrep, CodeQL, trivy, actionlint, hadolint) — automatic on push
- [ ] CodeRabbit / Greptile auto-review on PR
- [ ] SonarCloud coverage check on shared package

## Refs

- `docs/decisions/2026-05-19-guild-automation-module-executors.md`
- `docs/decisions/2026-05-19-queue-resolver-defensive-fallback-chain.md`
- `docs/decisions/2026-05-19-automod-does-not-create-moderation-cases.md`
- `CONTEXT.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive domain vocabulary glossary and agent skill documentation for development workflows
  * Added architectural decision records for guild automation and queue resolution strategies

* **Tests**
  * Expanded test coverage for auto-messages executor with capture/diff/apply scenarios

* **Chores**
  * Updated build artifact exclusions in version control

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->