### PR TITLE
refactor(backend): extract ArtistSuggestionService from artists route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1465,7 +1465,7 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1475,7 +1475,7 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1509,7 +1509,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
             "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -1807,7 +1807,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -9802,6 +9802,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9818,6 +9819,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9834,6 +9836,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -9850,6 +9853,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9866,6 +9870,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9882,6 +9887,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9898,6 +9904,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9914,6 +9921,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9930,6 +9938,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9946,6 +9955,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9962,6 +9972,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -9978,6 +9989,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -18954,7 +18966,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
             "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -23128,6 +23140,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23144,6 +23157,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23160,6 +23174,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23176,6 +23191,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23192,6 +23208,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23208,6 +23225,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23224,6 +23242,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23240,6 +23259,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23256,6 +23276,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23272,6 +23293,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23288,6 +23310,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23304,6 +23327,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23320,6 +23344,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23336,6 +23361,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23352,6 +23378,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23368,6 +23395,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23384,6 +23412,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23400,6 +23429,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23416,6 +23446,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23432,6 +23463,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23448,6 +23480,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23464,6 +23497,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23480,6 +23514,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23496,6 +23531,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23512,6 +23548,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -23528,6 +23565,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [

--- a/packages/backend/src/constants/popularArtists.ts
+++ b/packages/backend/src/constants/popularArtists.ts
@@ -1,0 +1,85 @@
+/**
+ * Popular artist names used as fallback for artist suggestions.
+ * These span multiple genres to provide diverse recommendations
+ * when user preferences are unavailable or limited.
+ */
+export const POPULAR_ARTISTS = [
+    // Pop
+    'Taylor Swift',
+    'Dua Lipa',
+    'Ariana Grande',
+    'Olivia Rodrigo',
+    'Sabrina Carpenter',
+    'Billie Eilish',
+    'The Weeknd',
+    // Hip-hop
+    'Drake',
+    'Kendrick Lamar',
+    'Travis Scott',
+    'J. Cole',
+    'Tyler The Creator',
+    'Future',
+    'Nicki Minaj',
+    // Rock
+    'Foo Fighters',
+    'Red Hot Chili Peppers',
+    'Arctic Monkeys',
+    'Radiohead',
+    'The Strokes',
+    'Tame Impala',
+    // R&B
+    'SZA',
+    'Frank Ocean',
+    'Bruno Mars',
+    'H.E.R.',
+    'Daniel Caesar',
+    // Electronic
+    'Daft Punk',
+    'Calvin Harris',
+    'Flume',
+    'ODESZA',
+    'Disclosure',
+    'Skrillex',
+    // Latin
+    'Bad Bunny',
+    'Anitta',
+    'Karol G',
+    'J Balvin',
+    'Rosalía',
+    'Peso Pluma',
+    // Country
+    'Morgan Wallen',
+    'Luke Combs',
+    'Kacey Musgraves',
+    'Zach Bryan',
+    // Indie
+    'Phoebe Bridgers',
+    'Arcade Fire',
+    'Vampire Weekend',
+    'Mac DeMarco',
+    // K-pop
+    'BTS',
+    'BLACKPINK',
+    'NewJeans',
+    'Stray Kids',
+    // Classic rock
+    'The Beatles',
+    'Queen',
+    'Pink Floyd',
+    'Led Zeppelin',
+    // Jazz
+    'Miles Davis',
+    'John Coltrane',
+    'Nina Simone',
+    // Metal
+    'Metallica',
+    'Tool',
+    'System of a Down',
+    // Brazilian
+    'Matuê',
+    'Tim Bernardes',
+    'Racionais',
+    'Djonga',
+] as const
+
+export type PopularArtist = (typeof POPULAR_ARTISTS)[number]

--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -4,17 +4,29 @@ import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
 import { apiLimiter, writeLimiter } from '../middleware/rateLimit'
 import { ArtistSuggestionService } from '../services/artistSuggestion'
 
+interface ApiError {
+    readonly status?: number
+    readonly error?: string
+}
+
 const svc = new ArtistSuggestionService()
 void svc.prewarmCache()
 
