### PR TITLE
feat(backend): autoplay telemetry read path (Phase C of #889 follow-up roadmap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - feat(bot): autoplay closed-loop telemetry writers (Phase B of the recommendation roadmap). `recordRecommendationPick` inserts a `Recommendation` row at every autoplay pick (wired via the new `markAndRecordAutoplayTrack` wrapper in `diversitySelector.addSelectedTracks`); `recordRecommendationOutcome` flips `isAccepted`/`isRejected` on `playerFinish` (played > 30%) and `playerSkip` (< 5s). Thresholds exported as `OUTCOME_ACCEPT_PLAY_RATIO` / `OUTCOME_REJECT_EARLY_SKIP_MS` for Phase C tuning. All telemetry is non-throwing; failures never block queue replenishment or player events.
+- feat(backend): autoplay telemetry read path — `GET /api/guilds/:guildId/recommendations/history?days=<n>` (Phase C of the recommendation roadmap). Returns per-source acceptance rate + global summary aggregated over the requested window (default 7 days, clamped to [1, 30]). Backed by the new `recommendationTelemetryReadService` in `@lucky/shared/services`. Read-only; zero regression risk.
 
 ## [2.13.0] - 2026-05-21
 

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -8,6 +8,7 @@ import { setupLastFmRoutes } from './lastfm'
 import { setupSpotifyRoutes } from './spotify'
 import { setupGuildSettingsRoutes } from './guildSettings'
 import { setupTrackHistoryRoutes } from './trackHistory'
+import { setupRecommendationsRoutes } from './recommendations'
 import { setupTwitchRoutes } from './twitch'
 import { setupLyricsRoutes } from './lyrics'
 import { setupRolesRoutes } from './roles'
@@ -59,6 +60,7 @@ const guildGuardConfigs: GuildGuardConfig[] = [
     { path: '/api/guilds/:id/features', module: 'automation' },
     { path: '/api/guilds/:guildId/levels', module: 'settings' },
     { path: '/api/guilds/:guildId/starboard', module: 'settings' },
+    { path: '/api/guilds/:guildId/recommendations', module: 'settings' },
 ]
 
 const routeSetups = [
@@ -71,6 +73,7 @@ const routeSetups = [
     setupSpotifyRoutes,
     setupGuildSettingsRoutes,
     setupTrackHistoryRoutes,
+    setupRecommendationsRoutes,
     setupTwitchRoutes,
     setupLyricsRoutes,
     setupRolesRoutes,

--- a/packages/backend/src/routes/recommendations.ts
+++ b/packages/backend/src/routes/recommendations.ts
@@ -1,0 +1,40 @@
+import type { Express, Response } from 'express'
+import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
+import { validateParams, validateQuery } from '../middleware/validate'
+import { asyncHandler } from '../middleware/asyncHandler'
+import { managementSchemas as s } from '../schemas/management'
+import {
+    getPerSourceAcceptance,
+    getSummary,
+    type PerSourceRow,
+    type Summary,
+} from '@lucky/shared/services'
+import { z } from 'zod'
+
+function p(val: string | string[]): string {
+    return typeof val === 'string' ? val : val[0]
+}
+
+const historyQuery = z.object({
+    days: z.coerce.number().int().min(1).max(30).optional(),
+})
+
+export function setupRecommendationsRoutes(app: Express): void {
+    app.get(
+        '/api/guilds/:guildId/recommendations/history',
+        requireAuth,
+        validateParams(s.guildIdParam),
+        validateQuery(historyQuery),
+        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+            const guildId = p(req.params.guildId)
+            const days = req.query.days ? Number(req.query.days) : undefined
+
+            const [summary, perSource] = await Promise.all([
+                getSummary(guildId, days),
+                getPerSourceAcceptance(guildId, days),
+            ])
+
+            res.json({ summary, perSource })
+        }),
+    )
+}

--- a/packages/backend/src/routes/recommendations.ts
+++ b/packages/backend/src/routes/recommendations.ts
@@ -3,12 +3,7 @@ import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
 import { validateParams, validateQuery } from '../middleware/validate'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { managementSchemas as s } from '../schemas/management'
-import {
-    getPerSourceAcceptance,
-    getSummary,
-    type PerSourceRow,
-    type Summary,
-} from '@lucky/shared/services'
+import { getPerSourceAcceptance, getSummary } from '@lucky/shared/services'
 import { z } from 'zod'
 
 function p(val: string | string[]): string {

--- a/packages/backend/tests/integration/recommendations.test.ts
+++ b/packages/backend/tests/integration/recommendations.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+
+jest.mock('../../src/services/SessionService', () => ({
+    sessionService: {
+        getSession: jest.fn(),
+        setSession: jest.fn(),
+        deleteSession: jest.fn(),
+    },
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    ...jest.requireActual('@lucky/shared/services'),
+    getSummary: jest.fn(),
+    getPerSourceAcceptance: jest.fn(),
+}))
+
+import request from 'supertest'
+import express from 'express'
+import { setupRecommendationsRoutes } from '../../src/routes/recommendations'
+import { setupSessionMiddleware } from '../../src/middleware/session'
+import { sessionService } from '../../src/services/SessionService'
+import { getSummary, getPerSourceAcceptance } from '@lucky/shared/services'
+import { MOCK_SESSION_DATA, MOCK_SESSION_ID } from '../fixtures/mock-data'
+
+const SESSION_COOKIE = [`sessionId=${MOCK_SESSION_ID}`]
+
+describe('Recommendations Routes', () => {
+    let app: express.Express
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        app = express()
+        app.use(express.json())
+        setupSessionMiddleware(app)
+        setupRecommendationsRoutes(app)
+
+        const mockSessionService = sessionService as jest.Mocked<
+            typeof sessionService
+        >
+        mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+    })
+
+    describe('GET /api/guilds/:guildId/recommendations/history', () => {
+        test('should return 200 with summary and perSource data on success', async () => {
+            const mockSummary = {
+                totalPicks: 100,
+                accepted: 60,
+                rejected: 30,
+                pending: 10,
+                globalAcceptanceRate: 0.6666666666666666,
+            }
+
+            const mockPerSource = [
+                {
+                    source: 'autoplay',
+                    count: 50,
+                    acceptedCount: 35,
+                    rejectedCount: 10,
+                    pendingCount: 5,
+                    acceptanceRate: 0.7777777777777778,
+                },
+                {
+                    source: 'manual',
+                    count: 50,
+                    acceptedCount: 25,
+                    rejectedCount: 20,
+                    pendingCount: 5,
+                    acceptanceRate: 0.5555555555555556,
+                },
+            ]
+
+            ;(getSummary as jest.Mock).mockResolvedValue(mockSummary)
+            ;(getPerSourceAcceptance as jest.Mock).mockResolvedValue(
+                mockPerSource,
+            )
+
+            const res = await request(app)
+                .get('/api/guilds/111111111111111111/recommendations/history')
+                .set('Cookie', SESSION_COOKIE)
+
+            expect(res.status).toBe(200)
+            expect(res.body).toEqual({
+                summary: mockSummary,
+                perSource: mockPerSource,
+            })
+            expect(getSummary).toHaveBeenCalledWith(
+                '111111111111111111',
+                undefined,
+            )
+            expect(getPerSourceAcceptance).toHaveBeenCalledWith(
+                '111111111111111111',
+                undefined,
+            )
+        })
+
+        test('should respect days query parameter', async () => {
+            const mockSummary = {
+                totalPicks: 50,
+                accepted: 30,
+                rejected: 15,
+                pending: 5,
+                globalAcceptanceRate: 0.6666666666666666,
+            }
+
+            const mockPerSource = []
+
+            ;(getSummary as jest.Mock).mockResolvedValue(mockSummary)
+            ;(getPerSourceAcceptance as jest.Mock).mockResolvedValue(
+                mockPerSource,
+            )
+
+            const res = await request(app)
+                .get(
+                    '/api/guilds/111111111111111111/recommendations/history?days=14',
+                )
+                .set('Cookie', SESSION_COOKIE)
+
+            expect(res.status).toBe(200)
+            expect(getSummary).toHaveBeenCalledWith('111111111111111111', 14)
+            expect(getPerSourceAcceptance).toHaveBeenCalledWith(
+                '111111111111111111',
+                14,
+            )
+        })
+
+        test('should reject days > 30 with 400', async () => {
+            const res = await request(app)
+                .get(
+                    '/api/guilds/111111111111111111/recommendations/history?days=999',
+                )
+                .set('Cookie', SESSION_COOKIE)
+
+            expect(res.status).toBe(400)
+        })
+
+        test('should reject invalid guildId with 400', async () => {
+            const res = await request(app)
+                .get('/api/guilds/invalid-id/recommendations/history')
+                .set('Cookie', SESSION_COOKIE)
+
+            expect(res.status).toBe(400)
+        })
+
+        test('should return 401 when not authenticated', async () => {
+            const res = await request(app).get(
+                '/api/guilds/111111111111111111/recommendations/history',
+            )
+
+            expect(res.status).toBe(401)
+        })
+
+        test('should return 500 when service throws', async () => {
+            ;(getSummary as jest.Mock).mockRejectedValue(
+                new Error('Database error'),
+            )
+
+            const res = await request(app)
+                .get('/api/guilds/111111111111111111/recommendations/history')
+                .set('Cookie', SESSION_COOKIE)
+
+            expect(res.status).toBe(500)
+        })
+    })
+})

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -58,6 +58,22 @@ export {
     GuildRoleGrantStorageError,
 } from './GuildRoleAccessService'
 export { redisClient } from './redis/index.js'
