### PR TITLE
fix(docker): redeclare npm-cache-key arg in build and deps stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ CMD ["sh", "-c", "npm ci --legacy-peer-deps --no-audit --no-fund && npx prisma g
 
 # Build stage — installs all deps, generates prisma, builds shared + target
 FROM node:${NODE_VERSION} AS build
+ARG NPM_CACHE_KEY
 
 RUN apk add --no-cache git build-base python3 python3-dev opus-dev && rm -rf /var/cache/apk/*
 
@@ -88,6 +89,7 @@ RUN npm run build --workspace=packages/frontend
 
 # Production deps — slim install (no dev deps)
 FROM node:${NODE_VERSION} AS deps-production
+ARG NPM_CACHE_KEY
 
 RUN apk add --no-cache python3 && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
## Problem

`ARG NPM_CACHE_KEY=v1` was declared in global scope (before any `FROM`) but never redeclared inside the `build` or `deps-production` stages that use `${NPM_CACHE_KEY}` in their `--mount=type=cache` IDs.

Per Docker multi-stage build semantics, ARGs declared before the first `FROM` are **not** inherited by build stages. Without redeclaration, `${NPM_CACHE_KEY}` resolves to an empty string inside those stages, collapsing all cache mount IDs to a fixed key (`npm-build-stage-` and `npm-deps-production-`) regardless of `package-lock.json` hash.

This caused stale esbuild binaries to be reused across builds with different lockfiles:

```
npm error Error: Expected "0.28.0" but got "0.27.3"
```

First detected when the `docker-build` matrix gate (PR #1061) ran on older PRs with a stale BuildKit GHA cache.

## Fix

Added `ARG NPM_CACHE_KEY` inside the `build` and `deps-production` stages, after each respective `FROM` instruction. The global-scope `ARG NPM_CACHE_KEY=v1` still provides the default fallback for local `docker build` without `--build-arg`.

## Test

Docker builds on the open PRs blocked by this failure.