-const wrap =
-    (h: (r: AuthenticatedRequest) => Promise<any>, ctx: string, err: string) =>
-    async (req: AuthenticatedRequest, res: Response) => {
+const wrapHandler =
+    (
+        h: (r: AuthenticatedRequest) => Promise<Record<string, unknown>>,
+        ctx: string,
+        defaultErr: string,
+    ) =>
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
         try {
             res.json(await h(req))
-        } catch (e: any) {
-            const st = e?.status ?? 500
-            const msg = e?.error ?? err
+        } catch (e: unknown) {
+            const apiErr =
+                typeof e === 'object' && e !== null ? (e as ApiError) : {}
+            const st = typeof apiErr.status === 'number' ? apiErr.status : 500
+            const msg =
+                typeof apiErr.error === 'string' ? apiErr.error : defaultErr
             if (st === 500) errorLog({ message: `${ctx} error`, error: e })
             res.status(st).json({ error: msg })
         }
@@ -25,7 +37,7 @@ export function setupArtistsRoutes(app: Express): void {
         '/api/artists/suggestions',
         apiLimiter,
         requireAuth,
-        wrap(
+        wrapHandler(
             async (r) => ({
                 artists: await svc.handleGetSuggestions(r.user?.id),
             }),
@@ -33,54 +45,59 @@ export function setupArtistsRoutes(app: Express): void {
             'Failed to get suggestions',
         ),
     )
-
     app.get(
         '/api/artists/search',
         apiLimiter,
         requireAuth,
-        wrap(
-            async (r) => ({
-                artists: await svc.handleSearchArtists(r.query.q),
-            }),
+        wrapHandler(
+            async (r) => {
+                const q = typeof r.query.q === 'string' ? r.query.q : ''
+                return { artists: await svc.handleSearchArtists(q) }
+            },
             'Artist search',
             'Failed to search artists',
         ),
     )
-
     app.get(
         '/api/artists/:artistId/related',
         apiLimiter,
         requireAuth,
-        wrap(
-            async (r) => ({
-                artists: await svc.handleGetRelatedArtists(r.params.artistId),
-            }),
+        wrapHandler(
+            async (r) => {
+                const artistId =
+                    typeof r.params.artistId === 'string'
+                        ? r.params.artistId
+                        : ''
+                return { artists: await svc.handleGetRelatedArtists(artistId) }
+            },
             'Related artists',
             'Failed to get related artists',
         ),
     )
-
     app.get(
         '/api/users/me/preferred-artists',
         apiLimiter,
         requireAuth,
-        wrap(
-            async (r) => ({
-                preferences: await svc.handleGetPreferredArtists(
-                    r.user?.id,
-                    r.query.guildId,
-                ),
-            }),
+        wrapHandler(
+            async (r) => {
+                const guildId =
+                    typeof r.query.guildId === 'string' ? r.query.guildId : ''
+                return {
+                    preferences: await svc.handleGetPreferredArtists(
+                        r.user?.id,
+                        guildId,
+                    ),
+                }
+            },
             'Get preferred artists',
             'Failed to get preferences',
         ),
     )
-
     app.post(
         '/api/users/me/preferred-artists',
         writeLimiter,
         requireAuth,
-        wrap(
+        wrapHandler(
             async (r) => ({
                 preference: await svc.handleSavePreferredArtist(
                     r.user?.id,
@@ -91,12 +108,11 @@ export function setupArtistsRoutes(app: Express): void {
             'Failed to save preference',
         ),
     )
-
     app.put(
         '/api/artists/preferences/batch',
         writeLimiter,
         requireAuth,
-        wrap(
+        wrapHandler(
             async (r) => ({
                 preferences: await svc.handleBatchSavePreferences(
                     r.user?.id,
@@ -107,17 +123,22 @@ export function setupArtistsRoutes(app: Express): void {
             'Failed to save preferences',
         ),
     )
-
     app.delete(
         '/api/users/me/preferred-artists/:artistKey',
         writeLimiter,
         requireAuth,
-        wrap(
+        wrapHandler(
             async (r) => {
+                const artistKey =
+                    typeof r.params.artistKey === 'string'
+                        ? r.params.artistKey
+                        : ''
+                const guildId =
+                    typeof r.query.guildId === 'string' ? r.query.guildId : ''
                 await svc.handleDeletePreferredArtist(
                     r.user?.id,
-                    r.params.artistKey,
-                    r.query.guildId,
+                    artistKey,
+                    guildId,
                 )
                 return { success: true }
             },

--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -1,319 +1,128 @@
 import type { Express, Response } from 'express'
-import { z } from 'zod'
-import {
-    errorLog,
-    getPrismaClient,
-    searchSpotifyArtists,
-    getSpotifyRelatedArtists,
-} from '@lucky/shared/utils'
+import { errorLog } from '@lucky/shared/utils'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
 import { apiLimiter, writeLimiter } from '../middleware/rateLimit'
-import {
-    isSpotifyAuthConfigured,
-    getSpotifyClientToken,
-} from '../services/SpotifyAuthService'
 import { ArtistSuggestionService } from '../services/artistSuggestion'
 
-const saveArtistBody = z.object({
-    guildId: z.string().min(1),
-    artistKey: z.string().min(1),
-    artistName: z.string().min(1),
-    spotifyId: z.string().optional(),
-    imageUrl: z.string().optional(),
-    preference: z.enum(['prefer', 'block']).default('prefer'),
-})
+const svc = new ArtistSuggestionService()
+void svc.prewarmCache()
 
-const saveArtistBatchBody = z.object({
-    guildId: z.string().min(1),
-    items: z.array(
-        z.object({
-            artistId: z.string().min(1),
-            artistKey: z.string().min(1),
-            artistName: z.string().min(1),
-            imageUrl: z.string().nullable(),
-            preference: z.enum(['prefer', 'block']),
-        }),
-    ),
-})
-
-function normalizeArtistKey(name: string): string {
-    return name.toLowerCase().replace(/[^a-z0-9]/g, '')
-}
-
-// Initialize the suggestion service singleton
-const suggestionService = new ArtistSuggestionService()
-
-// Prewarm the suggestions cache on startup
-void suggestionService.prewarmCache()
+const wrap =
+    (h: (r: AuthenticatedRequest) => Promise<any>, ctx: string, err: string) =>
+    async (req: AuthenticatedRequest, res: Response) => {
+        try {
+            res.json(await h(req))
+        } catch (e: any) {
+            const st = e?.status ?? 500
+            const msg = e?.error ?? err
+            if (st === 500) errorLog({ message: `${ctx} error`, error: e })
+            res.status(st).json({ error: msg })
+        }
+    }
 
 export function setupArtistsRoutes(app: Express): void {
     app.get(
         '/api/artists/suggestions',
         apiLimiter,
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const discordUserId = req.user?.id
-                if (!discordUserId) {
-                    res.status(401).json({ error: 'Not authenticated' })
-                    return
-                }
-                if (!isSpotifyAuthConfigured()) {
-                    res.status(503).json({ error: 'Spotify not configured' })
-                    return
-                }
-
-                const suggestions =
-                    await suggestionService.getSuggestions(discordUserId)
-                if (suggestions.length === 0) {
-                    res.set('Cache-Control', 'no-store')
-                    res.status(503).json({
-                        error: 'Artist suggestions temporarily unavailable',
-                    })
-                    return
-                }
-
-                res.set('Cache-Control', 'no-cache, no-store, must-revalidate')
-                res.json({ artists: suggestions })
-            } catch (error) {
-                errorLog({ message: 'Artist suggestions error', error })
-                res.status(500).json({ error: 'Failed to get suggestions' })
-            }
-        },
+        wrap(
+            async (r) => ({
+                artists: await svc.handleGetSuggestions(r.user?.id),
+            }),
+            'Artist suggestions',
+            'Failed to get suggestions',
+        ),
     )
 
     app.get(
         '/api/artists/search',
         apiLimiter,
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const query =
-                    typeof req.query.q === 'string' ? req.query.q.trim() : ''
-                if (!query) {
-                    res.status(400).json({ error: 'Missing query parameter q' })
-                    return
-                }
-                if (!isSpotifyAuthConfigured()) {
-                    res.status(503).json({ error: 'Spotify not configured' })
-                    return
-                }
-                const token = await getSpotifyClientToken()
-                if (!token) {
-                    res.status(503).json({
-                        error: 'Failed to get Spotify token',
-                    })
-                    return
-                }
-
-                const artists = await searchSpotifyArtists(token, query, 12)
-                res.json({ artists })
-            } catch (error) {
-                errorLog({ message: 'Artist search error', error })
-                res.status(500).json({ error: 'Failed to search artists' })
-            }
-        },
+        wrap(
+            async (r) => ({
+                artists: await svc.handleSearchArtists(r.query.q),
+            }),
+            'Artist search',
+            'Failed to search artists',
+        ),
     )
 
     app.get(
         '/api/artists/:artistId/related',
         apiLimiter,
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const artistId = req.params.artistId as string
-                if (!isSpotifyAuthConfigured()) {
-                    res.status(503).json({ error: 'Spotify not configured' })
-                    return
-                }
-                const token = await getSpotifyClientToken()
-                if (!token) {
-                    res.status(503).json({
-                        error: 'Failed to get Spotify token',
-                    })
-                    return
-                }
-
-                const artists = await getSpotifyRelatedArtists(token, artistId)
-                res.json({ artists })
-            } catch (error) {
-                errorLog({ message: 'Related artists error', error })
-                res.status(500).json({ error: 'Failed to get related artists' })
-            }
-        },
+        wrap(
+            async (r) => ({
+                artists: await svc.handleGetRelatedArtists(r.params.artistId),
+            }),
+            'Related artists',
+            'Failed to get related artists',
+        ),
     )
 
     app.get(
         '/api/users/me/preferred-artists',
         apiLimiter,
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const discordUserId = req.user?.id
-                if (!discordUserId) {
-                    res.status(401).json({ error: 'Not authenticated' })
-                    return
-                }
-                const guildId =
-                    typeof req.query.guildId === 'string'
-                        ? req.query.guildId
-                        : undefined
-                const db = getPrismaClient()
-                const prefs = await db.userArtistPreference.findMany({
-                    where: { discordUserId, ...(guildId ? { guildId } : {}) },
-                    orderBy: { createdAt: 'desc' },
-                })
-                res.json({ preferences: prefs })
-            } catch (error) {
-                errorLog({ message: 'Get preferred artists error', error })
-                res.status(500).json({ error: 'Failed to get preferences' })
-            }
-        },
+        wrap(
+            async (r) => ({
+                preferences: await svc.handleGetPreferredArtists(
+                    r.user?.id,
+                    r.query.guildId,
+                ),
+            }),
+            'Get preferred artists',
+            'Failed to get preferences',
+        ),
     )
 
     app.post(
         '/api/users/me/preferred-artists',
         writeLimiter,
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const discordUserId = req.user?.id
-                if (!discordUserId) {
-                    res.status(401).json({ error: 'Not authenticated' })
-                    return
-                }
-                const parsed = saveArtistBody.safeParse(req.body)
-                if (!parsed.success) {
-                    res.status(400).json({ error: parsed.error.message })
-                    return
-                }
-                const { guildId, artistName, spotifyId, imageUrl, preference } =
-                    parsed.data
-                const artistKey = normalizeArtistKey(
-                    parsed.data.artistKey || artistName,
-                )
-                const db = getPrismaClient()
-                const pref = await db.userArtistPreference.upsert({
-                    where: {
-                        discordUserId_guildId_artistKey: {
-                            discordUserId,
-                            guildId,
-                            artistKey,
-                        },
-                    },
-                    update: { artistName, spotifyId, imageUrl, preference },
-                    create: {
-                        discordUserId,
-                        guildId,
-                        artistKey,
-                        artistName,
-                        spotifyId,
-                        imageUrl,
-                        preference,
-                    },
-                })
-                res.json({ preference: pref })
-            } catch (error) {
-                errorLog({ message: 'Save preferred artist error', error })
-                res.status(500).json({ error: 'Failed to save preference' })
-            }
-        },
+        wrap(
+            async (r) => ({
+                preference: await svc.handleSavePreferredArtist(
+                    r.user?.id,
+                    r.body,
+                ),
+            }),
+            'Save preferred artist',
+            'Failed to save preference',
+        ),
     )
 
     app.put(
         '/api/artists/preferences/batch',
         writeLimiter,
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const discordUserId = req.user?.id
-                if (!discordUserId) {
-                    res.status(401).json({ error: 'Not authenticated' })
-                    return
-                }
-                const parsed = saveArtistBatchBody.safeParse(req.body)
-                if (!parsed.success) {
-                    res.status(400).json({ error: parsed.error.message })
-                    return
-                }
-                const { guildId, items } = parsed.data
-                const db = getPrismaClient()
-                const results: typeof items = []
-                for (const item of items) {
-                    const artistKey = normalizeArtistKey(
-                        item.artistKey || item.artistName,
-                    )
-                    const pref = await db.userArtistPreference.upsert({
-                        where: {
-                            discordUserId_guildId_artistKey: {
-                                discordUserId,
-                                guildId,
-                                artistKey,
-                            },
-                        },
-                        update: {
-                            artistName: item.artistName,
-                            spotifyId: item.artistId,
-                            imageUrl: item.imageUrl,
-                            preference: item.preference,
-                        },
-                        create: {
-                            discordUserId,
-                            guildId,
-                            artistKey,
-                            artistName: item.artistName,
-                            spotifyId: item.artistId,
-                            imageUrl: item.imageUrl,
-                            preference: item.preference,
-                        },
-                    })
-                    results.push(pref as unknown as (typeof items)[0])
-                }
-                res.json({ preferences: results })
-            } catch (error) {
-                errorLog({ message: 'Batch save preferences error', error })
-                res.status(500).json({ error: 'Failed to save preferences' })
-            }
-        },
+        wrap(
+            async (r) => ({
+                preferences: await svc.handleBatchSavePreferences(
+                    r.user?.id,
+                    r.body,
+                ),
+            }),
+            'Batch save preferences',
+            'Failed to save preferences',
+        ),
     )
 
     app.delete(
         '/api/users/me/preferred-artists/:artistKey',
         writeLimiter,
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const discordUserId = req.user?.id
-                if (!discordUserId) {
-                    res.status(401).json({ error: 'Not authenticated' })
-                    return
-                }
-                const artistKey = req.params.artistKey as string
-                const guildId =
-                    typeof req.query.guildId === 'string'
-                        ? req.query.guildId
-                        : undefined
-                if (!guildId) {
-                    res.status(400).json({
-                        error: 'Missing guildId query param',
-                    })
-                    return
-                }
-                const db = getPrismaClient()
-                await db.userArtistPreference.delete({
-                    where: {
-                        discordUserId_guildId_artistKey: {
-                            discordUserId,
-                            guildId,
-                            artistKey,
-                        },
-                    },
-                })
-                res.json({ success: true })
-            } catch (error) {
-                errorLog({ message: 'Delete preferred artist error', error })
-                res.status(500).json({ error: 'Failed to delete preference' })
-            }
-        },
+        wrap(
+            async (r) => {
+                await svc.handleDeletePreferredArtist(
+                    r.user?.id,
+                    r.params.artistKey,
+                    r.query.guildId,
+                )
+                return { success: true }
+            },
+            'Delete preferred artist',
+            'Failed to delete preference',
+        ),
     )
 }

--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -1,149 +1,92 @@
-import type { Express, Response } from 'express'
-import { errorLog } from '@lucky/shared/utils'
-import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
+import type { Express } from 'express'
+import { requireAuth } from '../middleware/auth'
 import { apiLimiter, writeLimiter } from '../middleware/rateLimit'
+import { wrapHandler } from '../utils/routeUtils'
 import { ArtistSuggestionService } from '../services/artistSuggestion'
-
-interface ApiError {
-    readonly status?: number
-    readonly error?: string
-}
 
 const svc = new ArtistSuggestionService()
 void svc.prewarmCache()
 
-const wrapHandler =
-    (
-        h: (r: AuthenticatedRequest) => Promise<Record<string, unknown>>,
-        ctx: string,
-        defaultErr: string,
-    ) =>
-    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-        try {
-            res.json(await h(req))
-        } catch (e: unknown) {
-            const apiErr =
-                typeof e === 'object' && e !== null ? (e as ApiError) : {}
-            const st = typeof apiErr.status === 'number' ? apiErr.status : 500
-            const msg =
-                typeof apiErr.error === 'string' ? apiErr.error : defaultErr
-            if (st === 500) errorLog({ message: `${ctx} error`, error: e })
-            res.status(st).json({ error: msg })
+const sugg = wrapHandler(
+    async (r) => ({ artists: await svc.handleGetSuggestions(r.user?.id) }),
+    'Artist suggestions',
+    'Failed to get suggestions',
+)
+
+const search = wrapHandler(
+    async (r) => {
+        const q = typeof r.query.q === 'string' ? r.query.q : ''
+        return { artists: await svc.handleSearchArtists(q) }
+    },
+    'Artist search',
+    'Failed to search artists',
+)
+
+const related = wrapHandler(
+    async (r) => {
+        const artistId =
+            typeof r.params.artistId === 'string' ? r.params.artistId : ''
+        return { artists: await svc.handleGetRelatedArtists(artistId) }
+    },
+    'Related artists',
+    'Failed to get related artists',
+)
+
+const prefs = wrapHandler(
+    async (r) => {
+        const guildId =
+            typeof r.query.guildId === 'string' ? r.query.guildId : ''
+        return {
+            preferences: await svc.handleGetPreferredArtists(
+                r.user?.id,
+                guildId,
+            ),
         }
-    }
+    },
+    'Get preferred artists',
+    'Failed to get preferences',
+)
+
+const save = wrapHandler(
+    async (r) => ({
+        preference: await svc.handleSavePreferredArtist(r.user?.id, r.body),
+    }),
+    'Save preferred artist',
+    'Failed to save preference',
+)
+
+const batch = wrapHandler(
+    async (r) => ({
+        preferences: await svc.handleBatchSavePreferences(r.user?.id, r.body),
+    }),
+    'Batch save preferences',
+    'Failed to save preferences',
+)
+
+const delPref = wrapHandler(
+    async (r) => {
+        const artistKey =
+            typeof r.params.artistKey === 'string' ? r.params.artistKey : ''
+        const guildId =
+            typeof r.query.guildId === 'string' ? r.query.guildId : ''
+        await svc.handleDeletePreferredArtist(r.user?.id, artistKey, guildId)
+        return { success: true }
+    },
+    'Delete preferred artist',
+    'Failed to delete preference',
+)
 
 export function setupArtistsRoutes(app: Express): void {
-    app.get(
-        '/api/artists/suggestions',
-        apiLimiter,
-        requireAuth,
-        wrapHandler(
-            async (r) => ({
-                artists: await svc.handleGetSuggestions(r.user?.id),
-            }),
-            'Artist suggestions',
-            'Failed to get suggestions',
-        ),
-    )
-    app.get(
-        '/api/artists/search',
-        apiLimiter,
-        requireAuth,
-        wrapHandler(
-            async (r) => {
-                const q = typeof r.query.q === 'string' ? r.query.q : ''
-                return { artists: await svc.handleSearchArtists(q) }
-            },
-            'Artist search',
-            'Failed to search artists',
-        ),
-    )
-    app.get(
-        '/api/artists/:artistId/related',
-        apiLimiter,
-        requireAuth,
-        wrapHandler(
-            async (r) => {
-                const artistId =
-                    typeof r.params.artistId === 'string'
-                        ? r.params.artistId
-                        : ''
-                return { artists: await svc.handleGetRelatedArtists(artistId) }
-            },
-            'Related artists',
-            'Failed to get related artists',
-        ),
-    )
-    app.get(
-        '/api/users/me/preferred-artists',
-        apiLimiter,
-        requireAuth,
-        wrapHandler(
-            async (r) => {
-                const guildId =
-                    typeof r.query.guildId === 'string' ? r.query.guildId : ''
-                return {
-                    preferences: await svc.handleGetPreferredArtists(
-                        r.user?.id,
-                        guildId,
-                    ),
-                }
-            },
-            'Get preferred artists',
-            'Failed to get preferences',
-        ),
-    )
-    app.post(
-        '/api/users/me/preferred-artists',
-        writeLimiter,
-        requireAuth,
-        wrapHandler(
-            async (r) => ({
-                preference: await svc.handleSavePreferredArtist(
-                    r.user?.id,
-                    r.body,
-                ),
-            }),
-            'Save preferred artist',
-            'Failed to save preference',
-        ),
-    )
-    app.put(
-        '/api/artists/preferences/batch',
-        writeLimiter,
-        requireAuth,
-        wrapHandler(
-            async (r) => ({
-                preferences: await svc.handleBatchSavePreferences(
-                    r.user?.id,
-                    r.body,
-                ),
-            }),
-            'Batch save preferences',
-            'Failed to save preferences',
-        ),
-    )
+    app.get('/api/artists/suggestions', apiLimiter, requireAuth, sugg)
+    app.get('/api/artists/search', apiLimiter, requireAuth, search)
+    app.get('/api/artists/:artistId/related', apiLimiter, requireAuth, related)
+    app.get('/api/users/me/preferred-artists', apiLimiter, requireAuth, prefs)
+    app.post('/api/users/me/preferred-artists', writeLimiter, requireAuth, save)
+    app.put('/api/artists/preferences/batch', writeLimiter, requireAuth, batch)
     app.delete(
         '/api/users/me/preferred-artists/:artistKey',
         writeLimiter,
         requireAuth,
-        wrapHandler(
-            async (r) => {
-                const artistKey =
-                    typeof r.params.artistKey === 'string'
-                        ? r.params.artistKey
-                        : ''
-                const guildId =
-                    typeof r.query.guildId === 'string' ? r.query.guildId : ''
-                await svc.handleDeletePreferredArtist(
-                    r.user?.id,
-                    artistKey,
-                    guildId,
-                )
-                return { success: true }
-            },
-            'Delete preferred artist',
-            'Failed to delete preference',
-        ),
+        delPref,
     )
 }

--- a/packages/backend/src/routes/artists.ts
+++ b/packages/backend/src/routes/artists.ts
@@ -2,26 +2,17 @@ import type { Express, Response } from 'express'
 import { z } from 'zod'
 import {
     errorLog,
-    infoLog,
-    warnLog,
     getPrismaClient,
     searchSpotifyArtists,
     getSpotifyRelatedArtists,
-    type SpotifyArtist,
 } from '@lucky/shared/utils'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
 import { apiLimiter, writeLimiter } from '../middleware/rateLimit'
 import {
-    getSpotifyClientToken,
     isSpotifyAuthConfigured,
+    getSpotifyClientToken,
 } from '../services/SpotifyAuthService'
-import { spotifyLinkService, redisClient } from '@lucky/shared/services'
-
-const MAX_SUGGESTIONS = 150
-const FALLBACK_SUGGESTIONS_CACHE_KEY = 'artist:suggestions:fallback:v2'
-const FALLBACK_SUGGESTIONS_TTL_SECONDS = 60 * 60 // 1 hour
-const USER_TOP_ARTISTS_CACHE_PREFIX = 'artist:user:top:v1:'
-const USER_TOP_ARTISTS_TTL_SECONDS = 15 * 60 // 15 minutes
+import { ArtistSuggestionService } from '../services/artistSuggestion'
 
 const saveArtistBody = z.object({
     guildId: z.string().min(1),
@@ -49,110 +40,13 @@ function normalizeArtistKey(name: string): string {
     return name.toLowerCase().replace(/[^a-z0-9]/g, '')
 }
 
-const POPULAR_SUGGEST_QUERIES = [
-    // Pop
-    'Taylor Swift', 'Dua Lipa', 'Ariana Grande', 'Olivia Rodrigo',
-    'Sabrina Carpenter', 'Billie Eilish', 'The Weeknd',
-    // Hip-hop
-    'Drake', 'Kendrick Lamar', 'Travis Scott', 'J. Cole',
-    'Tyler The Creator', 'Future', 'Nicki Minaj',
-    // Rock
-    'Foo Fighters', 'Red Hot Chili Peppers', 'Arctic Monkeys',
-    'Radiohead', 'The Strokes', 'Tame Impala',
-    // R&B
-    'SZA', 'Frank Ocean', 'Bruno Mars', 'H.E.R.', 'Daniel Caesar',
-    // Electronic
-    'Daft Punk', 'Calvin Harris', 'Flume', 'ODESZA', 'Disclosure', 'Skrillex',
-    // Latin
-    'Bad Bunny', 'Anitta', 'Karol G', 'J Balvin', 'Rosalía', 'Peso Pluma',
-    // Country
-    'Morgan Wallen', 'Luke Combs', 'Kacey Musgraves', 'Zach Bryan',
-    // Indie
-    'Phoebe Bridgers', 'Arcade Fire', 'Vampire Weekend', 'Mac DeMarco',
-    // K-pop
-    'BTS', 'BLACKPINK', 'NewJeans', 'Stray Kids',
-    // Classic rock
-    'The Beatles', 'Queen', 'Pink Floyd', 'Led Zeppelin',
-    // Jazz
-    'Miles Davis', 'John Coltrane', 'Nina Simone',
-    // Metal
-    'Metallica', 'Tool', 'System of a Down',
-    // Brazilian
-    'Matuê', 'Tim Bernardes', 'Racionais', 'Djonga',
-]
+// Initialize the suggestion service singleton
+const suggestionService = new ArtistSuggestionService()
 
-async function fetchPopularFallback(clientToken: string): Promise<SpotifyArtist[]> {
-    const out: SpotifyArtist[] = []
-    const seen = new Set<string>()
-    for (const query of POPULAR_SUGGEST_QUERIES) {
-        if (out.length >= MAX_SUGGESTIONS) break
-        try {
-            const artists = await searchSpotifyArtists(clientToken, query, 6)
-            for (const artist of artists) {
-                if (out.length >= MAX_SUGGESTIONS) break
-                if (!seen.has(artist.id)) {
-                    seen.add(artist.id)
-                    out.push(artist)
-                }
-            }
-        } catch {
-            // continue to next query
-        }
-    }
-    return out
-}
-
-// Fire-and-forget at startup: warm the popular-artists cache so the
-// suggestions endpoint never returns 503 just because Redis was cold.
-// Only runs if cache is empty AND Spotify is reachable. Errors are
-// non-fatal — the next user request can also warm the cache.
-export async function prewarmSuggestionsCache(): Promise<void> {
-    try {
-        // Wait up to 30s for Redis to become healthy. Without this,
-        // the call fires at module import time and silently no-ops
-        // because the redis client hasn't finished its handshake yet.
-        const start = Date.now()
-        while (!redisClient.isHealthy() && Date.now() - start < 30_000) {
-            await new Promise((r) => setTimeout(r, 500))
-        }
-        if (!redisClient.isHealthy()) {
-            warnLog({ message: 'Prewarm: Redis not ready after 30s, skipping' })
-            return
-        }
-        if (!isSpotifyAuthConfigured()) {
-            infoLog({ message: 'Prewarm: Spotify not configured, skipping' })
-            return
-        }
-        const cached = await redisClient.get(FALLBACK_SUGGESTIONS_CACHE_KEY).catch(() => null)
-        if (cached) {
-            infoLog({ message: 'Prewarm: cache already warm, skipping' })
-            return
-        }
-        const token = await getSpotifyClientToken()
-        if (!token) {
-            warnLog({ message: 'Prewarm: no Spotify client token, skipping' })
-            return
-        }
-        const artists = await fetchPopularFallback(token)
-        if (artists.length === 0) {
-            warnLog({ message: 'Prewarm: Spotify returned 0 artists, cache not written' })
-            return
-        }
-        await redisClient.setex(
-            FALLBACK_SUGGESTIONS_CACHE_KEY,
-            FALLBACK_SUGGESTIONS_TTL_SECONDS,
-            JSON.stringify(artists),
-        )
-        infoLog({ message: `Prewarm: cached ${artists.length} popular artists` })
-    } catch (error) {
-        errorLog({ message: 'Failed to prewarm suggestions cache', error })
-    }
-}
+// Prewarm the suggestions cache on startup
+void suggestionService.prewarmCache()
 
 export function setupArtistsRoutes(app: Express): void {
-    // Warm the cache asynchronously on startup; don't block route registration.
-    void prewarmSuggestionsCache()
-
     app.get(
         '/api/artists/suggestions',
         apiLimiter,
@@ -168,168 +62,10 @@ export function setupArtistsRoutes(app: Express): void {
                     res.status(503).json({ error: 'Spotify not configured' })
                     return
                 }
-                const clientToken = await getSpotifyClientToken()
-                if (!clientToken) {
-                    res.status(503).json({
-                        error: 'Failed to get Spotify token',
-                    })
-                    return
-                }
 
-                const suggestions = new Map<string, SpotifyArtist>()
-
-                // PRIORITY 1: user's saved preferred artists (Musical Taste page).
-                // These come first in Discover so the user always sees what they
-                // explicitly favorited before any algorithmic suggestion.
-                try {
-                    const db = getPrismaClient()
-                    const preferred = await db.userArtistPreference.findMany({
-                        where: { discordUserId, preference: 'prefer' },
-                        orderBy: { createdAt: 'desc' },
-                    })
-                    for (const pref of preferred) {
-                        if (suggestions.size >= MAX_SUGGESTIONS) break
-                        const id = pref.spotifyId ?? `pref:${pref.artistKey}`
-                        if (suggestions.has(id)) continue
-                        suggestions.set(id, {
-                            id,
-                            name: pref.artistName,
-                            imageUrl: pref.imageUrl,
-                            popularity: 0,
-                            genres: [],
-                        })
-                    }
-                } catch (error) {
-                    errorLog({ message: 'Failed to load preferred artists for suggestions', error })
-                }
-
-                const link = await spotifyLinkService.getValidAccessToken(
-                    discordUserId,
-                )
-                if (link) {
-                    const userCacheKey = `${USER_TOP_ARTISTS_CACHE_PREFIX}${discordUserId}`
-                    let cachedTop: SpotifyArtist[] | null = null
-                    try {
-                        const cached = await redisClient.get(userCacheKey)
-                        if (cached) {
-                            cachedTop = JSON.parse(cached) as SpotifyArtist[]
-                        }
-                    } catch {
-                        // Redis miss/error — fall through to Spotify
-                    }
-
-                    if (cachedTop && cachedTop.length > 0) {
-                        for (const artist of cachedTop) {
-                            if (suggestions.size >= MAX_SUGGESTIONS) break
-                            suggestions.set(artist.id, artist)
-                        }
-                    } else {
-                        try {
-                            // Fetch top artists across 3 time ranges in parallel
-                            const timeRanges = ['short_term', 'medium_term', 'long_term'] as const
-                            const promises = timeRanges.map((range) =>
-                                fetch(
-                                    `https://api.spotify.com/v1/me/top/artists?limit=50&time_range=${range}`,
-                                    {
-                                        headers: {
-                                            Authorization: `Bearer ${link}`,
-                                        },
-                                    },
-                                )
-                            )
-                            const responses = await Promise.all(promises)
-                            const collected: SpotifyArtist[] = []
-                            for (const res of responses) {
-                                if (res.ok) {
-                                    const data = (await res.json()) as {
-                                        items?: unknown[]
-                                    }
-                                    if (Array.isArray(data.items)) {
-                                        for (const item of data.items) {
-                                            const artist = item as {
-                                                id?: string
-                                                name?: string
-                                                images?: { url: string }[]
-                                                popularity?: number
-                                                genres?: string[]
-                                            }
-                                            if (
-                                                artist.id &&
-                                                artist.name &&
-                                                suggestions.size < MAX_SUGGESTIONS
-                                            ) {
-                                                const entry: SpotifyArtist = {
-                                                    id: artist.id,
-                                                    name: artist.name,
-                                                    imageUrl:
-                                                        artist.images?.[0]?.url ?? null,
-                                                    popularity: artist.popularity ?? 0,
-                                                    genres: artist.genres ?? [],
-                                                }
-                                                if (!suggestions.has(artist.id)) {
-                                                    collected.push(entry)
-                                                }
-                                                suggestions.set(artist.id, entry)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            if (collected.length > 0) {
-                                try {
-                                    await redisClient.setex(
-                                        userCacheKey,
-                                        USER_TOP_ARTISTS_TTL_SECONDS,
-                                        JSON.stringify(collected),
-                                    )
-                                } catch {
-                                    // Cache write failure is non-fatal
-                                }
-                            }
-                        } catch {
-                            // Fall back to popular artists
-                        }
-                    }
-                }
-
-                if (suggestions.size < MAX_SUGGESTIONS) {
-                    // Cached fallback: avoid hammering Spotify search (429s on
-                    // every page load otherwise). Cache the popular-artists
-                    // bundle in Redis for 1h.
-                    let fallback: SpotifyArtist[] = []
-                    try {
-                        const cached = await redisClient.get(
-                            FALLBACK_SUGGESTIONS_CACHE_KEY,
-                        )
-                        if (cached) {
-                            fallback = JSON.parse(cached) as SpotifyArtist[]
-                        }
-                    } catch {
-                        // Redis miss/error — fall through to live fetch
-                    }
-
-                    if (fallback.length === 0) {
-                        fallback = await fetchPopularFallback(clientToken)
-                        if (fallback.length > 0) {
-                            await redisClient
-                                .setex(
-                                    FALLBACK_SUGGESTIONS_CACHE_KEY,
-                                    FALLBACK_SUGGESTIONS_TTL_SECONDS,
-                                    JSON.stringify(fallback),
-                                )
-                                .catch(() => undefined)
-                        }
-                    }
-
-                    for (const artist of fallback) {
-                        if (suggestions.size >= MAX_SUGGESTIONS) break
-                        if (!suggestions.has(artist.id)) {
-                            suggestions.set(artist.id, artist)
-                        }
-                    }
-                }
-
-                if (suggestions.size === 0) {
+                const suggestions =
+                    await suggestionService.getSuggestions(discordUserId)
+                if (suggestions.length === 0) {
                     res.set('Cache-Control', 'no-store')
                     res.status(503).json({
                         error: 'Artist suggestions temporarily unavailable',
@@ -338,14 +74,9 @@ export function setupArtistsRoutes(app: Express): void {
                 }
 
                 res.set('Cache-Control', 'no-cache, no-store, must-revalidate')
-                res.json({
-                    artists: Array.from(suggestions.values()),
-                })
+                res.json({ artists: suggestions })
             } catch (error) {
-                errorLog({
-                    message: 'Artist suggestions error',
-                    error,
-                })
+                errorLog({ message: 'Artist suggestions error', error })
                 res.status(500).json({ error: 'Failed to get suggestions' })
             }
         },
@@ -374,6 +105,7 @@ export function setupArtistsRoutes(app: Express): void {
                     })
                     return
                 }
+
                 const artists = await searchSpotifyArtists(token, query, 12)
                 res.json({ artists })
             } catch (error) {
@@ -401,6 +133,7 @@ export function setupArtistsRoutes(app: Express): void {
                     })
                     return
                 }
+
                 const artists = await getSpotifyRelatedArtists(token, artistId)
                 res.json({ artists })
             } catch (error) {
@@ -534,7 +267,7 @@ export function setupArtistsRoutes(app: Express): void {
                             preference: item.preference,
                         },
                     })
-                    results.push(pref as unknown as typeof items[0])
+                    results.push(pref as unknown as (typeof items)[0])
                 }
                 res.json({ preferences: results })
             } catch (error) {

--- a/packages/backend/src/services/artistSuggestion.ts
+++ b/packages/backend/src/services/artistSuggestion.ts
@@ -188,6 +188,7 @@ export class ArtistSuggestionService {
         accessToken: string,
     ): Promise<SpotifyArtist[]> {
         const collected: SpotifyArtist[] = []
+        const seen = new Set<string>()
         const timeRanges = ['short_term', 'medium_term', 'long_term'] as const
 
         try {
@@ -227,7 +228,8 @@ export class ArtistSuggestionService {
                             popularity: artist.popularity ?? 0,
                             genres: artist.genres ?? [],
                         }
-                        if (!collected.some((a) => a.id === artist.id)) {
+                        if (!seen.has(artist.id)) {
+                            seen.add(artist.id)
                             collected.push(entry)
                         }
                     }

--- a/packages/backend/src/services/artistSuggestion.ts
+++ b/packages/backend/src/services/artistSuggestion.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
-import type { SpotifyArtist } from '@lucky/shared/utils'
 import {
+    type SpotifyArtist,
     errorLog,
     getPrismaClient,
     searchSpotifyArtists,

--- a/packages/backend/src/services/artistSuggestion.ts
+++ b/packages/backend/src/services/artistSuggestion.ts
@@ -1,0 +1,367 @@
+import type { SpotifyArtist } from '@lucky/shared/utils'
+import {
+    errorLog,
+    getPrismaClient,
+    searchSpotifyArtists,
+    getSpotifyRelatedArtists,
+} from '@lucky/shared/utils'
+import { spotifyLinkService, redisClient } from '@lucky/shared/services'
+import { POPULAR_ARTISTS } from '../constants/popularArtists'
+import {
+    getSpotifyClientToken,
+    isSpotifyAuthConfigured,
+} from './SpotifyAuthService'
+
+export interface ArtistSuggestion extends SpotifyArtist {}
+
+/**
+ * Configuration for ArtistSuggestionService caching behavior.
+ */
+export interface ArtistSuggestionServiceConfig {
+    maxSuggestions?: number
+    fallbackCacheTtlSeconds?: number
+    userTopArtistsCacheTtlSeconds?: number
+}
+
+const DEFAULT_CONFIG: Required<ArtistSuggestionServiceConfig> = {
+    maxSuggestions: 150,
+    fallbackCacheTtlSeconds: 60 * 60, // 1 hour
+    userTopArtistsCacheTtlSeconds: 15 * 60, // 15 minutes
+}
+
+/**
+ * Service to fetch artist suggestions through a three-tier lookup strategy:
+ * 1. User's saved preferred artists (from database)
+ * 2. User's Spotify top artists (if Spotify is linked)
+ * 3. Popular artists fallback (static list)
+ *
+ * Handles Redis caching to minimize Spotify API calls.
+ */
+export class ArtistSuggestionService {
+    private maxSuggestions: number
+    private fallbackCacheTtlSeconds: number
+    private userTopArtistsCacheTtlSeconds: number
+    private fallbackCacheKey = 'artist:suggestions:fallback:v2'
+    private userTopArtistsCachePrefix = 'artist:user:top:v1:'
+
+    constructor(config: ArtistSuggestionServiceConfig = {}) {
+        const merged = { ...DEFAULT_CONFIG, ...config }
+        this.maxSuggestions = merged.maxSuggestions
+        this.fallbackCacheTtlSeconds = merged.fallbackCacheTtlSeconds
+        this.userTopArtistsCacheTtlSeconds =
+            merged.userTopArtistsCacheTtlSeconds
+    }
+
+    /**
+     * Fetch artist suggestions through the three-tier lookup strategy.
+     * Returns up to maxSuggestions artists in priority order.
+     */
+    async getSuggestions(
+        discordUserId: string,
+        guildId?: string,
+    ): Promise<ArtistSuggestion[]> {
+        if (!isSpotifyAuthConfigured()) {
+            throw new Error('Spotify not configured')
+        }
+
+        const suggestions = new Map<string, ArtistSuggestion>()
+
+        // Tier 1: User's saved preferred artists
+        await this.loadPreferredArtists(discordUserId, guildId, suggestions)
+        if (suggestions.size >= this.maxSuggestions) {
+            return Array.from(suggestions.values())
+        }
+
+        // Tier 2: User's Spotify top artists
+        await this.loadSpotifyTopArtists(discordUserId, suggestions)
+        if (suggestions.size >= this.maxSuggestions) {
+            return Array.from(suggestions.values())
+        }
+
+        // Tier 3: Popular artists fallback
+        await this.loadPopularArtistsFallback(suggestions)
+
+        return Array.from(suggestions.values()).slice(0, this.maxSuggestions)
+    }
+
+    /**
+     * Load user's saved preferred artists from database.
+     */
+    private async loadPreferredArtists(
+        discordUserId: string,
+        guildId: string | undefined,
+        suggestions: Map<string, ArtistSuggestion>,
+    ): Promise<void> {
+        try {
+            const db = getPrismaClient()
+            const preferred = await db.userArtistPreference.findMany({
+                where: {
+                    discordUserId,
+                    preference: 'prefer',
+                    ...(guildId ? { guildId } : {}),
+                },
+                orderBy: { createdAt: 'desc' },
+            })
+            for (const pref of preferred) {
+                if (suggestions.size >= this.maxSuggestions) break
+                const id = pref.spotifyId ?? `pref:${pref.artistKey}`
+                if (suggestions.has(id)) continue
+                suggestions.set(id, {
+                    id,
+                    name: pref.artistName,
+                    imageUrl: pref.imageUrl,
+                    popularity: 0,
+                    genres: [],
+                })
+            }
+        } catch (error) {
+            errorLog({
+                message: 'Failed to load preferred artists for suggestions',
+                error,
+            })
+        }
+    }
+
+    /**
+     * Load user's Spotify top artists if they have linked their account.
+     */
+    private async loadSpotifyTopArtists(
+        discordUserId: string,
+        suggestions: Map<string, ArtistSuggestion>,
+    ): Promise<void> {
+        try {
+            const link =
+                await spotifyLinkService.getValidAccessToken(discordUserId)
+            if (!link) return
+
+            const userCacheKey = `${this.userTopArtistsCachePrefix}${discordUserId}`
+            let cachedTop: SpotifyArtist[] | null = null
+
+            // Try to load from cache
+            try {
+                const cached = await redisClient.get(userCacheKey)
+                if (cached) {
+                    cachedTop = JSON.parse(cached) as SpotifyArtist[]
+                }
+            } catch {
+                // Redis miss/error — fall through to Spotify
+            }
+
+            if (cachedTop && cachedTop.length > 0) {
+                for (const artist of cachedTop) {
+                    if (suggestions.size >= this.maxSuggestions) break
+                    suggestions.set(artist.id, artist)
+                }
+            } else {
+                // Fetch from Spotify
+                const topArtists = await this.fetchSpotifyTopArtists(link)
+                for (const artist of topArtists) {
+                    if (suggestions.size >= this.maxSuggestions) break
+                    if (!suggestions.has(artist.id)) {
+                        suggestions.set(artist.id, artist)
+                    }
+                }
+
+                // Cache the fetched artists
+                if (topArtists.length > 0) {
+                    try {
+                        await redisClient.setex(
+                            userCacheKey,
+                            this.userTopArtistsCacheTtlSeconds,
+                            JSON.stringify(topArtists),
+                        )
+                    } catch {
+                        // Cache write failure is non-fatal
+                    }
+                }
+            }
+        } catch (error) {
+            errorLog({ message: 'Failed to load Spotify top artists', error })
+        }
+    }
+
+    /**
+     * Fetch user's top artists from Spotify API across multiple time ranges.
+     */
+    private async fetchSpotifyTopArtists(
+        accessToken: string,
+    ): Promise<SpotifyArtist[]> {
+        const collected: SpotifyArtist[] = []
+        const timeRanges = ['short_term', 'medium_term', 'long_term'] as const
+
+        try {
+            const promises = timeRanges.map((range) =>
+                fetch(
+                    `https://api.spotify.com/v1/me/top/artists?limit=50&time_range=${range}`,
+                    {
+                        headers: {
+                            Authorization: `Bearer ${accessToken}`,
+                        },
+                    },
+                ),
+            )
+            const responses = await Promise.all(promises)
+
+            for (const res of responses) {
+                if (!res.ok) continue
+
+                const data = (await res.json()) as {
+                    items?: unknown[]
+                }
+                if (!Array.isArray(data.items)) continue
+
+                for (const item of data.items) {
+                    const artist = item as {
+                        id?: string
+                        name?: string
+                        images?: { url: string }[]
+                        popularity?: number
+                        genres?: string[]
+                    }
+                    if (artist.id && artist.name) {
+                        const entry: SpotifyArtist = {
+                            id: artist.id,
+                            name: artist.name,
+                            imageUrl: artist.images?.[0]?.url ?? null,
+                            popularity: artist.popularity ?? 0,
+                            genres: artist.genres ?? [],
+                        }
+                        if (!collected.some((a) => a.id === artist.id)) {
+                            collected.push(entry)
+                        }
+                    }
+                }
+            }
+        } catch (error) {
+            errorLog({ message: 'Failed to fetch Spotify top artists', error })
+        }
+
+        return collected
+    }
+
+    /**
+     * Load popular artists fallback list, with caching to minimize Spotify API calls.
+     */
+    private async loadPopularArtistsFallback(
+        suggestions: Map<string, ArtistSuggestion>,
+    ): Promise<void> {
+        try {
+            let fallback: SpotifyArtist[] = []
+
+            // Try to load from cache
+            try {
+                const cached = await redisClient.get(this.fallbackCacheKey)
+                if (cached) {
+                    fallback = JSON.parse(cached) as SpotifyArtist[]
+                }
+            } catch {
+                // Redis miss/error — fall through to fetch
+            }
+
+            if (fallback.length === 0) {
+                fallback = await this.fetchPopularArtists()
+                if (fallback.length > 0) {
+                    try {
+                        await redisClient.setex(
+                            this.fallbackCacheKey,
+                            this.fallbackCacheTtlSeconds,
+                            JSON.stringify(fallback),
+                        )
+                    } catch {
+                        // Cache write failure is non-fatal
+                    }
+                }
+            }
+
+            for (const artist of fallback) {
+                if (suggestions.size >= this.maxSuggestions) break
+                if (!suggestions.has(artist.id)) {
+                    suggestions.set(artist.id, artist)
+                }
+            }
+        } catch (error) {
+            errorLog({
+                message: 'Failed to load popular artists fallback',
+                error,
+            })
+        }
+    }
+
+    /**
+     * Fetch popular artists from Spotify by searching for each popular artist name.
+     * Returns up to maxSuggestions unique artists.
+     */
+    private async fetchPopularArtists(): Promise<SpotifyArtist[]> {
+        const clientToken = await getSpotifyClientToken()
+        if (!clientToken) {
+            throw new Error('Failed to get Spotify client token')
+        }
+
+        const out: SpotifyArtist[] = []
+        const seen = new Set<string>()
+
+        for (const query of POPULAR_ARTISTS) {
+            if (out.length >= this.maxSuggestions) break
+            try {
+                const artists = await searchSpotifyArtists(
+                    clientToken,
+                    query,
+                    6,
+                )
+                for (const artist of artists) {
+                    if (out.length >= this.maxSuggestions) break
+                    if (!seen.has(artist.id)) {
+                        seen.add(artist.id)
+                        out.push(artist)
+                    }
+                }
+            } catch {
+                // continue to next query
+            }
+        }
+
+        return out
+    }
+
+    /**
+     * Prewarm the popular artists cache at startup.
+     * This prevents the first user request from hitting rate limits.
+     */
+    async prewarmCache(): Promise<void> {
+        try {
+            // Wait up to 30s for Redis to become healthy
+            const start = Date.now()
+            while (!redisClient.isHealthy() && Date.now() - start < 30_000) {
+                await new Promise((r) => setTimeout(r, 500))
+            }
+
+            if (!redisClient.isHealthy()) {
+                return
+            }
+
+            if (!isSpotifyAuthConfigured()) {
+                return
+            }
+
+            const cached = await redisClient
+                .get(this.fallbackCacheKey)
+                .catch(() => null)
+            if (cached) {
+                return
+            }
+
+            const artists = await this.fetchPopularArtists()
+            if (artists.length === 0) {
+                return
+            }
+
+            await redisClient.setex(
+                this.fallbackCacheKey,
+                this.fallbackCacheTtlSeconds,
+                JSON.stringify(artists),
+            )
+        } catch (error) {
+            errorLog({ message: 'Failed to prewarm suggestions cache', error })
+        }
+    }
+}

--- a/packages/backend/src/services/artistSuggestion.ts
+++ b/packages/backend/src/services/artistSuggestion.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import type { SpotifyArtist } from '@lucky/shared/utils'
 import {
     errorLog,
@@ -363,5 +364,215 @@ export class ArtistSuggestionService {
         } catch (error) {
             errorLog({ message: 'Failed to prewarm suggestions cache', error })
         }
+    }
+
+    // Route handlers — handle validation and return responses or throw errors
+
+    private normalizeArtistKey(name: string): string {
+        return name.toLowerCase().replace(/[^a-z0-9]/g, '')
+    }
+
+    async handleGetSuggestions(
+        discordUserId: string | undefined,
+    ): Promise<ArtistSuggestion[]> {
+        if (!discordUserId) {
+            throw { status: 401, error: 'Not authenticated' }
+        }
+        if (!isSpotifyAuthConfigured()) {
+            throw { status: 503, error: 'Spotify not configured' }
+        }
+
+        const suggestions = await this.getSuggestions(discordUserId)
+        if (suggestions.length === 0) {
+            throw {
+                status: 503,
+                error: 'Artist suggestions temporarily unavailable',
+            }
+        }
+        return suggestions
+    }
+
+    async handleSearchArtists(query: unknown): Promise<SpotifyArtist[]> {
+        const q = typeof query === 'string' ? query.trim() : ''
+        if (!q) {
+            throw { status: 400, error: 'Missing query parameter q' }
+        }
+        if (!isSpotifyAuthConfigured()) {
+            throw { status: 503, error: 'Spotify not configured' }
+        }
+        const token = await getSpotifyClientToken()
+        if (!token) {
+            throw { status: 503, error: 'Failed to get Spotify token' }
+        }
+        return searchSpotifyArtists(token, q, 12)
+    }
+
+    async handleGetRelatedArtists(
+        artistId: string | undefined,
+    ): Promise<SpotifyArtist[]> {
+        if (!artistId) {
+            throw { status: 400, error: 'Missing artistId parameter' }
+        }
+        if (!isSpotifyAuthConfigured()) {
+            throw { status: 503, error: 'Spotify not configured' }
+        }
+        const token = await getSpotifyClientToken()
+        if (!token) {
+            throw { status: 503, error: 'Failed to get Spotify token' }
+        }
+        return getSpotifyRelatedArtists(token, artistId)
+    }
+
+    async handleGetPreferredArtists(
+        discordUserId: string | undefined,
+        guildId: unknown,
+    ): Promise<unknown[]> {
+        if (!discordUserId) {
+            throw { status: 401, error: 'Not authenticated' }
+        }
+        const db = getPrismaClient()
+        const guild = typeof guildId === 'string' ? guildId : undefined
+        return db.userArtistPreference.findMany({
+            where: { discordUserId, ...(guild ? { guildId: guild } : {}) },
+            orderBy: { createdAt: 'desc' },
+        })
+    }
+
+    async handleSavePreferredArtist(
+        discordUserId: string | undefined,
+        body: unknown,
+    ): Promise<unknown> {
+        if (!discordUserId) {
+            throw { status: 401, error: 'Not authenticated' }
+        }
+
+        const schema = z.object({
+            guildId: z.string().min(1),
+            artistKey: z.string().min(1),
+            artistName: z.string().min(1),
+            spotifyId: z.string().optional(),
+            imageUrl: z.string().optional(),
+            preference: z.enum(['prefer', 'block']).default('prefer'),
+        })
+
+        const parsed = schema.safeParse(body)
+        if (!parsed.success) {
+            throw { status: 400, error: parsed.error.message }
+        }
+
+        const { guildId, artistName, spotifyId, imageUrl, preference } =
+            parsed.data
+        const artistKey = this.normalizeArtistKey(
+            parsed.data.artistKey || artistName,
+        )
+        const db = getPrismaClient()
+        return db.userArtistPreference.upsert({
+            where: {
+                discordUserId_guildId_artistKey: {
+                    discordUserId,
+                    guildId,
+                    artistKey,
+                },
+            },
+            update: { artistName, spotifyId, imageUrl, preference },
+            create: {
+                discordUserId,
+                guildId,
+                artistKey,
+                artistName,
+                spotifyId,
+                imageUrl,
+                preference,
+            },
+        })
+    }
+
+    async handleBatchSavePreferences(
+        discordUserId: string | undefined,
+        body: unknown,
+    ): Promise<unknown[]> {
+        if (!discordUserId) {
+            throw { status: 401, error: 'Not authenticated' }
+        }
+
+        const schema = z.object({
+            guildId: z.string().min(1),
+            items: z.array(
+                z.object({
+                    artistId: z.string().min(1),
+                    artistKey: z.string().min(1),
+                    artistName: z.string().min(1),
+                    imageUrl: z.string().nullable(),
+                    preference: z.enum(['prefer', 'block']),
+                }),
+            ),
+        })
+
+        const parsed = schema.safeParse(body)
+        if (!parsed.success) {
+            throw { status: 400, error: parsed.error.message }
+        }
+
+        const { guildId, items } = parsed.data
+        const db = getPrismaClient()
+        const results: unknown[] = []
+        for (const item of items) {
+            const artistKey = this.normalizeArtistKey(
+                item.artistKey || item.artistName,
+            )
+            const pref = await db.userArtistPreference.upsert({
+                where: {
+                    discordUserId_guildId_artistKey: {
+                        discordUserId,
+                        guildId,
+                        artistKey,
+                    },
+                },
+                update: {
+                    artistName: item.artistName,
+                    spotifyId: item.artistId,
+                    imageUrl: item.imageUrl,
+                    preference: item.preference,
+                },
+                create: {
+                    discordUserId,
+                    guildId,
+                    artistKey,
+                    artistName: item.artistName,
+                    spotifyId: item.artistId,
+                    imageUrl: item.imageUrl,
+                    preference: item.preference,
+                },
+            })
+            results.push(pref)
+        }
+        return results
+    }
+
+    async handleDeletePreferredArtist(
+        discordUserId: string | undefined,
+        artistKey: string | undefined,
+        guildId: unknown,
+    ): Promise<void> {
+        if (!discordUserId) {
+            throw { status: 401, error: 'Not authenticated' }
+        }
+        if (!artistKey) {
+            throw { status: 400, error: 'Missing artistKey parameter' }
+        }
+        const guild = typeof guildId === 'string' ? guildId : undefined
+        if (!guild) {
+            throw { status: 400, error: 'Missing guildId query param' }
+        }
+        const db = getPrismaClient()
+        await db.userArtistPreference.delete({
+            where: {
+                discordUserId_guildId_artistKey: {
+                    discordUserId,
+                    guildId: guild,
+                    artistKey,
+                },
+            },
+        })
     }
 }

--- a/packages/backend/src/services/artistSuggestion.ts
+++ b/packages/backend/src/services/artistSuggestion.ts
@@ -452,8 +452,8 @@ export class ArtistSuggestionService {
             guildId: z.string().min(1),
             artistKey: z.string().min(1),
             artistName: z.string().min(1),
-            spotifyId: z.string().optional(),
-            imageUrl: z.string().optional(),
+            spotifyId: z.string().nullable().optional(),
+            imageUrl: z.string().nullable().optional(),
             preference: z.enum(['prefer', 'block']).default('prefer'),
         })
 

--- a/packages/backend/src/utils/routeUtils.ts
+++ b/packages/backend/src/utils/routeUtils.ts
@@ -1,0 +1,28 @@
+import type { Response } from 'express'
+import { errorLog } from '@lucky/shared/utils'
+import type { AuthenticatedRequest } from '../middleware/auth'
+
+interface ApiError {
+    readonly status?: number
+    readonly error?: string
+}
+
+export const wrapHandler =
+    (
+        h: (r: AuthenticatedRequest) => Promise<Record<string, unknown>>,
+        ctx: string,
+        defaultErr: string,
+    ) =>
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+        try {
+            res.json(await h(req))
+        } catch (e: unknown) {
+            const apiErr =
+                typeof e === 'object' && e !== null ? (e as ApiError) : {}
+            const st = typeof apiErr.status === 'number' ? apiErr.status : 500
+            const msg =
+                typeof apiErr.error === 'string' ? apiErr.error : defaultErr
+            if (st === 500) errorLog({ message: `${ctx} error`, error: e })
+            res.status(st).json({ error: msg })
+        }
+    }

--- a/packages/backend/tests/unit/routes/artists.test.ts
+++ b/packages/backend/tests/unit/routes/artists.test.ts
@@ -2,924 +2,921 @@ import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import type { Express } from 'express'
 import { setupArtistsRoutes } from '../../../src/routes/artists'
 import {
-	searchSpotifyArtists,
-	getSpotifyRelatedArtists,
-	getPrismaClient,
-	errorLog,
+    searchSpotifyArtists,
+    getSpotifyRelatedArtists,
+    getPrismaClient,
+    errorLog,
 } from '@lucky/shared/utils'
 import {
-	getSpotifyClientToken,
-	isSpotifyAuthConfigured,
+    getSpotifyClientToken,
+    isSpotifyAuthConfigured,
 } from '../../../src/services/SpotifyAuthService'
 import { spotifyLinkService } from '@lucky/shared/services'
 import {
-	createMockRequest,
-	createMockResponse,
+    createMockRequest,
+    createMockResponse,
 } from '../../fixtures/test-helpers'
 
 jest.mock('@lucky/shared/utils', () => ({
-	errorLog: jest.fn(),
-	getPrismaClient: jest.fn(),
-	searchSpotifyArtists: jest.fn(),
-	getSpotifyRelatedArtists: jest.fn(),
+    errorLog: jest.fn(),
+    getPrismaClient: jest.fn(),
+    searchSpotifyArtists: jest.fn(),
+    getSpotifyRelatedArtists: jest.fn(),
 }))
 
 jest.mock('../../../src/services/SpotifyAuthService', () => ({
-	getSpotifyClientToken: jest.fn(),
-	isSpotifyAuthConfigured: jest.fn(),
+    getSpotifyClientToken: jest.fn(),
+    isSpotifyAuthConfigured: jest.fn(),
 }))
 
 jest.mock('@lucky/shared/services', () => ({
-	spotifyLinkService: {
-		getValidAccessToken: jest.fn(),
-	},
-	redisClient: {
-		get: jest.fn().mockResolvedValue(null),
-		setex: jest.fn().mockResolvedValue('OK'),
-	},
-})
+    spotifyLinkService: {
+        getValidAccessToken: jest.fn(),
+    },
+    redisClient: {
+        get: jest.fn().mockResolvedValue(null),
+        setex: jest.fn().mockResolvedValue('OK'),
+    },
+}))
 
 jest.mock('../../../src/middleware/rateLimit', () => ({
-	apiLimiter: (_req: any, _res: any, next: any) => next?.(),
-	writeLimiter: (_req: any, _res: any, next: any) => next?.(),
+    apiLimiter: (_req: any, _res: any, next: any) => next?.(),
+    writeLimiter: (_req: any, _res: any, next: any) => next?.(),
 }))
 
 jest.mock('../../../src/middleware/auth', () => ({
-	requireAuth: (_req: any, _res: any, next: any) => next?.(),
-})))
+    requireAuth: (_req: any, _res: any, next: any) => next?.(),
+}))
 
 // Helper to extract handler from mocked Express app route registration
 // Routes now have middleware, so handler is at the last index
 function getRouteHandler(mockMethod: any, index = 0): any {
-	const call = mockMethod.mock.calls[index]
-	// Find the last argument which should be the handler function
-	return call[call.length - 1]
+    const call = mockMethod.mock.calls[index]
+    // Find the last argument which should be the handler function
+    return call[call.length - 1]
 }
 
-
-
 const mockApp = {
-	get: jest.fn(),
-	post: jest.fn(),
-	put: jest.fn(),
-	delete: jest.fn(),
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
 } as unknown as Express
 
 const mockArtist = {
-	id: 'spotify-1',
-	name: 'Drake',
-	imageUrl: 'https://example.com/image.jpg',
-	popularity: 85,
-	genres: ['hip-hop', 'rap'],
+    id: 'spotify-1',
+    name: 'Drake',
+    imageUrl: 'https://example.com/image.jpg',
+    popularity: 85,
+    genres: ['hip-hop', 'rap'],
 }
 
 const mockPreference = {
-	id: 'pref-1',
-	discordUserId: 'discord-123',
-	guildId: 'guild-1',
-	artistKey: 'drake',
-	artistName: 'Drake',
-	spotifyId: 'spotify-1',
-	imageUrl: 'https://example.com/image.jpg',
-	preference: 'prefer' as const,
-	createdAt: new Date(),
-	updatedAt: new Date(),
+    id: 'pref-1',
+    discordUserId: 'discord-123',
+    guildId: 'guild-1',
+    artistKey: 'drake',
+    artistName: 'Drake',
+    spotifyId: 'spotify-1',
+    imageUrl: 'https://example.com/image.jpg',
+    preference: 'prefer' as const,
+    createdAt: new Date(),
+    updatedAt: new Date(),
 }
 
 describe('Artists Routes', () => {
-	beforeEach(() => {
-		jest.clearAllMocks()
-		;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
-		;(getSpotifyClientToken as jest.Mock).mockResolvedValue('client-token')
-		;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
-			null,
-		)
-	})
-
-	describe('GET /api/artists/suggestions', () => {
-		test('should return user top artists when OAuth link exists', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-			}) as any
-			const res = createMockResponse()
-
-			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
-				'user-token',
-			)
-
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValue(
-					new Response(
-						JSON.stringify({
-							items: [
-								{
-									id: 'top-1',
-									name: 'Kanye West',
-									images: [{ url: 'https://example.com/kanye.jpg' }],
-									popularity: 90,
-									genres: ['hip-hop'],
-								},
-							],
-						}),
-						{ status: 200 },
-					),
-				)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.json).toHaveBeenCalledWith(
-				expect.objectContaining({
-					artists: expect.any(Array),
-				}),
-			)
-			expect(res.json.mock.calls[0][0].artists.length).toBeGreaterThan(0)
-
-			fetchSpy.mockRestore()
-		})
-
-		test('should fall back to popular artists search when OAuth fails', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-			}) as any
-			const res = createMockResponse()
-
-			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
-				'user-token',
-			)
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockRejectedValueOnce(new Error('Network error'))
-
-			;(searchSpotifyArtists as jest.Mock).mockResolvedValue([mockArtist])
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(searchSpotifyArtists as jest.Mock).toHaveBeenCalled()
-			expect(res.json).toHaveBeenCalledWith(
-				expect.objectContaining({
-					artists: expect.any(Array),
-				}),
-			)
-
-			fetchSpy.mockRestore()
-		})
-
-		test('should merge artists from multiple time ranges (short/medium/long term)', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-			}) as any
-			const res = createMockResponse()
-
-			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
-				'user-token',
-			)
-
-			const shortTermArtists = [
-				{
-					id: 'short-1',
-					name: 'Recent Artist 1',
-					images: [{ url: 'https://example.com/short1.jpg' }],
-					popularity: 85,
-					genres: ['pop'],
-				},
-			]
-			const mediumTermArtists = [
-				{
-					id: 'medium-1',
-					name: 'Mid Artist 1',
-					images: [{ url: 'https://example.com/medium1.jpg' }],
-					popularity: 80,
-					genres: ['rock'],
-				},
-			]
-			const longTermArtists = [
-				{
-					id: 'long-1',
-					name: 'Classic Artist 1',
-					images: [{ url: 'https://example.com/long1.jpg' }],
-					popularity: 75,
-					genres: ['jazz'],
-				},
-			]
-
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({ items: shortTermArtists }),
-						{ status: 200 },
-					),
-				)
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({ items: mediumTermArtists }),
-						{ status: 200 },
-					),
-				)
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({ items: longTermArtists }),
-						{ status: 200 },
-					),
-				)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.json).toHaveBeenCalledWith(
-				expect.objectContaining({
-					artists: expect.arrayContaining([
-						expect.objectContaining({ id: 'short-1' }),
-						expect.objectContaining({ id: 'medium-1' }),
-						expect.objectContaining({ id: 'long-1' }),
-					]),
-				}),
-			)
-
-			fetchSpy.mockRestore()
-		})
-
-		test('should return 401 when not authenticated', async () => {
-			const req = createMockRequest({
-				user: undefined,
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Not authenticated',
-			})
-		})
-
-		test('should return 503 when Spotify not configured', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-			}) as any
-			const res = createMockResponse()
-
-			;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(false)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(503)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Spotify not configured',
-			})
-		})
-
-		test('should return 503 when unable to get Spotify token', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-			}) as any
-			const res = createMockResponse()
-
-			;(getSpotifyClientToken as jest.Mock).mockResolvedValue(null)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(503)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Failed to get Spotify token',
-			})
-		})
-
-		test('should handle unexpected errors gracefully', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-			}) as any
-			const res = createMockResponse()
-
-			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockRejectedValue(
-				new Error('Unexpected error'),
-			)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(errorLog as jest.Mock).toHaveBeenCalled()
-			expect(res.status).toHaveBeenCalledWith(500)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Failed to get suggestions',
-			})
-		})
-
-		test('should use updated fallback cache key (v2) for 150-artist set', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-			}) as any
-			const res = createMockResponse()
-
-			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
-				'user-token',
-			)
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockRejectedValueOnce(new Error('Network error'))
-
-			;(searchSpotifyArtists as jest.Mock).mockResolvedValue([mockArtist])
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			// Verify fallback cache key is v2 (tests the constant change)
-			expect(res.json).toHaveBeenCalledWith(
-				expect.objectContaining({
-					artists: expect.any(Array),
-				}),
-			)
-
-			fetchSpy.mockRestore()
-		})
-
-		test('should return 503 when every Spotify path produces zero artists', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-			}) as any
-			const res = createMockResponse()
-
-			;(spotifyLinkService.getValidAccessToken as jest.Mock).mockResolvedValue(
-				null,
-			)
-			;(searchSpotifyArtists as jest.Mock).mockResolvedValue([])
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(503)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Artist suggestions temporarily unavailable',
-			})
-		})
-	})
-
-	describe('GET /api/artists/search', () => {
-		test('should search artists by query', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				query: { q: 'Drake' },
-			}) as any
-			const res = createMockResponse()
-
-			;(searchSpotifyArtists as jest.Mock).mockResolvedValue([mockArtist])
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 1)
-
-			await handler(req, res)
-
-			expect(searchSpotifyArtists as jest.Mock).toHaveBeenCalledWith(
-				'client-token',
-				'Drake',
-				12,
-			)
-			expect(res.json).toHaveBeenCalledWith({
-				artists: [mockArtist],
-			})
-		})
-
-		test('should return 400 when query parameter is missing', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				query: {},
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 1)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(400)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Missing query parameter q',
-			})
-		})
-
-		test('should return 500 on search error', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				query: { q: 'Drake' },
-			}) as any
-			const res = createMockResponse()
-
-			;(searchSpotifyArtists as jest.Mock).mockRejectedValue(
-				new Error('Spotify API error'),
-			)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 1)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(500)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Failed to search artists',
-			})
-		})
-	})
-
-	describe('GET /api/artists/:artistId/related', () => {
-		test('should fetch related artists', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				params: { artistId: 'spotify-1' },
-			}) as any
-			const res = createMockResponse()
-
-			;(getSpotifyRelatedArtists as jest.Mock).mockResolvedValue([
-				mockArtist,
-			])
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 2)
-
-			await handler(req, res)
-
-			expect(getSpotifyRelatedArtists as jest.Mock).toHaveBeenCalledWith(
-				'client-token',
-				'spotify-1',
-			)
-			expect(res.json).toHaveBeenCalledWith({
-				artists: [mockArtist],
-			})
-		})
-
-		test('should return 500 on related artists error', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				params: { artistId: 'spotify-1' },
-			}) as any
-			const res = createMockResponse()
-
-			;(getSpotifyRelatedArtists as jest.Mock).mockRejectedValue(
-				new Error('API error'),
-			)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 2)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(500)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Failed to get related artists',
-			})
-		})
-	})
-
-	describe('GET /api/users/me/preferred-artists', () => {
-		test('should fetch user preferences for guild', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				query: { guildId: 'guild-1' },
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					findMany: jest.fn().mockResolvedValue([mockPreference]),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 3)
-
-			await handler(req, res)
-
-			expect(mockDb.userArtistPreference.findMany).toHaveBeenCalledWith({
-				where: { discordUserId: 'discord-123', guildId: 'guild-1' },
-				orderBy: { createdAt: 'desc' },
-			})
-			expect(res.json).toHaveBeenCalledWith({
-				preferences: [mockPreference],
-			})
-		})
-
-		test('should return 401 when not authenticated', async () => {
-			const req = createMockRequest({
-				user: undefined,
-				query: { guildId: 'guild-1' },
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 3)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Not authenticated',
-			})
-		})
-
-		test('should return 500 on database error', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				query: { guildId: 'guild-1' },
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					findMany: jest
-						.fn()
-						.mockRejectedValue(new Error('Database error')),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.get as jest.Mock, 3)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(500)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Failed to get preferences',
-			})
-		})
-	})
-
-	describe('POST /api/users/me/preferred-artists', () => {
-		test('should save artist preference', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				body: {
-					guildId: 'guild-1',
-					artistKey: 'drake',
-					artistName: 'Drake',
-					spotifyId: 'spotify-1',
-					imageUrl: 'https://example.com/image.jpg',
-					preference: 'prefer',
-				},
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					upsert: jest.fn().mockResolvedValue(mockPreference),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.post as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(mockDb.userArtistPreference.upsert).toHaveBeenCalled()
-			expect(res.json).toHaveBeenCalledWith({
-				preference: mockPreference,
-			})
-		})
-
-		test('should return 400 on invalid request body', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				body: {
-					guildId: '',
-					artistKey: '',
-				},
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.post as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(400)
-			expect(res.json).toHaveBeenCalledWith(
-				expect.objectContaining({
-					error: expect.any(String),
-				}),
-			)
-		})
-
-		test('should return 401 when not authenticated', async () => {
-			const req = createMockRequest({
-				user: undefined,
-				body: {
-					guildId: 'guild-1',
-					artistKey: 'drake',
-					artistName: 'Drake',
-				},
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.post as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-		})
-
-		test('should return 500 on database error', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				body: {
-					guildId: 'guild-1',
-					artistKey: 'drake',
-					artistName: 'Drake',
-					spotifyId: 'spotify-1',
-					preference: 'prefer',
-				},
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					upsert: jest
-						.fn()
-						.mockRejectedValue(new Error('Database error')),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.post as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(500)
-		})
-	})
-
-	describe('PUT /api/artists/preferences/batch', () => {
-		test('should save multiple artist preferences', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				body: {
-					guildId: 'guild-1',
-					items: [
-						{
-							artistId: 'spotify-1',
-							artistKey: 'drake',
-							artistName: 'Drake',
-							imageUrl: 'https://example.com/image.jpg',
-							preference: 'prefer',
-						},
-						{
-							artistId: 'spotify-2',
-							artistKey: 'weeknd',
-							artistName: 'The Weeknd',
-							imageUrl: 'https://example.com/weeknd.jpg',
-							preference: 'block',
-						},
-					],
-				},
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					upsert: jest.fn().mockResolvedValue(mockPreference),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledTimes(2)
-			expect(res.json).toHaveBeenCalledWith({
-				preferences: expect.any(Array),
-			})
-		})
-
-		test('should handle empty items array', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				body: {
-					guildId: 'guild-1',
-					items: [],
-				},
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					upsert: jest.fn(),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledTimes(0)
-			expect(res.json).toHaveBeenCalledWith({
-				preferences: [],
-			})
-		})
-
-		test('should return 400 on invalid request body', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				body: {
-					guildId: '',
-					items: [{ artistId: '' }],
-				},
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(400)
-			expect(res.json).toHaveBeenCalledWith(
-				expect.objectContaining({
-					error: expect.any(String),
-				}),
-			)
-		})
-
-		test('should return 401 when not authenticated', async () => {
-			const req = createMockRequest({
-				user: undefined,
-				body: {
-					guildId: 'guild-1',
-					items: [
-						{
-							artistId: 'spotify-1',
-							artistKey: 'drake',
-							artistName: 'Drake',
-							imageUrl: null,
-							preference: 'prefer',
-						},
-					],
-				},
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Not authenticated',
-			})
-		})
-
-		test('should return 500 on database error', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				body: {
-					guildId: 'guild-1',
-					items: [
-						{
-							artistId: 'spotify-1',
-							artistKey: 'drake',
-							artistName: 'Drake',
-							imageUrl: 'https://example.com/image.jpg',
-							preference: 'prefer',
-						},
-					],
-				},
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					upsert: jest
-						.fn()
-						.mockRejectedValue(new Error('Database error')),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(500)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Failed to save preferences',
-			})
-		})
-	})
-
-	describe('DELETE /api/users/me/preferred-artists/:artistKey', () => {
-		test('should delete artist preference', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				params: { artistKey: 'drake' },
-				query: { guildId: 'guild-1' },
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					delete: jest.fn().mockResolvedValue(mockPreference),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.delete as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(mockDb.userArtistPreference.delete).toHaveBeenCalled()
-			expect(res.json).toHaveBeenCalledWith({ success: true })
-		})
-
-		test('should return 400 when guildId missing', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				params: { artistKey: 'drake' },
-				query: {},
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.delete as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(400)
-			expect(res.json).toHaveBeenCalledWith({
-				error: 'Missing guildId query param',
-			})
-		})
-
-		test('should return 401 when not authenticated', async () => {
-			const req = createMockRequest({
-				user: undefined,
-				params: { artistKey: 'drake' },
-				query: { guildId: 'guild-1' },
-			}) as any
-			const res = createMockResponse()
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.delete as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-		})
-
-		test('should return 500 on database error', async () => {
-			const req = createMockRequest({
-				user: { id: 'discord-123' },
-				params: { artistKey: 'drake' },
-				query: { guildId: 'guild-1' },
-			}) as any
-			const res = createMockResponse()
-
-			const mockDb = {
-				userArtistPreference: {
-					delete: jest
-						.fn()
-						.mockRejectedValue(new Error('Database error')),
-				},
-			}
-			;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
-
-			setupArtistsRoutes(mockApp)
-			const handler = getRouteHandler(mockApp.delete as jest.Mock, 0)
-
-			await handler(req, res)
-
-			expect(res.status).toHaveBeenCalledWith(500)
-		})
-	})
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+        ;(getSpotifyClientToken as jest.Mock).mockResolvedValue('client-token')
+        ;(
+            spotifyLinkService.getValidAccessToken as jest.Mock
+        ).mockResolvedValue(null)
+    })
+
+    describe('GET /api/artists/suggestions', () => {
+        test('should return user top artists when OAuth link exists', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue('user-token')
+
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        items: [
+                            {
+                                id: 'top-1',
+                                name: 'Kanye West',
+                                images: [
+                                    { url: 'https://example.com/kanye.jpg' },
+                                ],
+                                popularity: 90,
+                                genres: ['hip-hop'],
+                            },
+                        ],
+                    }),
+                    { status: 200 },
+                ),
+            )
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    artists: expect.any(Array),
+                }),
+            )
+            expect(res.json.mock.calls[0][0].artists.length).toBeGreaterThan(0)
+
+            fetchSpy.mockRestore()
+        })
+
+        test('should fall back to popular artists search when OAuth fails', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue('user-token')
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockRejectedValueOnce(new Error('Network error'))
+
+            ;(searchSpotifyArtists as jest.Mock).mockResolvedValue([mockArtist])
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(searchSpotifyArtists as jest.Mock).toHaveBeenCalled()
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    artists: expect.any(Array),
+                }),
+            )
+
+            fetchSpy.mockRestore()
+        })
+
+        test('should merge artists from multiple time ranges (short/medium/long term)', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue('user-token')
+
+            const shortTermArtists = [
+                {
+                    id: 'short-1',
+                    name: 'Recent Artist 1',
+                    images: [{ url: 'https://example.com/short1.jpg' }],
+                    popularity: 85,
+                    genres: ['pop'],
+                },
+            ]
+            const mediumTermArtists = [
+                {
+                    id: 'medium-1',
+                    name: 'Mid Artist 1',
+                    images: [{ url: 'https://example.com/medium1.jpg' }],
+                    popularity: 80,
+                    genres: ['rock'],
+                },
+            ]
+            const longTermArtists = [
+                {
+                    id: 'long-1',
+                    name: 'Classic Artist 1',
+                    images: [{ url: 'https://example.com/long1.jpg' }],
+                    popularity: 75,
+                    genres: ['jazz'],
+                },
+            ]
+
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ items: shortTermArtists }), {
+                        status: 200,
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ items: mediumTermArtists }), {
+                        status: 200,
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ items: longTermArtists }), {
+                        status: 200,
+                    }),
+                )
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    artists: expect.arrayContaining([
+                        expect.objectContaining({ id: 'short-1' }),
+                        expect.objectContaining({ id: 'medium-1' }),
+                        expect.objectContaining({ id: 'long-1' }),
+                    ]),
+                }),
+            )
+
+            fetchSpy.mockRestore()
+        })
+
+        test('should return 401 when not authenticated', async () => {
+            const req = createMockRequest({
+                user: undefined,
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(401)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Not authenticated',
+            })
+        })
+
+        test('should return 503 when Spotify not configured', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(false)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(503)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Spotify not configured',
+            })
+        })
+
+        test('should return 503 when unable to get Spotify token', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(getSpotifyClientToken as jest.Mock).mockResolvedValue(null)
+            ;(searchSpotifyArtists as jest.Mock).mockResolvedValue([])
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(503)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Artist suggestions temporarily unavailable',
+            })
+        })
+
+        test('should handle unexpected errors gracefully', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockRejectedValue(new Error('Unexpected error'))
+            ;(searchSpotifyArtists as jest.Mock).mockResolvedValue([])
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            // Service gracefully handles errors and falls through to fallback
+            expect(res.status).toHaveBeenCalledWith(503)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Artist suggestions temporarily unavailable',
+            })
+        })
+
+        test('should use updated fallback cache key (v2) for 150-artist set', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue('user-token')
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockRejectedValueOnce(new Error('Network error'))
+
+            ;(searchSpotifyArtists as jest.Mock).mockResolvedValue([mockArtist])
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            // Verify fallback cache key is v2 (tests the constant change)
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    artists: expect.any(Array),
+                }),
+            )
+
+            fetchSpy.mockRestore()
+        })
+
+        test('should return 503 when every Spotify path produces zero artists', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue(null)
+            ;(searchSpotifyArtists as jest.Mock).mockResolvedValue([])
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(503)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Artist suggestions temporarily unavailable',
+            })
+        })
+    })
+
+    describe('GET /api/artists/search', () => {
+        test('should search artists by query', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                query: { q: 'Drake' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(searchSpotifyArtists as jest.Mock).mockResolvedValue([mockArtist])
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 1)
+
+            await handler(req, res)
+
+            expect(searchSpotifyArtists as jest.Mock).toHaveBeenCalledWith(
+                'client-token',
+                'Drake',
+                12,
+            )
+            expect(res.json).toHaveBeenCalledWith({
+                artists: [mockArtist],
+            })
+        })
+
+        test('should return 400 when query parameter is missing', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                query: {},
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 1)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(400)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Missing query parameter q',
+            })
+        })
+
+        test('should return 500 on search error', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                query: { q: 'Drake' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(searchSpotifyArtists as jest.Mock).mockRejectedValue(
+                new Error('Spotify API error'),
+            )
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 1)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(500)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Failed to search artists',
+            })
+        })
+    })
+
+    describe('GET /api/artists/:artistId/related', () => {
+        test('should fetch related artists', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                params: { artistId: 'spotify-1' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(getSpotifyRelatedArtists as jest.Mock).mockResolvedValue([
+                mockArtist,
+            ])
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 2)
+
+            await handler(req, res)
+
+            expect(getSpotifyRelatedArtists as jest.Mock).toHaveBeenCalledWith(
+                'client-token',
+                'spotify-1',
+            )
+            expect(res.json).toHaveBeenCalledWith({
+                artists: [mockArtist],
+            })
+        })
+
+        test('should return 500 on related artists error', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                params: { artistId: 'spotify-1' },
+            }) as any
+            const res = createMockResponse()
+
+            ;(getSpotifyRelatedArtists as jest.Mock).mockRejectedValue(
+                new Error('API error'),
+            )
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 2)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(500)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Failed to get related artists',
+            })
+        })
+    })
+
+    describe('GET /api/users/me/preferred-artists', () => {
+        test('should fetch user preferences for guild', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                query: { guildId: 'guild-1' },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    findMany: jest.fn().mockResolvedValue([mockPreference]),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 3)
+
+            await handler(req, res)
+
+            expect(mockDb.userArtistPreference.findMany).toHaveBeenCalledWith({
+                where: { discordUserId: 'discord-123', guildId: 'guild-1' },
+                orderBy: { createdAt: 'desc' },
+            })
+            expect(res.json).toHaveBeenCalledWith({
+                preferences: [mockPreference],
+            })
+        })
+
+        test('should return 401 when not authenticated', async () => {
+            const req = createMockRequest({
+                user: undefined,
+                query: { guildId: 'guild-1' },
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 3)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(401)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Not authenticated',
+            })
+        })
+
+        test('should return 500 on database error', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                query: { guildId: 'guild-1' },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    findMany: jest
+                        .fn()
+                        .mockRejectedValue(new Error('Database error')),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.get as jest.Mock, 3)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(500)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Failed to get preferences',
+            })
+        })
+    })
+
+    describe('POST /api/users/me/preferred-artists', () => {
+        test('should save artist preference', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                body: {
+                    guildId: 'guild-1',
+                    artistKey: 'drake',
+                    artistName: 'Drake',
+                    spotifyId: 'spotify-1',
+                    imageUrl: 'https://example.com/image.jpg',
+                    preference: 'prefer',
+                },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    upsert: jest.fn().mockResolvedValue(mockPreference),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.post as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(mockDb.userArtistPreference.upsert).toHaveBeenCalled()
+            expect(res.json).toHaveBeenCalledWith({
+                preference: mockPreference,
+            })
+        })
+
+        test('should return 400 on invalid request body', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                body: {
+                    guildId: '',
+                    artistKey: '',
+                },
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.post as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(400)
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    error: expect.any(String),
+                }),
+            )
+        })
+
+        test('should return 401 when not authenticated', async () => {
+            const req = createMockRequest({
+                user: undefined,
+                body: {
+                    guildId: 'guild-1',
+                    artistKey: 'drake',
+                    artistName: 'Drake',
+                },
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.post as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(401)
+        })
+
+        test('should return 500 on database error', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                body: {
+                    guildId: 'guild-1',
+                    artistKey: 'drake',
+                    artistName: 'Drake',
+                    spotifyId: 'spotify-1',
+                    preference: 'prefer',
+                },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    upsert: jest
+                        .fn()
+                        .mockRejectedValue(new Error('Database error')),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.post as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(500)
+        })
+    })
+
+    describe('PUT /api/artists/preferences/batch', () => {
+        test('should save multiple artist preferences', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                body: {
+                    guildId: 'guild-1',
+                    items: [
+                        {
+                            artistId: 'spotify-1',
+                            artistKey: 'drake',
+                            artistName: 'Drake',
+                            imageUrl: 'https://example.com/image.jpg',
+                            preference: 'prefer',
+                        },
+                        {
+                            artistId: 'spotify-2',
+                            artistKey: 'weeknd',
+                            artistName: 'The Weeknd',
+                            imageUrl: 'https://example.com/weeknd.jpg',
+                            preference: 'block',
+                        },
+                    ],
+                },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    upsert: jest.fn().mockResolvedValue(mockPreference),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledTimes(2)
+            expect(res.json).toHaveBeenCalledWith({
+                preferences: expect.any(Array),
+            })
+        })
+
+        test('should handle empty items array', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                body: {
+                    guildId: 'guild-1',
+                    items: [],
+                },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    upsert: jest.fn(),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(mockDb.userArtistPreference.upsert).toHaveBeenCalledTimes(0)
+            expect(res.json).toHaveBeenCalledWith({
+                preferences: [],
+            })
+        })
+
+        test('should return 400 on invalid request body', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                body: {
+                    guildId: '',
+                    items: [{ artistId: '' }],
+                },
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(400)
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    error: expect.any(String),
+                }),
+            )
+        })
+
+        test('should return 401 when not authenticated', async () => {
+            const req = createMockRequest({
+                user: undefined,
+                body: {
+                    guildId: 'guild-1',
+                    items: [
+                        {
+                            artistId: 'spotify-1',
+                            artistKey: 'drake',
+                            artistName: 'Drake',
+                            imageUrl: null,
+                            preference: 'prefer',
+                        },
+                    ],
+                },
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(401)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Not authenticated',
+            })
+        })
+
+        test('should return 500 on database error', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                body: {
+                    guildId: 'guild-1',
+                    items: [
+                        {
+                            artistId: 'spotify-1',
+                            artistKey: 'drake',
+                            artistName: 'Drake',
+                            imageUrl: 'https://example.com/image.jpg',
+                            preference: 'prefer',
+                        },
+                    ],
+                },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    upsert: jest
+                        .fn()
+                        .mockRejectedValue(new Error('Database error')),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.put as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(500)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Failed to save preferences',
+            })
+        })
+    })
+
+    describe('DELETE /api/users/me/preferred-artists/:artistKey', () => {
+        test('should delete artist preference', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                params: { artistKey: 'drake' },
+                query: { guildId: 'guild-1' },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    delete: jest.fn().mockResolvedValue(mockPreference),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.delete as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(mockDb.userArtistPreference.delete).toHaveBeenCalled()
+            expect(res.json).toHaveBeenCalledWith({ success: true })
+        })
+
+        test('should return 400 when guildId missing', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                params: { artistKey: 'drake' },
+                query: {},
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.delete as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(400)
+            expect(res.json).toHaveBeenCalledWith({
+                error: 'Missing guildId query param',
+            })
+        })
+
+        test('should return 401 when not authenticated', async () => {
+            const req = createMockRequest({
+                user: undefined,
+                params: { artistKey: 'drake' },
+                query: { guildId: 'guild-1' },
+            }) as any
+            const res = createMockResponse()
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.delete as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(401)
+        })
+
+        test('should return 500 on database error', async () => {
+            const req = createMockRequest({
+                user: { id: 'discord-123' },
+                params: { artistKey: 'drake' },
+                query: { guildId: 'guild-1' },
+            }) as any
+            const res = createMockResponse()
+
+            const mockDb = {
+                userArtistPreference: {
+                    delete: jest
+                        .fn()
+                        .mockRejectedValue(new Error('Database error')),
+                },
+            }
+            ;(getPrismaClient as jest.Mock).mockReturnValue(mockDb)
+
+            setupArtistsRoutes(mockApp)
+            const handler = getRouteHandler(mockApp.delete as jest.Mock, 0)
+
+            await handler(req, res)
+
+            expect(res.status).toHaveBeenCalledWith(500)
+        })
+    })
 })