-export { starboardService, type StarboardConfig, type StarboardEntry } from './StarboardService.js'
-export { levelService, type LevelConfig, type MemberXP, type LevelReward, xpNeededForLevel } from './LevelService.js'
+export {
+    starboardService,
+    type StarboardConfig,
+    type StarboardEntry,
+} from './StarboardService.js'
+export {
+    levelService,
+    type LevelConfig,
+    type MemberXP,
+    type LevelReward,
+    xpNeededForLevel,
+} from './LevelService.js'
 export { autoroleService, type AutoRoleEntry } from './AutoRoleService.js'
+export {
+    getPerSourceAcceptance,
+    getSummary,
+    type PerSourceRow,
+    type Summary,
+} from './recommendationTelemetryReadService'

--- a/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
+import { RecommendationSource } from '../types'
+
+// Mock functions defined first (before jest.mock calls)
+const mockGroupBy = jest.fn<any>()
+const mockCount = jest.fn<any>()
+const mockGetPrismaClient = jest.fn<any>()
+
+jest.mock('../utils/database/prismaClient', () => ({
+    getPrismaClient: mockGetPrismaClient,
+    disconnectPrisma: jest.fn(),
+}))
+
+// Now import the module under test
+import {
+    getPerSourceAcceptance,
+    getSummary,
+    type PerSourceRow,
+    type Summary,
+} from './recommendationTelemetryReadService'
+
+describe('recommendationTelemetryReadService', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        // Set up the default mock implementation
+        mockGetPrismaClient.mockReturnValue({
+            recommendation: {
+                groupBy: mockGroupBy,
+                count: mockCount,
+            },
+        })
+    })
+
+    describe('getPerSourceAcceptance', () => {
+        it('returns empty array when guild has no recommendations', async () => {
+            mockGroupBy.mockResolvedValue([])
+
+            const result = await getPerSourceAcceptance('guild-123')
+
+            expect(result).toEqual([])
+            expect(mockGroupBy).toHaveBeenCalled()
+        })
+
+        it('returns single row for single source with mixed outcomes', async () => {
+            const mockGroupResult = [
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    _count: {
+                        id: 10,
+                    },
+                },
+            ]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            // Mock count calls for accepted, rejected, pending
+            const countCalls = [
+                { count: 7 }, // accepted
+                { count: 2 }, // rejected
+                { count: 1 }, // pending
+            ]
+            mockCount
+                .mockResolvedValueOnce(countCalls[0])
+                .mockResolvedValueOnce(countCalls[1])
+                .mockResolvedValueOnce(countCalls[2])
+
+            const result = await getPerSourceAcceptance('guild-123')
+
+            expect(result).toHaveLength(1)
+            expect(result[0]).toEqual({
+                source: RecommendationSource.SPOTIFY_REC,
+                count: 10,
+                acceptedCount: 7,
+                rejectedCount: 2,
+                pendingCount: 1,
+                acceptanceRate: 7 / 9, // 7 / (7 + 2)
+            })
+        })
+
+        it('returns multiple rows for multiple sources', async () => {
+            const mockGroupResult = [
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    _count: { id: 10 },
+                },
+                {
+                    source: RecommendationSource.LASTFM_LOVED,
+                    _count: { id: 5 },
+                },
+                {
+                    source: RecommendationSource.ARTIST_FALLBACK,
+                    _count: { id: 3 },
+                },
+            ]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            // Spotify: 7 accepted, 2 rejected, 1 pending
+            mockCount
+                .mockResolvedValueOnce({ count: 7 })
+                .mockResolvedValueOnce({ count: 2 })
+                .mockResolvedValueOnce({ count: 1 })
+                // LastFM: 3 accepted, 1 rejected, 1 pending
+                .mockResolvedValueOnce({ count: 3 })
+                .mockResolvedValueOnce({ count: 1 })
+                .mockResolvedValueOnce({ count: 1 })
+                // Artist: 2 accepted, 1 rejected, 0 pending
+                .mockResolvedValueOnce({ count: 2 })
+                .mockResolvedValueOnce({ count: 1 })
+                .mockResolvedValueOnce({ count: 0 })
+
+            const result = await getPerSourceAcceptance('guild-123')
+
+            expect(result).toHaveLength(3)
+            expect(result[0]).toMatchObject({
+                source: RecommendationSource.SPOTIFY_REC,
+                count: 10,
+                acceptedCount: 7,
+                rejectedCount: 2,
+                pendingCount: 1,
+                acceptanceRate: 7 / 9,
+            })
+            expect(result[1]).toMatchObject({
+                source: RecommendationSource.LASTFM_LOVED,
+                count: 5,
+                acceptedCount: 3,
+                rejectedCount: 1,
+                pendingCount: 1,
+                acceptanceRate: 3 / 4,
+            })
+            expect(result[2]).toMatchObject({
+                source: RecommendationSource.ARTIST_FALLBACK,
+                count: 3,
+                acceptedCount: 2,
+                rejectedCount: 1,
+                pendingCount: 0,
+                acceptanceRate: 2 / 3,
+            })
+        })
+
+        it('returns null acceptanceRate when denominator is zero (all pending)', async () => {
+            const mockGroupResult = [
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    _count: { id: 5 },
+                },
+            ]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            // All pending
+            mockCount
+                .mockResolvedValueOnce({ count: 0 }) // accepted
+                .mockResolvedValueOnce({ count: 0 }) // rejected
+                .mockResolvedValueOnce({ count: 5 }) // pending
+
+            const result = await getPerSourceAcceptance('guild-123')
+
+            expect(result[0].acceptanceRate).toBeNull()
+        })
+
+        it('handles null source value (legacy/fallback)', async () => {
+            const mockGroupResult = [
+                {
+                    source: null,
+                    _count: { id: 2 },
+                },
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    _count: { id: 3 },
+                },
+            ]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            mockCount
+                .mockResolvedValueOnce({ count: 1 }) // null: accepted
+                .mockResolvedValueOnce({ count: 1 }) // null: rejected
+                .mockResolvedValueOnce({ count: 0 }) // null: pending
+                .mockResolvedValueOnce({ count: 2 }) // spotify: accepted
+                .mockResolvedValueOnce({ count: 1 }) // spotify: rejected
+                .mockResolvedValueOnce({ count: 0 }) // spotify: pending
+
+            const result = await getPerSourceAcceptance('guild-123')
+
+            expect(result).toHaveLength(2)
+            expect(result[0].source).toBeNull()
+            expect(result[0].acceptanceRate).toBe(0.5) // 1/(1+1)
+        })
+
+        it('clamps days to [1, 30] range', async () => {
+            mockGroupBy.mockResolvedValue([])
+            mockCount.mockResolvedValue({ count: 0 })
+
+            // Test with days: 0 (should clamp to 1)
+            await getPerSourceAcceptance('guild-123', 0)
+            const firstCall = mockGroupBy.mock.calls[0][0] as any
+            const minusOneDay = Date.now() - 1 * 86_400_000
+            expect(firstCall.where.createdAt.gte.getTime()).toBeCloseTo(
+                minusOneDay,
+                -2,
+            )
+
+            jest.clearAllMocks()
+            mockGetPrismaClient.mockReturnValue({
+                recommendation: {
+                    groupBy: mockGroupBy,
+                    count: mockCount,
+                },
+            })
+
+            // Test with days: 999 (should clamp to 30)
+            await getPerSourceAcceptance('guild-123', 999)
+            const secondCall = mockGroupBy.mock.calls[0][0] as any
+            const minus30Days = Date.now() - 30 * 86_400_000
+            expect(secondCall.where.createdAt.gte.getTime()).toBeCloseTo(
+                minus30Days,
+                -2,
+            )
+        })
+
+        it('defaults to 7 days when days is undefined', async () => {
+            mockGroupBy.mockResolvedValue([])
+            mockCount.mockResolvedValue({ count: 0 })
+
+            await getPerSourceAcceptance('guild-123')
+
+            const call = mockGroupBy.mock.calls[0][0] as any
+            const minus7Days = Date.now() - 7 * 86_400_000
+            expect(call.where.createdAt.gte.getTime()).toBeCloseTo(
+                minus7Days,
+                -2,
+            )
+        })
+    })
+
+    describe('getSummary', () => {
+        it('returns aggregated totals for happy path', async () => {
+            mockCount
+                .mockResolvedValueOnce({ count: 100 }) // total picks
+                .mockResolvedValueOnce({ count: 65 }) // accepted
+                .mockResolvedValueOnce({ count: 25 }) // rejected
+                .mockResolvedValueOnce({ count: 10 }) // pending
+
+            const result = await getSummary('guild-123')
+
+            expect(result).toEqual({
+                totalPicks: 100,
+                accepted: 65,
+                rejected: 25,
+                pending: 10,
+                globalAcceptanceRate: 65 / (65 + 25), // 65 / 90
+            })
+        })
+
+        it('returns zeros for empty guild', async () => {
+            mockCount
+                .mockResolvedValueOnce({ count: 0 }) // total
+                .mockResolvedValueOnce({ count: 0 }) // accepted
+                .mockResolvedValueOnce({ count: 0 }) // rejected
+                .mockResolvedValueOnce({ count: 0 }) // pending
+
+            const result = await getSummary('guild-123')
+
+            expect(result).toEqual({
+                totalPicks: 0,
+                accepted: 0,
+                rejected: 0,
+                pending: 0,
+                globalAcceptanceRate: null,
+            })
+        })
+
+        it('returns null globalAcceptanceRate when all pending', async () => {
+            mockCount
+                .mockResolvedValueOnce({ count: 50 }) // total
+                .mockResolvedValueOnce({ count: 0 }) // accepted
+                .mockResolvedValueOnce({ count: 0 }) // rejected
+                .mockResolvedValueOnce({ count: 50 }) // pending
+
+            const result = await getSummary('guild-123')
+
+            expect(result).toEqual({
+                totalPicks: 50,
+                accepted: 0,
+                rejected: 0,
+                pending: 50,
+                globalAcceptanceRate: null,
+            })
+        })
+
+        it('clamps days to [1, 30] range', async () => {
+            mockCount.mockResolvedValue({ count: 0 })
+
+            // Test with days: 0 (should clamp to 1)
+            await getSummary('guild-123', 0)
+            const firstCall = mockCount.mock.calls[0][0] as any
+            const minusOneDay = Date.now() - 1 * 86_400_000
+            expect(firstCall.where.createdAt.gte.getTime()).toBeCloseTo(
+                minusOneDay,
+                -2,
+            )
+
+            jest.clearAllMocks()
+            mockGetPrismaClient.mockReturnValue({
+                recommendation: {
+                    groupBy: mockGroupBy,
+                    count: mockCount,
+                },
+            })
+
+            // Test with days: 50 (should clamp to 30)
+            await getSummary('guild-123', 50)
+            const secondCall = mockCount.mock.calls[0][0] as any
+            const minus30Days = Date.now() - 30 * 86_400_000
+            expect(secondCall.where.createdAt.gte.getTime()).toBeCloseTo(
+                minus30Days,
+                -2,
+            )
+        })
+
+        it('defaults to 7 days when days is undefined', async () => {
+            mockCount.mockResolvedValue({ count: 0 })
+
+            await getSummary('guild-123')
+
+            const call = mockCount.mock.calls[0][0] as any
+            const minus7Days = Date.now() - 7 * 86_400_000
+            expect(call.where.createdAt.gte.getTime()).toBeCloseTo(
+                minus7Days,
+                -2,
+            )
+        })
+    })
+})

