### PR TITLE
ci: add docker build required pr gate and deploy wait timer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,61 +133,47 @@ jobs:
                   path: packages/frontend/coverage/lcov.info
                   retention-days: 1
 
+    docker-build:
+        name: Build — ${{ matrix.service }}
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - {service: bot, file: Dockerfile, target: production-bot}
+                    - {service: backend, file: Dockerfile, target: production-backend}
+                    - {service: frontend, file: Dockerfile, target: production-frontend}
+                    - {service: nginx, file: Dockerfile.nginx, target: ''}
+        steps:
+            - uses: actions/checkout@v6
+            - uses: docker/setup-buildx-action@v4
+            - name: Build ${{ matrix.service }}
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: ${{ matrix.file }}
+                  target: ${{ matrix.target }}
+                  push: false
+                  load: false
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+                  build-args: |
+                      COMMIT_SHA=${{ github.sha }}
+                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
+
     docker-build-check:
         name: Build — Docker images
         runs-on: ubuntu-latest
-        if: github.event_name == 'pull_request'
+        needs: docker-build
+        if: always() && github.event_name == 'pull_request'
         steps:
-            - uses: actions/checkout@v6
-            - uses: docker/setup-buildx-action@v3
-            - name: Build bot
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  file: Dockerfile
-                  target: production-bot
-                  push: false
-                  load: false
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-                  build-args: |
-                      COMMIT_SHA=${{ github.sha }}
-                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
-            - name: Build backend
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  file: Dockerfile
-                  target: production-backend
-                  push: false
-                  load: false
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-                  build-args: |
-                      COMMIT_SHA=${{ github.sha }}
-                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
-            - name: Build frontend
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  file: Dockerfile
-                  target: production-frontend
-                  push: false
-                  load: false
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-                  build-args: |
-                      COMMIT_SHA=${{ github.sha }}
-                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
-            - name: Build nginx
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  file: Dockerfile.nginx
-                  push: false
-                  load: false
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
+            - name: Assert all builds passed
+              run: |
+                  if [[ "${{ needs.docker-build.result }}" != "success" ]]; then
+                      echo "Docker build result: ${{ needs.docker-build.result }}"
+                      exit 1
+                  fi
 
     quality-gate:
         # test-youtube-smoke intentionally excluded: advisory-only, runs on YouTube dependency PRs only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,62 @@ jobs:
                   path: packages/frontend/coverage/lcov.info
                   retention-days: 1
 
+    docker-build-check:
+        name: Build — Docker images
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
+        steps:
+            - uses: actions/checkout@v6
+            - uses: docker/setup-buildx-action@v3
+            - name: Build bot
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: Dockerfile
+                  target: production-bot
+                  push: false
+                  load: false
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+                  build-args: |
+                      COMMIT_SHA=${{ github.sha }}
+                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
+            - name: Build backend
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: Dockerfile
+                  target: production-backend
+                  push: false
+                  load: false
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+                  build-args: |
+                      COMMIT_SHA=${{ github.sha }}
+                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
+            - name: Build frontend
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: Dockerfile
+                  target: production-frontend
+                  push: false
+                  load: false
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+                  build-args: |
+                      COMMIT_SHA=${{ github.sha }}
+                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
+            - name: Build nginx
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: Dockerfile.nginx
+                  push: false
+                  load: false
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+
     quality-gate:
         # test-youtube-smoke intentionally excluded: advisory-only, runs on YouTube dependency PRs only
         name: Quality Gates

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        environment: Production
         permissions:
             actions: read
             contents: read

--- a/docs/decisions/2026-05-19-guild-automation-module-executors.md
+++ b/docs/decisions/2026-05-19-guild-automation-module-executors.md
@@ -1,7 +1,8 @@
 ---
 status: accepted
 date: 2026-05-19
-revisit_after: after-pilot-executor
+amended: 2026-05-24
+revisit_after: after-guild-automation-decommission
 ---
 
 # Guild Automation reconciles via Module Executors with a Capture / Diff / Apply seam in shared
