### PR TITLE
chore(process): add feature-removal sweep checklist (#908)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description
+<!-- Briefly describe what this PR does and why. -->
+
+## Checklist
+- [ ] Tests pass locally
+- [ ] CHANGELOG.md updated (if user-facing)
+- [ ] TypeScript builds cleanly
+
+## Feature-removal sweep
+**Skip this section if this PR doesn't remove a route, handler, endpoint, model, or toggle.**
+
+When removing a feature, ensure no orphan code is left behind:
+- [ ] Orphan Prisma models removed (or depended-upon by other models)
+- [ ] Broken or stale test files removed
+- [ ] Unused type aliases removed
+- [ ] Imports/exports cleaned up
+- [ ] ADRs and CONTEXT.md cross-references updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 - fix(ci): group $GITHUB_STEP_SUMMARY redirects in madge workflow to satisfy shellcheck SC2129 (#905)
 - test(shared): add `coverageThreshold` gate to `packages/shared/jest.config.cjs` (no-regression floor at current baseline -2%, statements=19/branches=16/functions=15/lines=18) (#909)
+- chore(process): add Feature-removal sweep checklist to PR template + advisory dangerfile guard that flags PRs with removal-pattern commits missing the sweep (#908)
 
 ## [2.11.0] - 2026-05-15
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -135,6 +135,26 @@ if (!validPrefixes.test(headRef) && !headRef.startsWith('worktree-')) {
     )
 }
 
+
+// --- 9. Feature-removal sweep guard -----------------------------------------
+// When a commit message indicates feature/route/model removal,
+// flag if the PR body doesn't mention the sweep checklist.
+const removalPattern = /^(remove|delete|retire|drop|deprecate).*\b(route|handler|endpoint|model|toggle|feature)\b/i
+const prBody = pr.body || ''
+const hasSweepChecklistInBody = prBody.includes('Feature-removal sweep')
+const hasRemovalCommit = danger.git.commits.some((c) =>
+    removalPattern.test(c.message),
+)
+
+if (hasRemovalCommit && !hasSweepChecklistInBody) {
+    warn(
+        `This PR appears to remove a feature or route (detected in commit message). ` +
+            `Please fill in the **Feature-removal sweep** checklist in the PR template ` +
+            `to ensure no orphan code (models, tests, types, imports) is left behind. ` +
+            `[See docs/decisions/2026-05-19-retire-per-guild-feature-toggles.md](${pr.html_url}) for context.`,
+    )
+}
+
 // --- 8. Big-file warning ----------------------------------------------------
 // Files > 500 lines are review-hostile. Flag new ones.
 async function checkLargeFiles(): Promise<void> {

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -139,19 +139,24 @@ if (!validPrefixes.test(headRef) && !headRef.startsWith('worktree-')) {
 // --- 9. Feature-removal sweep guard -----------------------------------------
 // When a commit message indicates feature/route/model removal,
 // flag if the PR body doesn't mention the sweep checklist.
-const removalPattern = /^(remove|delete|retire|drop|deprecate).*\b(route|handler|endpoint|model|toggle|feature)\b/i
+const removalVerb = /\b(remove|delete|retire|drop|deprecate)\b/i
+const removalTarget = /\b(route|handler|endpoint|model|toggle|feature)\b/i
 const prBody = pr.body || ''
-const hasSweepChecklistInBody = prBody.includes('Feature-removal sweep')
-const hasRemovalCommit = danger.git.commits.some((c) =>
-    removalPattern.test(c.message),
+const hasSweepChecklistInBody = /feature-removal sweep/i.test(prBody)
+const hasRemovalCommit = danger.git.commits.some(
+    (c) => removalVerb.test(c.message) && removalTarget.test(c.message),
 )
 
 if (hasRemovalCommit && !hasSweepChecklistInBody) {
+    const baseRepo = pr.base.repo.full_name
+    const baseRef = pr.base.ref
+    const adrPath = 'docs/decisions/2026-05-19-retire-per-guild-feature-toggles.md'
+    const adrUrl = `https://github.com/${baseRepo}/blob/${baseRef}/${adrPath}`
     warn(
         `This PR appears to remove a feature or route (detected in commit message). ` +
             `Please fill in the **Feature-removal sweep** checklist in the PR template ` +
             `to ensure no orphan code (models, tests, types, imports) is left behind. ` +
-            `[See docs/decisions/2026-05-19-retire-per-guild-feature-toggles.md](${pr.html_url}) for context.`,
+            `[See ${adrPath}](${adrUrl}) for context.`,
     )
 }
 


### PR DESCRIPTION
## Goal
Prevent orphan code (Prisma models, broken test files, dead types) from being left behind after feature/route removal PRs. PR #903 had to clean up 2-week-old orphans from PR #801.

## Changes
1. **PR Template**: Added `.github/PULL_REQUEST_TEMPLATE.md` with a new "Feature-removal sweep" checklist section (skip-friendly) covering:
   - Orphan Prisma models removed
   - Broken/stale test files removed
   - Unused type aliases removed
   - Imports/exports cleaned up
   - ADRs and CONTEXT.md cross-references updated

2. **Dangerfile Guard**: Added rule #9 to `dangerfile.ts` that detects commit messages matching removal patterns (`remove|delete|retire|drop|deprecate` + `route|handler|endpoint|model|toggle|feature`) and warns if the PR body doesn't contain the sweep checklist text.

## Acceptance
- [x] PR template has "Feature-removal sweep" section  
- [x] Dangerfile rule flags qualifying commit bodies  
- Ready for validation against next 3 feature-removal PRs

See docs/decisions/2026-05-19-retire-per-guild-feature-toggles.md for context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request template with contributor guidelines, including reminders for testing and changelog updates.
  * Added automated CI check to ensure feature removal pull requests include proper code cleanup verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->