--- a/packages/shared/src/services/recommendationTelemetryReadService.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.ts
@@ -1,0 +1,200 @@
+import { getPrismaClient } from '../utils/database/prismaClient'
+import { RecommendationSource } from '../types'
+
+export interface PerSourceRow {
+    source: RecommendationSource | null
+    count: number
+    acceptedCount: number
+    rejectedCount: number
+    pendingCount: number
+    acceptanceRate: number | null
+}
+
+export interface Summary {
+    totalPicks: number
+    accepted: number
+    rejected: number
+    pending: number
+    globalAcceptanceRate: number | null
+}
+
+/**
+ * Clamps days to [1, 30] range.
+ */
+function clampDays(days?: number): number {
+    const value = days ?? 7
+    return Math.max(1, Math.min(30, value))
+}
+
+/**
+ * Computes the cutoff date based on days in the past.
+ */
+function getCreatedAtCutoff(days?: number): Date {
+    const clampedDays = clampDays(days)
+    return new Date(Date.now() - clampedDays * 86_400_000)
+}
+
+/**
+ * Returns one row per distinct source value seen in the Recommendation table
+ * for this guild within the window. Null source is its own row.
+ */
+export async function getPerSourceAcceptance(
+    guildId: string,
+    days?: number,
+): Promise<PerSourceRow[]> {
+    const prisma = getPrismaClient()
+    const createdAtGte = getCreatedAtCutoff(days)
+
+    // Group by source to get distinct sources and total count per source
+    const groupByResult = await prisma.recommendation.groupBy({
+        by: ['source'],
+        where: {
+            guildId,
+            createdAt: {
+                gte: createdAtGte,
+            },
+        },
+        _count: {
+            id: true,
+        },
+    })
+
+    // For each source, fetch accepted, rejected, and pending counts
+    const rows: PerSourceRow[] = []
+    for (const group of groupByResult) {
+        const source = group.source
+        const count = group._count.id
+
+        const getCountValue = (result: any): number =>
+            typeof result === 'number' ? result : result.count
+
+        const acceptedCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    source,
+                    isAccepted: true,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const rejectedCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    source,
+                    isRejected: true,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const pendingCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    source,
+                    isAccepted: null,
+                    isRejected: null,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const denominator = acceptedCount + rejectedCount
+        const acceptanceRate =
+            denominator === 0 ? null : acceptedCount / denominator
+
+        rows.push({
+            source,
+            count,
+            acceptedCount,
+            rejectedCount,
+            pendingCount,
+            acceptanceRate,
+        })
+    }
+
+    return rows
+}
+
+/**
+ * Returns aggregated totals across all sources for this guild within the window.
+ */
+export async function getSummary(
+    guildId: string,
+    days?: number,
+): Promise<Summary> {
+    const prisma = getPrismaClient()
+    const createdAtGte = getCreatedAtCutoff(days)
+
+    const getCountValue = (result: any): number =>
+        typeof result === 'number' ? result : result.count
+
+    const totalPicks = getCountValue(
+        await prisma.recommendation.count({
+            where: {
+                guildId,
+                createdAt: {
+                    gte: createdAtGte,
+                },
+            },
+        }),
+    )
+
+    const accepted = getCountValue(
+        await prisma.recommendation.count({
+            where: {
+                guildId,
+                isAccepted: true,
+                createdAt: {
+                    gte: createdAtGte,
+                },
+            },
+        }),
+    )
+
+    const rejected = getCountValue(
+        await prisma.recommendation.count({
+            where: {
+                guildId,
+                isRejected: true,
+                createdAt: {
+                    gte: createdAtGte,
+                },
+            },
+        }),
+    )
+
+    const pending = getCountValue(
+        await prisma.recommendation.count({
+            where: {
+                guildId,
+                isAccepted: null,
+                isRejected: null,
+                createdAt: {
+                    gte: createdAtGte,
+                },
+            },
+        }),
+    )
+
+    const denominator = accepted + rejected
+    const globalAcceptanceRate =
+        denominator === 0 ? null : accepted / denominator
+
+    return {
+        totalPicks,
+        accepted,
+        rejected,
+        pending,
+        globalAcceptanceRate,
+    }
+}


