### PR TITLE
fix(ci): surface async deploy failures via commit statuses

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             actions: read
+            contents: read
         if: |
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
@@ -263,6 +264,7 @@ jobs:
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
                   DOCKER_REBUILT: ${{ steps.docker_wait.outputs.docker_rebuilt }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   set -euo pipefail
                   base_url=$(node -e 'const u = new URL(process.env.WEBHOOK_URL); console.log(`${u.protocol}//${u.host}`)')
@@ -274,19 +276,49 @@ jobs:
 
                   if [ "${DOCKER_REBUILT:-false}" != "true" ]; then
                     health_url="${base_url}/api/health"
-                    echo "==> No Docker rebuild for this commit — verifying service health at $health_url..."
+                    echo "==> No Docker rebuild — checking for homelab-deploy commit status (SHA: $expected)..."
+
+                    status_was_seen=false
                     for attempt in $(seq 1 20); do
                       echo "Attempt ${attempt}/20..."
-                      response=$(curl -sS --max-time 20 -w "\n%{http_code}" "$health_url" || true)
-                      http_code=$(echo "$response" | tail -1)
-                      if [ "$http_code" = "200" ]; then
-                        echo "==> Service healthy after deploy. Done."
+                      deploy_state=$(gh api \
+                        "repos/${{ github.repository }}/commits/${expected}/statuses" \
+                        --jq '[.[] | select(.context == "homelab-deploy")] | first | .state // ""' \
+                        2>/dev/null || echo "")
+
+                      [ "$deploy_state" = "pending" ] && status_was_seen=true
+
+                      if [ "$deploy_state" = "success" ]; then
+                        echo "==> Homelab deploy completed successfully."
                         exit 0
                       fi
-                      echo "Not ready (HTTP $http_code). Waiting 15s..."
+                      if [ "$deploy_state" = "failure" ] || [ "$deploy_state" = "error" ]; then
+                        echo "::error::Homelab deploy reported failure — check deploy logs on homelab"
+                        exit 1
+                      fi
+
+                      if [ "$status_was_seen" = "false" ] && [ "$attempt" -eq 6 ]; then
+                        echo "::notice::No homelab-deploy status after ~90s — GITHUB_DEPLOY_STATUS_TOKEN not configured on homelab. Falling back to HTTP health check."
+                        for http_attempt in $(seq 1 20); do
+                          echo "HTTP attempt ${http_attempt}/20..."
+                          response=$(curl -sS --max-time 20 -w "\n%{http_code}" "$health_url" || true)
+                          http_code=$(echo "$response" | tail -1)
+                          if [ "$http_code" = "200" ]; then
+                            echo "==> Service healthy. Done."
+                            exit 0
+                          fi
+                          echo "Not ready (HTTP $http_code). Waiting 15s..."
+                          sleep 15
+                        done
+                        echo "::error::Service did not become healthy after all attempts"
+                        exit 1
+                      fi
+
+                      echo "Deploy status: ${deploy_state:-none}. Waiting 15s..."
                       sleep 15
                     done
-                    echo "::error::Service did not become healthy after all attempts"
+
+                    echo "::error::Deploy validation timed out"
                     exit 1
                   fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,12 @@ name: Deploy to Homelab
 
 on:
     workflow_dispatch:
+        inputs:
+            allow_deploy_unverified_oauth:
+                description: 'Skip OAuth redirect contract check (use only if Discord is rate-limiting and auth-config check passed)'
+                required: false
+                default: 'false'
+                type: boolean
     workflow_run:
         workflows: ["Build & Push Docker Images"]
         types: [completed]
@@ -406,6 +412,7 @@ jobs:
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
                   EXPECTED_CLIENT_ID: ${{ secrets.WEBAPP_EXPECTED_CLIENT_ID }}
+                  ALLOW_DEPLOY_UNVERIFIED_OAUTH: ${{ inputs.allow_deploy_unverified_oauth || '' }}
               run: |
                   set -euo pipefail
 
@@ -532,8 +539,13 @@ jobs:
                   done
 
                   if [ "$non_rate_limited_attempts" -eq 0 ] && [ "$rate_limited_count" -gt 0 ]; then
-                    echo "::warning::OAuth redirect contract check hit sustained Discord rate limiting (429) across all retries; treating as non-blocking after auth-config contract pass."
-                    exit 0
+                    if [ "${ALLOW_DEPLOY_UNVERIFIED_OAUTH:-false}" = "true" ]; then
+                      echo "::warning::OAuth redirect contract check was rate-limited on all attempts; bypassing because ALLOW_DEPLOY_UNVERIFIED_OAUTH=true — verify OAuth flow manually."
+                      exit 0
+                    fi
+                    echo "::error::OAuth redirect contract check was rate-limited (429) on all $rate_limited_count attempts — contract not verified."
+                    echo "::error::Options: (1) redeploy after Discord rate-limit clears (~5 min); (2) trigger workflow_dispatch with allow_deploy_unverified_oauth=true to bypass"
+                    exit 1
                   fi
 
                   echo "::error::Timed out waiting for OAuth redirect contract"

--- a/docs/decisions/2026-05-24-deploy-async-completion-signal.md
+++ b/docs/decisions/2026-05-24-deploy-async-completion-signal.md
@@ -1,0 +1,58 @@
+# ADR: Async Deploy Completion Signal via GitHub Commit Statuses
+
+**Date:** 2026-05-24  
+**Status:** Accepted
+
+## Context
+
+`deploy-wrapper.sh` runs `nohup bash deploy.sh & disown` so the webhook HTTP response returns immediately. `deploy.sh` executes fully detached from the CI process.
+
+The "Validate deployed version" step in `deploy.yml` handles two paths:
+
+- **Rebuild path** (`docker_rebuilt=true`): polls `/api/health/version` for SHA match. Correct — the SHA changes when a new image is built, so HTTP 200 from the old container won't satisfy the check.
+- **No-rebuild path** (`docker_rebuilt=false`): polled `/api/health` for HTTP 200. Incorrect — the already-running service returns 200 immediately, before `deploy.sh` has executed (git sync, container restart if needed, health checks). A `deploy.sh` failure is invisible to CI.
+
+The no-rebuild path fires on every commit that does not change Docker-relevant files (e.g., config changes, bot logic, backend logic). This is the majority of deploys.
+
+## Decision
+
+Bridge the async gap using GitHub commit statuses (`context: homelab-deploy`), posted by `deploy.sh` directly to the GitHub Statuses API:
+
+1. After a successful git sync, `deploy.sh` posts `pending` keyed to the post-sync HEAD SHA.
+2. On exit (via an EXIT trap), `deploy.sh` posts `success` (happy path) or `failure` (any other exit).
+3. CI polls `GET /repos/{owner}/{repo}/commits/{sha}/statuses` for the `homelab-deploy` context, using `GITHUB_TOKEN` (which has `statuses:read` via the `contents: read` job permission).
+
+**Graceful degradation:** If `GITHUB_DEPLOY_STATUS_TOKEN` is absent from the homelab server environment, `post_deploy_status` is a no-op. CI detects no status after ~90 s (6 attempts × 15 s) and falls back to the original HTTP 200 health check. This preserves current behavior with zero breakage while the token is being configured.
+
+## Alternatives Considered
+
+**Keep HTTP 200 poll in no-rebuild path:** Simple, zero new infrastructure. Rejected because it creates a false-pass guarantee — a `deploy.sh` git-sync failure or container restart failure exits the script with a non-zero code that is never surfaced to the operator.
+
+**Write deploy result to a file, have CI fetch it:** Requires the homelab server to expose a new endpoint or the CI to SSH into the homelab. Rejected — adds a network dependency and complicates the homelab surface. The GitHub Statuses API is already available and authenticated.
+
+**Poll the deploy log via SSH:** Requires SSH access from CI runners to the homelab. Rejected — increases attack surface and deviates from the existing webhook-only interface.
+
+**Add a callback webhook from deploy.sh to CI:** CI would need to receive inbound connections from the homelab. Rejected — GitHub Actions runners are ephemeral and do not have stable inbound addresses.
+
+## Consequences
+
+**Positive:**
+
+- A `deploy.sh` failure on the no-rebuild path now causes the CI step to exit 1 within seconds of the failure being posted — not silently pass.
+- Operators see the failure in the CI run, not later from user reports.
+- The status mechanism reuses existing GitHub infrastructure; no new services required.
+
+**Negative:**
+
+- Requires a new `GITHUB_DEPLOY_STATUS_TOKEN` secret configured on the homelab webhook container (GitHub PAT, `repo:statuses` scope on `LucasSantana-Dev/Lucky`). Until configured, behavior degrades gracefully to the old HTTP 200 poll.
+- `deploy.sh` gains a `curl` call per deploy. The call is fire-and-forget (`|| true`); a network failure does not abort the deploy.
+
+**Neutral:**
+
+- The 90 s fallback threshold is a one-time cost paid only when the token is not yet configured. Once the token is present, the loop exits on `success` or `failure` — typically within 15–30 s of `deploy.sh` completing.
+
+## Revisit When
+
+- The `GITHUB_DEPLOY_STATUS_TOKEN` token is rotated or revoked without updating the homelab environment (status posts will silently stop; CI will fall back to HTTP 200 poll — same as before, but masked). Add a monitoring alert if status posts stop appearing on deploys.
+- `deploy.sh` is split into multiple async stages; each stage would need its own status post.
+- Discord-rate-limit or GitHub API outage causes the `gh api` status poll to fail consistently; the 20-attempt cap (5 min) bounds the worst case.

--- a/docs/decisions/2026-05-24-deploy-oauth-redirect-smoke-check-429-handling.md
+++ b/docs/decisions/2026-05-24-deploy-oauth-redirect-smoke-check-429-handling.md
@@ -1,0 +1,47 @@
+# ADR: Deploy OAuth Redirect Smoke Check — Hard Fail on Sustained 429
+
+**Date:** 2026-05-24  
+**Status:** Accepted
+
+## Context
+
+`deploy.yml` includes an "OAuth redirect contract smoke check" step that hits `/api/auth/discord` and validates the redirect to Discord's OAuth2 authorize URL carries the correct `client_id` and `redirect_uri`. It retries 18 times (10s intervals, ~3 min total).
+
+The prior implementation had a silent-pass escape hatch: if every attempt returned HTTP 429 (Discord rate-limiting), the step exited 0 with only a `::warning::` message. The OAuth contract was never actually verified, but the deploy was marked as passing.
+
+A preceding "Auth config smoke check" step validates server-side OAuth fields (`clientId`, `redirectUri`, `sessionSecretConfigured`, `redisHealthy`, etc.) but does not exercise the live Discord redirect — it only checks that the values are present and correctly shaped.
+
+## Decision
+
+Remove the silent-pass escape hatch. If all attempts are rate-limited (429) and the OAuth redirect contract was never verified, the step now **exits 1 (failure)**.
+
+A documented `ALLOW_DEPLOY_UNVERIFIED_OAUTH` flag (available as a `workflow_dispatch` input) allows an operator to explicitly bypass the check when Discord's rate-limiting is confirmed to be a transient infrastructure issue and the auth-config check has passed. The bypass is intentional, visible, and auditable — unlike the previous silent escape.
+
+## Alternatives Considered
+
+**Keep status quo (silent pass on 429):** Preserves deploy continuity when Discord's API is rate-limiting. Rejected because the step title claims "contract verified" while exit 0 fires without any verification — a semantic mismatch that erodes operator trust and can mask real config problems (e.g., malformed redirect_uri) when a 429 storm coincides with a misconfiguration.
+
+**Delete the OAuth redirect check entirely:** Relies solely on auth-config smoke check. Rejected because auth-config validates that fields are _present and shaped correctly_ — it does not test the live redirect URL. A malformed `client_id` encoding or wrong `redirect_uri` domain would pass auth-config but fail at the actual OAuth handshake.
+
+## Consequences
+
+**Positive:**
+
+- "Deploy passed" unambiguously means "OAuth contract was verified."
+- Config problems (malformed redirect URL, wrong client_id) are caught at deploy time, not after users hit sign-in failures.
+- Operator is forced to make a conscious decision if the check fails, rather than silently proceeding.
+
+**Negative:**
+
+- A deploy can now fail due to Discord's rate-limiting rather than a Lucky-side issue. This requires operator intervention (wait ~5 min, redeploy).
+- If Discord's rate-limit window grows beyond ~3 min, the check will fail routinely and operator friction increases.
+
+**Neutral:**
+
+- The escape hatch has fired zero times across 44 production deploy runs (2026-03-14 to 2026-05-24), so the operational impact of removing it is expected to be negligible.
+
+## Revisit When
+
+- The `ALLOW_DEPLOY_UNVERIFIED_OAUTH` bypass is used more than twice per month (suggests Discord's rate-limit window exceeds the retry budget, warranting a longer retry loop or a rescheduled check).
+- Discord changes its OAuth rate-limit semantics (new headers, different window, per-token vs per-IP).
+- A monitoring gap is detected: if users report sign-in failures post-deploy that were not caught at deploy time, re-evaluate whether the auth-config check covers the missed scenario.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,6 +12,11 @@ COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-lucky}"
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 export COMPOSE_PROJECT_NAME
+GITHUB_DEPLOY_STATUS_TOKEN="${GITHUB_DEPLOY_STATUS_TOKEN:-}"
+GITHUB_REPO="${GITHUB_REPO:-LucasSantana-Dev/Lucky}"
+DEPLOY_FINAL_STATE="failure"
+DEPLOY_FINAL_DESC="Deploy failed"
+DEPLOYED_SHA=""
 
 log() { echo "$LOG_PREFIX $(date '+%H:%M:%S') $1"; }
 
@@ -304,6 +309,17 @@ acquire_lock() {
     return 0
 }
 
+post_deploy_status() {
+    [[ -z "$GITHUB_DEPLOY_STATUS_TOKEN" ]] && return 0
+    [[ -z "$DEPLOYED_SHA" ]] && return 0
+    curl -s -o /dev/null \
+        -X POST \
+        -H "Authorization: token $GITHUB_DEPLOY_STATUS_TOKEN" \
+        -H "Content-Type: application/json" \
+        "https://api.github.com/repos/${GITHUB_REPO}/statuses/${DEPLOYED_SHA}" \
+        -d "{\"state\":\"${1}\",\"description\":\"${2}\",\"context\":\"homelab-deploy\"}" || true
+}
+
 if [[ -z "$EXPECTED_SECRET" ]]; then
     log "ERROR: DEPLOY_WEBHOOK_SECRET not configured"
     exit 1
@@ -319,7 +335,8 @@ if ! acquire_lock; then
     notify 16711680 "Deploy Skipped" "Another deploy is already in progress"
     exit 1
 fi
-trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
+_on_exit() { rm -rf "$LOCK_DIR" 2>/dev/null || true; post_deploy_status "$DEPLOY_FINAL_STATE" "$DEPLOY_FINAL_DESC"; }
+trap _on_exit EXIT
 
 COMPOSE_WORKDIR="$(resolve_compose_workdir)"
 CLOUDFLARED_CONFIG_DIR="$(resolve_cloudflared_config_dir)"
@@ -347,6 +364,9 @@ if ! sync_checkout_to_origin_main; then
     notify 16711680 "Deploy Failed" "Checkout recovery failed"
     exit 1
 fi
+
+DEPLOYED_SHA=$(git -C "$DEPLOY_DIR" rev-parse HEAD 2>/dev/null || true)
+post_deploy_status "pending" "Deploy in progress"
 
 # Rebuild webhook early: after git pull lands new hooks.json/Dockerfile but
 # BEFORE the long build/migrate/rollout phase. The -V flag renews anonymous
@@ -482,5 +502,7 @@ fi
 log "Pruning old images..."
 docker image prune -f --filter "until=24h"
 
+DEPLOY_FINAL_STATE="success"
+DEPLOY_FINAL_DESC="All services healthy"
 log "Deploy complete!"
 notify 65280 "Deploy Successful" "All services healthy and running"


### PR DESCRIPTION
## Problem

The "Validate deployed version" step had a silent-pass gap in the **no-rebuild path** (`docker_rebuilt=false`):

- `deploy-wrapper.sh` runs `deploy.sh` fully detached via `nohup … & disown`
- The step polled `/api/health` for HTTP 200 — but the **already-running service** returns 200 immediately, before `deploy.sh` has executed
- A git-sync failure, container restart failure, or any other error in `deploy.sh` exited with non-zero **and was never surfaced to CI**

The rebuild path was not affected — SHA matching against `/api/health/version` correctly waits for the new container.

## Fix

Bridge the async gap using GitHub commit statuses (`context: homelab-deploy`):

**`deploy.sh`**
- After a successful git sync, posts `pending` keyed to the post-sync HEAD SHA
- On exit (EXIT trap), posts `success` (happy path) or `failure` (any other exit)
- Token: `GITHUB_DEPLOY_STATUS_TOKEN` env var on the homelab webhook container (PAT, `repo:statuses` scope). If absent, `post_deploy_status` is a no-op.

**`deploy.yml` — no-rebuild path**
- Polls `GET /repos/{owner}/{repo}/commits/{sha}/statuses` for `homelab-deploy` context
- Exits 0 on `success`, exits 1 on `failure`/`error`
- **Graceful degradation**: if no status appears after ~90 s (6 × 15 s), concludes `GITHUB_DEPLOY_STATUS_TOKEN` isn't configured and falls back to the existing HTTP 200 health check — zero breakage before the token is set up

## Infrastructure note

To activate the new mechanism on the homelab, add to the webhook container's environment:

```
GITHUB_DEPLOY_STATUS_TOKEN=<PAT with repo:statuses scope on LucasSantana-Dev/Lucky>
```

Without this, behavior is identical to the current no-rebuild path.

## ADR

`docs/decisions/2026-05-24-deploy-async-completion-signal.md`