### PR TITLE
chore(release): cut v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-05-21
+
+### Added
+- feat(shared): Guild Automation Module Executor seam + AutoMessages pilot — `Capture / Diff / Apply` lifecycle behind a port; first executor (AutoMessages) composed at orchestrator roots (#901)
+- feat(frontend): Sentry React SDK + Router v7 tracing + replay — production frontend observability (#876)
+- feat(backend): Prometheus `/metrics` endpoint + request middleware (#875)
+- feat(bot): Prometheus `/metrics` endpoint + guild count gauge (#873)
+- feat(bot): track guild join/leave history (#872)
+- feat(ci): trivy image-scan on docker-publish — Phase A audit-only (#883)
+- ui(landing): self-hosted developer-tooling register redesign (#868)
+
+### Changed
+- refactor(backend): migrate `validate.ts` + `autoMessages` schemas to Zod 4 API — closes the Zod 3/4 drift that was masking the brace-expansion CVE patch (#919)
+- refactor(bot): break Cluster A + D circular dependencies (#885)
+- refactor(bot): break monitoring telemetry cycles (Cluster B, #886)
+- refactor(bot): break Cluster C autoplay cycles (#888)
+
+### Fixed
+- fix(deps): patch `brace-expansion` 5.0.5 → 5.0.6 (CVE-2024-45049 / GHSA-jxxr-4gwj-5jf2) and `ws` to 8.20.1 (GHSA-58qx-3vcg-4xpx) — `npm audit` clean (#921)
+- fix(shared): import jest globals explicitly in autoMessagesExecutor spec (#902)
+- fix(security): apk upgrade `nginx-alpine` base on build to patch CVEs (#881)
+- fix(ci): unblock postinstall scripts hitting GitHub API rate limit (#878)
+- fix(ci): group `$GITHUB_STEP_SUMMARY` redirects in madge workflow to satisfy shellcheck SC2129 (#905)
+
 ### Internal
-- fix(ci): group $GITHUB_STEP_SUMMARY redirects in madge workflow to satisfy shellcheck SC2129 (#905)
-- test(shared): add `coverageThreshold` gate to `packages/shared/jest.config.cjs` (no-regression floor at current baseline -2%, statements=19/branches=16/functions=15/lines=18) (#909)
+- test(shared): add `coverageThreshold` gate to `packages/shared/jest.config.cjs` — no-regression floor at current baseline -2% (statements=19/branches=16/functions=15/lines=18) (#909)
 - chore(process): add Feature-removal sweep checklist to PR template + advisory dangerfile guard that flags PRs with removal-pattern commits missing the sweep (#908)
+- chore(docker): join bot+backend to shared `lucky-monitoring` network (#877)
+- chore(docs): delete AI-generated noise + add policy ADR (#879)
+- chore(docs): wire up AI-doc policy enforcement (gitignore + pre-commit) (#880)
+- ci(madge): audit-only circular-deps gate (#887)
+- docs(adr): trivy image-scan in CI, keep Snyk dashboard only (#882)
+- docs(adr): pick #871 (bot circular-deps) as next refactor-pipeline target (#884)
+- docs(adr): backend Zod 3 → 4 migration rationale + plan
+- docs(adr): replace plan-limited PR review tools — drop Snyk/Greptile/CodeRabbit, adopt OSV-Scanner
+- docs(adr): DiscordWriteAdapter port for Module Executors (design)
+- docs(context): add `CONTEXT.md` with Module / Interface / Adapter / Seam vocabulary + Guild Automation glossary
 
 ## [2.11.0] - 2026-05-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucky-bot",
-  "version": "2.11.0",
+  "version": "2.13.0",
   "description": "All-in-one Discord bot platform \u2014 music, moderation, auto-mod, custom commands, and web dashboard",
   "type": "module",
   "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.11.0",
+    "version": "2.13.0",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.11.0",
+    "version": "2.13.0",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.11.0",
+    "version": "2.13.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.11.0",
+    "version": "2.13.0",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Cut v2.13.0 of Lucky. Bumps root + 4 workspaces from `2.11.0` → `2.13.0` (skipping the archived `2.12.0`) and promotes the CHANGELOG `[Unreleased]` block to `[2.13.0] - 2026-05-21`.

## Headline changes since v2.11.0

**Added**
- Guild Automation Module Executor seam + AutoMessages pilot (#901)
- Sentry React SDK + Router v7 tracing/replay on frontend (#876)
- Prometheus `/metrics` on backend (#875) + bot (#873)
- Guild join/leave history tracking (#872)
- Trivy image-scan on docker-publish, Phase A audit-only (#883)
- Self-hosted developer-tooling register on landing page (#868)

**Changed**
- Backend migrated to Zod 4 API (#919) — unblocked the CVE patch + ended the lockfile fragility loop
- 3 bot circular-deps clusters broken (#885, #886, #888)

**Fixed**
- brace-expansion DoS + ws uninit-memory CVEs patched (#921)
- nginx-alpine CVEs (#881)
- CI postinstall rate limit + madge actionlint (#878, #905)

Full list in CHANGELOG.md.

## Next steps (after this PR merges)

1. Open `release/v2.13.0 → main` PR with merge-commit method
2. Tag `v2.13.0` on the merge commit
3. Cut next `release` (homelab-style bare branch) — Lucky's bare-release migration is still pending the user removing protection on `release/v2.11.0`