### PR DESCRIPTION
**Phase C** of the autoplay recommendation roadmap (ADR \`2026-05-21-autoplay-recommendation-roadmap\`).

Phase A landed the schema (PR #932). Phase B wired the writers (PR #933). This PR closes the loop with the **read path** — so the 7-day baseline can be observed and (eventually) feed Phase D's go/no-go decision.

## What ships

### C1 — Read service
\`packages/shared/src/services/recommendationTelemetryReadService.ts\`:
- \`getPerSourceAcceptance(guildId, days = 7)\` → per-\`RecommendationSource\` rollup with \`count\`, \`acceptedCount\`, \`rejectedCount\`, \`pendingCount\`, \`acceptanceRate\`.
- \`getSummary(guildId, days = 7)\` → totals + \`globalAcceptanceRate\`.
- \`days\` clamped to \`[1, 30]\`.
- \`acceptanceRate = acceptedCount / (acceptedCount + rejectedCount)\` — \`null\` when denominator is 0 (pending-only window).
- Per-source counts composed from \`prisma.recommendation.count\` calls; clearer than \`groupBy\` for this shape.

**Tests: 12/12** covering zero-row, single-source, multi-source, null-source, denominator-zero, default-days, days-clamping.

### C2 — Backend route
\`packages/backend/src/routes/recommendations.ts\`:

\`\`\`
GET /api/guilds/:guildId/recommendations/history?days=<n>
\`\`\`

- \`requireAuth\`
- \`validateParams(guildIdParam)\` (reuses existing management schema)
- Zod query: \`{ days?: number().int().min(1).max(30) }\`
- Calls both service functions in parallel via \`Promise.all\`.
- Response: \`{ summary, perSource }\`.

Registered in \`packages/backend/src/routes/index.ts\` alongside the other guild-scoped routes. Guild-guard config: \`{ path: '/api/guilds/:guildId/recommendations', module: 'settings' }\`.

**Tests: 6/6** — happy path, custom days, days clamp/reject (Zod max:30), invalid guildId (400), no auth (401), service throw (500 via asyncHandler).

**Backend regression check: 343/343** integration tests pass.

## Out of scope (deferred)

- **Frontend dashboard surface** — defer to a follow-up. Will only ship if Phase C baseline data motivates it (the read path can be consumed by curl / a Sentry breadcrumb in the meantime).
- **Phase D session-coherence layer** — gated on 7 days of production baseline showing per-source acceptance < 85%. If the layered drift defense already produces high acceptance, Phase D becomes optional per the ADR.

## Methodology

Same pattern as Phase B: \`/adt-tdd\` + \`/subagent-driven-development\`. C1 and C2 dispatched as separate subagents (C2 blocked-by C1). TDD throughout.

## Changelog

\`[Unreleased]\` Added: feat(backend): autoplay telemetry read path (Phase C of the recommendation roadmap).