### PR TITLE
fix: resolve Prettier syntax error in queueManipulation.spec.ts

### DIFF
--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -208,10 +208,12 @@ describe('queueManipulation.replenishQueue', () => {
                 search: jest.fn().mockResolvedValue({
                     tracks: [
                         {
-                            title: options.candidateTitle ?? 'Stairway to Heaven',
+                            title:
+                                options.candidateTitle ?? 'Stairway to Heaven',
                             author: options.candidateAuthor ?? 'Led Zeppelin',
                             url:
-                                options.candidateUrl ?? 'https://example.com/stairway',
+                                options.candidateUrl ??
+                                'https://example.com/stairway',
                             metadata: options.candidateMetadata ?? {},
                         },
                     ],
@@ -356,9 +358,9 @@ describe('queueManipulation.replenishQueue', () => {
     it.each([
         {
             name: 'when Spotify seed search throws',
-            seedSearch: () =>
-                Promise.reject(new Error('Spotify unavailable')),
-            artistSearch: () => Promise.reject(new Error('Artist search failed')),
+            seedSearch: () => Promise.reject(new Error('Spotify unavailable')),
+            artistSearch: () =>
+                Promise.reject(new Error('Artist search failed')),
             fallbackUrl: 'https://example.com/fallback',
         },
         {
@@ -3797,7 +3799,9 @@ describe('queueManipulation — within-cycle dedup via extractSongCore', () => {
         }
         expect(debugLog).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: expect.stringContaining('seed search returned 0 results'),
+                message: expect.stringContaining(
+                    'seed search returned 0 results',
+                ),
             }),
         )
     })
@@ -4234,8 +4238,18 @@ describe('queueManipulation — diversity improvements', () => {
             history: {
                 tracks: {
                     toArray: jest.fn().mockReturnValue([
-                        { title: 'Rock Song', author: 'Rock Artist', url: 'https://example.com/r', durationMS: 240000 },
-                        { title: 'Pop Song', author: 'Pop Artist', url: 'https://example.com/p', durationMS: 200000 },
+                        {
+                            title: 'Rock Song',
+                            author: 'Rock Artist',
+                            url: 'https://example.com/r',
+                            durationMS: 240000,
+                        },
+                        {
+                            title: 'Pop Song',
+                            author: 'Pop Artist',
+                            url: 'https://example.com/p',
+                            durationMS: 200000,
+                        },
                     ]),
                 },
             },
@@ -4270,8 +4284,18 @@ describe('queueManipulation — diversity improvements', () => {
             history: {
                 tracks: {
                     toArray: jest.fn().mockReturnValue([
-                        { title: 'Cumbia vieja', author: 'Artist', url: 'https://example.com/c', durationMS: 200000 },
-                        { title: 'Bachata romántica', author: 'Artist', url: 'https://example.com/b', durationMS: 200000 },
+                        {
+                            title: 'Cumbia vieja',
+                            author: 'Artist',
+                            url: 'https://example.com/c',
+                            durationMS: 200000,
+                        },
+                        {
+                            title: 'Bachata romántica',
+                            author: 'Artist',
+                            url: 'https://example.com/b',
+                            durationMS: 200000,
+                        },
                     ]),
                 },
             },
@@ -4289,8 +4313,6 @@ describe('queueManipulation — diversity improvements', () => {
             )
         }
     })
-})
-
 
     describe('getGenreFamilies', () => {
         it('identifies single genre family', () => {
@@ -4363,7 +4385,9 @@ describe('queueManipulation — diversity improvements', () => {
         })
 
         it('treats latin as strong', () => {
-            expect(calculateGenreFamilyPenalty(['reggaeton'], ['pop'])).toBe(-0.6)
+            expect(calculateGenreFamilyPenalty(['reggaeton'], ['pop'])).toBe(
+                -0.6,
+            )
         })
     })
 
@@ -4371,7 +4395,11 @@ describe('queueManipulation — diversity improvements', () => {
         it('returns unchanged when features null', async () => {
             const tracks = [
                 {
-                    track: { title: 'T', author: 'A', url: 'https://spotify.com' },
+                    track: {
+                        title: 'T',
+                        author: 'A',
+                        url: 'https://spotify.com',
+                    },
                     score: 1,
                     basis: { source: 'spotify-rec' as const, signals: [] },
                 },
@@ -4383,32 +4411,38 @@ describe('queueManipulation — diversity improvements', () => {
         it('returns unchanged when userId empty', async () => {
             const tracks = [
                 {
-                    track: { title: 'T', author: 'A', url: 'https://spotify.com' },
+                    track: {
+                        title: 'T',
+                        author: 'A',
+                        url: 'https://spotify.com',
+                    },
                     score: 1,
                     basis: { source: 'spotify-rec' as const, signals: [] },
                 },
             ]
-            const result = await enrichWithAudioFeatures(
-                tracks,
-                '',
-                { energy: 0.7, valence: 0.6 } as any,
-            )
+            const result = await enrichWithAudioFeatures(tracks, '', {
+                energy: 0.7,
+                valence: 0.6,
+            } as any)
             expect(result).toEqual(tracks)
         })
 
         it('returns unchanged when no Spotify links', async () => {
             const tracks = [
                 {
-                    track: { title: 'T', author: 'A', url: 'https://youtube.com' },
+                    track: {
+                        title: 'T',
+                        author: 'A',
+                        url: 'https://youtube.com',
+                    },
                     score: 1,
                     basis: { source: 'spotify-rec' as const, signals: [] },
                 },
             ]
-            const result = await enrichWithAudioFeatures(
-                tracks,
-                'u1',
-                { energy: 0.7, valence: 0.6 } as any,
-            )
+            const result = await enrichWithAudioFeatures(tracks, 'u1', {
+                energy: 0.7,
+                valence: 0.6,
+            } as any)
             expect(result).toEqual(tracks)
         })
     })


### PR DESCRIPTION
Fixes a pre-existing syntax error (extra closing brace) that prevented Prettier from parsing the file. This was blocking Phase 4 test cleanup work (#956).

The file had a stray `})` that prematurely closed the outer describe block, causing Prettier to emit 'Declaration or statement expected' error. Jest can parse the file fine, but the pre-commit hook uses Prettier, which was failing.

Changes:
- Removed the extra closing brace
- Fixed indentation of nested describes
- File now parses correctly with both Prettier and Jest

No functional changes to tests.