### PR TITLE
chore(bot): tighten coverage gate after Phase 4 cleanup (#964)

### DIFF
--- a/packages/bot/jest.config.cjs
+++ b/packages/bot/jest.config.cjs
@@ -11,16 +11,16 @@ module.exports = {
     ],
     coverageDirectory: 'coverage',
     coverageReporters: ['text', 'lcov'],
-    // Floor pinned to the round-down of the post-#821 baseline
-    // (stmts 67 / branches 63 / functions 63 / lines 68). Binding without
-    // forcing emergency work; tighten 2-3 % per cleanup phase as the suite
-    // shrinks. See .agents/plans/test-cleanup-phase2.md.
+    // Floor tightened after Phase 4 cleanup (post-Phase-4 baseline: stmts 66.33 /
+    // branches 64.04 / functions 62.51 / lines 67.28). Each threshold = actual − 0.5pp.
+    // Statements/functions/lines didn't reach the 68/63/63/68 target — actual coverage
+    // didn't improve enough after Phase 4 deletions. See issue #964.
     coverageThreshold: {
         global: {
-            statements: 65,
-            branches: 60,
-            functions: 60,
-            lines: 65,
+            statements: 65.8,
+            branches: 63.5,
+            functions: 62,
+            lines: 66.7,
         },
     },
     moduleNameMapper: {


### PR DESCRIPTION
## Summary

Raises the `packages/bot` Jest coverage thresholds from 65/60/60/65 to 65.8/63.5/62/66.7, using `actual − 0.5pp` for each dimension.

**Post-Phase-4 baseline** (main @ `773c95f6`, 2,760 tests):

| Dimension  | Actual  | Old gate | New gate | Target (68/63/63/68) |
|------------|---------|----------|----------|----------------------|
| Statements | 66.33%  | 65       | **65.8** | 68 — unreachable     |
| Branches   | 64.04%  | 60       | **63.5** | 63 ✓                 |
| Functions  | 62.51%  | 60       | **62.0** | 63 — unreachable     |
| Lines      | 67.28%  | 65       | **66.7** | 68 — unreachable     |

Branches crossed the 63.5 threshold (actual 64.04 > target 63.5). Statements, functions, and lines didn't reach the 68/63/63/68 target because Phase 4 agents kept more behavioral tests than projected (2,760 total vs the ~2,185–2,253 estimate), so coverage didn't lift as expected.

## Test plan
- [x] `npx jest --silent --coverage --coverageReporters=text-summary` from `packages/bot/` — passes with all four new thresholds
- [x] CI: Test-bot required check

Closes #964