### PR TITLE
fix(ci): make husky optional in prepare script to unblock docker builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "packages/*"
     ],
     "scripts": {
-        "prepare": "husky",
+        "prepare": "husky || true",
         "build": "npm run db:generate && npm run build --workspace=packages/shared && npm run build --workspace=packages/bot && npm run build --workspace=packages/backend && npm run build --workspace=packages/frontend",
         "build:shared": "npm run build --workspace=packages/shared",
         "build:bot": "npm run build --workspace=packages/bot",


### PR DESCRIPTION
## Root cause

`npm ci --omit=dev` in production Docker builds runs the `prepare` lifecycle script, which calls `husky`. `husky` is a devDep not present in production installs, causing `exit code: 127` and failing every `build-and-push` job since PR #1007 (pre-commit hooks) merged yesterday.

This is why every merged commit showed ❌ in the GitHub mobile CI view — the Docker backend image has not been building successfully since #1007 landed.

## Fix

```
"prepare": "husky || true"
```

The `|| true` makes husky optional: if the binary is missing (Docker, CI with `--omit=dev`), the lifecycle step exits 0 instead of failing the build. Husky still runs normally on developer machines where it is installed.

## Verification

After merge, the `build-and-push (backend, Dockerfile, production-backend)` job should go green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced stability of the package installation process to handle potential setup issues gracefully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->