### PR TITLE
fix(shared): update getSpotifyRelatedArtists tests for the #648 Last.fm fallback

### DIFF
--- a/packages/shared/src/__tests__/utils/spotify/artistApi.test.ts
+++ b/packages/shared/src/__tests__/utils/spotify/artistApi.test.ts
@@ -1,223 +1,313 @@
-import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import {
-	searchSpotifyArtists,
-	getSpotifyRelatedArtists,
-	type SpotifyArtist,
+    describe,
+    test,
+    expect,
+    beforeEach,
+    afterEach,
+    jest,
+} from '@jest/globals'
+import {
+    searchSpotifyArtists,
+    getSpotifyRelatedArtists,
+    type SpotifyArtist,
 } from '../../../../src/utils/spotify/artistApi'
 
+// Spotify deprecated /v1/recommendations and /v1/artists/{id}/related-artists
+// for new apps in 2024 (PR #648). The current impl uses a three-step chain:
+//   1. GET https://api.spotify.com/v1/artists/{id} → seed artist name
+//   2. GET https://ws.audioscrobbler.com/2.0/?method=artist.getSimilar → similar names
+//   3. GET https://api.spotify.com/v1/search?type=artist (per name) → full artist
+// All three call `global.fetch`, so the tests below mock `fetch` with sequential
+// `mockResolvedValueOnce` responses in that order.
+
+function makeSpotifyArtistNameResponse(name: string) {
+    return new Response(JSON.stringify({ name }), { status: 200 })
+}
+
+function makeLastFmSimilarResponse(names: string[]) {
+    return new Response(
+        JSON.stringify({
+            similarartists: { artist: names.map((name) => ({ name })) },
+        }),
+        { status: 200 },
+    )
+}
+
+function makeSpotifySearchResponse(
+    artists: Array<{
+        id: string
+        name: string
+        imageUrl?: string
+        popularity?: number
+        genres?: string[]
+    }>,
+) {
+    return new Response(
+        JSON.stringify({
+            artists: {
+                items: artists.map((a) => ({
+                    id: a.id,
+                    name: a.name,
+                    images: a.imageUrl ? [{ url: a.imageUrl }] : [],
+                    popularity: a.popularity ?? 50,
+                    genres: a.genres ?? [],
+                })),
+            },
+        }),
+        { status: 200 },
+    )
+}
+
 describe('Spotify Artist API', () => {
-	beforeEach(() => {
-		jest.clearAllMocks()
-	})
+    const originalLastFmKey = process.env.LASTFM_API_KEY
 
-	const mockArtist: SpotifyArtist = {
-		id: 'spotify-1',
-		name: 'Drake',
-		imageUrl: 'https://example.com/image.jpg',
-		popularity: 85,
-		genres: ['hip-hop', 'rap'],
-	}
+    beforeEach(() => {
+        jest.clearAllMocks()
+        process.env.LASTFM_API_KEY = 'test-lastfm-key'
+    })
 
-	describe('getSpotifyRelatedArtists', () => {
-		test('should return unique artists from recommendations', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({
-							tracks: [
-								{
-									artists: [
-										{
-											id: 'artist-1',
-											name: 'Artist One',
-											images: [{ url: 'http://example.com/img1.jpg' }],
-											popularity: 80,
-											genres: ['pop'],
-										},
-										{
-											id: 'artist-2',
-											name: 'Artist Two',
-											images: [{ url: 'http://example.com/img2.jpg' }],
-											popularity: 75,
-											genres: ['rock'],
-										},
-									],
-								},
-								{
-									artists: [
-										{
-											id: 'artist-3',
-											name: 'Artist Three',
-											images: [{ url: 'http://example.com/img3.jpg' }],
-											popularity: 70,
-											genres: ['jazz'],
-										},
-									],
-								},
-							],
-						}),
-						{ status: 200 },
-					),
-				)
+    afterEach(() => {
+        if (originalLastFmKey === undefined) {
+            delete process.env.LASTFM_API_KEY
+        } else {
+            process.env.LASTFM_API_KEY = originalLastFmKey
+        }
+    })
 
-			const result = await getSpotifyRelatedArtists('access-token', 'seed-artist')
+    const mockArtist: SpotifyArtist = {
+        id: 'spotify-1',
+        name: 'Drake',
+        imageUrl: 'https://example.com/image.jpg',
+        popularity: 85,
+        genres: ['hip-hop', 'rap'],
+    }
 
-			expect(result).toHaveLength(3)
-			expect(result[0].id).toBe('artist-1')
-			expect(result[1].id).toBe('artist-2')
-			expect(result[2].id).toBe('artist-3')
-			fetchSpy.mockRestore()
-		})
+    describe('getSpotifyRelatedArtists', () => {
+        test('returns artists found via Spotify → Last.fm → Spotify search chain', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                // 1. Spotify seed-artist lookup
+                .mockResolvedValueOnce(makeSpotifyArtistNameResponse('Drake'))
+                // 2. Last.fm similar artist names
+                .mockResolvedValueOnce(
+                    makeLastFmSimilarResponse([
+                        'Artist One',
+                        'Artist Two',
+                        'Artist Three',
+                    ]),
+                )
+                // 3. Spotify search per similar name — one artist each
+                .mockResolvedValueOnce(
+                    makeSpotifySearchResponse([
+                        {
+                            id: 'artist-1',
+                            name: 'Artist One',
+                            imageUrl: 'http://example.com/img1.jpg',
+                            popularity: 80,
+                            genres: ['pop'],
+                        },
+                    ]),
+                )
+                .mockResolvedValueOnce(
+                    makeSpotifySearchResponse([
+                        {
+                            id: 'artist-2',
+                            name: 'Artist Two',
+                            imageUrl: 'http://example.com/img2.jpg',
+                            popularity: 75,
+                            genres: ['rock'],
+                        },
+                    ]),
+                )
+                .mockResolvedValueOnce(
+                    makeSpotifySearchResponse([
+                        {
+                            id: 'artist-3',
+                            name: 'Artist Three',
+                            imageUrl: 'http://example.com/img3.jpg',
+                            popularity: 70,
+                            genres: ['jazz'],
+                        },
+                    ]),
+                )
 
-		test('should deduplicate duplicate artist ids in recommendations', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({
-							tracks: [
-								{
-									artists: [
-										{
-											id: 'artist-1',
-											name: 'Artist One',
-											images: [{ url: 'http://example.com/img1.jpg' }],
-											popularity: 80,
-											genres: ['pop'],
-										},
-									],
-								},
-								{
-									artists: [
-										{
-											id: 'artist-1',
-											name: 'Artist One',
-											images: [{ url: 'http://example.com/img1.jpg' }],
-											popularity: 80,
-											genres: ['pop'],
-										},
-									],
-								},
-							],
-						}),
-						{ status: 200 },
-					),
-				)
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'seed-artist',
+            )
 
-			const result = await getSpotifyRelatedArtists('access-token', 'seed-artist')
+            expect(result).toHaveLength(3)
+            expect(result[0].id).toBe('artist-1')
+            expect(result[1].id).toBe('artist-2')
+            expect(result[2].id).toBe('artist-3')
+            fetchSpy.mockRestore()
+        })
 
