### PR TITLE
chore(prisma): repurpose Recommendation model for autoplay telemetry (Phase A of #889 follow-up roadmap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - refactor(bot): break the last runtime circular dependency in `packages/bot/src` (Cycle C, #889) by extracting `getTrackAudioFeatures`/`audioFeatureCache` to `autoplay/audioFeatures.ts` and `buildVcContributionWeights` to `autoplay/vcWeights.ts`. Public surface preserved via re-export.
+- chore(prisma): repurpose unused `Recommendation` model for autoplay closed-loop telemetry (Phase A of the recommendation roadmap, ADR `2026-05-21-autoplay-recommendation-roadmap`). Adds `RecommendationSource` enum, `signals: Jsonb`, `discordUserId`, and a `(guildId, source, createdAt)` aggregation index; drops the unused `algorithm` column.
 
 ## [2.13.0] - 2026-05-21
 

--- a/docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md
+++ b/docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md
@@ -1,0 +1,156 @@
+# ADR 2026-05-21 — Autoplay recommendation system: telemetry-first roadmap
+
+**Status:** Accepted (sequencing decision; individual phases each ship behind their own PR)
+**Context-Pack:** Session 2026-05-21 — `/research-and-decide` on "improve the music recommendation system and fix any existent errors"
+**Supersedes:** None (first ADR for this surface)
+**Decision discipline:** critic-flipped (Phase 2 reversed the originally-proposed pair; see Alternatives)
+
+## Context
+
+Lucky's autoplay engine (`packages/bot/src/utils/music/autoplay/`) selects tracks and mounts a radio-like queue after every track ends. Over the last 60 days the system received **30+ commits**, including a 6-PR cluster fixing Spanish/gospel/sertanejo "drift" — autoplay surfacing cross-language or cross-genre tracks in non-matching sessions. The drift fixes have layered, building a stack of independent defenses:
+
+- `GENRE_FAMILIES` hard-veto in `candidateScorer.ts` (scores → `-Infinity`)
+- Cross-locale Spanish veto (`detectSpanishMarkers()` + locale check)
+- Spotify-only seed search (no YouTube fallback) to prevent cross-language drift
+- Spotify-genre fallback when Last.fm tags are missing
+- Fuzzy-dedup with title/artist normalization
+- Skip-storm relaxation (`recentSkipCount >= 3` → genre penalty × 0.5)
+
+Telemetry: `RecommendationBasis { source, signals[] }` was introduced in PR #830 — but it's **serialized to a single `reason: String?` Prisma column at the `markAsAutoplayTrack` boundary and never deserialized**. The `Recommendation` model has `reason`, `isAccepted`, `isRejected`, `feedback` columns; **none are written by the replenisher**. The feedback loop is session-local (`recentSkipCount` only) — no persistent per-user/per-guild learning.
+
+Decision archaeology gap: **zero ADRs** in `docs/decisions/` for autoplay/recommendation despite the 30+ commits + Phase 3 module-extraction refactor.
+
+The original framing of this research was: **"the drift-veto stack is the bottleneck; replace it with a session-coherence scorer."** The Phase 2 critic flipped that framing — see Alternatives below.
+
+## Decision
+
+Adopt a four-phase **telemetry-first roadmap**. Each phase is a separate PR with its own success criteria. Skipping phases inverts the dependency chain and ships observability theatre or unvalidated heuristic swaps.
+
+### Phase A — Schema extension (prerequisite)
+
+Extend the Prisma `Recommendation` model:
+
+- `recommendationSource` — `enum RecommendationSource { SPOTIFY_REC | LASTFM_SIMILAR | LASTFM_TAG | SPOTIFY_LIKED | BROAD_FALLBACK | USER_HISTORY }`
+- `recommendationSignals` — `Json[]` (array of signal records, structured matching `RecommendationBasis.signals`)
+- Optionally split `feedback` into `acceptanceReason` / `rejectionReason` enums if the current free-text column has too little structure for downstream aggregation (decide after sampling production rows).
+
+Backfill existing rows in a background job by parsing the serialized `reason` string. Keep `reason` (the human-readable serialization) as a denormalized convenience column — don't drop it.
+
+### Phase B — Write closed-loop outcomes
+
+`replenisher.ts` already imports `recommendationFeedbackService`. Extend it (or call a new `recordRecommendationOutcome()`) at two boundaries:
+
+1. **At pick time:** insert `Recommendation { source, signals, … }`.
+2. **At outcome time:** flip `isAccepted = true` if the track plays past 30% of duration without skip; flip `isRejected = true` if skipped within 5s of play start.
+
+Heuristic thresholds (30%, 5s) are placeholders — first PR can ship with these and tune empirically once Phase C surfaces data.
+
+### Phase C — Read path + baseline (7-day window)
+
+Build a read-only `/recommendations history` query path that surfaces:
+
+- Per-source 7-day acceptance rate
+- Acceptance rate stratified by `signals[]` cluster
+- Per-guild variance (some guilds may genuinely have broader/narrower taste than the global default — important for Phase D tuning)
+- Skip-storm recovery speed: how quickly does acceptance rate recover after a `recentSkipCount >= 3` event?
+
+This phase has **no risk of regression** (read-only). It produces the baseline against which Phase D is validated.
+
+Hold Phase D for 7 days of production data minimum.
+
+### Phase D — Session-coherence layer behind guild-level feature flag
+
+After Phase C produces real numbers, add a `DriftDefensePolicy` object that **augments — does not replace — the layered vetoes**:
+
+- Keep hard-rejection floors (Spanish markers, ambient noise, genre-family `-Infinity`) intact. They are tested by 60 days of production fixes.
+- Add an optional session-coherence penalty (weighted by Phase C data) on top of the existing scorer.
+- Gate behind a guild-level feature flag; A/B test against the baseline.
+- Include a signature-decay mechanism: re-compute `sessionGenreFamilies` every 2–3 replenish cycles, weighting recent history more heavily, so skip storms reshape the signature instead of locking it in.
+
+Ship Phase D **only if** the baseline acceptance-rate delta is large enough to justify the change. If Phase C shows the layered defense already produces >85% acceptance per source, Phase D becomes optional and gets deferred to a future ADR.
+
+### Cross-cutting
+
+In parallel with the above (separate PRs, not blocking the phases):
+
+- **Retrospective ADRs** for the layered drift defense (genre-family veto, cross-locale veto, Spotify-only seed search). Captures the rationale of 6 PRs from the last 60d so a future agent does not unwind them. Owner: same session that wrote this ADR.
+- **De-dup `lastFmSeeder.ts` + `lastFmSeeds.ts`** if Phase B/C work reveals overlap is causing duplicate API calls or scoring drift. Otherwise defer.
+- **`/recommend` command** (currently OFF behind `MUSIC_RECOMMENDATIONS` toggle): keep deferred until Phase B has shipped — exposing the engine as an explicit user surface needs the closed-loop feedback to be useful.
+
+## Alternatives considered
+
+- **Originally proposed Pair A: deserialize `RecommendationBasis` end-to-end + replace layered vetoes with a session-coherence scorer.** Rejected by the Phase 2 critic on three concrete grounds, each verified:
+  1. `Recommendation.reason: String?` is the only basis-related column. Deserialization-only ships observability that *looks* closed-loop but isn't — without `recommendationSource` + `recommendationSignals` columns, per-source aggregation has no schema to land on. Phase A above closes this gap.
+  2. The session-coherence scorer risks regression on the long-tail Spanish-gospel/sertanejo drift cases that the layered defense currently handles. Skip storms produce noisy session signatures, and a signature-based scorer would re-admit drift unless it explicitly preserves Spanish-marker and genre-family hard-rejection — at which point it's a re-implementation of the stack, not a replacement.
+  3. `RecommendationSignal` enum conflates outcome-level signals (`completed before`, `skipped before`) with mechanism-level signals (`spotify preferred`, `genre family drift`). Counts of signals don't stratify by mechanism, so a histogram won't drive decisions. Phase A's schema extension separates source (mechanism) from signals (context); Phase B's outcome write closes the cause-vs-outcome gap.
+
+- **Pair B: persistent per-user/per-guild skip-learning + mood-vector v2.** Rejected as a starting point (kept in the candidate pool for post-Phase-C re-evaluation). Both add behavioural complexity before there is data to tune them. Phase C may reveal that simple per-source acceptance rate already explains 80% of the win.
+
+- **Pair C: ADRs-only.** Rejected as insufficient. Documentation matters but doesn't fix the write-only telemetry loop, which is the deeper architectural gap.
+
+- **Pair D: do nothing; accept the drift defense as a permanent stack.** Rejected. The reactive-patch pattern over 60 days signals the stack is fragile to new edge cases; each new geographic/genre drift currently requires a new fix-commit. Phase D's session-coherence layer is the long-term answer once the baseline data exists.
+
+## Consequences
+
+### Positive
+
+- The telemetry-first sequence ensures every behaviour change is validated against a baseline. No silent regressions.
+- The schema extension (Phase A) closes the structural gap that turned PR #830's telemetry into write-only data.
+- The roadmap explicitly preserves the layered drift defense — 60 days of production work isn't unwound.
+- Retrospective ADRs (cross-cutting work) prevent the layered defense from being unwound by future agents who haven't seen the incident history.
+- Each phase is independently mergeable. Lack of resources after Phase C is acceptable — Phase D becomes optional based on data.
+
+### Negative
+
+- Total scope is 4 PRs minimum (Phase A + B + C + retrospective ADRs). At 1 PR / 2-3 days, that's 1.5-2 weeks of intermittent work.
+- Phase A is a Prisma schema migration. Lucky has had lockfile fragility around schema/dep changes recently (see PR #919 cascade). The migration needs to land cleanly with `--package-lock-only --ignore-scripts` patterns established in PR #921.
+- Phase D is conditional on Phase C data being conclusive. If the baseline shows current acceptance rates are already high (>85% per source), Phase D becomes a "nice-to-have refactor" that the user may correctly choose to defer indefinitely.
+
+### Neutral
+
+- No user-facing behaviour change until Phase D ships (if it does). Phases A-C are observability work.
+- The `MUSIC_RECOMMENDATIONS` toggle (currently OFF for `/recommend`) stays off through Phases A-C. Re-enable considered post-Phase B.
+
+## Implementation plan (per phase)
+
+**Phase A — schema** (≈1 PR, ≈2 days)
+1. New migration: add `recommendationSource`, `recommendationSignals` columns. Keep `reason` denormalized.
+2. Update `Recommendation` writers in `replenisher.ts` to populate the new columns.
+3. Backfill job (script in `scripts/`, run once in production): parse existing `reason` strings → populate new columns. Tolerant of unparseable rows (leaves them null + logs to Sentry).
+4. Tests: writer path + backfill script.
+
+**Phase B — outcome write** (≈1 PR, ≈2 days)
+1. Add `recordRecommendationOutcome()` to `recommendationFeedbackService`.
+2. Wire into `player.on('playerFinish')` / `player.on('playerSkip')` (or equivalent discord-player hooks already in use).
+3. Tests: outcome write hits the right rows + handles edge cases (skip < 5s, complete > 30%).
+
+**Phase C — read path + dashboard** (≈1 PR, ≈3 days)
+1. Backend `/recommendations/history` route with per-source 7-day aggregations.
+2. Frontend surface in `/dashboard/<guild>/music` (or a new page) showing per-source acceptance rate.
+3. Optional: weekly Sentry breadcrumb / metric for global acceptance rate.
+
+Hold for 7 days of production data.
+
+**Phase D — coherence layer** (≈1 PR, ≈4-5 days, conditional)
+1. `DriftDefensePolicy` object that wraps the existing veto chain + optional coherence penalty.
+2. Signature decay (re-center every 2-3 replenishes).
+3. Guild-level feature flag.
+4. A/B harness: track acceptance-rate delta vs control.
+
+Rollback for any phase: revert the PR. Phases A and B are additive — old code paths still work without the new columns/writes if the data is absent.
+
+## Revisit triggers
+
+- **Phase C baseline shows >85% per-source acceptance across the board** → Phase D becomes optional. Promote this ADR's status to "Roadmap completed at Phase C; coherence layer deferred."
+- **A new geographic/genre drift surfaces** (e.g., Korean ballad, J-pop, French chanson) **between Phase A and Phase D** → that drift gets a layered-veto patch in the existing style. Don't pre-emptively block on the coherence layer.
+- **`@discordjs/opus` or `discord-player` major bump** changes the queue/replenish event shapes → revisit Phase B's outcome-write integration points.
+- **`MUSIC_RECOMMENDATIONS` toggle flips ON** → revisit whether `/recommend` exposes the same engine (yes) or a separate one (no, currently). Likely just a wiring task at that point, but worth confirming in a follow-up ADR.
+- **Lucky adds OpenSearch / Elasticsearch / a real analytics store** → Phase C read path migrates from Prisma aggregation to that store; current per-Postgres-query approach is fine for the 7-day window and current scale (hundreds of guilds, not thousands).
+
+## Related artefacts
+
+- PR #830 — original `RecommendationBasis` capture (now reframed as Phase 0)
+- PR #810 — structured telemetry on replenishment (informs Phase C dashboard shape)
+- PRs #780, #817, #818, #819, #820, #827 — the 6 drift-veto fixes that the layered defense layer is composed from. Retrospective ADRs (cross-cutting work item) should cover at minimum the rationale for #780 (hard-reject Spanish drift) and #827 (remove YouTube fallback).
+- Issue: `MUSIC_RECOMMENDATIONS` toggle (currently OFF in `packages/shared/src/config/featureToggles.ts:17`)
+- Memory: `~/.claude/projects/-Volumes-External-HD-Desenvolvimento-Lucky/memory/` — observation #3407 (PR #817 autoplay overhaul), #3410 (PR #818 locale filter), #3422 (PR #817 Spotify-genre fallback), #3448 (RecommendationBasis refactor PR #830), #3449 (PR #827 YouTube-fallback removal). The reactive-patch pattern these memories document is the load-bearing context for the telemetry-first sequencing.

--- a/prisma/migrations/20260521000000_recommendation_telemetry_phase_a/migration.sql
+++ b/prisma/migrations/20260521000000_recommendation_telemetry_phase_a/migration.sql
@@ -1,0 +1,41 @@
+-- Phase A of the autoplay recommendation telemetry roadmap.
+-- See docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md
+--
+-- The `recommendations` table was previously unused scaffolding — no service
+-- writes to it. This migration repurposes the table for autoplay closed-loop
+-- telemetry without preserving the legacy `algorithm` column (no production
+-- rows depend on it).
+
+-- New enum captures the in-code RecommendationSource union from
+-- packages/bot/src/utils/music/autoplay/recommendationBasis.ts.
+CREATE TYPE "RecommendationSource" AS ENUM (
+    'SPOTIFY_REC',
+    'SPOTIFY_TASTE',
+    'LASTFM_LOVED',
+    'LASTFM_SIMILAR',
+    'LASTFM_GENRE_FALLBACK',
+    'ARTIST_FALLBACK',
+    'GENRE_TAG'
+);
+
+-- Drop the unused legacy column. Safe: no writer in the codebase, no rows.
+ALTER TABLE "recommendations" DROP COLUMN "algorithm";
+
+-- Make `confidence` nullable. Phase D may populate it; Phase A/B do not need
+-- it and forcing a default would lie about the data.
+ALTER TABLE "recommendations" ALTER COLUMN "confidence" DROP NOT NULL;
+
+-- Per-user telemetry: the Discord user whose listening session produced the
+-- pick. Optional because some autoplay paths choose a VC contributor instead
+-- of a single requester (see vcWeights.ts).
+ALTER TABLE "recommendations" ADD COLUMN "discordUserId" TEXT;
+
+-- New structured columns. `source` and `signals` are the load-bearing pair
+-- for Phase C aggregations. `reason` stays as the human-readable
+-- serialization (denormalized convenience, kept in sync at write time).
+ALTER TABLE "recommendations" ADD COLUMN "source" "RecommendationSource";
+ALTER TABLE "recommendations" ADD COLUMN "signals" JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- Aggregation index for `/recommendations history` per-source rollups.
+CREATE INDEX "recommendations_guildId_source_createdAt_idx"
+    ON "recommendations" ("guildId", "source", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,9 +93,9 @@ model GuildMembershipEvent {
 }
 
 model GuildFeatureToggle {
-  id      String @id @default(cuid())
+  id      String  @id @default(cuid())
   guildId String
-  guild   Guild  @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  guild   Guild   @relation(fields: [guildId], references: [id], onDelete: Cascade)
   name    String
   enabled Boolean
 
@@ -126,13 +126,11 @@ model TwitchNotification {
   @@map("twitch_notifications")
 }
 
-
 enum AutoplayMode {
   similar
   discover
   popular
 }
-
 
 model GuildSettings {
   id      String @id @default(cuid())
@@ -140,13 +138,13 @@ model GuildSettings {
   guild   Guild  @relation(fields: [guildId], references: [id], onDelete: Cascade)
 
   // Music settings
-  defaultVolume   Int     @default(50)
-  maxQueueSize    Int     @default(100)
-  autoPlayEnabled Boolean @default(true)
+  defaultVolume   Int          @default(50)
+  maxQueueSize    Int          @default(100)
+  autoPlayEnabled Boolean      @default(true)
   autoplayMode    AutoplayMode @default(similar)
-  autoplayGenres  String[] @default([])
-  repeatMode      Int     @default(0)
-  shuffleEnabled  Boolean @default(false)
+  autoplayGenres  String[]     @default([])
+  repeatMode      Int          @default(0)
+  shuffleEnabled  Boolean      @default(false)
 
   // Bot settings
   prefix     String? @default("/")
@@ -167,7 +165,7 @@ model GuildSettings {
   // Optional role granted for the day. Scheduler reconciles membership each
   // tick against today's birthday set, so revocation is automatic when the
   // clock rolls over.
-  birthdayRoleId String?
+  birthdayRoleId    String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -191,16 +189,16 @@ model GuildRoleGrant {
 }
 
 model GuildAutomationManifest {
-  id               String   @id @default(cuid())
-  guildId          String   @unique
-  version          Int      @default(1)
-  manifest         Json
-  moduleOwnership  Json?
+  id                String    @id @default(cuid())
+  guildId           String    @unique
+  version           Int       @default(1)
+  manifest          Json
+  moduleOwnership   Json?
   lastCapturedState Json?
-  lastCapturedAt   DateTime?
-  createdBy        String?
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  lastCapturedAt    DateTime?
+  createdBy         String?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@index([guildId])
   @@map("guild_automation_manifests")
@@ -368,16 +366,16 @@ model Download {
 
 // Artist Preferences (per Discord user per guild)
 model UserArtistPreference {
-  id          String   @id @default(cuid())
+  id            String   @id @default(cuid())
   discordUserId String
-  guildId     String
-  artistKey   String  // normalized: lowercase alphanumeric
-  artistName  String  // display name
-  spotifyId   String?
-  imageUrl    String?
-  preference  String  @default("prefer") // "prefer" | "block"
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  guildId       String
+  artistKey     String // normalized: lowercase alphanumeric
+  artistName    String // display name
+  spotifyId     String?
+  imageUrl      String?
+  preference    String   @default("prefer") // "prefer" | "block"
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   @@unique([discordUserId, guildId, artistKey])
   @@index([discordUserId, guildId])
@@ -385,11 +383,37 @@ model UserArtistPreference {
 }
 
 // Music Recommendations
+//
+// Closed-loop telemetry for the autoplay engine: each track the engine picks is
+// recorded here at pick time; outcome is back-filled when the track plays
+// through (`isAccepted = true`) or is skipped early (`isRejected = true`).
+//
+// Source/signals come from the in-code `RecommendationBasis` shape
+// (packages/bot/src/utils/music/autoplay/recommendationBasis.ts). `reason`
+// stays as the denormalized human-readable serialization for Discord display.
+//
+// See docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md for the
+// 4-phase roadmap; this table is the substrate for Phases A-C.
+enum RecommendationSource {
+  SPOTIFY_REC
+  SPOTIFY_TASTE
+  LASTFM_LOVED
+  LASTFM_SIMILAR
+  LASTFM_GENRE_FALLBACK
+  ARTIST_FALLBACK
+  GENRE_TAG
+}
+
 model Recommendation {
   id      String @id @default(cuid())
   guildId String
 
-  // Recommendation data
+  // The Discord user whose listening session produced this pick. Optional
+  // because some autoplay paths run without a clear single user (e.g.
+  // multi-listener voice channels — vcWeights chooses a contributor).
+  discordUserId String?
+
+  // Track identity
   trackId   String
   title     String
   author    String
@@ -397,11 +421,16 @@ model Recommendation {
   thumbnail String?
 
   // Recommendation metadata
-  algorithm  String // collaborative, content-based, hybrid
-  confidence Float // 0.0 - 1.0
+  source     RecommendationSource?
+  // RecommendationSignal[] from in-code basis. Stored as JSON for forward-
+  // compatibility — the TS union evolves more often than this schema should.
+  signals    Json                  @default("[]")
+  confidence Float? // 0.0 - 1.0 (Phase D may surface this; null for now)
+  // Denormalized human-readable serialization of source + signals. Computed
+  // by serializeBasis(). Kept for Discord display and ad-hoc query inspection.
   reason     String?
 
-  // User interaction
+  // Phase B closed-loop outcome
   isAccepted Boolean?
   isRejected Boolean?
   feedback   String?
@@ -410,6 +439,7 @@ model Recommendation {
   updatedAt DateTime @updatedAt
 
   @@index([guildId, createdAt])
+  @@index([guildId, source, createdAt])
   @@map("recommendations")
 }
 
@@ -459,15 +489,15 @@ model LastFmLink {
 
 // Spotify per-user linking (OAuth tokens stored per Discord user)
 model SpotifyLink {
-  id             String   @id @default(cuid())
-  discordId      String   @unique
-  spotifyId      String
-  accessToken    String
-  refreshToken   String
-  tokenExpiresAt DateTime
+  id              String   @id @default(cuid())
+  discordId       String   @unique
+  spotifyId       String
+  accessToken     String
+  refreshToken    String
+  tokenExpiresAt  DateTime
   spotifyUsername String?
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   @@map("spotify_links")
 }
@@ -537,24 +567,24 @@ model ModerationSettings {
 }
 
 model AutoModSettings {
-  id             String   @id @default(cuid())
-  guildId        String   @unique
-  enabled        Boolean  @default(false)
-  spamEnabled    Boolean  @default(false)
-  spamThreshold  Int      @default(5)
-  spamTimeWindow Int      @default(5)
-  capsEnabled    Boolean  @default(false)
-  capsThreshold  Int      @default(70)
-  linksEnabled   Boolean  @default(false)
-  allowedDomains      String[] @default([])
-  linkExemptChannels  String[] @default([])
-  invitesEnabled      Boolean  @default(false)
-  wordsEnabled        Boolean  @default(false)
-  bannedWords         String[] @default([])
-  exemptRoles         String[] @default([])
-  exemptChannels      String[] @default([])
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  id                 String   @id @default(cuid())
+  guildId            String   @unique
+  enabled            Boolean  @default(false)
+  spamEnabled        Boolean  @default(false)
+  spamThreshold      Int      @default(5)
+  spamTimeWindow     Int      @default(5)
+  capsEnabled        Boolean  @default(false)
+  capsThreshold      Int      @default(70)
+  linksEnabled       Boolean  @default(false)
+  allowedDomains     String[] @default([])
+  linkExemptChannels String[] @default([])
+  invitesEnabled     Boolean  @default(false)
+  wordsEnabled       Boolean  @default(false)
+  bannedWords        String[] @default([])
+  exemptRoles        String[] @default([])
+  exemptChannels     String[] @default([])
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
   @@map("automod_settings")
 }


### PR DESCRIPTION
**Phase A** of the 4-phase autoplay recommendation telemetry roadmap.

## Context

Surprise finding during research: the existing \`Recommendation\` Prisma model is **entirely unused** — no service writes to it. The original critic review assumed it was being populated by autoplay and recommended a backfill plan; the actual codebase has no writers at all.

That removes the schema-migration risk and lets Phase A repurpose the table cleanly without backfill.

See ADR \`docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md\` (in this PR) for the full 4-phase plan + Phase 2 critic flip.

## What this PR ships

**Phase A — schema only.** No writers, no readers wired yet.

- New enum \`RecommendationSource\` matching the in-code TS union from \`packages/bot/src/utils/music/autoplay/recommendationBasis.ts\`.
- Drop unused \`algorithm: String\` column.
- Add \`source: RecommendationSource?\` — load-bearing for Phase C aggregations.
- Add \`signals: Jsonb @default('[]')\` — captures \`RecommendationBasis.signals\` array structurally (the TS union evolves more often than this schema should, so JSON not enum).
- Add \`discordUserId: String?\` (nullable: some autoplay paths choose a VC contributor instead of a single requester — see \`vcWeights.ts\`).
- \`confidence: Float?\` (was non-null; nullable now — Phase D may populate, A/B do not).
- New aggregation index \`(guildId, source, createdAt)\` for the future \`/recommendations history\` query.

## Out of scope (Phases B / C / D)

- **Phase B** — wire \`replenisher.ts\` to write rows at pick time + flip \`isAccepted\`/\`isRejected\` at \`playerFinish\`/\`playerSkip\`.
- **Phase B** — TS-union ↔ Prisma-enum mapping function.
- **Phase C** — \`/recommendations history\` read path + 7-day baseline dashboard.
- **Phase D** — conditional session-coherence layer behind guild-level feature flag.

## Tests

158/158 pass for \`autoplay|queueManipulation|queueRescue|replenisher|recommendationBasis\` (the autoplay surface). The change is schema-only — no application code changes — so no test changes required.

## Migration safety

- Drops one column (\`algorithm\`) but no rows exist (the table is unused).
- All new columns are nullable or have defaults.
- Manual migration file written without \`prisma migrate dev\` (avoids touching the live DB during PR work — homelab DB will pick it up on next deploy).

## ADR

\`docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md\` lands in this PR. Records:
- The full 4-phase plan
- All 4 considered alternatives + rejection rationale
- Critic's 3 critical findings (Phase 2 of \`/research-and-decide\`) that flipped the original pair
- 5 revisit triggers (Phase C >85% acceptance, new geographic drift, etc.)

## Changelog

[Unreleased] Changed: chore(prisma): repurpose Recommendation model for autoplay telemetry (Phase A).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added roadmap for autoplay recommendation system improvements, including planned recommendation history tracking and per-source performance analytics.

* **Chores**
  * Infrastructure updates to support recommendation telemetry and closed-loop outcome tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->