### PR TITLE
fix(ci): archive squash-merged release branch instead of failing FF

### DIFF
--- a/.github/workflows/release-branch-autosync.yml
+++ b/.github/workflows/release-branch-autosync.yml
@@ -40,9 +40,26 @@ jobs:
           active="${{ steps.detect.outputs.active }}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "$active":"$active" || true
+
+          # Extract the semver tag name, e.g. release/v2.14.0 → v2.14.0
+          version="${active#release/}"
+
+          # If a tag for this version already exists on the remote, the release
+          # branch was squash-merged to main. Archive it and exit cleanly.
+          if git ls-remote --tags origin "refs/tags/$version" | grep -q .; then
+            echo "$version already shipped — archiving $active"
+            git fetch origin "$active":"$active"
+            git push origin "$active:refs/heads/archive/release-${version#v}" \
+              || echo "Archive branch already exists, skipping creation"
+            git push origin --delete "$active" \
+              || echo "Branch $active already deleted"
+            echo "Archived $active → archive/release-${version#v}"
+            exit 0
+          fi
+
+          # Normal case: FF the release branch forward to main.
+          git fetch origin "$active":"$active"
           if git merge-base --is-ancestor "$active" main; then
-            # main is ahead of or equal to active release branch — ff-only push
             git push origin "main:$active" --force-with-lease="$active:$(git rev-parse $active)" \
               || echo "::warning::Could not fast-forward $active to main (likely diverged); manual sync needed"
           else


### PR DESCRIPTION
## Root cause

The `ff-active-release` job fires on every push to `main`. After a squash-merge release (e.g. `release: v2.14.1 (#943)`), the job found `release/v2.14.0` as the latest `release/v*` branch and tried to fast-forward it to `main`.

Because Lucky uses squash merges, individual commits on `release/v2.14.0` are not in `main`'s history — only the squash commit (`524655de`) is. So `git merge-base --is-ancestor release/v2.14.0 main` returns false and the job exits 1.

```
Warning: main is NOT an ancestor of release/v2.14.0 — divergence detected. Manual sync required.
Error: Process completed with exit code 1.
```

## Fix

Before attempting a fast-forward, check if the branch's semver tag already exists on the remote (`git ls-remote --tags`). If the tag exists, the release has shipped — the branch should be archived, not synced:

1. Push the branch pointer to `archive/release-vX.Y.Z`
2. Delete the stale `release/vX.Y.Z` branch
3. Exit 0

Future workflow runs find no `release/v*` branch and skip cleanly. The normal FF path is unchanged for in-progress release branches (where the version tag does not yet exist).