### PR TITLE
fix(ci): lockfile-hash BuildKit npm cache key to prevent esbuild version mismatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,7 +82,9 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  build-args: COMMIT_SHA=${{ github.sha }}
+                  build-args: |
+                      COMMIT_SHA=${{ github.sha }}
+                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 # Usage: docker compose --env-file .env.production up -d --build
 
 ARG NODE_VERSION=22-alpine
+# Lockfile-hash cache key — auto-busts npm BuildKit caches when package-lock.json
+# changes. Passed as a build-arg from the workflow: hashFiles('package-lock.json').
+# Bump the default (v1 → v2) only if you need a forced one-off cache wipe.
+ARG NPM_CACHE_KEY=v1
 
 FROM node:${NODE_VERSION} AS base-runtime
 
@@ -52,7 +56,7 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-RUN --mount=type=cache,id=npm-build-stage,target=/root/.npm,sharing=locked \
+RUN --mount=type=cache,id=npm-build-stage-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
     YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     npm ci --legacy-peer-deps --no-audit --no-fund && \
     (npm cache verify 2>/dev/null || true)
@@ -95,7 +99,7 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-RUN --mount=type=cache,id=npm-deps-production,target=/root/.npm,sharing=locked \
+RUN --mount=type=cache,id=npm-deps-production-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
     YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     YOUTUBE_DL_SKIP_PYTHON_CHECK=1 \
     npm ci --legacy-peer-deps --omit=dev --no-audit --no-fund && \

--- a/docs/decisions/2026-05-24-docker-npm-cache-key-strategy.md
+++ b/docs/decisions/2026-05-24-docker-npm-cache-key-strategy.md
@@ -1,0 +1,64 @@
+# ADR: Docker BuildKit npm cache key strategy
+
+**Date:** 2026-05-24
+**Status:** Accepted
+
+## Context
+
+The `Build & Push Docker Images` workflow failed with:
+
+```
+npm error Error: Expected "0.28.0" but got "0.27.3"
+npm error path /app/node_modules/tsx/node_modules/esbuild
+npm error command sh -c node install.js
+```
+
+The Dockerfile has two `npm ci` stages that use `--mount=type=cache` to persist `/root/.npm` (npm's download cache) across BuildKit runs:
+
+- `npm-build-stage` — full install in the `build` stage
+- `npm-deps-production` — prod-only install in the `deps-production` stage
+
+The GHA workflow also uses `type=gha,mode=max` for Docker layer caching. When `tsx`'s nested esbuild dependency was updated (0.27.3 → 0.28.0 in the lockfile), the stale binary surfaced through either the BuildKit mount cache or the GHA layer cache, causing esbuild's postinstall version check to fail.
+
+## Decision
+
+Use the lockfile hash as the BuildKit npm mount cache key, passed from the workflow as a build arg:
+
+**Dockerfile:**
+```dockerfile
+ARG NPM_CACHE_KEY=v1
+...
+RUN --mount=type=cache,id=npm-build-stage-${NPM_CACHE_KEY},...
+RUN --mount=type=cache,id=npm-deps-production-${NPM_CACHE_KEY},...
+```
+
+**docker-publish.yml:**
+```yaml
+build-args: |
+    COMMIT_SHA=${{ github.sha }}
+    NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
+```
+
+Both cache mounts are updated — using the same key ensures build and production stages always share a consistent npm cache state when the lockfile changes.
+
+The `ARG NPM_CACHE_KEY=v1` default allows local `docker build` invocations and non-GHA CI to work without passing the arg (they get `v1`, which is stable between runs without the workflow).
+
+## Alternatives considered
+
+**A. Remove `--mount=type=cache` entirely.** GHA runners are ephemeral — the mount cache doesn't persist across runs anyway. This would guarantee a clean npm install on every build. Rejected: keeps the door open for self-hosted runners where the cache IS persistent, and the keyed approach achieves the same correctness with better ergonomics.
+
+**B. Bump the cache ID suffix manually** (`id=npm-deps-production-v2`). Unblocks immediately but requires a human to remember to bump it again on the next version mismatch. Rejected in favor of the self-healing lockfile-hash approach.
+
+**C. Delete GHA cache entries via API.** No code change, immediate unblock. Rejected as a solo fix: doesn't prevent the same failure on the next dependency update.
+
+## Consequences
+
+- **Positive:** Any change to `package-lock.json` automatically invalidates both npm mount caches AND (via the ARG value changing the layer hash) the GHA layer cache for all downstream layers — guaranteeing a clean install.
+- **Positive:** Self-healing. No manual intervention required when deps update.
+- **Negative:** When the lockfile changes, the GHA layer cache for the `build` and `deps-production` stages is fully invalidated. Build time for those runs is longer (full npm download + compilation). This is the correct trade-off: correctness over cache hit rate when deps change.
+- **Neutral:** Local `docker build` without `--build-arg NPM_CACHE_KEY=...` uses `v1` — a stable cache ID that behaves identically to the old hardcoded IDs.
+
+## Revisit when
+
+- Project switches to self-hosted runners: re-evaluate whether `--mount=type=cache` provides meaningful cross-run speedup (it would, with persistent runners). The current approach is compatible — the cache is still used, just busted on lockfile changes.
+- `hashFiles('package-lock.json')` produces cache misses too frequently (e.g., if lockfile changes every PR due to automatic dep updates): consider scoping to a subset of the lockfile, or switching to a manual version suffix.


### PR DESCRIPTION
## Problem

`Build & Push Docker Images` failing on main with:

```
npm error Error: Expected "0.28.0" but got "0.27.3"
npm error path /app/node_modules/tsx/node_modules/esbuild
npm error command sh -c node install.js
```

Both npm install stages (`build` and `deps-production`) used hardcoded BuildKit mount cache IDs (`npm-build-stage`, `npm-deps-production`). When tsx's nested esbuild dependency updated from 0.27.3 → 0.28.0, the stale cached binary surfaced and esbuild's postinstall version check failed.

## Fix

Pass `NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}` from the workflow as a build ARG and embed it in both mount cache IDs:

```dockerfile
ARG NPM_CACHE_KEY=v1
# ...
RUN --mount=type=cache,id=npm-build-stage-${NPM_CACHE_KEY},...
RUN --mount=type=cache,id=npm-deps-production-${NPM_CACHE_KEY},...
```

Any change to `package-lock.json` now automatically busts both npm mount caches **and** all downstream GHA layer cache entries — guaranteeing a clean install. Self-healing: no manual intervention needed on future dep updates.

## ADR

`docs/decisions/2026-05-24-docker-npm-cache-key-strategy.md` — documents alternatives considered (remove mount cache entirely, manual suffix bump, one-time cache delete) and why the lockfile-hash approach was chosen.

## Testing

- The `Build & Push Docker Images` workflow will run on merge; a green build confirms the fix.
- Local: `docker build --build-arg NPM_CACHE_KEY=test-v1 ...` works without the workflow.