### PR TITLE
fix(docker): copy CHANGELOG.md into frontend build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,7 @@ downloads/
 docs/
 *.md
 !README.md
+!CHANGELOG.md
 
 # Logs
 logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,10 @@ RUN npm run build --workspace=packages/backend
 # in PR #846. Sharing the build stage eliminates that class of failure.
 FROM build AS build-frontend
 COPY packages/frontend ./packages/frontend
+# Frontend's /changelog page imports the repo-root CHANGELOG.md via
+# `import md from '../../../../CHANGELOG.md?raw'` (vite raw loader). The
+# build context's project root is /app, so the file must be present there.
+COPY CHANGELOG.md ./CHANGELOG.md
 RUN npm run build --workspace=packages/frontend
 
 # Production deps — slim install (no dev deps)


### PR DESCRIPTION
## Root cause

\`packages/frontend/src/pages/Changelog.tsx\` imports the repo-root \`CHANGELOG.md\`:

\`\`\`ts
import changelogMd from '../../../../CHANGELOG.md?raw'
\`\`\`

…via Vite's \`?raw\` loader. From \`/app/packages/frontend/src/pages/Changelog.tsx\` that resolves to \`/app/CHANGELOG.md\` at build time.

The multi-stage \`Dockerfile\` builds the frontend in the \`build-frontend\` stage but **never copies the repo-root \`CHANGELOG.md\` into \`/app/\`** — only \`packages/*\` and \`prisma/\` get copied. Result on the most recent main push (\`524655de\`):

\`\`\`
✗ Build failed in 932ms
error during build:
Build failed with 1 error:
[UNRESOLVED_IMPORT] Error: Could not resolve '../../../../CHANGELOG.md?raw' in src/pages/Changelog.tsx
\`\`\`

…which cascaded to the backend + bot image builds (cancelled).

## Why it didn't surface until now

Latent since PR #923 (v2.13.0 added \`Changelog.tsx\`). PR #934 was holding it back: the trivy-action tag lookup failure aborted every docker-publish run *before* this build step ran. Once that fix landed, the build progressed further and exposed this.

## Fix

Two-part change:

1. **\`Dockerfile\`** — \`COPY CHANGELOG.md ./CHANGELOG.md\` in the \`build-frontend\` stage, after the \`packages/frontend\` copy. Two-line addition + comment explaining why.
2. **\`.dockerignore\`** — \`!CHANGELOG.md\` negative-pattern under the existing \`*.md\` block, so the COPY isn't silently filtered.

## Verification

After merge:
- Docker publish on the merge commit should succeed for all 4 matrix jobs (frontend, backend, bot, nginx).
- The \`/changelog\` page on the production frontend should render the new v2.14.0 release notes.

## Related

- The autosync workflow on the same main push also failed (\`release-branch-autosync.yml\` — \`main is NOT an ancestor of release/v2.14.0\`). That's the natural consequence of a squash-merge release-cut and is unrelated to this fix. Handling that separately (likely by archiving \`release/v2.14.0\` so the workflow stops finding it as the active release branch).