### PR TITLE
fix(ci): add figurinhas2026 to Vercel deploy watch

### DIFF
--- a/.github/workflows/vercel-deploy-watch.yml
+++ b/.github/workflows/vercel-deploy-watch.yml
@@ -25,7 +25,7 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_DEPLOY_ALERT_WEBHOOK }}
           # Comma-separated project IDs to monitor. Discover via `vercel projects ls --json`.
           PROJECT_IDS: >-
-            prj_ILW1nAjuVfyFfpxfe9hm5gfQCnkt,prj_2XcjG9xAWA7XTWrp2GLhki5VXrxF,prj_OGMBqswlIdcZYCtN7pobeaAnsZyr,prj_3NBVHR7IAZ5KUuc3Oc8j36OhEkYu
+            prj_ILW1nAjuVfyFfpxfe9hm5gfQCnkt,prj_CVyJOhht0WdcRg01Z5opf2rE2LXX,prj_2XcjG9xAWA7XTWrp2GLhki5VXrxF,prj_OGMBqswlIdcZYCtN7pobeaAnsZyr,prj_3NBVHR7IAZ5KUuc3Oc8j36OhEkYu
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Adds `figurinhas2026` (`prj_CVyJOhht0WdcRg01Z5opf2rE2LXX`) to the `PROJECT_IDS` list in `vercel-deploy-watch.yml`
- All 5 LukSantana team projects are now monitored: `lucky`, `figurinhas2026`, `siza-web`, `forgespace-web`, `portfolio`

## Root cause of the email alert

The "Failed production deployment" email was triggered by a TypeScript build failure on the `ui/music-surfaces` branch (preview deploy, not production). Errors in `packages/frontend/src/pages/Music.tsx`:
- `QueueState` is missing properties `duration` and `isShuffle` (did you mean `shuffled`?)
- `TrackInfo` is missing property `albumArt`

That's a separate code bug to fix in the `ui/music-surfaces` branch.

## Test plan

- [ ] Merge and confirm the next scheduled run (`:*/15 * * * *`) shows "5 projects" in its success log
- [ ] Fix TypeScript errors in `packages/frontend/src/pages/Music.tsx` on `ui/music-surfaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment monitoring configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->