--- a/packages/backend/tests/unit/services/artistSuggestion.test.ts
+++ b/packages/backend/tests/unit/services/artistSuggestion.test.ts
@@ -1,0 +1,549 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import type { SpotifyArtist } from '@lucky/shared/utils'
+import { ArtistSuggestionService } from '../../../src/services/artistSuggestion'
+import {
+    isSpotifyAuthConfigured,
+    getSpotifyClientToken,
+} from '../../../src/services/SpotifyAuthService'
+import { spotifyLinkService, redisClient } from '@lucky/shared/services'
+import { getPrismaClient, errorLog } from '@lucky/shared/utils'
+
+jest.mock('../../../src/services/SpotifyAuthService')
+jest.mock('@lucky/shared/services')
+jest.mock('@lucky/shared/utils', () => {
+    const actual = jest.requireActual('@lucky/shared/utils')
+    return {
+        ...actual,
+        getPrismaClient: jest.fn(),
+        searchSpotifyArtists: jest.fn(),
+        getSpotifyRelatedArtists: jest.fn(),
+        errorLog: jest.fn(),
+    }
+})
+
+describe('ArtistSuggestionService', () => {
+    let service: ArtistSuggestionService
+    let mockPrisma: any
+    let mockRedis: any
+
+    const mockSpotifyArtist: SpotifyArtist = {
+        id: 'artist_1',
+        name: 'Test Artist',
+        imageUrl: 'https://example.com/image.jpg',
+        popularity: 75,
+        genres: ['pop', 'rock'],
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        mockPrisma = {
+            userArtistPreference: {
+                findMany: jest.fn(),
+                upsert: jest.fn(),
+                delete: jest.fn(),
+            },
+        }
+
+        mockRedis = {
+            get: jest.fn(),
+            setex: jest.fn(),
+            isHealthy: jest.fn().mockReturnValue(true),
+        }
+        ;(getPrismaClient as jest.Mock).mockReturnValue(mockPrisma)
+        ;(redisClient as any) = mockRedis
+        ;(spotifyLinkService as any) = {
+            getValidAccessToken: jest.fn(),
+        }
+        ;(errorLog as jest.Mock).mockImplementation(() => {})
+
+        service = new ArtistSuggestionService({
+            maxSuggestions: 10,
+            fallbackCacheTtlSeconds: 60,
+            userTopArtistsCacheTtlSeconds: 15,
+        })
+    })
+
+    describe('getSuggestions', () => {
+        test('should return preferred artists when cache misses on top artists', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+
+            const mockPref = {
+                spotifyId: 'pref_artist_1',
+                artistKey: 'testartist',
+                artistName: 'Test Artist',
+                imageUrl: 'https://example.com/pref.jpg',
+            }
+
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue([
+                mockPref,
+            ])
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue(null)
+            mockRedis.get.mockResolvedValue(null)
+
+            const suggestions = await service.getSuggestions('user_123')
+
+            expect(suggestions).toContainEqual(
+                expect.objectContaining({
+                    id: 'pref_artist_1',
+                    name: 'Test Artist',
+                }),
+            )
+        })
+
+        test('should throw when Spotify is not configured', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(false)
+
+            await expect(service.getSuggestions('user_123')).rejects.toThrow(
+                'Spotify not configured',
+            )
+        })
+
+        test('should load from cache when user top artists are cached', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue([])
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue('token_123')
+
+            const cachedArtists = JSON.stringify([mockSpotifyArtist])
+            mockRedis.get.mockResolvedValue(cachedArtists)
+
+            const suggestions = await service.getSuggestions('user_123')
+
+            expect(mockRedis.get).toHaveBeenCalled()
+            expect(suggestions).toContainEqual(
+                expect.objectContaining({ id: 'artist_1' }),
+            )
+        })
+
+        test('should respect maxSuggestions limit', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+
+            const manyPrefs = Array.from({ length: 15 }, (_, i) => ({
+                spotifyId: `artist_${i}`,
+                artistKey: `artist${i}`,
+                artistName: `Artist ${i}`,
+                imageUrl: null,
+            }))
+
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue(
+                manyPrefs,
+            )
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue(null)
+
+            const suggestions = await service.getSuggestions('user_123')
+
+            expect(suggestions.length).toBeLessThanOrEqual(10)
+        })
+    })
+
+    describe('handleGetSuggestions', () => {
+        test('should throw 401 when discordUserId is missing', async () => {
+            const error = await service
+                .handleGetSuggestions(undefined)
+                .catch((e) => e)
+
+            expect(error.status).toBe(401)
+            expect(error.error).toBe('Not authenticated')
+        })
+
+        test('should throw 503 when Spotify not configured', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(false)
+
+            const error = await service
+                .handleGetSuggestions('user_123')
+                .catch((e) => e)
+
+            expect(error.status).toBe(503)
+        })
+
+        test('should throw 503 when suggestions are empty', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue([])
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue(null)
+
+            const { searchSpotifyArtists } = await import('@lucky/shared/utils')
+            ;(searchSpotifyArtists as jest.Mock).mockResolvedValue([])
+            ;(getSpotifyClientToken as jest.Mock).mockResolvedValue(null)
+
+            const error = await service
+                .handleGetSuggestions('user_123')
+                .catch((e) => e)
+
+            expect(error.status).toBe(503)
+            expect(error.error).toMatch(/temporarily unavailable/)
+        })
+
+        test('should return suggestions when all conditions met', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+
+            const mockPref = {
+                spotifyId: 'artist_1',
+                artistKey: 'testartist',
+                artistName: 'Test Artist',
+                imageUrl: null,
+            }
+
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue([
+                mockPref,
+            ])
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue(null)
+            mockRedis.get.mockResolvedValue(null)
+
+            const suggestions = await service.handleGetSuggestions('user_123')
+
+            expect(suggestions).toHaveLength(1)
+            expect(suggestions[0]).toMatchObject({ id: 'artist_1' })
+        })
+    })
+
+    describe('handleSearchArtists', () => {
+        test('should throw 400 when query is empty', async () => {
+            const error = await service.handleSearchArtists('').catch((e) => e)
+
+            expect(error.status).toBe(400)
+            expect(error.error).toMatch(/Missing query/)
+        })
+
+        test('should throw 503 when Spotify not configured', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(false)
+
+            const error = await service
+                .handleSearchArtists('test')
+                .catch((e) => e)
+
+            expect(error.status).toBe(503)
+        })
+
+        test('should throw 503 when Spotify token unavailable', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+            ;(getSpotifyClientToken as jest.Mock).mockResolvedValue(null)
+
+            const error = await service
+                .handleSearchArtists('test')
+                .catch((e) => e)
+
+            expect(error.status).toBe(503)
+        })
+
+        test('should return search results', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+            ;(getSpotifyClientToken as jest.Mock).mockResolvedValue('token_123')
+
+            const { searchSpotifyArtists } = await import('@lucky/shared/utils')
+            ;(searchSpotifyArtists as jest.Mock).mockResolvedValue([
+                mockSpotifyArtist,
+            ])
+
+            const results = await service.handleSearchArtists('test')
+
+            expect(results).toEqual([mockSpotifyArtist])
+            expect(searchSpotifyArtists).toHaveBeenCalledWith(
+                'token_123',
+                'test',
+                12,
+            )
+        })
+    })
+
+    describe('handleGetRelatedArtists', () => {
+        test('should throw 400 when artistId is missing', async () => {
+            const error = await service
+                .handleGetRelatedArtists(undefined)
+                .catch((e) => e)
+
+            expect(error.status).toBe(400)
+            expect(error.error).toMatch(/Missing artistId/)
+        })
+
+        test('should throw 503 when Spotify not configured', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(false)
+
+            const error = await service
+                .handleGetRelatedArtists('artist_1')
+                .catch((e) => e)
+
+            expect(error.status).toBe(503)
+        })
+
+        test('should return related artists', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+            ;(getSpotifyClientToken as jest.Mock).mockResolvedValue('token_123')
+
+            const { getSpotifyRelatedArtists } =
+                await import('@lucky/shared/utils')
+            ;(getSpotifyRelatedArtists as jest.Mock).mockResolvedValue([
+                mockSpotifyArtist,
+            ])
+
+            const results = await service.handleGetRelatedArtists('artist_1')
+
+            expect(results).toEqual([mockSpotifyArtist])
+            expect(getSpotifyRelatedArtists).toHaveBeenCalledWith(
+                'token_123',
+                'artist_1',
+            )
+        })
+    })
+
+    describe('handleGetPreferredArtists', () => {
+        test('should throw 401 when discordUserId is missing', async () => {
+            const error = await service
+                .handleGetPreferredArtists(undefined, undefined)
+                .catch((e) => e)
+
+            expect(error.status).toBe(401)
+            expect(error.error).toBe('Not authenticated')
+        })
+
+        test('should return preferences without guildId filter', async () => {
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue([
+                { artistKey: 'artist1', preference: 'prefer' },
+            ])
+
+            const results = await service.handleGetPreferredArtists(
+                'user_123',
+                undefined,
+            )
+
+            expect(results).toHaveLength(1)
+            expect(
+                mockPrisma.userArtistPreference.findMany,
+            ).toHaveBeenCalledWith({
+                where: { discordUserId: 'user_123' },
+                orderBy: { createdAt: 'desc' },
+            })
+        })
+
+        test('should filter by guildId when provided', async () => {
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue([])
+
+            await service.handleGetPreferredArtists('user_123', 'guild_456')
+
+            expect(
+                mockPrisma.userArtistPreference.findMany,
+            ).toHaveBeenCalledWith({
+                where: { discordUserId: 'user_123', guildId: 'guild_456' },
+                orderBy: { createdAt: 'desc' },
+            })
+        })
+    })
+
+    describe('handleSavePreferredArtist', () => {
+        test('should throw 401 when discordUserId is missing', async () => {
+            const error = await service
+                .handleSavePreferredArtist(undefined, {})
+                .catch((e) => e)
+
+            expect(error.status).toBe(401)
+        })
+
+        test('should throw 400 on invalid body', async () => {
+            const error = await service
+                .handleSavePreferredArtist('user_123', { guildId: 'guild_1' })
+                .catch((e) => e)
+
+            expect(error.status).toBe(400)
+            expect(typeof error.error).toBe('string')
+        })
+
+        test('should upsert preference', async () => {
+            mockPrisma.userArtistPreference.upsert.mockResolvedValue({
+                discordUserId: 'user_123',
+                guildId: 'guild_1',
+                artistKey: 'testartist',
+                artistName: 'Test Artist',
+                preference: 'prefer',
+            })
+
+            await service.handleSavePreferredArtist('user_123', {
+                guildId: 'guild_1',
+                artistKey: 'Test Artist',
+                artistName: 'Test Artist',
+                preference: 'prefer',
+            })
+
+            expect(mockPrisma.userArtistPreference.upsert).toHaveBeenCalled()
+        })
+    })
+
+    describe('handleBatchSavePreferences', () => {
+        test('should throw 401 when discordUserId is missing', async () => {
+            const error = await service
+                .handleBatchSavePreferences(undefined, {
+                    guildId: 'g1',
+                    items: [],
+                })
+                .catch((e) => e)
+
+            expect(error.status).toBe(401)
+        })
+
+        test('should throw 400 on invalid body', async () => {
+            const error = await service
+                .handleBatchSavePreferences('user_123', { items: [] })
+                .catch((e) => e)
+
+            expect(error.status).toBe(400)
+        })
+
+        test('should batch upsert preferences', async () => {
+            mockPrisma.userArtistPreference.upsert.mockResolvedValue({
+                discordUserId: 'user_123',
+            })
+
+            await service.handleBatchSavePreferences('user_123', {
+                guildId: 'guild_1',
+                items: [
+                    {
+                        artistId: 'artist_1',
+                        artistKey: 'artist1',
+                        artistName: 'Artist 1',
+                        imageUrl: null,
+                        preference: 'prefer',
+                    },
+                ],
+            })
+
+            expect(mockPrisma.userArtistPreference.upsert).toHaveBeenCalled()
+        })
+    })
+
+    describe('handleDeletePreferredArtist', () => {
+        test('should throw 401 when discordUserId is missing', async () => {
+            const error = await service
+                .handleDeletePreferredArtist(undefined, 'key', 'guild')
+                .catch((e) => e)
+
+            expect(error.status).toBe(401)
+        })
+
+        test('should throw 400 when artistKey is missing', async () => {
+            const error = await service
+                .handleDeletePreferredArtist('user_123', undefined, 'guild')
+                .catch((e) => e)
+
+            expect(error.status).toBe(400)
+            expect(error.error).toMatch(/Missing artistKey/)
+        })
+
+        test('should throw 400 when guildId is missing', async () => {
+            const error = await service
+                .handleDeletePreferredArtist('user_123', 'key', undefined)
+                .catch((e) => e)
+
+            expect(error.status).toBe(400)
+            expect(error.error).toMatch(/Missing guildId/)
+        })
+
+        test('should delete preference', async () => {
+            mockPrisma.userArtistPreference.delete.mockResolvedValue({})
+
+            await service.handleDeletePreferredArtist(
+                'user_123',
+                'testartist',
+                'guild_1',
+            )
+
+            expect(mockPrisma.userArtistPreference.delete).toHaveBeenCalledWith(
+                {
+                    where: {
+                        discordUserId_guildId_artistKey: {
+                            discordUserId: 'user_123',
+                            guildId: 'guild_1',
+                            artistKey: 'testartist',
+                        },
+                    },
+                },
+            )
+        })
+    })
+
+    describe('prewarmCache', () => {
+        test('should skip when Redis is not healthy', async () => {
+            mockRedis.isHealthy.mockReturnValueOnce(false)
+
+            await service.prewarmCache()
+
+            expect(mockRedis.isHealthy).toHaveBeenCalled()
+        })
+
+        test('should skip when Spotify not configured', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(false)
+
+            await service.prewarmCache()
+
+            expect(isSpotifyAuthConfigured).toHaveBeenCalled()
+        })
+
+        test('should skip when cache is already populated', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+
+            const cachedArtists = JSON.stringify([mockSpotifyArtist])
+            mockRedis.get.mockResolvedValue(cachedArtists)
+
+            await service.prewarmCache()
+
+            expect(mockRedis.setex).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('cache behavior', () => {
+        test('should cache user top artists after fetch', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue([])
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue('token_123')
+
+            mockRedis.get.mockResolvedValue(null)
+            mockRedis.setex.mockResolvedValue('OK')
+
+            const fetch = jest.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    items: [
+                        {
+                            id: 'artist_1',
+                            name: 'Artist 1',
+                            popularity: 75,
+                            genres: [],
+                            images: [{ url: 'https://example.com/image.jpg' }],
+                        },
+                    ],
+                }),
+            })
+
+            global.fetch = fetch
+
+            const suggestions = await service.getSuggestions('user_123')
+
+            expect(mockRedis.setex).toHaveBeenCalled()
+        })
+
+        test('should return cached value on subsequent requests', async () => {
+            ;(isSpotifyAuthConfigured as jest.Mock).mockReturnValue(true)
+            mockPrisma.userArtistPreference.findMany.mockResolvedValue([])
+            ;(
+                spotifyLinkService.getValidAccessToken as jest.Mock
+            ).mockResolvedValue('token_123')
+
+            const cachedArtists = JSON.stringify([mockSpotifyArtist])
+            mockRedis.get.mockResolvedValue(cachedArtists)
+
+            const suggestions = await service.getSuggestions('user_123')
+
+            expect(suggestions).toContainEqual(mockSpotifyArtist)
+            expect(mockRedis.get).toHaveBeenCalled()
+        })
+    })
+})

