### PR TITLE
ci: add docker build check for pull requests

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -1,0 +1,70 @@
+name: Build — Docker images
+
+on:
+    pull_request:
+        branches: [main]
+        paths:
+            - 'packages/**'
+            - 'prisma/**'
+            - 'Dockerfile'
+            - 'Dockerfile.*'
+            - 'nginx/**'
+            - 'package*.json'
+            - '.github/workflows/docker-build-check.yml'
+            - '.github/workflows/docker-publish.yml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - service: bot
+                      dockerfile: Dockerfile
+                      target: production-bot
+                    - service: backend
+                      dockerfile: Dockerfile
+                      target: production-backend
+                    - service: frontend
+                      dockerfile: Dockerfile
+                      target: production-frontend
+                    - service: nginx
+                      dockerfile: Dockerfile.nginx
+                      target: ''
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v4
+
+            - name: Build ${{ matrix.service }}
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: ${{ matrix.dockerfile }}
+                  target: ${{ matrix.target || '' }}
+                  push: false
+                  build-args: |
+                      COMMIT_SHA=${{ github.sha }}
+                      NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+
+    check:
+        name: Build — Docker images
+        needs: build
+        runs-on: ubuntu-latest
+        if: always()
+        steps:
+            - name: Assert all builds passed
+              run: |
+                  if [[ "${{ needs.build.result }}" != "success" ]]; then
+                    echo "One or more Docker image builds failed or were cancelled."
+                    exit 1
+                  fi


### PR DESCRIPTION
Satisfies the `Build — Docker images` required status check on PRs.

The existing `docker-publish.yml` only triggers on push to `main`, leaving the required check permanently unposted for PR commits. This makes every PR that has `Build — Docker images` as a required check permanently `BLOCKED`, regardless of whether all other checks pass.

## What this adds

A `docker-build-check.yml` workflow that:
- Triggers on `pull_request` targeting `main` (same path filter as `docker-publish.yml`)
- Matrix-builds all 4 images (bot / backend / frontend / nginx) without pushing
- Aggregates results in a final job named exactly `Build — Docker images` to satisfy the required status check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image building and validation for pull requests across multiple service variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->