### PR TITLE
chore: bump version to 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0] - 2026-05-24
+
+### Added
+- feat(frontend): ServerLogs + ServerSettings UI pages — view live container logs and edit server config from the dashboard (#965)
+- feat(guild-automation): wire AutoMessages executor into the execution service; full apply path now flows through the Module Executor seam (#950)
+
+### Changed
+- ui(admin,config): redesign Admin + Config pages with full test coverage (#970)
+- ui(entry-funnel): redesign Login + ServersPage; all tests passing (#967)
+- ui(automation): redesign CustomCommands + GuildAutomation with full test coverage (#969)
+- ui(integrations): add Spotify + LastFm test coverage (#968)
+- refactor(bot): introduce `AutoplayContext` value object — removes primitive obsession in the autoplay pipeline (#983)
+- refactor(shared): split `GuildAutomationService` into `GuildAutomationOrchestrator` + `GuildAutomationRepository` (#982)
+- refactor(bot): extract `MessagePipeline` handler chain from the command dispatch layer (#981)
+- refactor(artists): extract `ArtistSuggestionService` from the route handler into a testable service (#980)
+- refactor(musicRecommendation): collapse multi-entrypoint engine to a single `recommendTracks` function (#979)
+
+### Fixed
+- fix(ci): add `lucky-bot` to required containers, remove dead unhealthy-grep before HEALTHCHECK TTL, add bot health poll after API checks (#1054)
+- fix(bot): healthcheck now polls the Discord gateway (`/healthz` HTTP 200) instead of the Redis TCP port — catches real bot connectivity loss (#1047)
+- fix(ci): post `error` commit status on deploy lock contention so CI sees the failure instead of timing out silently (#1052)
+- ci(deploy): add "Wait for homelab deploy completion" step on the `docker_rebuilt=true` path — closes the race where CI went green before `deploy.sh` finished the bot health poll (#1056)
+- fix(ci): surface async deploy outcomes via GitHub Statuses API (`homelab-deploy` context) — `deploy.sh` now posts `pending` → `success`/`failure` (#1046)
+- fix(ci): hard-fail `deploy.sh` on sustained HTTP 429 from the OAuth endpoint instead of treating it as a successful deploy (#1045)
+- fix(ci): lockfile-hash BuildKit npm cache key to prevent esbuild version mismatch across concurrent jobs (#1016)
+- fix(ci): archive squash-merged release branches instead of failing the fast-forward job (#946)
+- fix: resolve Prettier syntax error in `queueManipulation.spec.ts` (#985)
+
+### Internal
+- chore(backend): delete orphaned automod templates constant (#1053)
+- test(bot): add YouTube smoke tests for search + playlist flows (#948)
+- test(bot): Phase 4 test cleanup — ~93 tests removed (2,853 → 2,760); replace delegation-only specs with focused behavioural tests (#956–#1035)
+- chore(bot): tighten coverage gate to 65.8/63.5/62/66.7 after Phase 4 cleanup (#996)
+- chore: wire husky + lint-staged + `tsc --noEmit` pre-commit hook (#1007)
+- chore: OSS positioning — portfolio framing, `SECURITY.md`, ADR-first README (#952)
+- chore: repo organisation — untrack machine-local AI config, move release cadence docs (#951)
+- ci: promote `madge` circular-dep gate to blocking on `main`
+- docs: ADR for branch protection required checks (#949)
+- docs: add decision records for May 23 refactor batch (#1040)
+- chore(deps): routine dependabot bumps — actions, dev tools, production patches (#971–#977, #1042)
+
 ## [2.14.1] - 2026-05-23
 
 ### Fixed

--- a/docs/decisions/2026-05-24-ci-runtime-baseline-accepted.md
+++ b/docs/decisions/2026-05-24-ci-runtime-baseline-accepted.md
@@ -1,0 +1,87 @@
+# CI runtime: baseline accepted, sharding deferred
+
+Date: 2026-05-24
+
+## Context
+
+After test-reduction PRs #1013–#1018 (Phase 4 bot/backend test cleanup), CI wall time
+was re-measured across four recent runs on the `main`-targeting workflow:
+
+| Run | test-backend | test-bot | SonarCloud | Total wall |
+| --- | ------------ | -------- | ---------- | ---------- |
+| #1  | 2:11         | 1:42     | 1:03       | ~3:50      |
+| #2  | 2:02         | 1:38     | 0:58       | ~3:40      |
+| #3  | 2:08         | 1:44     | 1:01       | ~3:50      |
+| #4  | 2:05         | 1:41     | 1:00       | ~3:45      |
+
+Critical path: `test-backend` (~2:02–2:11) → `SonarCloud` (~1 min) = **~3-4 min**.
+
+The memory reference to "8-10 min" pre-dates these PRs (baseline from v2.14.0 ship notes
+for the CI parallel-jobs restructure in PR #942, which itself cut from ~13-15 min to ~8-10
+min). Current state is meaningfully better.
+
+The project's memory note at `project_v2_14_1_ship_2026-05-23` and the broader discussion
+raised the question of whether further optimization was warranted — specifically Jest
+sharding (`--shard N/M` flag) across matrix runners for `test-backend`.
+
+PRD #966 is open and plans ~29 additional test removals across `memberHandler.spec.ts`,
+`embed.spec.ts`, and `errorHandlers.spec.ts`. This was not yet applied when measurements
+were taken.
+
+## Decision
+
+Accept the current 3-4 min baseline. Do not introduce Jest sharding or runner-count
+expansion at this time. Continue executing PRD #966 (deferred test cleanup) on its own
+merits.
+
+## Alternatives considered
+
+**Jest sharding (`--shard N/M` across 2-4 matrix runners)** — Splits the `test-backend`
+suite across multiple runners in parallel. Maximum gain if `test-backend` is the critical
+path is ~1 min (halving ~2 min, assuming even distribution). Rejected:
+
+- Fails the effort-to-impact threshold at 3-4 min baseline. Saving 1 min from an already
+  fast pipeline introduces matrix configuration, coverage-artifact merging (`lcov-result-merger`
+  or equivalent), `quality-gate` fan-in changes, and ongoing maintenance surface.
+- GitHub-hosted runners are 2 vCPU; `maxWorkers: '50%'` = 1 effective worker. Adding
+  shards spreads the _process count_ but does not improve per-shard CPU parallelism.
+- Merging coverage from N shards before the SonarCloud job adds a new failure mode and
+  requires explicit merge logic not currently present.
+
+**Increase `maxWorkers`** — Raising `maxWorkers` above `'50%'` on a 2-vCPU runner causes
+CPU contention; test time increases or is unchanged. Rejected.
+
+**Move SonarCloud to non-blocking** — SonarCloud's ~1 min occupies the critical path after
+`test-backend`. Making it advisory-only would cut wall time by ~1 min but remove the
+quality gate enforcing the coverage floor. Rejected: quality gate is load-bearing.
+
+**Continue PRD #966 only** — Planned ~29 test removals reduce suite size, which shortens
+`test-backend` slightly without pipeline complexity. Not a substitute for sharding if CI
+becomes a problem later, but the right next step from the current baseline.
+
+## Consequences
+
+**Positive:**
+
+- No new CI infrastructure complexity introduced.
+- 3-4 min is within acceptable feedback-loop latency for a monorepo of this size.
+- PRD #966 execution removes tests of questionable value, improving suite quality
+  independent of runtime.
+
+**Negative:**
+
+- Suite continues to grow with new features; if sharding is needed later, it will need to
+  be introduced reactively.
+
+**Neutral:**
+
+- The `maxWorkers: '50%'` setting in `backend/jest.config.cjs` and `bot/jest.config.cjs`
+  is appropriate for 2-vCPU runners and remains unchanged.
+
+## Revisit when
+
+- Post-PRD #966, `test-backend` consistently exceeds **4 min** in wall time (currently ~2 min).
+- A new feature phase adds a large test surface (e.g., integration test expansion from
+  `docs/decisions/2026-05-09-autoplay-integration-tests-phase-a.md`).
+- Runner count increases (self-hosted runners with >2 vCPU would change the `maxWorkers`
+  calculus and make sharding more impactful).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.14.1",
+    "version": "2.15.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps all package.json files from `2.14.1` → `2.15.0`
- Populates `CHANGELOG.md` with everything since v2.14.1
- Adds ADR `docs/decisions/2026-05-24-ci-runtime-baseline-accepted.md` (CI runtime baseline: 3–4 min accepted, Jest sharding deferred)

### Changes included in this release

**Added**
- ServerLogs + ServerSettings UI pages (#965)
- AutoMessages executor wiring into execution service (#950)

**Changed**
- 4 UI redesigns: Admin, Config, Login, ServersPage, CustomCommands, GuildAutomation, Spotify, LastFm (#967–#970)
- 5 refactors: AutoplayContext VO (#983), GuildAutomationOrchestrator/Repository split (#982), MessagePipeline chain (#981), ArtistSuggestionService (#980), recommendTracks entrypoint (#979)

**Fixed** — deploy CI gap sweep (A–F)
- Gap A: hard-fail on OAuth 429 (#1045)
- Gap B: surface async deploy via commit statuses (#1046)
- Gap C: bot healthcheck polls Discord gateway, not Redis TCP (#1047)
- Gap D: post error status on lock contention (#1052)
- Gap E: add bot to required containers, remove dead unhealthy grep (#1054)
- Gap F: wait for homelab-deploy completion on docker_rebuilt=true path (#1056)
- lockfile-hash BuildKit cache key (#1016)
- squash-merged release branch archive (#946)

**Internal**
- Phase 4 test cleanup — 93 tests removed (#956–#1035)
- Pre-commit hooks: husky + lint-staged + tsc (#1007)
- madge gate promoted to blocking
- Dependabot routine bumps (#971–#977, #1042)

> **Note:** #1054 (Gap E) may still be in CI — merge this PR after #1054 lands.