### PR TITLE
fix(deps): patch brace-expansion + ws CVEs (#907)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "chalk": "^5.6.2",
         "discord-player-youtubei": "^3.0.0-beta.4",
         "jintr": "^3.3.1",
-        "minipass-flush": "^2.0.0"
+        "minipass-flush": "^2.0.0",
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",
@@ -13173,9 +13174,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -24256,9 +24257,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -24659,27 +24660,6 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/bot/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "packages/bot/node_modules/youtubei.js": {
       "version": "16.0.1",

--- a/package.json
+++ b/package.json
@@ -101,10 +101,11 @@
     "chalk": "^5.6.2",
     "discord-player-youtubei": "^3.0.0-beta.4",
     "jintr": "^3.3.1",
-    "minipass-flush": "^2.0.0"
+    "minipass-flush": "^2.0.0",
+    "ws": "^8.20.1"
   },
   "overrides": {
-    "brace-expansion": ">=5.0.5",
+    "brace-expansion": ">=5.0.6",
     "handlebars": ">=4.7.9",
     "path-to-regexp": ">=8.4.0",
     "fast-xml-parser": ">=5.5.6",


### PR DESCRIPTION
Re-opens [#920](https://github.com/LucasSantana-Dev/Lucky/pull/920) — closed because pull_request workflows didn't fire on the original (same head-SHA desync we saw on #918→#919). Same branch, same content.

## Summary

Closes the moderate-severity CVE pair from issue #907.

| Dep | Before | After | CVE |
|---|---|---|---|
| brace-expansion | 5.0.5 override | 5.0.6 override | CVE-2024-45049 / GHSA-jxxr-4gwj-5jf2 |
| ws | 8.19.0 root | 8.20.1 root | GHSA-58qx-3vcg-4xpx |

`npm audit` post-patch: **0 vulnerabilities**.

## Approach

Same pattern as #919 (Zod 4 migration): declare the pinned version as a direct root dependency rather than fight override semantics for transitives. The nested-override at `@discordjs/ws.ws` was ignored by npm; direct root dep hoists naturally.

## Lockfile diff

36 lines. No transitive cascade — `rolldown`, `undici`, `vitest`, `jsdom`, et al all unchanged.

## Verified locally

- ✓ `npm audit` 0 vulnerabilities
- ✓ `npm ci --legacy-peer-deps --ignore-scripts` succeeds
- ✓ `npm run build:shared`
- ✓ `npm test --workspace=packages/backend` — 66 suites / 832 tests pass

Closes #907.