-			expect(result).toHaveLength(1)
-			expect(result[0].id).toBe('artist-1')
-			fetchSpy.mockRestore()
-		})
+        test('deduplicates when distinct similar names resolve to the same Spotify id', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(makeSpotifyArtistNameResponse('Drake'))
+                .mockResolvedValueOnce(
+                    makeLastFmSimilarResponse([
+                        'Artist One',
+                        'Artist One (alias)',
+                    ]),
+                )
+                // Both names happen to resolve to the same Spotify artist id
+                .mockResolvedValueOnce(
+                    makeSpotifySearchResponse([
+                        {
+                            id: 'artist-1',
+                            name: 'Artist One',
+                            imageUrl: 'http://example.com/img1.jpg',
+                            popularity: 80,
+                            genres: ['pop'],
+                        },
+                    ]),
+                )
+                .mockResolvedValueOnce(
+                    makeSpotifySearchResponse([
+                        {
+                            id: 'artist-1',
+                            name: 'Artist One',
+                            imageUrl: 'http://example.com/img1.jpg',
+                            popularity: 80,
+                            genres: ['pop'],
+                        },
+                    ]),
+                )
 
-		test('should handle API 403 error gracefully', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ error: 'Forbidden' }), {
-						status: 403,
-					}),
-				)
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'seed-artist',
+            )
 
