### PR TITLE
fix(ci): use v-prefixed trivy-action tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,7 +107,7 @@ jobs:
                 echo "ref=${IMAGE}:${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
 
             - name: Trivy image scan (audit-only)
-              uses: aquasecurity/trivy-action@0.36.0
+              uses: aquasecurity/trivy-action@v0.36.0
               with:
                   image-ref: ${{ steps.imgref.outputs.ref }}
                   format: sarif


### PR DESCRIPTION
Hotfix targeted directly at main — every \`Build & Push Docker Images\` run on main has been failing since v2.13.0 because of this single-character bug.

## Root cause

\`.github/workflows/docker-publish.yml:110\` referenced \`aquasecurity/trivy-action@0.36.0\` but the action's releases are tagged with a \`v\` prefix:

\`\`\`
$ gh api repos/aquasecurity/trivy-action/releases --jq '.[0:3] | .[].tag_name'
v0.36.0
v0.35.0
0.35.0
\`\`\`

GitHub Actions emitted:

\`\`\`
##[error]Unable to resolve action 'aquasecurity/trivy-action@0.36.0', unable to find version '0.36.0'
\`\`\`

…and aborted **every matrix job** (backend, nginx, bot, frontend) before it could push images to ghcr.

## Effect

- All Docker image builds on main have been failing since the trivy step was introduced in v2.13.0 (workflow run 26253521960).
- Homelab is running the previous (v2.12.x) images because new ones never published.
- 2 of the 4 matrix jobs were cancelled (not failed) because the failure cascaded.

## Fix

\`@0.36.0\` → \`@v0.36.0\`. One-character change.

## Propagation to release/v2.14.0

\`release-branch-autosync.yml\` runs on push to main and fast-forwards \`release/v2.14.0\`. The fix lands there automatically — no separate hotfix branch needed for release.

## Why hotfix-to-main, not via release

Standard release-branch flow (PR → release/v2.14.0 → eventual release-cut to main) would leave production images stale for the entire release cycle. Per project policy ("if any check or CI step is failing on a pull request it should never get to main"), the right move is a direct-to-main hotfix that gets autosynced back to release.

## Verification

After merge:
1. Docker publish runs on the merge commit should succeed (all 4 matrix jobs).
2. ghcr should show new \`production-backend\`, \`production-bot\`, \`production-frontend\`, \`production-nginx\` tags.
3. release-branch-autosync should FF \`release/v2.14.0\` to include this commit.

Memory: \`feedback_bulk_workflow_rollout_2026-05-13\` already documents this gotcha; this fix reinforces the canonical \`v\`-prefix convention.