### PR TITLE
release: v2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.1] - 2026-05-23
+
+### Fixed
+- fix(docker): include repo-root `CHANGELOG.md` in the frontend build stage context — resolves broken production frontend image since v2.13.0 (#937)
+
+### Internal
+- ci: split sequential `quality-gates` job into four parallel test jobs; absorb `sonarcloud.yml` into `ci.yml` — tests run once with coverage, SonarCloud downloads artifacts. PR wall time ~8–10 min vs ~13–15 min (#942)
+- chore(tests): three-phase bot + backend test cleanup — ~77 tests + ~5k LOC removed (#938 #939 #940)
+- chore: add `.husky/post-merge` hook to auto-prune local branches whose remote was deleted (#941)
+
 ## [2.14.0] - 2026-05-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.14.0",
+    "version": "2.14.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## What

Patch release v2.14.1.

## Changes since v2.14.0

### Fixed
- fix(docker): include repo-root `CHANGELOG.md` in the frontend build stage context — resolves broken production frontend image since v2.13.0 (#937)

### Internal
- ci: split sequential `quality-gates` job into four parallel test jobs; absorb `sonarcloud.yml` into `ci.yml` — tests run once with coverage, SonarCloud downloads artifacts. PR wall time ~8–10 min vs ~13–15 min (#942)
- chore(tests): three-phase bot + backend test cleanup — ~77 tests + ~5k LOC removed (#938 #939 #940)
- chore: add `.husky/post-merge` hook to auto-prune local branches whose remote has been deleted (#941)