### PR TITLE
refactor(guild-automation): swap AutoMessages to shared Module Executor

### DIFF
--- a/packages/backend/src/services/GuildAutomationExecutionService.ts
+++ b/packages/backend/src/services/GuildAutomationExecutionService.ts
@@ -1,5 +1,6 @@
 import {
     autoMessageService,
+    autoMessagesExecutor,
     autoModService,
     getModerationSettings,
     guildAutomationService,
@@ -22,12 +23,6 @@ const DEFAULT_SOURCE = 'discord-capture'
 
 type AutoModUpdatePayload = Parameters<typeof autoModService.updateSettings>[1]
 type ModerationUpdatePayload = Parameters<typeof updateModerationSettings>[1]
-
-type ManagedAutoMessage = {
-    enabled?: boolean
-    channelId?: string
-    message?: string
-}
 
 type DiscordGuildResponse = {
     id: string
@@ -220,7 +215,6 @@ function defaultParityChecklist() {
     ]
 }
 
-
 type RemapFn = (id: string | undefined | null) => string | undefined | null
 
 function remapRolesSection(
@@ -269,9 +263,10 @@ function remapModerationSection(
     remapChannel: RemapFn,
 ): void {
     if (next.moderation?.automod) {
-        next.moderation.automod.exemptRoles = next.moderation.automod.exemptRoles
-            ?.map((id) => remapRole(id))
-            .filter((id): id is string => Boolean(id))
+        next.moderation.automod.exemptRoles =
+            next.moderation.automod.exemptRoles
+                ?.map((id) => remapRole(id))
+                .filter((id): id is string => Boolean(id))
         next.moderation.automod.exemptChannels =
             next.moderation.automod.exemptChannels
                 ?.map((id) => remapChannel(id))
@@ -319,11 +314,13 @@ function remapReactionRolesSection(
             })),
         }),
     )