@@ -95,6 +96,42 @@ Four locked design choices:
 2. **Bot consumer.** Wire bot to call the AutoMessages Executor through `DiscordJsAdapter`. Delete the duplicated automessages logic in `bot/src/utils/guildAutomation/applyPlan.ts`. This is the first cross-package consumption — proves the location works.
 3. **Migrate remaining 6 Executors** one PR per Executor, easiest first: Moderation (DB-only) → ReactionRoles → CommandAccess → Onboarding (mostly read) → Channels → Roles (most complex; ID remap-heavy).
 4. **Decommission the monolith.** Once all 7 executors are migrated, delete `GuildAutomationExecutionService` and the duplicated bot apply path. Verify the guardrail test in `bot/utils/guildAutomation/` is updated to enforce "no Manifest reconciliation outside `shared/services/guildAutomation/`".
+
+## Amendment — 2026-05-24: cross-module ID remapping and executor execution order
+
+### Status of pilot
+
+AutoMessages Executor ✅ implemented and wired into both bot (`applyPlan.ts`) and backend (`GuildAutomationExecutionService.ts`).
+Moderation Executor ✅ implemented and wired into bot only; backend wiring is the next PR.
+Five remaining: Roles, Channels, Onboarding, ReactionRoles, CommandAccess.
+
+### ID remapping contract
+
+The orchestrator builds a `roleRemap: Map<desiredId, liveId>` and `channelRemap: Map<desiredId, liveId>` by name-matching desired manifest IDs against live Discord state. It then calls `remapManifestEntityIds()` to produce a remapped manifest where all cross-module references use live Discord IDs, BEFORE passing sections to executor `diff()`.
+
+**Executors always receive a remapped manifest section. Executors must never resolve IDs themselves.**
+
+When the Roles executor creates new roles during `apply()`, the orchestrator receives those new `{desiredId → liveId}` pairs in the apply result and adds them to `roleRemap` / `channelRemap` before processing later sections. This is why execution order is mandatory.
+
+### Mandatory execution order for Discord-write executors
+
+Roles → Channels → Onboarding
+
+Roles executor runs first and produces new role and channel IDs. Orchestrator extends the remap maps from the Roles apply result. Channels executor runs next using the extended channelRemap. Onboarding executor runs last using both extended maps.
+
+DB-only executors (Moderation, AutoMessages, ReactionRoles, CommandAccess) are order-independent relative to each other and should run after the Discord-write trilogy completes.
+
+The Roles executor apply result **must** expose a `createdIds: { roles: Map<desiredId, liveId>; channels: Map<desiredId, liveId> }` field so the orchestrator can extend the remap maps. This is the only output that crosses executor boundaries.
+
+### Recommended sequencing for remaining PRs
+
+1. Wire `moderationExecutor` into `GuildAutomationExecutionService.ts` backend (currently bot-only) — no new executor file needed.
+2. `ReactionRoles Executor` — DB-only, `reactionRolesService` port. No DiscordWriteAdapter extension needed.
+3. `CommandAccess Executor` — DB-only, `guildRoleAccessService` port.
+4. `Onboarding Executor` — one DiscordWriteAdapter write (`PATCH /guilds/:id/onboarding`). Extend `DiscordWriteAdapter` with `patchOnboarding`.
+5. `Channels Executor` — Discord write (create/edit/delete channels). Extend `DiscordWriteAdapter` with channel methods. Receives pre-remapped section.
+6. `Roles Executor` — Most complex. Discord role CRUD. Must return `createdIds` for orchestrator remap extension. Runs first in the Discord-write trilogy.
+7. **Decommission** `GuildAutomationExecutionService.ts` — delete legacy code once all 7 executors are wired.
 
 ## Revisit when
 