-			const result = await getSpotifyRelatedArtists('invalid-token', 'artist-id')
+            expect(result).toHaveLength(1)
+            expect(result[0].id).toBe('artist-1')
+            fetchSpy.mockRestore()
+        })
 
-			expect(result).toEqual([])
-			fetchSpy.mockRestore()
-		})
+        test('should handle API 403 error gracefully', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: 'Forbidden' }), {
+                    status: 403,
+                }),
+            )
 
-		test('should handle empty response', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ tracks: [] }), { status: 200 }),
-				)
+            const result = await getSpotifyRelatedArtists(
+                'invalid-token',
+                'artist-id',
+            )
 
-			const result = await getSpotifyRelatedArtists('access-token', 'artist-id')
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
 
-			expect(result).toEqual([])
-			fetchSpy.mockRestore()
-		})
+        test('should handle empty response', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ tracks: [] }), {
+                        status: 200,
+                    }),
+                )
 
-		test('should limit results to 12 artists', async () => {
-			const tracks = Array.from({ length: 20 }, (_, i) => ({
-				artists: [
-					{
-						id: `artist-${i}`,
-						name: `Artist ${i}`,
-						images: [{ url: `http://example.com/img${i}.jpg` }],
-						popularity: 80 - i,
-						genres: ['pop'],
-					},
-				],
-			}))
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'artist-id',
+            )
 
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ tracks }), { status: 200 }),
-				)
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
 
-			const result = await getSpotifyRelatedArtists('access-token', 'artist-id')
+        test('returns all unique resolved artists from Last.fm similar (no artificial cap below the lookup bound)', async () => {
+            // The pre-#648 impl capped to 12; the new impl asks Last.fm for up to
+            // Math.max(limit, 30) names, looks each up via Spotify search, dedupes,
+            // and returns the full unique set. This guards against re-introducing
+            // a silent cap.
+            const similarNames = Array.from(
+                { length: 15 },
+                (_, i) => `Artist ${i}`,
+            )
 
-			expect(result).toHaveLength(12)
-			fetchSpy.mockRestore()
-		})
-	})
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(makeSpotifyArtistNameResponse('Drake'))
+                .mockResolvedValueOnce(makeLastFmSimilarResponse(similarNames))
 
-	describe('searchSpotifyArtists', () => {
-		test('should return artists matching search query', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({
-							artists: {
-								items: [mockArtist],
-							},
-						}),
-						{ status: 200 },
-					),
-				)
+            for (let i = 0; i < similarNames.length; i++) {
+                fetchSpy.mockResolvedValueOnce(
+                    makeSpotifySearchResponse([
+                        {
+                            id: `artist-${i}`,
+                            name: `Artist ${i}`,
+                            imageUrl: `http://example.com/img${i}.jpg`,
+                            popularity: 80 - i,
+                            genres: ['pop'],
+                        },
+                    ]),
+                )
+            }
 
-			const result = await searchSpotifyArtists('access-token', 'Drake')
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'artist-id',
+            )
 
-			expect(result).toHaveLength(1)
-			expect(result[0].name).toBe('Drake')
-			fetchSpy.mockRestore()
-		})
+            expect(result).toHaveLength(15)
+            fetchSpy.mockRestore()
+        })
+    })
 
-		test('should return empty array for empty query', async () => {
-			const result = await searchSpotifyArtists('access-token', '   ')
+    describe('searchSpotifyArtists', () => {
+        test('should return artists matching search query', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        artists: {
+                            items: [mockArtist],
+                        },
+                    }),
+                    { status: 200 },
+                ),
+            )
 
-			expect(result).toEqual([])
-		})
+            const result = await searchSpotifyArtists('access-token', 'Drake')
 
