### PR TITLE
chore(git): add post-merge hook to auto-prune [gone] local branches

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -2,7 +2,7 @@
 # Auto-prune local branches whose remote was deleted (e.g. after PR merge + GitHub auto-delete).
 # Fires on: git pull, git merge
 git fetch --prune --quiet
-gone=$(git branch -v | grep '\[gone\]' | sed 's/^[+* ]*//' | awk '{print $1}')
+gone=$(git branch -vv | grep '\[gone\]' | sed 's/^[+* ]*//' | awk '{print $1}')
 if [ -n "$gone" ]; then
   echo "post-merge: pruning gone branches..."
   echo "$gone" | xargs git branch -D

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# Auto-prune local branches whose remote was deleted (e.g. after PR merge + GitHub auto-delete).
+# Fires on: git pull, git merge
+git fetch --prune --quiet
+gone=$(git branch -v | grep '\[gone\]' | sed 's/^[+* ]*//' | awk '{print $1}')
+if [ -n "$gone" ]; then
+  echo "post-merge: pruning gone branches..."
+  echo "$gone" | xargs git branch -D
+fi


### PR DESCRIPTION
Adds `.husky/post-merge` that runs on every `git pull` / `git merge`:

1. `git fetch --prune` — refreshes remote-tracking refs
2. Detects local branches with `[gone]` upstream (remote deleted after merge)
3. `git branch -D` on each — clears the stale locals automatically

**Why:** GitHub auto-delete-on-merge is already enabled, but local branches linger until manually cleaned. This hook closes that gap — no more 200+ stale local branches accumulating over time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Local Git repositories are now automatically cleaned up when pulling or merging changes, removing local branches whose remote counterparts have been deleted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->