--- a/docs/decisions/2026-05-24-candidate-aggregator-deferred.md
+++ b/docs/decisions/2026-05-24-candidate-aggregator-deferred.md
@@ -1,0 +1,51 @@
+---
+status: deferred
+date: 2026-05-24
+revisit_after: after-guild-automation-decommission
+---
+
+# CandidateAggregator seam on the Replenisher is deferred
+
+During an architecture review (`/improve-codebase-architecture`) of `packages/bot/src/utils/music/autoplay/replenisher.ts` (609 LOC), introducing a `CandidateAggregator` interface behind the 4 candidate sources was proposed as a deepening opportunity. The proposal was evaluated and deferred.
+
+## Context
+
+`replenisher.ts` imports 12+ sibling modules and wires together 4 candidate sources (similar-artist lookup, popular-in-genre, listening-history seed, discovery). The initial proposal was to introduce a `collect(context: AutoplayContext): Promise<Candidate[]>` interface, extract each source as an `Aggregator` implementation, and inject them via constructor or function parameter so each source could be tested and swapped independently.
+
+## Decision
+
+**Defer.** Do not introduce `CandidateAggregator` until Guild Automation executor extraction is complete.
+
+Three blocking issues were identified:
+
+1. **Test-mock benefit is false.** `AutoplayContext` has 15+ fields (`queue`, `excludedUrls`, `excludedKeys`, `dislikedWeights`, `likedWeights`, `preferredArtistKeys`, `blockedArtistKeys`, `currentTrack`, `recentArtists`, `autoplayMode`, `artistFrequency`, `implicitDislikeKeys`, `implicitLikeKeys`, `sessionMood`, `genreContext`). Mocking cost does not decrease — it redistributes from one spec file to N aggregator spec files. The original claim that "mock count drops from 9×18 to ≤4 aggregator stubs" is wrong.
+
+2. **Injection breaks the singleton architecture.** Lucky bot uses module-level singleton service instances. Injecting aggregator instances via function parameter or constructor would require either (a) factory functions that accept aggregator lists at call time — unusual in this codebase — or (b) a class constructor, which would create a new instance pattern inconsistent with everything else in `packages/bot/src/services/`. Neither fits.
+
+3. **Production-path initialization risk.** Replenisher sits on the hot path of every autoplay cycle. Changing its initialization pattern before the Guild Automation work (which is already touching shared service wiring) risks introducing subtle initialization-order bugs at the intersection of two large concurrent changes.
+
+## Considered options
+
+- **A. Introduce CandidateAggregator with function-parameter injection.** Rejected: breaks singleton pattern, test benefit claim is false.
+- **B. Introduce CandidateAggregator with class constructor injection.** Rejected: introduces a new instance-creation pattern inconsistent with the rest of the service layer.
+- **C. Leave replenisher.ts as-is (deferred).** Accepted: no behavior change, no risk, revisit after Guild Automation decommission when the service wiring picture is clearer.
+
+## Consequences
+
+- `replenisher.ts` remains a 609-LOC flat orchestrator. Its 12+ imports are a sign of shallow module decomposition but not actively causing delivery friction today.
+- If a new candidate source is added, the developer adds one import and one call in `replenisher.ts` — straightforward and consistent with the existing pattern.
+- The `AutoplayContext` value object (ADR `docs/decisions/2026-05-23-autoplay-context-value-object.md`) and the `recommendTracks()` single entrypoint (ADR `docs/decisions/2026-05-23-recommendation-engine-single-entrypoint.md`) already reduced the surface area that a future CandidateAggregator seam would need to cross.
+
+## Revisit when
+
+- Guild Automation Module Executor extraction is complete and `GuildAutomationExecutionService.ts` is decommissioned — the service wiring patterns will be clearer then.
+- A third candidate source is added and the `replenisher.ts` import list grows beyond ~15 modules — that signals real locality breakdown.
+- AutoplayContext builder pattern is implemented (see `2026-05-23-autoplay-context-value-object.md`) — if building context remains expensive, the aggregator boundary may become worthwhile to cache at.
+- The test-mock claim is revisited and a concrete test-reduction number is demonstrated rather than asserted.
+
+## Cross-references
+
+- `docs/decisions/2026-05-23-autoplay-context-value-object.md` — AutoplayContext VO (type in place, builder pending).
+- `docs/decisions/2026-05-23-recommendation-engine-single-entrypoint.md` — `recommendTracks()` single entrypoint (implemented).
+- `docs/decisions/2026-05-19-guild-automation-module-executors.md` — Guild Automation executor extraction (prerequisite for revisiting this ADR).
+- This decision was produced via `/improve-codebase-architecture` + `/research-and-decide` (2026-05-24 session). The critic assessment explicitly flipped the test-mock benefit claim.

