### PR TITLE
fix(shared): import jest globals explicitly in autoMessagesExecutor spec

### DIFF
--- a/packages/shared/src/services/guildAutomation/autoMessagesExecutor.spec.ts
+++ b/packages/shared/src/services/guildAutomation/autoMessagesExecutor.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals'
 import { createAutoMessagesExecutor } from './autoMessagesExecutor'
 
 type ServiceRow = {
@@ -7,6 +8,18 @@ type ServiceRow = {
     enabled: boolean
 } | null
 
+type GetMessageFn = (guildId: string) => Promise<ServiceRow>
+type CreateMessageFn = (
+    guildId: string,
+    type: 'welcome' | 'leave',
+    data: { message: string },
+    options?: { channelId?: string },
+) => Promise<{ id: string }>
+type UpdateMessageFn = (
+    id: string,
+    data: Record<string, unknown>,
+) => Promise<void>
+
 function makeService(
     overrides: Partial<{
         welcome: ServiceRow
@@ -15,27 +28,21 @@ function makeService(
 ) {
     return {
         getWelcomeMessage: jest
-            .fn<Promise<ServiceRow>, [string]>()
+            .fn<GetMessageFn>()
             .mockResolvedValue(overrides.welcome ?? null),
         getLeaveMessage: jest
-            .fn<Promise<ServiceRow>, [string]>()
+            .fn<GetMessageFn>()
             .mockResolvedValue(overrides.leave ?? null),
         createMessage: jest
-            .fn<
-                Promise<{ id: string }>,
-                [
-                    string,
-                    'welcome' | 'leave',
-                    { message: string },
-                    { channelId?: string } | undefined,
-                ]
-            >()
-            .mockImplementation((_g, type) =>
-                Promise.resolve({ id: `new-${type}` }),
+            .fn<CreateMessageFn>()
+            .mockImplementation(
+                (
+                    _guildId: string,
+                    type: 'welcome' | 'leave',
+                ): Promise<{ id: string }> =>
+                    Promise.resolve({ id: `new-${type}` }),
             ),
-        updateMessage: jest
-            .fn<Promise<void>, [string, Record<string, unknown>]>()
-            .mockResolvedValue(undefined),
+        updateMessage: jest.fn<UpdateMessageFn>().mockResolvedValue(undefined),
     }
 }
 


### PR DESCRIPTION
## Summary

The `autoMessagesExecutor.spec.ts` landed in #901 relied on ambient jest types. It passed in isolated `npx jest` runs (looser typing path) but fails under `npm run test:ci --workspace=packages/shared` (the workspace invocation, which is `jest --ci --silent` and enforces the shared package's strict tsconfig — which does not include `@types/jest` in `types`).

## What changed

- Adds `import { describe, expect, it, jest } from '@jest/globals'` — matches the shared convention used by `PremiumService.spec.ts`, `LastFmLinkService/index.spec.ts`, and `SpotifyLinkService/index.spec.ts`.
- Updates mock typing from the legacy `jest.fn<R, [Args]>()` two-arg form to `@jest/globals`'s required single-type-arg `jest.fn<Fn>()` form.

## Verification

- `npx jest --config packages/shared/jest.config.cjs --ci --silent packages/shared/src/services/guildAutomation/autoMessagesExecutor.spec.ts` — 4/4 passing
- `npm run test:ci --workspace=packages/shared` — failing test-suite count drops from 3 to 2 (this spec is no longer one of them). The remaining 2 failures (`FeatureToggleService.spec.ts`, `__tests__/utils/spotify/artistApi.test.ts`) are pre-existing tech debt last touched in #762/#614/#648 respectively, out of scope for this fix.

## Why this slipped through #901

PR #901 was merged on `UNSTABLE` while `Quality Gates` (the workspace test:ci runner) was still in flight. The check that would have caught this never reported before merge. Going forward, prefer waiting for `Quality Gates` on PRs touching `packages/shared`.

## Test plan

- [x] `npm run test:ci --workspace=packages/shared` locally — autoMessagesExecutor spec green
- [ ] Quality Gates check on this PR (the one we should have waited for)

Refs: #901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test infrastructure with enhanced type safety for mock functions.

---

**Note:** This release contains internal test improvements with no changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->