-    next.reactionroles.exclusiveRoles =
-        next.reactionroles.exclusiveRoles?.map((item) => ({
+    next.reactionroles.exclusiveRoles = next.reactionroles.exclusiveRoles?.map(
+        (item) => ({
             roleId: remapRole(item.roleId) ?? item.roleId,
-            excludedRoleId: remapRole(item.excludedRoleId) ?? item.excludedRoleId,
-        }))
+            excludedRoleId:
+                remapRole(item.excludedRoleId) ?? item.excludedRoleId,
+        }),
+    )
 }
 
 function remapCommandAccessSection(
@@ -549,42 +546,6 @@ class GuildAutomationExecutionService {
         return next
     }
 
-    private async upsertAutoMessage(
-        guildId: string,
-        type: 'welcome' | 'leave',
-        payload: ManagedAutoMessage | undefined,
-    ): Promise<void> {
-        if (!payload?.message) {
-            return
-        }
-
-        const existing = (
-            type === 'welcome'
-                ? await autoMessageService.getWelcomeMessage(guildId)
-                : await autoMessageService.getLeaveMessage(guildId)
-        ) as unknown
-
-        if (!existing) {
-            await autoMessageService.createMessage(
-                guildId,
-                type,
-                {
-                    message: payload.message,
-                },
-                {
-                    channelId: payload.channelId,
-                },
-            )
-            return
-        }
-
-        await autoMessageService.updateMessage((existing as unknown & { id: string }).id, {
-            message: payload.message,
-            channelId: payload.channelId,
-            enabled: payload.enabled,
-        })
-    }
-
     private async applyOneRole(params: {
         token: string
         guildId: string
@@ -593,7 +554,14 @@ class GuildAutomationExecutionService {
         usedActualRoleIds: Set<string>
         roleRemap: RoleRemap
     }): Promise<void> {
-        const { token, guildId, role, actualRoles, usedActualRoleIds, roleRemap } = params
+        const {
+            token,
+            guildId,
+            role,
+            actualRoles,
+            usedActualRoleIds,
+            roleRemap,
+        } = params
         const targetRoleId = this.resolveRoleTargetId({
             desiredRoleId: role.id,
             desiredRoleName: role.name,
@@ -639,7 +607,14 @@ class GuildAutomationExecutionService {
         actualChannels: ManifestChannel[]
         usedActualChannelIds: Set<string>
     }): Promise<void> {
-        const { token, guildId, channel, channelRemap, actualChannels, usedActualChannelIds } = params
+        const {
+            token,
+            guildId,
+            channel,
+            channelRemap,
+            actualChannels,
+            usedActualChannelIds,
+        } = params
         const remappedParentId =
             (channel.parentId
                 ? channelRemap.get(channel.parentId)
@@ -716,12 +691,12 @@ class GuildAutomationExecutionService {
         desiredChannels: ManifestChannel[],
         channelRemap: ChannelRemap,
     ): Promise<void> {
-        const latestChannels = await this.discordRequest<DiscordChannelResponse[]>(
-            {
-                token,
-                endpoint: `/guilds/${guildId}/channels`,
-            },
-        )
+        const latestChannels = await this.discordRequest<
+            DiscordChannelResponse[]
+        >({
+            token,
+            endpoint: `/guilds/${guildId}/channels`,
+        })
         const desiredChannelIds = new Set(
             desiredChannels.map(
                 (channel) => channelRemap.get(channel.id) ?? channel.id,
@@ -811,10 +786,15 @@ class GuildAutomationExecutionService {
             ),
         )
 
-        const existing = (await roleManagementService.listExclusiveRoles(guildId)) as unknown[]
+        const existing = (await roleManagementService.listExclusiveRoles(
+            guildId,
+        )) as unknown[]
 
         for (const item of existing as unknown[]) {
-            const typedItem = item as unknown & { roleId: string; excludedRoleId: string }
+            const typedItem = item as unknown & {
+                roleId: string
+                excludedRoleId: string
+            }
             const key = `${typedItem.roleId}:${typedItem.excludedRoleId}`
             if (!nextPairs.has(key)) {
                 await roleManagementService.removeExclusiveRole(
@@ -826,7 +806,10 @@ class GuildAutomationExecutionService {
         }
 
         for (const item of desired.reactionroles?.exclusiveRoles ?? []) {
-            const typedItem = item as unknown & { roleId: string; excludedRoleId: string };
+            const typedItem = item as unknown & {
+                roleId: string
+                excludedRoleId: string
+            }
             await roleManagementService.setExclusiveRole(
                 guildId,
                 typedItem.roleId,
@@ -836,19 +819,19 @@ class GuildAutomationExecutionService {
     }
 
     private buildGuildAutomationManifest(data: {
-        guild: unknown & { id: string; name: string };
-        manifestRoles: unknown[];
-        manifestChannels: unknown[];
-        onboarding: unknown;
-        manifest: unknown;
-        automodSettings: Record<string, unknown> | null;
-        moderationSettings: Record<string, unknown> | null;
-        welcomeMessage: unknown;
-        leaveMessage: unknown;
-        reactionRoleMessages: unknown[];
-        exclusiveRoles: unknown[];
-        roleGrants: unknown[];
-        parity: unknown;
+        guild: unknown & { id: string; name: string }
+        manifestRoles: unknown[]
+        manifestChannels: unknown[]
+        onboarding: unknown
+        manifest: unknown
+        automodSettings: Record<string, unknown> | null
+        moderationSettings: Record<string, unknown> | null
+        welcomeMessage: unknown
+        leaveMessage: unknown
+        reactionRoleMessages: unknown[]
+        exclusiveRoles: unknown[]
+        roleGrants: unknown[]
+        parity: unknown
     }): GuildAutomationManifestDocument {
         const {
             guild,
@@ -864,35 +847,39 @@ class GuildAutomationExecutionService {
             exclusiveRoles,
             roleGrants,
             parity,
-        } = data;
+        } = data
 
         const typedWelcomeMessage = welcomeMessage as unknown & {
-            enabled?: boolean;
-            channelId?: string | null;
-            message?: string | null;
-        };
+            enabled?: boolean
+            channelId?: string | null
+            message?: string | null
+        }
         const typedLeaveMessage = leaveMessage as unknown & {
-            enabled?: boolean;
-            channelId?: string | null;
-            message?: string | null;
-        };
+            enabled?: boolean
+            channelId?: string | null
+            message?: string | null
+        }
 
         return {
-            version: ((manifest as unknown & { manifest?: { version?: number } })?.manifest?.version) ?? 1,
+            version:
+                (manifest as unknown & { manifest?: { version?: number } })
+                    ?.manifest?.version ?? 1,
             guild: {
                 id: guild.id,
                 name: guild.name,
             },
-            onboarding: this.toOnboardingManifest(onboarding as DiscordOnboardingResponse | null),
+            onboarding: this.toOnboardingManifest(
+                onboarding as DiscordOnboardingResponse | null,
+            ),
             roles: {
                 roles: manifestRoles as GuildAutomationRole[],
                 channels: manifestChannels as GuildAutomationChannel[],
             },
             moderation: {
-                automod:
-                    toAutoModPayload(automodSettings ?? null) ?? undefined,
+                automod: toAutoModPayload(automodSettings ?? null) ?? undefined,
                 moderationSettings:
-                    toModerationPayload(moderationSettings ?? null) ?? undefined,
+                    toModerationPayload(moderationSettings ?? null) ??
+                    undefined,
             },
             automessages: {
                 welcome: typedWelcomeMessage
@@ -912,44 +899,67 @@ class GuildAutomationExecutionService {
             },
             reactionroles: {
                 messages: reactionRoleMessages.map((message) => {
-                    const msg = message as unknown & { id: string; messageId: string; channelId: string; mappings: unknown[] };
+                    const msg = message as unknown & {
+                        id: string
+                        messageId: string
+                        channelId: string
+                        mappings: unknown[]
+                    }
                     return {
                         id: msg.id,
                         messageId: msg.messageId,
                         channelId: msg.channelId,
                         mappings: (msg.mappings ?? []).map((mapping) => {
-                            const map = mapping as unknown & { roleId: string; label?: string; emoji?: string; style?: string };
+                            const map = mapping as unknown & {
+                                roleId: string
+                                label?: string
+                                emoji?: string
+                                style?: string
+                            }
                             return {
                                 roleId: map.roleId,
                                 label: map.label ?? map.roleId,
                                 emoji: map.emoji ?? undefined,
                                 style: map.style ?? undefined,
-                            };
+                            }
                         }),
-                    };
+                    }
                 }),
                 exclusiveRoles: exclusiveRoles.map((item) => {
-                    const typed = item as unknown & { roleId: string; excludedRoleId: string };
+                    const typed = item as unknown & {
+                        roleId: string
+                        excludedRoleId: string
+                    }
                     return {
                         roleId: typed.roleId,
                         excludedRoleId: typed.excludedRoleId,
-                    };
+                    }
                 }),
             },
             commandaccess: {
                 grants: roleGrants.map((grant) => {
-                    const g = grant as unknown & { roleId: string; module: 'overview' | 'settings' | 'moderation' | 'automation' | 'music' | 'integrations'; mode: 'view' | 'manage' };
+                    const g = grant as unknown & {
+                        roleId: string
+                        module:
+                            | 'overview'
+                            | 'settings'
+                            | 'moderation'
+                            | 'automation'
+                            | 'music'
+                            | 'integrations'
+                        mode: 'view' | 'manage'
+                    }
                     return {
                         roleId: g.roleId,
                         module: g.module,
                         mode: g.mode,
-                    };
+                    }
                 }),
             },
             parity: parity as GuildAutomationParity | undefined,
             source: DEFAULT_SOURCE,
             capturedAt: new Date().toISOString(),
-        };
+        }
     }
 
     async captureGuildAutomationState(
@@ -1029,7 +1039,9 @@ class GuildAutomationExecutionService {
                 readonly: false,
             }))
 
-        const parity = (manifest as unknown & { manifest?: { parity?: unknown } })?.manifest?.parity ?? {
+        const parity = (
+            manifest as unknown & { manifest?: { parity?: unknown } }
+        )?.manifest?.parity ?? {
             shadowMode: true,
             externalBots: [],
             checklist: defaultParityChecklist(),
@@ -1043,7 +1055,10 @@ class GuildAutomationExecutionService {
             onboarding,
             manifest,
             automodSettings: automodSettings as Record<string, unknown> | null,
-            moderationSettings: moderationSettings as Record<string, unknown> | null,
+            moderationSettings: moderationSettings as Record<
+                string,
+                unknown
+            > | null,
             welcomeMessage,
             leaveMessage,
             reactionRoleMessages,
@@ -1113,8 +1128,13 @@ class GuildAutomationExecutionService {
         desired: GuildAutomationManifestDocument,
         appliedModules: string[],
     ): Promise<void> {
-        await this.upsertAutoMessage(guildId, 'welcome', desired.automessages?.welcome)
-        await this.upsertAutoMessage(guildId, 'leave', desired.automessages?.leave)
+        // Module Executor pilot — see
+        // docs/decisions/2026-05-19-guild-automation-module-executors.md.
+        // TODO: gate `apply` on Run.type once the orchestrator threads it.
+        const ctx = { guildId }
+        const live = await autoMessagesExecutor.capture(ctx)
+        const diff = autoMessagesExecutor.diff(live, desired.automessages ?? {})
+        await autoMessagesExecutor.apply(diff, ctx)
         appliedModules.push('automessages')
     }
 
@@ -1162,8 +1182,15 @@ class GuildAutomationExecutionService {
         const channelRemap: ChannelRemap = new Map()
         let effectiveDesired = params.desired
 
-        if (shouldApplyModule(params.plan, 'onboarding', params.allowProtected)) {
-            await this.applyOnboardingModule(token, params.guildId, effectiveDesired, appliedModules)
+        if (
+            shouldApplyModule(params.plan, 'onboarding', params.allowProtected)
+        ) {
+            await this.applyOnboardingModule(
+                token,
+                params.guildId,
+                effectiveDesired,
+                appliedModules,
+            )
         }
 
         if (shouldApplyModule(params.plan, 'roles', params.allowProtected)) {
@@ -1186,20 +1213,57 @@ class GuildAutomationExecutionService {
             appliedModules.push('roles')
         }
 
-        if (shouldApplyModule(params.plan, 'moderation', params.allowProtected)) {
-            await this.applyModerationModule(params.guildId, effectiveDesired, appliedModules)
+        if (
+            shouldApplyModule(params.plan, 'moderation', params.allowProtected)
+        ) {
+            await this.applyModerationModule(
+                params.guildId,
+                effectiveDesired,
+                appliedModules,
+            )
         }
 
-        if (shouldApplyModule(params.plan, 'automessages', params.allowProtected)) {
-            await this.applyAutoMessagesModule(params.guildId, effectiveDesired, appliedModules)
+        if (
+            shouldApplyModule(
+                params.plan,
+                'automessages',
+                params.allowProtected,
+            )
+        ) {
+            await this.applyAutoMessagesModule(
+                params.guildId,
+                effectiveDesired,
+                appliedModules,
+            )
         }
 
-        if (shouldApplyModule(params.plan, 'reactionroles', params.allowProtected)) {
-            await this.applyReactionRolesModule(params.guildId, effectiveDesired, appliedModules, skippedModules)
+        if (
+            shouldApplyModule(
+                params.plan,
+                'reactionroles',
+                params.allowProtected,
+            )
+        ) {
+            await this.applyReactionRolesModule(
+                params.guildId,
+                effectiveDesired,
+                appliedModules,
+                skippedModules,
+            )
         }
 
-        if (shouldApplyModule(params.plan, 'commandaccess', params.allowProtected)) {
-            await this.applyCommandAccessModule(params.guildId, effectiveDesired, appliedModules)
+        if (
+            shouldApplyModule(
+                params.plan,
+                'commandaccess',
+                params.allowProtected,
+            )
+        ) {
+            await this.applyCommandAccessModule(
+                params.guildId,
+                effectiveDesired,
+                appliedModules,
+            )
         }
 
         if (shouldApplyModule(params.plan, 'parity', params.allowProtected)) {

--- a/packages/backend/tests/unit/services/GuildAutomationExecutionService.test.ts
+++ b/packages/backend/tests/unit/services/GuildAutomationExecutionService.test.ts
@@ -3,35 +3,44 @@ import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 const mockFetch = jest.fn<any>()
 global.fetch = mockFetch as any
 
-jest.mock('@lucky/shared/services', () => ({
-    autoMessageService: {
+jest.mock('@lucky/shared/services', () => {
+    const autoMessageServiceMock = {
         getWelcomeMessage: jest.fn<any>(),
         getLeaveMessage: jest.fn<any>(),
         createMessage: jest.fn<any>(),
         updateMessage: jest.fn<any>(),
-    },
-    autoModService: {
-        getSettings: jest.fn<any>(),
-        updateSettings: jest.fn<any>(),
-    },
-    getModerationSettings: jest.fn<any>(),
-    updateModerationSettings: jest.fn<any>(),
-    guildAutomationService: {
-        getManifest: jest.fn<any>(),
-    },
-    guildRoleAccessService: {
-        listRoleGrants: jest.fn<any>(),
-        replaceRoleGrants: jest.fn<any>(),
-    },
-    reactionRolesService: {
-        listReactionRoleMessages: jest.fn<any>(),
-    },
-    roleManagementService: {
-        listExclusiveRoles: jest.fn<any>(),
-        setExclusiveRole: jest.fn<any>(),
-        removeExclusiveRole: jest.fn<any>(),
-    },
-}))
+    }
+    const { createAutoMessagesExecutor } = jest.requireActual(
+        '@lucky/shared/services/guildAutomation/autoMessagesExecutor',
+    )
+    return {
+        autoMessageService: autoMessageServiceMock,
+        autoMessagesExecutor: createAutoMessagesExecutor({
+            autoMessageService: autoMessageServiceMock,
+        }),
+        autoModService: {
+            getSettings: jest.fn<any>(),
+            updateSettings: jest.fn<any>(),
+        },
+        getModerationSettings: jest.fn<any>(),
+        updateModerationSettings: jest.fn<any>(),
+        guildAutomationService: {
+            getManifest: jest.fn<any>(),
+        },
+        guildRoleAccessService: {
+            listRoleGrants: jest.fn<any>(),
+            replaceRoleGrants: jest.fn<any>(),
+        },
+        reactionRolesService: {
+            listReactionRoleMessages: jest.fn<any>(),
+        },
+        roleManagementService: {
+            listExclusiveRoles: jest.fn<any>(),
+            setExclusiveRole: jest.fn<any>(),
+            removeExclusiveRole: jest.fn<any>(),
+        },
+    }
+})
 
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
@@ -1340,15 +1349,33 @@ describe('GuildAutomationExecutionService', () => {
             })
             const actual = createMinimalManifest()
             const plan = createMinimalPlan([
-                { module: 'onboarding', action: 'update', protected: false, description: 'Update' },
+                {
+                    module: 'onboarding',
+                    action: 'update',
+                    protected: false,
+                    description: 'Update',
+                },
             ])
-            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({}),
             })
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: false,
+                })
             expect(result.diagnostics.appliedModules).toContain('onboarding')
-            const body = JSON.parse((mockFetch.mock.calls[0] as any[])[1].body as string)
-            expect(body.prompts[0].options[0].channel_ids).toEqual([CHANNEL_ID_1])
+            const body = JSON.parse(
+                (mockFetch.mock.calls[0] as any[])[1].body as string,
+            )
+            expect(body.prompts[0].options[0].channel_ids).toEqual([
+                CHANNEL_ID_1,
+            ])
             expect(body.prompts[0].options[0].role_ids).toEqual([ROLE_ID_1])
         })
 
@@ -1356,24 +1383,42 @@ describe('GuildAutomationExecutionService', () => {
             const desired = createMinimalManifest({
                 commandaccess: {
                     grants: [
-                        { roleId: ROLE_ID_1, module: 'music', mode: 'allow' as any },
+                        {
+                            roleId: ROLE_ID_1,
+                            module: 'music',
+                            mode: 'allow' as any,
+                        },
                     ],
                 },
             })
             const actual = createMinimalManifest()
             const plan = createMinimalPlan([
-                { module: 'commandaccess', action: 'update', protected: false, description: 'Update' },
+                {
+                    module: 'commandaccess',
+                    action: 'update',
+                    protected: false,
+                    description: 'Update',
+                },
             ])
-            const { guildRoleAccessService } = await import('@lucky/shared/services')
-            ;(guildRoleAccessService.replaceRoleGrants as jest.Mock).mockResolvedValue(undefined)
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
-            })
+            const { guildRoleAccessService } =
+                await import('@lucky/shared/services')
+            ;(
+                guildRoleAccessService.replaceRoleGrants as jest.Mock
+            ).mockResolvedValue(undefined)
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: false,
+                })
             expect(result.diagnostics.appliedModules).toContain('commandaccess')
-            expect(guildRoleAccessService.replaceRoleGrants as jest.Mock).toHaveBeenCalledWith(
-                GUILD_ID,
-                [{ roleId: ROLE_ID_1, module: 'music', mode: 'allow' }],
-            )
+            expect(
+                guildRoleAccessService.replaceRoleGrants as jest.Mock,
+            ).toHaveBeenCalledWith(GUILD_ID, [
+                { roleId: ROLE_ID_1, module: 'music', mode: 'allow' },
+            ])
         })
 
         test('should update existing channel by ID', async () => {
@@ -1381,7 +1426,14 @@ describe('GuildAutomationExecutionService', () => {
                 roles: {
                     roles: [],
                     channels: [
-                        { id: CHANNEL_ID_1, name: 'updated-name', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                        {
+                            id: CHANNEL_ID_1,
+                            name: 'updated-name',
+                            type: 'GuildText',
+                            parentId: null,
+                            topic: null,
+                            readonly: false,
+                        },
                     ],
                 },
             })
@@ -1389,17 +1441,38 @@ describe('GuildAutomationExecutionService', () => {
                 roles: {
                     roles: [],
                     channels: [
-                        { id: CHANNEL_ID_1, name: 'old-name', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                        {
+                            id: CHANNEL_ID_1,
+                            name: 'old-name',
+                            type: 'GuildText',
+                            parentId: null,
+                            topic: null,
+                            readonly: false,
+                        },
                     ],
                 },
             })
             const plan = createMinimalPlan([
-                { module: 'roles', action: 'update', protected: false, description: 'Update channel' },
+                {
+                    module: 'roles',
+                    action: 'update',
+                    protected: false,
+                    description: 'Update channel',
+                },
             ])
-            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({}),
             })
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: false,
+                })
             expect(result.diagnostics.appliedModules).toContain('roles')
             expect(mockFetch).toHaveBeenCalledWith(
                 expect.stringContaining(`/channels/${CHANNEL_ID_1}`),
@@ -1412,7 +1485,14 @@ describe('GuildAutomationExecutionService', () => {
                 roles: {
                     roles: [],
                     channels: [
-                        { id: CHANNEL_ID_1, name: 'keep', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                        {
+                            id: CHANNEL_ID_1,
+                            name: 'keep',
+                            type: 'GuildText',
+                            parentId: null,
+                            topic: null,
+                            readonly: false,
+                        },
                     ],
                 },
             })
@@ -1420,18 +1500,45 @@ describe('GuildAutomationExecutionService', () => {
                 roles: { roles: [], channels: [] },
             })
             const plan = createMinimalPlan([
-                { module: 'roles', action: 'delete', protected: true, description: 'Delete stale' },
+                {
+                    module: 'roles',
+                    action: 'delete',
+                    protected: true,
+                    description: 'Delete stale',
+                },
             ])
             mockFetch
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: CHANNEL_ID_1, name: 'keep' }) })  // POST create channel
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })  // GET roles for prune
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [  // GET channels for prune
-                    { id: CHANNEL_ID_2, name: 'stale' },
-                ] })
-                .mockResolvedValueOnce({ ok: true, status: 204, json: async () => undefined })  // DELETE stale channel
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: true,
-            })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ id: CHANNEL_ID_1, name: 'keep' }),
+                }) // POST create channel
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => [],
+                }) // GET roles for prune
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => [
+                        // GET channels for prune
+                        { id: CHANNEL_ID_2, name: 'stale' },
+                    ],
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 204,
+                    json: async () => undefined,
+                }) // DELETE stale channel
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: true,
+                })
             expect(result.diagnostics.appliedModules).toContain('roles')
             expect(mockFetch).toHaveBeenCalledWith(
                 expect.stringContaining(`/channels/${CHANNEL_ID_2}`),
@@ -1447,37 +1554,122 @@ describe('GuildAutomationExecutionService', () => {
 
             const desired = createMinimalManifest({
                 roles: {
-                    roles: [{ id: OLD_ROLE, name: 'Member', color: 0, hoist: false, mentionable: false }],
-                    channels: [{ id: OLD_CHANNEL, name: 'general', type: 'GuildText', parentId: null, topic: null, readonly: false }],
+                    roles: [
+                        {
+                            id: OLD_ROLE,
+                            name: 'Member',
+                            color: 0,
+                            hoist: false,
+                            mentionable: false,
+                        },
+                    ],
+                    channels: [
+                        {
+                            id: OLD_CHANNEL,
+                            name: 'general',
+                            type: 'GuildText',
+                            parentId: null,
+                            topic: null,
+                            readonly: false,
+                        },
+                    ],
                 },
-                onboarding: { enabled: true, mode: 0, defaultChannelIds: [OLD_CHANNEL], prompts: [] },
+                onboarding: {
+                    enabled: true,
+                    mode: 0,
+                    defaultChannelIds: [OLD_CHANNEL],
+                    prompts: [],
+                },
                 moderation: {
-                    automod: { exemptRoles: [OLD_ROLE], exemptChannels: [OLD_CHANNEL] } as any,
-                    moderationSettings: { muteRoleId: OLD_ROLE, modRoleIds: [OLD_ROLE], adminRoleIds: [] } as any,
+                    automod: {
+                        exemptRoles: [OLD_ROLE],
+                        exemptChannels: [OLD_CHANNEL],
+                    } as any,
+                    moderationSettings: {
+                        muteRoleId: OLD_ROLE,
+                        modRoleIds: [OLD_ROLE],
+                        adminRoleIds: [],
+                    } as any,
                 },
                 automessages: {
-                    welcome: { enabled: true, channelId: OLD_CHANNEL, message: 'hi' },
-                    leave: { enabled: true, channelId: OLD_CHANNEL, message: 'bye' },
+                    welcome: {
+                        enabled: true,
+                        channelId: OLD_CHANNEL,
+                        message: 'hi',
+                    },
+                    leave: {
+                        enabled: true,
+                        channelId: OLD_CHANNEL,
+                        message: 'bye',
+                    },
                 },
                 reactionroles: {
-                    messages: [{ id: 'm1', messageId: 'dm1', channelId: OLD_CHANNEL, mappings: [{ roleId: OLD_ROLE, label: 'x', emoji: undefined, style: undefined }] }],
-                    exclusiveRoles: [{ roleId: OLD_ROLE, excludedRoleId: OLD_ROLE }],
+                    messages: [
+                        {
+                            id: 'm1',
+                            messageId: 'dm1',
+                            channelId: OLD_CHANNEL,
+                            mappings: [
+                                {
+                                    roleId: OLD_ROLE,
+                                    label: 'x',
+                                    emoji: undefined,
+                                    style: undefined,
+                                },
+                            ],
+                        },
+                    ],
+                    exclusiveRoles: [
+                        { roleId: OLD_ROLE, excludedRoleId: OLD_ROLE },
+                    ],
                 },
-                commandaccess: { grants: [{ roleId: OLD_ROLE, module: 'music', mode: 'allow' as any }] },
+                commandaccess: {
+                    grants: [
+                        {
+                            roleId: OLD_ROLE,
+                            module: 'music',
+                            mode: 'allow' as any,
+                        },
+                    ],
+                },
             })
-            const actual = createMinimalManifest({ roles: { roles: [], channels: [] } })
+            const actual = createMinimalManifest({
+                roles: { roles: [], channels: [] },
+            })
             const plan = createMinimalPlan([
-                { module: 'roles', action: 'create', protected: false, description: 'Create' },
+                {
+                    module: 'roles',
+                    action: 'create',
+                    protected: false,
+                    description: 'Create',
+                },
             ])
             mockFetch
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: NEW_ROLE, name: 'Member' }) })
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: NEW_CHANNEL, name: 'general' }) })
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
-            })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ id: NEW_ROLE, name: 'Member' }),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ id: NEW_CHANNEL, name: 'general' }),
+                })
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: false,
+                })
             expect(result.remappedManifest).toBeDefined()
