### PR TITLE
fix(ci): group $GITHUB_STEP_SUMMARY redirects in madge workflow (shellcheck SC2129)

### DIFF
--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -38,13 +38,15 @@ jobs:
                       | tee madge-bot.txt
                   COUNT=$(grep -cE '^[0-9]+\)' madge-bot.txt || echo 0)
                   echo "bot_cycles=$COUNT" >> "$GITHUB_OUTPUT"
-                  echo "## madge circular deps — packages/bot/src" >> "$GITHUB_STEP_SUMMARY"
-                  echo "" >> "$GITHUB_STEP_SUMMARY"
-                  echo "**Cycle count:** $COUNT" >> "$GITHUB_STEP_SUMMARY"
-                  echo "" >> "$GITHUB_STEP_SUMMARY"
-                  echo '```' >> "$GITHUB_STEP_SUMMARY"
-                  cat madge-bot.txt >> "$GITHUB_STEP_SUMMARY"
-                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+                  {
+                      echo "## madge circular deps — packages/bot/src"
+                      echo ""
+                      echo "**Cycle count:** $COUNT"
+                      echo ""
+                      echo '```'
+                      cat madge-bot.txt
+                      echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
               id: madge
 
             - name: Upload madge report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+- fix(ci): group $GITHUB_STEP_SUMMARY redirects in madge workflow to satisfy shellcheck SC2129 (#905)
+
 ## [2.11.0] - 2026-05-15
 
 ### Added


### PR DESCRIPTION
## Summary

The `quality / Workflow lint (actionlint)` CI check has been red on every PR since #887. The cause is a single shellcheck SC2129 violation in `.github/workflows/madge.yml:35` — six individual `>> "$GITHUB_STEP_SUMMARY"` redirects in one step. This PR groups them into a single redirect block.

## What changed

```diff
- echo "## madge circular deps — packages/bot/src" >> "$GITHUB_STEP_SUMMARY"
- echo "" >> "$GITHUB_STEP_SUMMARY"
- echo "**Cycle count:** $COUNT" >> "$GITHUB_STEP_SUMMARY"
- echo "" >> "$GITHUB_STEP_SUMMARY"
- echo '```' >> "$GITHUB_STEP_SUMMARY"
- cat madge-bot.txt >> "$GITHUB_STEP_SUMMARY"
- echo '```' >> "$GITHUB_STEP_SUMMARY"
+ {
+     echo "## madge circular deps — packages/bot/src"
+     echo ""
+     echo "**Cycle count:** $COUNT"
+     echo ""
+     echo '```'
+     cat madge-bot.txt
+     echo '```'
+ } >> "$GITHUB_STEP_SUMMARY"
```

Same content, same destination. Only the redirect shape changes.

## Verification

- `actionlint -color -ignore 'SC2016:' .github/workflows/madge.yml` → rc=0 (was rc=1)
- `actionlint -color -ignore 'SC2016:'` full-repo sweep → rc=0 (no other workflow offenders)

## Why now

Surfaced via `/diagnose`. The actionlint failure has been a chronic red on PRs #897–#905. It's non-blocking, so it shipped, but it adds CI-status noise and trains the team to ignore actionlint output. Killing it improves signal across the board.

## Refs

- PR #887 — introduced `madge.yml` (the workflow itself remains useful; only the redirect shape needed fixing).