-		test('should handle API errors gracefully', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ error: 'Unauthorized' }), {
-						status: 401,
-					}),
-				)
+            expect(result).toHaveLength(1)
+            expect(result[0].name).toBe('Drake')
+            fetchSpy.mockRestore()
+        })
 
-			const result = await searchSpotifyArtists('bad-token', 'Drake')
+        test('should return empty array for empty query', async () => {
+            const result = await searchSpotifyArtists('access-token', '   ')
 
-			expect(result).toEqual([])
-			fetchSpy.mockRestore()
-		})
+            expect(result).toEqual([])
+        })
 
-		test('should handle network errors gracefully', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockRejectedValueOnce(new Error('Network error'))
+        test('should handle API errors gracefully', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: 'Unauthorized' }), {
+                    status: 401,
+                }),
+            )
 
-			const result = await searchSpotifyArtists('access-token', 'Drake')
+            const result = await searchSpotifyArtists('bad-token', 'Drake')
 
-			expect(result).toEqual([])
-			fetchSpy.mockRestore()
-		})
-	})
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
+
+        test('should handle network errors gracefully', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockRejectedValueOnce(new Error('Network error'))
+
+            const result = await searchSpotifyArtists('access-token', 'Drake')
+
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
+    })
 })


### PR DESCRIPTION
## Summary

Three tests in `packages/shared/src/__tests__/utils/spotify/artistApi.test.ts` have been red since PR #648 (Spotify→Last.fm fallback rewrite). The impl was updated; the tests weren't. This PR brings the tests back into alignment with current behavior.

## Diagnostic trail

Followed `/diagnose` discipline. Phase 1 loop = the spec itself (2-sec deterministic). Phase 2 reproduced: all three failing tests early-return `[]` because the impl's first `fetch` (`fetchSpotifyArtistName`) isn't mocked by the existing old-shape mock. Phase 3 ranked four hypotheses; H1 (stale tests) confirmed against H2 (impl regressed) and H3 (dead code — `backend/src/routes/artists.ts:404` is a live consumer).

## What changed

- Three response-builder helpers (`makeSpotifyArtistNameResponse`, `makeLastFmSimilarResponse`, `makeSpotifySearchResponse`) make each test's fetch sequence legible.
- `process.env.LASTFM_API_KEY` is set in `beforeEach` and restored in `afterEach`; without it `fetchLastFmSimilarArtists` early-returns `[]`.
- Test 1 (`should return unique artists from recommendations`) → mocks the full Spotify → Last.fm → Spotify search chain.
- Test 2 (`should deduplicate duplicate artist ids in recommendations`) → mocks two similar names that resolve to the same Spotify id; asserts the dedupe by id still holds.
- Test 3 (`should limit results to 12 artists`) → **replaced**. The pre-#648 impl had a 12-cap; the post-#648 impl returns all unique resolved artists up to the `Math.max(limit, 30)` lookup bound. The new test name and body assert the actual contract and guard against a silent cap regression.

The two already-passing tests (403 graceful, empty response) are kept; they happen to pass because the impl's first fetch returns null in those cases, which is a real behavior worth keeping under test.

## Verification

- `npx jest --config packages/shared/jest.config.cjs --ci packages/shared/src/__tests__/utils/spotify/artistApi.test.ts`: 9/9 passing.
- `npm run test:ci --workspace=packages/shared`: 417/417 tests passing on this branch. The single remaining failed suite (`FeatureToggleService.spec.ts`) is fixed by in-flight PR #903 and out of scope here.

## Notes

- No impl change. `getSpotifyRelatedArtists` is correct; only the tests were lying about its contract.
- No regression-test seam needed (we are aligning existing tests with existing correct behavior; nothing to add or move).

## Test plan

- [x] Local shared test:ci — green for ours
- [ ] CI `Quality Gates` on this PR

Refs: PR #648 (introduced the chain), #903 (sibling test-cleanup PR open against same base).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Spotify artist API test suite to validate multi-source related artists lookup (Spotify + Last.fm integration)
  * Added comprehensive test coverage for deduplication, error handling, and increased result limits
  * Improved test fixtures and environment variable management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->