### PR TITLE
fix(ci): hard-fail deploy on sustained 429 instead of silent oauth pass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,12 @@ name: Deploy to Homelab
 
 on:
     workflow_dispatch:
+        inputs:
+            allow_deploy_unverified_oauth:
+                description: 'Skip OAuth redirect contract check (use only if Discord is rate-limiting and auth-config check passed)'
+                required: false
+                default: 'false'
+                type: boolean
     workflow_run:
         workflows: ["Build & Push Docker Images"]
         types: [completed]
@@ -406,6 +412,7 @@ jobs:
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
                   EXPECTED_CLIENT_ID: ${{ secrets.WEBAPP_EXPECTED_CLIENT_ID }}
+                  ALLOW_DEPLOY_UNVERIFIED_OAUTH: ${{ inputs.allow_deploy_unverified_oauth || '' }}
               run: |
                   set -euo pipefail
 
@@ -532,8 +539,13 @@ jobs:
                   done
 
                   if [ "$non_rate_limited_attempts" -eq 0 ] && [ "$rate_limited_count" -gt 0 ]; then
-                    echo "::warning::OAuth redirect contract check hit sustained Discord rate limiting (429) across all retries; treating as non-blocking after auth-config contract pass."
-                    exit 0
+                    if [ "${ALLOW_DEPLOY_UNVERIFIED_OAUTH:-false}" = "true" ]; then
+                      echo "::warning::OAuth redirect contract check was rate-limited on all attempts; bypassing because ALLOW_DEPLOY_UNVERIFIED_OAUTH=true — verify OAuth flow manually."
+                      exit 0
+                    fi
+                    echo "::error::OAuth redirect contract check was rate-limited (429) on all $rate_limited_count attempts — contract not verified."
+                    echo "::error::Options: (1) redeploy after Discord rate-limit clears (~5 min); (2) trigger workflow_dispatch with allow_deploy_unverified_oauth=true to bypass"
+                    exit 1
                   fi
 
                   echo "::error::Timed out waiting for OAuth redirect contract"

--- a/docs/decisions/2026-05-24-deploy-oauth-redirect-smoke-check-429-handling.md
+++ b/docs/decisions/2026-05-24-deploy-oauth-redirect-smoke-check-429-handling.md
@@ -1,0 +1,47 @@
+# ADR: Deploy OAuth Redirect Smoke Check — Hard Fail on Sustained 429
+
+**Date:** 2026-05-24  
+**Status:** Accepted
+
+## Context
+
+`deploy.yml` includes an "OAuth redirect contract smoke check" step that hits `/api/auth/discord` and validates the redirect to Discord's OAuth2 authorize URL carries the correct `client_id` and `redirect_uri`. It retries 18 times (10s intervals, ~3 min total).
+
+The prior implementation had a silent-pass escape hatch: if every attempt returned HTTP 429 (Discord rate-limiting), the step exited 0 with only a `::warning::` message. The OAuth contract was never actually verified, but the deploy was marked as passing.
+
+A preceding "Auth config smoke check" step validates server-side OAuth fields (`clientId`, `redirectUri`, `sessionSecretConfigured`, `redisHealthy`, etc.) but does not exercise the live Discord redirect — it only checks that the values are present and correctly shaped.
+
+## Decision
+
+Remove the silent-pass escape hatch. If all attempts are rate-limited (429) and the OAuth redirect contract was never verified, the step now **exits 1 (failure)**.
+
+A documented `ALLOW_DEPLOY_UNVERIFIED_OAUTH` flag (available as a `workflow_dispatch` input) allows an operator to explicitly bypass the check when Discord's rate-limiting is confirmed to be a transient infrastructure issue and the auth-config check has passed. The bypass is intentional, visible, and auditable — unlike the previous silent escape.
+
+## Alternatives Considered
+
+**Keep status quo (silent pass on 429):** Preserves deploy continuity when Discord's API is rate-limiting. Rejected because the step title claims "contract verified" while exit 0 fires without any verification — a semantic mismatch that erodes operator trust and can mask real config problems (e.g., malformed redirect_uri) when a 429 storm coincides with a misconfiguration.
+
+**Delete the OAuth redirect check entirely:** Relies solely on auth-config smoke check. Rejected because auth-config validates that fields are _present and shaped correctly_ — it does not test the live redirect URL. A malformed `client_id` encoding or wrong `redirect_uri` domain would pass auth-config but fail at the actual OAuth handshake.
+
+## Consequences
+
+**Positive:**
+
+- "Deploy passed" unambiguously means "OAuth contract was verified."
+- Config problems (malformed redirect URL, wrong client_id) are caught at deploy time, not after users hit sign-in failures.
+- Operator is forced to make a conscious decision if the check fails, rather than silently proceeding.
+
+**Negative:**
+
+- A deploy can now fail due to Discord's rate-limiting rather than a Lucky-side issue. This requires operator intervention (wait ~5 min, redeploy).
+- If Discord's rate-limit window grows beyond ~3 min, the check will fail routinely and operator friction increases.
+
+**Neutral:**
+
+- The escape hatch has fired zero times across 44 production deploy runs (2026-03-14 to 2026-05-24), so the operational impact of removing it is expected to be negligible.
+
+## Revisit When
+
+- The `ALLOW_DEPLOY_UNVERIFIED_OAUTH` bypass is used more than twice per month (suggests Discord's rate-limit window exceeds the retry budget, warranting a longer retry loop or a rescheduled check).
+- Discord changes its OAuth rate-limit semantics (new headers, different window, per-token vs per-IP).
+- A monitoring gap is detected: if users report sign-in failures post-deploy that were not caught at deploy time, re-evaluate whether the auth-config check covers the missed scenario.


### PR DESCRIPTION
## Problem

The OAuth redirect smoke check had a silent-pass escape hatch: if every attempt returned 429 (Discord rate-limiting), the step exited 0 with only a `::warning::`. The OAuth contract was never verified, yet the deploy was marked as passing.

This is a semantic mismatch — "Deploy passed" could mean "all checks passed" or "all checks were skipped due to rate-limiting."

## Changes

1. **Add `allow_deploy_unverified_oauth` workflow_dispatch input** — explicit, auditable bypass for Discord rate-limit incidents.
2. **Remove silent-pass escape hatch** — sustained 429 now exits 1 with a clear error message and actionable options.

## Behavior After

- All 18 attempts succeed/fail normally → pass or fail based on OAuth contract.
- All 18 attempts return 429 and `allow_deploy_unverified_oauth=false` (default) → **exit 1** with operator instructions.
- All 18 attempts return 429 and `allow_deploy_unverified_oauth=true` → exit 0 with a `::warning::` requiring manual OAuth verification.

## Evidence

Zero 429 incidents across 44 production deploy runs (2026-03-14 to 2026-05-24). Operational impact of removing the hatch is negligible.

## ADR

`docs/decisions/2026-05-24-deploy-oauth-redirect-smoke-check-429-handling.md`