--- a/docs/decisions/2026-05-25-release-cadence-gates.md
+++ b/docs/decisions/2026-05-25-release-cadence-gates.md
@@ -1,0 +1,71 @@
+---
+status: accepted
+date: 2026-05-25
+revisit_after: 2026-06-08
+---
+
+# Release cadence: Docker build as required PR check + production deploy wait timer
+
+On 2026-05-24, 20+ PRs merged to `main` in a single day. Docker `build-and-push` failed on every commit because `prepare: "husky"` in package.json called a devDep binary absent in the production `--omit=dev` build (PR #1007 wired husky but package.json still had `"prepare": "husky"` instead of `"husky || true"`). The backend image was broken for ~24 hours before detection via GitHub mobile. The developer's concern: ❌ icons visible on merged commits; no gate blocked the merge; Docker failures were advisory-only.
+
+## Decision
+
+Two changes:
+
+1. **Add `docker-build-check` as a required PR check.** A new job in `ci.yml` builds all four Docker services (bot, backend, frontend, nginx) without pushing on every PR targeting `main`. Catches build-step regressions (missing binaries, broken package.json lifecycle scripts, Dockerfile syntax errors) before merge. Added to branch protection required checks alongside Quality Gates, Security, SonarCloud Scan, and madge.
+
+2. **Add a 30-minute wait timer on the `production` GitHub Actions environment.** The production deploy job in `deploy.yml` references the `production` environment, which has a required wait of 30 minutes before the deployment step runs. This provides passive bake time between code landing on `main` and reaching the homelab, without branch-management overhead. For emergency hotfixes, the wait can be skipped by a manual environment approval.
+
+## Option rejected: `release/*` branch buffer
+
+Reinstating `release/vX.Y.Z` as the PR merge target was evaluated and rejected.
+
+Three blocking issues:
+
+1. **Wrong autosync direction.** `release-branch-autosync.yml` fast-forwards the release branch to track `main`, not the reverse. To create actual bake time (release→main promotion), a new workflow would be needed that doesn't exist, and the existing autosync would conflict.
+
+2. **Ceremony without bake time.** The bake-time benefit requires either manual promotion or new automation. Without it, a developer can still fast-forward release→main immediately — the buffer is only as long as the developer voluntarily waits. No technical enforcement.
+
+3. **Solo-developer branch orphan risk.** Stale `release/*` branches that diverge from `main` silently create ambiguous git history: which branch do you tag the release from? This is a material risk for a single-developer project where no one checks branch hygiene daily.
+
+The historical workflow (PRs targeting `release/*`, confirmed in `feedback_tbd_release_branches.md`) has no tracked evidence of preventing production bugs — it was the prior convention, not a validated safeguard.
+
+## Options rejected: other candidates
+
+- **Merge Queue**: Serializes merges but doesn't add bake time. Overhead without signal.
+- **Commit status gate on deploy**: Equivalent to the environment wait timer but less visible and harder to bypass during emergencies.
+- **Status quo + tighten only existing gates**: Does not address Docker advisory-only status.
+
+## Consequences
+
+**Positive:**
+
+- Docker build failures are caught before merge, not after. The husky bug class is prevented.
+- The 30-minute deploy timer gives passive bake time. A broken build on `main` won't reach production within 30 minutes, giving time to revert if another CI check surfaces an issue late.
+- No branch-management overhead — PR workflow is unchanged.
+
+**Negative:**
+
+- `docker-build-check` adds ~5–8 minutes to every PR CI run (4 matrix services, with layer cache).
+- If Docker builds fail frequently for unrelated CI environment reasons (native module binary mismatches, Alpine vs. glibc, disk space), the check becomes a recurring blocker. This must be monitored.
+- The 30-minute wait timer applies to all deploys including urgent hotfixes. The bypass path (manual environment approval) exists but adds a step.
+
+**Neutral:**
+
+- `release.yml` (triggered by tag push) is unchanged. Tagging a release remains a manual, explicit act.
+- `release-branch-autosync.yml` and `release-train-changelog-check.yml` remain wired but idle (no active `release/*` branches). They activate only if a release branch is created manually.
+
+## Revisit when
+
+- **2026-06-08** (2-week trial end): Measure Docker check failure rate during the trial window.
+    - If ≤2 unrelated failures/week: keep the check permanently.
+    - If >2 unrelated failures/week: remove the check, investigate CI environment stability (native modules, Alpine build toolchain), and revisit adding the check only after the environment is stable.
+- The 30-minute wait timer should be reduced to 10 minutes if urgent hotfixes are blocked more than once.
+- If Lucky adds integration tests that boot the Docker image and verify it serves traffic: the Docker build check becomes more comprehensive and its value increases significantly.
+- If Docker failures recur (despite this change) due to a different root cause: re-evaluate whether `release/*` buffer is worth the overhead.
+
+## Cross-references
+
+- PR #1060: root cause fix (`"prepare": "husky || true"`).
+- `docs/decisions/2026-05-23-branch-protection-required-checks.md` — prior branch protection ADR.
+- `feedback_tbd_release_branches.md` — historical `release/*` convention, now superseded by this ADR.

--- a/docs/decisions/2026-05-27-docker-build-check-workflow-architecture.md
+++ b/docs/decisions/2026-05-27-docker-build-check-workflow-architecture.md
@@ -1,0 +1,74 @@
+---
+status: accepted
+date: 2026-05-27
+revisit_after: 2026-06-08
+---
+
+# Docker build check uses parallel matrix in ci.yml without path filters
+
+## Context
+
+Two competing implementations landed on open PRs when the docker-build-check gate was designed:
+
+- **PR #1061** (`ci/docker-build-required-check`): integrated into `ci.yml`, sequential 4-step job, no path filters.
+- **PR #1062** (`ci/docker-build-pr-check`): separate `docker-build-check.yml` workflow, parallel matrix with path filters (`packages/**`, `prisma/**`, `Dockerfile*`, `nginx/**`, `package*.json`).
+
+A `/research-and-decide` critique (2026-05-27) surfaced a critical flaw in PR #1062: **path-filtered workflows do not post status checks when the filter excludes the PR**. GitHub treats a missing required check as "pending," permanently BLOCKING the PR. Any PR touching only docs, `.github/workflows/ci.yml`, or other non-filtered paths would be BLOCKED indefinitely because "Build — Docker images" never posts.
+
+PR #1062 also proposed path filtering to avoid running Docker builds on irrelevant PRs (e.g., a pure doc fix). This is a legitimate optimization, but it is incompatible with a **required** status check configuration: GitHub's branch protection requires the named check to be present AND pass before merge.
+
+## Decision
+
+Use a **parallel matrix with a summary job, no path filters, integrated in `ci.yml`**.
+
+- `docker-build` matrix job: 4 parallel builds (bot, backend, frontend, nginx), `fail-fast: false`, `push: false`, `load: false`, GHA layer cache. Runs only on `pull_request` events.
+- `docker-build-check` summary job: name `"Build — Docker images"`, `needs: docker-build`, `if: always() && github.event_name == 'pull_request'`. Posts pass/fail to branch protection.
+- No path filters. Every PR targeting `main` triggers all 4 builds.
+
+The summary job is the required check target. It always runs on PRs (via `if: always()`) so it always posts a status, regardless of what files the PR touches.
+
+## Considered options
+
+### File structure
+
+- **A. Integrated in ci.yml (accepted).** All CI logic in one file; no cross-file context switch to understand why a PR is BLOCKED.
+- **B. Separate `docker-build-check.yml`.** Cleaner file-level separation, but requires context switching and loses the single-file invariant. Not a meaningful benefit for a solo-developer project.
+
+### Parallel vs sequential
+
+- **A. Sequential 4-step job (original PR #1061).** If bot fails, backend/frontend/nginx never run. Slower combined time and incomplete failure signal.
+- **B. Parallel matrix, fail-fast: false (accepted).** All 4 builds run concurrently; all failures visible in one run. Faster wall time (~2–4 min vs ~5–8 min sequential).
+
+### Path filtering
+
+- **A. No path filters (accepted).** Required check always posts on every PR. Overhead: ~2–4 min on PRs that don't touch Docker-relevant files.
+- **B. Path-filtered workflow (rejected).** Path-filtered workflows don't post status checks when skipped. GitHub treats missing required check as "pending," BLOCKING the PR. This is a documented GitHub Actions footgun. Rejected unconditionally for required-check use.
+
+## Consequences
+
+**Positive:**
+
+- Required check always posts; no PR can be BLOCKED by a missing status.
+- All 4 build failures visible in one CI run (fail-fast: false).
+- CI logic remains in a single workflow file.
+
+**Negative:**
+
+- Pure doc or config PRs (≥1 per week) spend ~2–4 min running Docker builds with no diagnostic value.
+- 4 parallel jobs share GHA cache per-key; warming one cache entry doesn't help others.
+
+**Neutral:**
+
+- The revisit condition from the parent ADR (`docs/decisions/2026-05-25-release-cadence-gates.md`) still applies: if unrelated Docker failures exceed 2/week by 2026-06-08, remove the gate.
+
+## Revisit when
+
+- A GitHub-native solution for "required check + path filter" becomes available (e.g., GitHub adds "treat skipped check as passing" at the branch-protection level).
+- Build times exceed 10 min for the matrix, making the always-run overhead unacceptable.
+- Same conditions as parent ADR: >2 unrelated Docker failures per week by 2026-06-08.
+
+## Cross-references
+
+- Parent gate ADR: `docs/decisions/2026-05-25-release-cadence-gates.md`
+- PR #1061 (`ci/docker-build-required-check`) — contains this implementation
+- PR #1062 (`ci/docker-build-pr-check`) — closed; path-filter approach rejected


### PR DESCRIPTION
## Summary

- Replaces sequential 4-step docker-build-check with **parallel matrix** (bot, backend, frontend, nginx — `fail-fast: false`), all 4 builds visible in one run
- Summary job `docker-build-check` (`name: Build — Docker images`) posts pass/fail to branch protection — this is the required check target
- **No path filters** — required checks must always post; path-filtered workflows are silently skipped, permanently BLOCKING the PR for non-Docker PRs (documented GitHub footgun)
- Adds `environment: Production` to `deploy.yml`, wiring the existing 30-minute `wait_timer` between merge and homelab deploy

## ADRs

- `docs/decisions/2026-05-25-release-cadence-gates.md` — parent gate decision
- `docs/decisions/2026-05-27-docker-build-check-workflow-architecture.md` — workflow architecture decision (supersedes closed PR #1062)

## Revisit

2026-06-08: if unrelated Docker failures exceed 2/week, remove the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker build verification checks for all services in the continuous integration pipeline
  * Configured production environment protections and approval requirements for deployments
  * Implemented a 30-minute deployment gate timer to prevent rapid production releases

* **Documentation**
  * Documented architectural decisions for CI/CD gates, release cadence policies, and deployment safeguards

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->