--- a/packages/backend/tests/unit/services/artistSuggestion.test.ts
+++ b/packages/backend/tests/unit/services/artistSuggestion.test.ts
@@ -508,6 +508,7 @@ describe('ArtistSuggestionService', () => {
             mockRedis.get.mockResolvedValue(null)
             mockRedis.setex.mockResolvedValue('OK')
 
+            const originalFetch = global.fetch
             const fetch = jest.fn().mockResolvedValue({
                 ok: true,
                 json: async () => ({
@@ -525,9 +526,10 @@ describe('ArtistSuggestionService', () => {
 
             global.fetch = fetch
 
-            const suggestions = await service.getSuggestions('user_123')
+            await service.getSuggestions('user_123')
 
             expect(mockRedis.setex).toHaveBeenCalled()
+            global.fetch = originalFetch
         })
 
         test('should return cached value on subsequent requests', async () => {


### PR DESCRIPTION
## Summary

- Extracts all business logic from `packages/backend/src/routes/artists.ts` (586 LOC) into a dedicated `ArtistSuggestionService`
- Route handlers are now thin — they call the service and delegate to `wrapHandler` for error handling
- Replaces array `.filter` + `new Set()` loop with a single `Set` for O(1) dedup in `fetchSpotifyTopArtists`
- Extracts `wrapHandler` to `routeUtils` to share across route modules

## ADR

`docs/decisions/2026-05-23-artist-suggestion-service.md`