-            expect(result.diagnostics.roleIdRemaps).toEqual({ [OLD_ROLE]: NEW_ROLE })
-            expect(result.diagnostics.channelIdRemaps).toEqual({ [OLD_CHANNEL]: NEW_CHANNEL })
+            expect(result.diagnostics.roleIdRemaps).toEqual({
+                [OLD_ROLE]: NEW_ROLE,
+            })
+            expect(result.diagnostics.channelIdRemaps).toEqual({
+                [OLD_CHANNEL]: NEW_CHANNEL,
+            })
         })
 
         test('should note when reactionroles messages require manual setup', async () => {
@@ -1629,7 +1821,10 @@ describe('GuildAutomationExecutionService', () => {
                 })
                 .mockResolvedValueOnce({
                     ok: true,
-                    json: async () => [{ id: GUILD_ID, name: '@everyone' }, { id: ROLE_ID_1, name: 'Member' }],
+                    json: async () => [
+                        { id: GUILD_ID, name: '@everyone' },
+                        { id: ROLE_ID_1, name: 'Member' },
+                    ],
                 })
                 .mockResolvedValueOnce({
                     ok: true,
@@ -1695,7 +1890,10 @@ describe('GuildAutomationExecutionService', () => {
                 })
                 .mockResolvedValueOnce({
                     ok: true,
-                    json: async () => [{ id: GUILD_ID, name: '@everyone' }, { id: ROLE_ID_1, name: 'Admin' }],
+                    json: async () => [
+                        { id: GUILD_ID, name: '@everyone' },
+                        { id: ROLE_ID_1, name: 'Admin' },
+                    ],
                 })
                 .mockResolvedValueOnce({
                     ok: true,
@@ -1862,7 +2060,10 @@ describe('GuildAutomationExecutionService', () => {
         it('isExpectedDeleteError should identify forbidden and not found errors', () => {
             const err403 = new GuildAutomationExecutionError('Forbidden', 403)
             const err404 = new GuildAutomationExecutionError('Not found', 404)
-            const err500 = new GuildAutomationExecutionError('Server error', 500)
+            const err500 = new GuildAutomationExecutionError(
+                'Server error',
+                500,
+            )
             const nonError = new Error('Regular error')
 
             expect(isExpectedDeleteError(err403)).toBe(true)

--- a/packages/bot/src/utils/guildAutomation/applyPlan.spec.ts
+++ b/packages/bot/src/utils/guildAutomation/applyPlan.spec.ts
@@ -14,29 +14,43 @@ const removeExclusiveRoleMock = jest.fn()
 const setExclusiveRoleMock = jest.fn()
 const updateModerationSettingsMock = jest.fn()
 
-jest.mock('@lucky/shared/services', () => ({
-    autoMessageService: {
-        getWelcomeMessage: (...args: unknown[]) => getWelcomeMessageMock(...args),
+jest.mock('@lucky/shared/services', () => {
+    const autoMessageServiceMock = {
+        getWelcomeMessage: (...args: unknown[]) =>
+            getWelcomeMessageMock(...args),
         getLeaveMessage: (...args: unknown[]) => getLeaveMessageMock(...args),
         createMessage: (...args: unknown[]) => createMessageMock(...args),
         updateMessage: (...args: unknown[]) => updateMessageMock(...args),
-    },
-    autoModService: {
-        updateSettings: (...args: unknown[]) => updateSettingsMock(...args),
-    },
-    manifestOnboardingToDiscordEdit: (...args: unknown[]) =>
-        manifestOnboardingToDiscordEditMock(...args),
-    guildRoleAccessService: {
-        replaceRoleGrants: (...args: unknown[]) => replaceRoleGrantsMock(...args),
-    },
-    roleManagementService: {
-        listExclusiveRoles: (...args: unknown[]) => listExclusiveRolesMock(...args),
-        removeExclusiveRole: (...args: unknown[]) => removeExclusiveRoleMock(...args),
-        setExclusiveRole: (...args: unknown[]) => setExclusiveRoleMock(...args),
-    },
-    updateModerationSettings: (...args: unknown[]) =>
-        updateModerationSettingsMock(...args),
-}))
+    }
+    const { createAutoMessagesExecutor } = jest.requireActual(
+        '@lucky/shared/services/guildAutomation/autoMessagesExecutor',
+    )
+    return {
+        autoMessageService: autoMessageServiceMock,
+        autoMessagesExecutor: createAutoMessagesExecutor({
+            autoMessageService: autoMessageServiceMock,
+        }),
+        autoModService: {
+            updateSettings: (...args: unknown[]) => updateSettingsMock(...args),
+        },
+        manifestOnboardingToDiscordEdit: (...args: unknown[]) =>
+            manifestOnboardingToDiscordEditMock(...args),
+        guildRoleAccessService: {
+            replaceRoleGrants: (...args: unknown[]) =>
+                replaceRoleGrantsMock(...args),
+        },
+        roleManagementService: {
+            listExclusiveRoles: (...args: unknown[]) =>
+                listExclusiveRolesMock(...args),
+            removeExclusiveRole: (...args: unknown[]) =>
+                removeExclusiveRoleMock(...args),
+            setExclusiveRole: (...args: unknown[]) =>
+                setExclusiveRoleMock(...args),
+        },
+        updateModerationSettings: (...args: unknown[]) =>
+            updateModerationSettingsMock(...args),
+    }
+})
 
 const errorLogMock = jest.fn()
 jest.mock('@lucky/shared/utils', () => ({
@@ -200,7 +214,14 @@ describe('applyAutomationModules', () => {
             roles: {
                 cache: new Map([
                     ['guild-1', { id: 'guild-1', editable: false }],
-                    ['legacy-role', { id: 'legacy-role', editable: true, delete: deleteRoleMock }],
+                    [
+                        'legacy-role',
+                        {
+                            id: 'legacy-role',
+                            editable: true,
+                            delete: deleteRoleMock,
+                        },
+                    ],
                 ]),
                 create: jest.fn().mockResolvedValue(undefined),
             },
@@ -234,7 +255,8 @@ describe('applyAutomationModules', () => {
         expect(deleteRoleMock).toHaveBeenCalled()
         expect(errorLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: 'Failed to delete channel during guild automation apply',
+                message:
+                    'Failed to delete channel during guild automation apply',
                 data: expect.objectContaining({
                     guildId: 'guild-1',
                     channelId: 'old-channel',
@@ -253,7 +275,9 @@ describe('applyAutomationModules', () => {
                         {
                             id: 'channel-x',
                             name: 'channel-x',
-                            delete: jest.fn().mockRejectedValue(new Error('boom')),
+                            delete: jest
+                                .fn()
+                                .mockRejectedValue(new Error('boom')),
                         },
                     ],
                 ]),
@@ -281,7 +305,9 @@ describe('applyAutomationModules', () => {
         const channelCreateMock = jest.fn().mockResolvedValue(undefined)
         const guild = createGuild({
             roles: {
-                cache: new Map([['guild-1', { id: 'guild-1', editable: false }]]),
+                cache: new Map([
+                    ['guild-1', { id: 'guild-1', editable: false }],
+                ]),
                 create: roleCreateMock,
             },
             channels: {
@@ -376,7 +402,9 @@ describe('applyAutomationModules', () => {
         const staleDeleteMock = jest.fn().mockRejectedValue('delete-failed')
         const guild = createGuild({
             roles: {
-                cache: new Map([['guild-1', { id: 'guild-1', editable: false }]]),
+                cache: new Map([
+                    ['guild-1', { id: 'guild-1', editable: false }],
+                ]),
                 create: jest.fn().mockResolvedValue(undefined),
             },
             channels: {
@@ -550,7 +578,12 @@ describe('applyAutomationModules', () => {
         expect(result.appliedModules).toEqual(['roles'])
     })
 
-    it('skips auto-message upsert when payload message is missing', async () => {
+    it('skips auto-message writes when payload message is missing', async () => {
+        // Post Module Executor pilot: Capture always reads live state (one
+        // batched lookup) before Diff. The lazy "skip the DB read entirely"
+        // optimization the old upsertAutoMessage impl had is gone, but the
+        // end-to-end behavior (no create/update writes) is unchanged.
+        // See docs/decisions/2026-05-19-guild-automation-module-executors.md.
         const guild = createGuild()
 
         const result = await applyAutomationModules({
@@ -569,8 +602,6 @@ describe('applyAutomationModules', () => {
             allowProtected: false,
         })
 
-        expect(getWelcomeMessageMock).not.toHaveBeenCalled()
-        expect(getLeaveMessageMock).not.toHaveBeenCalled()
         expect(createMessageMock).not.toHaveBeenCalled()
         expect(updateMessageMock).not.toHaveBeenCalled()
         expect(result.appliedModules).toEqual(['automessages'])

--- a/packages/bot/src/utils/guildAutomation/applyPlan.ts
+++ b/packages/bot/src/utils/guildAutomation/applyPlan.ts
@@ -5,7 +5,7 @@ import {
     type GuildChannelCreateOptions,
 } from 'discord.js'
 import {
-    autoMessageService,
+    autoMessagesExecutor,
     autoModService,
     manifestOnboardingToDiscordEdit,
     guildRoleAccessService,
@@ -21,13 +21,10 @@ type ApplyResult = {
     skippedModules: string[]
 }
 
-type ReconciliableChannelType = Exclude<GuildChannelCreateOptions['type'], undefined>
-
-type ManagedAutoMessage = {
-    enabled?: boolean
-    channelId?: string
-    message?: string
-}
+type ReconciliableChannelType = Exclude<
+    GuildChannelCreateOptions['type'],
+    undefined
+>
 
 function toPermissions(value: string | undefined) {
     if (!value) {
@@ -64,41 +61,6 @@ function shouldApplyModule(
             operation.module === module &&
             (allowProtected || operation.protected === false),
     )
-}
-
-async function upsertAutoMessage(
-    guildId: string,
-    type: 'welcome' | 'leave',
-    payload: ManagedAutoMessage | undefined,
-): Promise<void> {
-    if (!payload?.message) {
-        return
-    }
-
-    const existing =
-        type === 'welcome'
-            ? await autoMessageService.getWelcomeMessage(guildId)
-            : await autoMessageService.getLeaveMessage(guildId)
-
-    if (!existing) {
-        await autoMessageService.createMessage(
-            guildId,
-            type,
-            {
-                message: payload.message,
-            },
-            {
-                channelId: payload.channelId,
-            },
-        )
-        return
-    }
-
-    await autoMessageService.updateMessage(existing.id, {
-        message: payload.message,
-        channelId: payload.channelId,
-        enabled: payload.enabled,
-    })
 }
 
 function findChannel(guild: Guild, id: string): GuildBasedChannel | null {
@@ -183,7 +145,9 @@ async function applyRolesAndChannels(
     }
 
     const desiredRoleIds = new Set(desiredRoles.map((role) => role.id))
-    const desiredChannelIds = new Set(desiredChannels.map((channel) => channel.id))
+    const desiredChannelIds = new Set(
+        desiredChannels.map((channel) => channel.id),
+    )
 
     for (const role of guild.roles.cache.values()) {
         if (role.id === guild.id || desiredRoleIds.has(role.id)) {
@@ -201,7 +165,9 @@ async function applyRolesAndChannels(
         }
 
         try {
-            await channel.delete('Lucky guild automation protected-delete apply')
+            await channel.delete(
+                'Lucky guild automation protected-delete apply',
+            )
         } catch (error) {
             if (shouldIgnoreProtectedDeleteError(error)) {
                 errorLog({
@@ -295,8 +261,13 @@ export async function applyAutomationModules(params: {
     }
 
     if (shouldApplyModule(plan, 'automessages', allowProtected)) {
-        await upsertAutoMessage(guild.id, 'welcome', desired.automessages?.welcome)
-        await upsertAutoMessage(guild.id, 'leave', desired.automessages?.leave)
+        // Module Executor pilot — see
+        // docs/decisions/2026-05-19-guild-automation-module-executors.md.
+        // TODO: gate `apply` on Run.type once the orchestrator threads it.
+        const ctx = { guildId: guild.id }
+        const live = await autoMessagesExecutor.capture(ctx)
+        const diff = autoMessagesExecutor.diff(live, desired.automessages ?? {})
+        await autoMessagesExecutor.apply(diff, ctx)
         appliedModules.push('automessages')
     }
 

--- a/packages/shared/src/services/guildAutomation/index.ts
+++ b/packages/shared/src/services/guildAutomation/index.ts
@@ -3,10 +3,7 @@ export {
     validateGuildAutomationManifest,
     type GuildAutomationManifestInput,
 } from './manifestSchema'
-export {
-    createAutomationPlan,
-    isPlanIdempotent,
-} from './diff'
+export { createAutomationPlan, isPlanIdempotent } from './diff'
 export {
     onboardingToManifest,
     manifestOnboardingToDiscordEdit,
@@ -29,3 +26,25 @@ export {
     type GuildAutomationDiffOperation,
     type GuildAutomationStatus,
 } from './types'
+export {
+    createAutoMessagesExecutor,
+    type AutoMessagesPort,
+    type AutoMessagesLiveState,
+    type AutoMessagesManifestSection,
+    type AutoMessagesDiff,
+    type AutoMessagesDiffOp,
+    type AutoMessagesResult,
+    type ExecutorContext,
+} from './autoMessagesExecutor'
+
+// Module Executor pilot. See
+// docs/decisions/2026-05-19-guild-automation-module-executors.md.
+//
+// Singleton built with the real autoMessageService. Orchestrators (backend
+// GuildAutomationExecutionService, bot applyPlan.ts) consume this instead of
+// running their own byte-identical upsertAutoMessage impls.
+import { autoMessageService } from '../AutoMessageService.js'
+import { createAutoMessagesExecutor } from './autoMessagesExecutor'
+export const autoMessagesExecutor = createAutoMessagesExecutor({
+    autoMessageService,
+})


### PR DESCRIPTION
## Summary

Step 2 of the Module Executor pilot from [ADR 2026-05-19-guild-automation-module-executors.md](docs/decisions/2026-05-19-guild-automation-module-executors.md). Both the backend monolith (`GuildAutomationExecutionService`) and the bot's parallel apply path (`bot/utils/guildAutomation/applyPlan.ts`) stop running their byte-identical `upsertAutoMessage` impls and delegate to the shared `autoMessagesExecutor` introduced by PR #901.

## What changed

- `packages/shared/src/services/guildAutomation/index.ts` — exports `createAutoMessagesExecutor`, related types, and a module-level `autoMessagesExecutor` singleton built with the real `autoMessageService`.
- `packages/bot/src/utils/guildAutomation/applyPlan.ts` — deletes the standalone `upsertAutoMessage` function and `ManagedAutoMessage` type; replaces the automessages block with the three-call `capture` → `diff` → `apply` triplet; drops the unused `autoMessageService` import.
- `packages/backend/src/services/GuildAutomationExecutionService.ts` — deletes the private `upsertAutoMessage` method and `ManagedAutoMessage` type; rewrites `applyAutoMessagesModule` to use the same triplet. Keeps the `autoMessageService` import (still used at L990 by the capture-guild-state pipeline).
- Both orchestrator specs — expose `autoMessagesExecutor` in their `@lucky/shared/services` mock factory, built from the same mocked `autoMessageService` via `jest.requireActual(...)`. Existing assertions on `getWelcomeMessageMock` / `createMessageMock` continue to fire end-to-end through the real executor.
- One bot test ("skips auto-message upsert when payload message is missing") was over-asserting on an impl detail (the old lazy short-circuit before reading the DB). The executor's `capture` always reads live state — correct architecture. Test renamed and loosened to assert only the end-to-end behavior (no create/update writes).

## TypeScript structural compat resolved no-adapter

The design plan hedged on whether `AutoMessageService` would satisfy `AutoMessagesPort` directly or need a dedicated adapter file. It satisfies it directly (method-parameter contravariance + return-type covariance), so no adapter file was needed. `tsc --noEmit` on shared confirms.

## Out of scope (per the design plan)

- `DiscordWriteAdapter` — AutoMessages is DB-only.
- `GuildAutomationDrift` persistence — severity heuristics need cross-module design; deferred to a post-pilot PR.
- `Run.type` gating — orchestrator doesn't thread `Run.type` today; future PR (TODO comments left at both call sites).
- Per-action records in `GuildAutomationRun.operations` — keeping the module-name shape uniform across all 7 modules until they all migrate.
- The other 6 Module Executors — one per follow-up PR per ADR sequencing (next = Moderation Executor).

## Verification

- `npm run type:check --workspace=packages/shared`: clean.
- `npm run type:check --workspace=packages/bot`: only the pre-existing `prom-client` missing-dep error (unchanged from base).
- `npm run type:check --workspace=packages/backend`: only the pre-existing `prom-client` missing-dep error (unchanged from base).
- `npx jest ... autoMessagesExecutor.spec.ts`: 4/4 green.
- `npx jest ... applyPlan.spec.ts`: 8/8 green.
- `npx jest ... GuildAutomationExecutionService.test.ts`: 42/42 green.
- `grep -rn 'upsertAutoMessage' packages/{backend,bot}/src/{utils/guildAutomation,services} --include='*.ts'` outside specs: empty (the unrelated helper in `packages/bot/src/functions/management/commands/helpers/serversetupCriativaria.ts` is not part of the orchestrator path).

## Net LOC

- Production paths: ~60 LOC removed (two byte-identical `upsertAutoMessage` impls + their helper types).
- Shared seam: ~15 LOC added (executor singleton + builder re-exports).
- Test files: net positive due to the mock factory expansion (intentional — preserves end-to-end assertions through the real executor).

## Test plan

- [x] Local: 3 baseline test suites all green.
- [x] Local: typecheck shared + bot + backend, only pre-existing `prom-client` issue.
- [ ] CI `Quality Gates`.
- [ ] CodeRabbit + SonarCloud + CodeQL + madge + Socket + GitGuardian + Vercel.

Refs: PR #901 (pilot executor + tests), ADR `docs/decisions/2026-05-19-guild-automation-module-executors.md`, this PR (#906).