### PR TITLE
feat(guild-automation): wire moderation executor into backend service

### DIFF
--- a/packages/backend/src/services/GuildAutomationExecutionService.ts
+++ b/packages/backend/src/services/GuildAutomationExecutionService.ts
@@ -10,7 +10,10 @@ import {
     type GuildAutomationManifestDocument,
     type GuildAutomationPlan,
 } from '@lucky/shared/services'
-import { createAutoMessagesExecutor } from '@lucky/shared/services/guildAutomation'
+import {
+    createAutoMessagesExecutor,
+    createModerationExecutor,
+} from '@lucky/shared/services/guildAutomation'
 import {
     type GuildAutomationRole,
     type GuildAutomationChannel,
@@ -337,6 +340,20 @@ function remapCommandAccessSection(
 class GuildAutomationExecutionService {
     private readonly autoMessagesExecutor = createAutoMessagesExecutor({
         autoMessageService,
+    })
+
+    private readonly moderationExecutor = createModerationExecutor({
+        port: {
+            updateAutoModSettings: async (guildId, settings) => {
+                const payload = toAutoModPayload(settings)
+                if (payload)
+                    await autoModService.updateSettings(guildId, payload)
+            },
+            updateModerationSettings: async (guildId, settings) => {
+                const payload = toModerationPayload(settings)
+                if (payload) await updateModerationSettings(guildId, payload)
+            },
+        },
     })
 
     private getBotToken(): string {
@@ -1114,15 +1131,21 @@ class GuildAutomationExecutionService {
         desired: GuildAutomationManifestDocument,
         appliedModules: string[],
     ): Promise<void> {
-        const automodPayload = toAutoModPayload(desired.moderation?.automod)
-        if (automodPayload) {
-            await autoModService.updateSettings(guildId, automodPayload)
-        }
-        const moderationPayload = toModerationPayload(
-            desired.moderation?.moderationSettings,
+        const live = this.moderationExecutor.capture()
+        const diff = this.moderationExecutor.diff(
+            live,
+            desired.moderation ?? {},
         )
-        if (moderationPayload) {
-            await updateModerationSettings(guildId, moderationPayload)
+        const result = await this.moderationExecutor.apply(diff, { guildId })
+        if (result.status !== 'success') {
+            warnLog({
+                message: `Moderation executor apply: ${result.status}`,
+                data: {
+                    guildId,
+                    errors:
+                        result.status === 'partial' ? result.errors : undefined,
+                },
+            })
         }
         appliedModules.push('moderation')
     }

--- a/packages/backend/tests/unit/services/GuildAutomationExecutionService.test.ts
+++ b/packages/backend/tests/unit/services/GuildAutomationExecutionService.test.ts
@@ -35,6 +35,7 @@ jest.mock('@lucky/shared/services', () => ({
 
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
+    warnLog: jest.fn(),
 }))
 
 import {
@@ -63,6 +64,7 @@ import type {
     GuildAutomationManifestDocument,
     GuildAutomationPlan,
 } from '@lucky/shared/services'
+import { warnLog } from '@lucky/shared/utils'
 
 describe('GuildAutomationExecutionService', () => {
     const GUILD_ID = '111111111111111111'
@@ -604,6 +606,73 @@ describe('GuildAutomationExecutionService', () => {
                 GUILD_ID,
                 expect.objectContaining({
                     enabled: true,
+                }),
+            )
+        })
+
+        test('should warn and still record module when moderation executor returns partial', async () => {
+            jest.spyOn(
+                (guildAutomationExecutionService as any).moderationExecutor,
+                'apply',
+            ).mockResolvedValue({
+                status: 'partial',
+                applied: [],
+                errors: [{ opKind: 'automod', reason: 'service error' }],
+            })
+
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan: createMinimalPlan([
+                        {
+                            module: 'moderation',
+                            action: 'update',
+                            protected: false,
+                            description: 'Update moderation',
+                        },
+                    ]),
+                    desired: createMinimalManifest(),
+                    actual: createMinimalManifest(),
+                    allowProtected: false,
+                })
+
+            expect(result.diagnostics.appliedModules).toContain('moderation')
+            expect(warnLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Moderation executor apply: partial',
+                }),
+            )
+        })
+
+        test('should warn and still record module when moderation executor returns failed', async () => {
+            jest.spyOn(
+                (guildAutomationExecutionService as any).moderationExecutor,
+                'apply',
+            ).mockResolvedValue({
+                status: 'failed',
+                error: 'automod service unavailable',
+            })
+
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan: createMinimalPlan([
+                        {
+                            module: 'moderation',
+                            action: 'update',
+                            protected: false,
+                            description: 'Update moderation',
+                        },
+                    ]),
+                    desired: createMinimalManifest(),
+                    actual: createMinimalManifest(),
+                    allowProtected: false,
+                })
+
+            expect(result.diagnostics.appliedModules).toContain('moderation')
+            expect(warnLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Moderation executor apply: failed',
                 }),
             )
         })
@@ -1340,15 +1409,33 @@ describe('GuildAutomationExecutionService', () => {
             })
             const actual = createMinimalManifest()
             const plan = createMinimalPlan([
-                { module: 'onboarding', action: 'update', protected: false, description: 'Update' },
+                {
+                    module: 'onboarding',
+                    action: 'update',
+                    protected: false,
+                    description: 'Update',
+                },
             ])
-            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({}),
             })
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: false,
+                })
             expect(result.diagnostics.appliedModules).toContain('onboarding')
-            const body = JSON.parse((mockFetch.mock.calls[0] as any[])[1].body as string)
-            expect(body.prompts[0].options[0].channel_ids).toEqual([CHANNEL_ID_1])
+            const body = JSON.parse(
+                (mockFetch.mock.calls[0] as any[])[1].body as string,
+            )
+            expect(body.prompts[0].options[0].channel_ids).toEqual([
+                CHANNEL_ID_1,
+            ])
             expect(body.prompts[0].options[0].role_ids).toEqual([ROLE_ID_1])
         })
 
@@ -1356,24 +1443,42 @@ describe('GuildAutomationExecutionService', () => {
             const desired = createMinimalManifest({
                 commandaccess: {
                     grants: [
-                        { roleId: ROLE_ID_1, module: 'music', mode: 'allow' as any },
+                        {
+                            roleId: ROLE_ID_1,
+                            module: 'music',
+                            mode: 'allow' as any,
+                        },
                     ],
                 },
             })
             const actual = createMinimalManifest()
             const plan = createMinimalPlan([
-                { module: 'commandaccess', action: 'update', protected: false, description: 'Update' },
+                {
+                    module: 'commandaccess',
+                    action: 'update',
+                    protected: false,
+                    description: 'Update',
+                },
             ])
-            const { guildRoleAccessService } = await import('@lucky/shared/services')
-            ;(guildRoleAccessService.replaceRoleGrants as jest.Mock).mockResolvedValue(undefined)
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
-            })
+            const { guildRoleAccessService } =
+                await import('@lucky/shared/services')
+            ;(
+                guildRoleAccessService.replaceRoleGrants as jest.Mock
+            ).mockResolvedValue(undefined)
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: false,
+                })
             expect(result.diagnostics.appliedModules).toContain('commandaccess')
-            expect(guildRoleAccessService.replaceRoleGrants as jest.Mock).toHaveBeenCalledWith(
-                GUILD_ID,
-                [{ roleId: ROLE_ID_1, module: 'music', mode: 'allow' }],
-            )
+            expect(
+                guildRoleAccessService.replaceRoleGrants as jest.Mock,
+            ).toHaveBeenCalledWith(GUILD_ID, [
+                { roleId: ROLE_ID_1, module: 'music', mode: 'allow' },
+            ])
         })
 
         test('should update existing channel by ID', async () => {
@@ -1381,7 +1486,14 @@ describe('GuildAutomationExecutionService', () => {
                 roles: {
                     roles: [],
                     channels: [
-                        { id: CHANNEL_ID_1, name: 'updated-name', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                        {
+                            id: CHANNEL_ID_1,
+                            name: 'updated-name',
+                            type: 'GuildText',
+                            parentId: null,
+                            topic: null,
+                            readonly: false,
+                        },
                     ],
                 },
             })
@@ -1389,17 +1501,38 @@ describe('GuildAutomationExecutionService', () => {
                 roles: {
                     roles: [],
                     channels: [
-                        { id: CHANNEL_ID_1, name: 'old-name', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                        {
+                            id: CHANNEL_ID_1,
+                            name: 'old-name',
+                            type: 'GuildText',
+                            parentId: null,
+                            topic: null,
+                            readonly: false,
+                        },
                     ],
                 },
             })
             const plan = createMinimalPlan([
-                { module: 'roles', action: 'update', protected: false, description: 'Update channel' },
+                {
+                    module: 'roles',
+                    action: 'update',
+                    protected: false,
+                    description: 'Update channel',
+                },
             ])
-            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({}),
             })
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: false,
+                })
             expect(result.diagnostics.appliedModules).toContain('roles')
             expect(mockFetch).toHaveBeenCalledWith(
                 expect.stringContaining(`/channels/${CHANNEL_ID_1}`),
@@ -1412,7 +1545,14 @@ describe('GuildAutomationExecutionService', () => {
                 roles: {
                     roles: [],
                     channels: [
-                        { id: CHANNEL_ID_1, name: 'keep', type: 'GuildText', parentId: null, topic: null, readonly: false },
+                        {
+                            id: CHANNEL_ID_1,
+                            name: 'keep',
+                            type: 'GuildText',
+                            parentId: null,
+                            topic: null,
+                            readonly: false,
+                        },
                     ],
                 },
             })
@@ -1420,18 +1560,45 @@ describe('GuildAutomationExecutionService', () => {
                 roles: { roles: [], channels: [] },
             })
             const plan = createMinimalPlan([
-                { module: 'roles', action: 'delete', protected: true, description: 'Delete stale' },
+                {
+                    module: 'roles',
+                    action: 'delete',
+                    protected: true,
+                    description: 'Delete stale',
+                },
             ])
             mockFetch
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: CHANNEL_ID_1, name: 'keep' }) })  // POST create channel
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })  // GET roles for prune
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [  // GET channels for prune
-                    { id: CHANNEL_ID_2, name: 'stale' },
-                ] })
-                .mockResolvedValueOnce({ ok: true, status: 204, json: async () => undefined })  // DELETE stale channel
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: true,
-            })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ id: CHANNEL_ID_1, name: 'keep' }),
+                }) // POST create channel
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => [],
+                }) // GET roles for prune
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => [
+                        // GET channels for prune
+                        { id: CHANNEL_ID_2, name: 'stale' },
+                    ],
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 204,
+                    json: async () => undefined,
+                }) // DELETE stale channel
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: true,
+                })
             expect(result.diagnostics.appliedModules).toContain('roles')
             expect(mockFetch).toHaveBeenCalledWith(
                 expect.stringContaining(`/channels/${CHANNEL_ID_2}`),
@@ -1447,37 +1614,122 @@ describe('GuildAutomationExecutionService', () => {
 
             const desired = createMinimalManifest({
                 roles: {
-                    roles: [{ id: OLD_ROLE, name: 'Member', color: 0, hoist: false, mentionable: false }],
-                    channels: [{ id: OLD_CHANNEL, name: 'general', type: 'GuildText', parentId: null, topic: null, readonly: false }],
+                    roles: [
+                        {
+                            id: OLD_ROLE,
+                            name: 'Member',
+                            color: 0,
+                            hoist: false,
+                            mentionable: false,
+                        },
+                    ],
+                    channels: [
+                        {
+                            id: OLD_CHANNEL,
+                            name: 'general',
+                            type: 'GuildText',
+                            parentId: null,
+                            topic: null,
+                            readonly: false,
+                        },
+                    ],
                 },
-                onboarding: { enabled: true, mode: 0, defaultChannelIds: [OLD_CHANNEL], prompts: [] },
+                onboarding: {
+                    enabled: true,
+                    mode: 0,
+                    defaultChannelIds: [OLD_CHANNEL],
+                    prompts: [],
+                },
                 moderation: {
-                    automod: { exemptRoles: [OLD_ROLE], exemptChannels: [OLD_CHANNEL] } as any,
-                    moderationSettings: { muteRoleId: OLD_ROLE, modRoleIds: [OLD_ROLE], adminRoleIds: [] } as any,
+                    automod: {
+                        exemptRoles: [OLD_ROLE],
+                        exemptChannels: [OLD_CHANNEL],
+                    } as any,
+                    moderationSettings: {
+                        muteRoleId: OLD_ROLE,
+                        modRoleIds: [OLD_ROLE],
+                        adminRoleIds: [],
+                    } as any,
                 },
                 automessages: {
-                    welcome: { enabled: true, channelId: OLD_CHANNEL, message: 'hi' },
-                    leave: { enabled: true, channelId: OLD_CHANNEL, message: 'bye' },
+                    welcome: {
+                        enabled: true,
+                        channelId: OLD_CHANNEL,
+                        message: 'hi',
+                    },
+                    leave: {
+                        enabled: true,
+                        channelId: OLD_CHANNEL,
+                        message: 'bye',
+                    },
                 },
                 reactionroles: {
-                    messages: [{ id: 'm1', messageId: 'dm1', channelId: OLD_CHANNEL, mappings: [{ roleId: OLD_ROLE, label: 'x', emoji: undefined, style: undefined }] }],
-                    exclusiveRoles: [{ roleId: OLD_ROLE, excludedRoleId: OLD_ROLE }],
+                    messages: [
+                        {
+                            id: 'm1',
+                            messageId: 'dm1',
+                            channelId: OLD_CHANNEL,
+                            mappings: [
+                                {
+                                    roleId: OLD_ROLE,
+                                    label: 'x',
+                                    emoji: undefined,
+                                    style: undefined,
+                                },
+                            ],
+                        },
+                    ],
+                    exclusiveRoles: [
+                        { roleId: OLD_ROLE, excludedRoleId: OLD_ROLE },
+                    ],
                 },
-                commandaccess: { grants: [{ roleId: OLD_ROLE, module: 'music', mode: 'allow' as any }] },
+                commandaccess: {
+                    grants: [
+                        {
+                            roleId: OLD_ROLE,
+                            module: 'music',
+                            mode: 'allow' as any,
+                        },
+                    ],
+                },
             })
-            const actual = createMinimalManifest({ roles: { roles: [], channels: [] } })
+            const actual = createMinimalManifest({
+                roles: { roles: [], channels: [] },
+            })
             const plan = createMinimalPlan([
-                { module: 'roles', action: 'create', protected: false, description: 'Create' },
+                {
+                    module: 'roles',
+                    action: 'create',
+                    protected: false,
+                    description: 'Create',
+                },
             ])
             mockFetch
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: NEW_ROLE, name: 'Member' }) })
-                .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: NEW_CHANNEL, name: 'general' }) })
-            const result = await guildAutomationExecutionService.executeApplyPlan({
-                guildId: GUILD_ID, plan, desired, actual, allowProtected: false,
-            })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ id: NEW_ROLE, name: 'Member' }),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ id: NEW_CHANNEL, name: 'general' }),
+                })
+            const result =
+                await guildAutomationExecutionService.executeApplyPlan({
+                    guildId: GUILD_ID,
+                    plan,
+                    desired,
+                    actual,
+                    allowProtected: false,
+                })
             expect(result.remappedManifest).toBeDefined()
-            expect(result.diagnostics.roleIdRemaps).toEqual({ [OLD_ROLE]: NEW_ROLE })
-            expect(result.diagnostics.channelIdRemaps).toEqual({ [OLD_CHANNEL]: NEW_CHANNEL })
+            expect(result.diagnostics.roleIdRemaps).toEqual({
+                [OLD_ROLE]: NEW_ROLE,
+            })
+            expect(result.diagnostics.channelIdRemaps).toEqual({
+                [OLD_CHANNEL]: NEW_CHANNEL,
+            })
         })
 
         test('should note when reactionroles messages require manual setup', async () => {
@@ -1629,7 +1881,10 @@ describe('GuildAutomationExecutionService', () => {
                 })
                 .mockResolvedValueOnce({
                     ok: true,
-                    json: async () => [{ id: GUILD_ID, name: '@everyone' }, { id: ROLE_ID_1, name: 'Member' }],
+                    json: async () => [
+                        { id: GUILD_ID, name: '@everyone' },
+                        { id: ROLE_ID_1, name: 'Member' },
+                    ],
                 })
                 .mockResolvedValueOnce({
                     ok: true,
@@ -1695,7 +1950,10 @@ describe('GuildAutomationExecutionService', () => {
                 })
                 .mockResolvedValueOnce({
                     ok: true,
-                    json: async () => [{ id: GUILD_ID, name: '@everyone' }, { id: ROLE_ID_1, name: 'Admin' }],
+                    json: async () => [
+                        { id: GUILD_ID, name: '@everyone' },
+                        { id: ROLE_ID_1, name: 'Admin' },
+                    ],
                 })
                 .mockResolvedValueOnce({
                     ok: true,
@@ -1862,7 +2120,10 @@ describe('GuildAutomationExecutionService', () => {
         it('isExpectedDeleteError should identify forbidden and not found errors', () => {
             const err403 = new GuildAutomationExecutionError('Forbidden', 403)
             const err404 = new GuildAutomationExecutionError('Not found', 404)
-            const err500 = new GuildAutomationExecutionError('Server error', 500)
+            const err500 = new GuildAutomationExecutionError(
+                'Server error',
+                500,
+            )
             const nonError = new Error('Regular error')
 
             expect(isExpectedDeleteError(err403)).toBe(true)


### PR DESCRIPTION
## Summary

- Replaces legacy direct `applyModerationModule` implementation in `GuildAutomationExecutionService` with `ModerationExecutor` from `@lucky/shared`
- Port wires `updateAutoModSettings` and `updateModerationSettings` through existing `autoModService`/`updateModerationSettings` helpers
- Executor already wired into bot-side `applyPlan.ts` (PR #906); this completes the backend side

## Context

Part of [ADR: Guild Automation Module Executors](../docs/decisions/2026-05-19-guild-automation-module-executors.md) migration. Moderation is executor #2 (DB-only, no DiscordWriteAdapter needed).

**Guild Automation executor status after this PR:**
| Executor | Shared | Bot | Backend |
|---|---|---|---|
| AutoMessages | ✅ | ✅ | ✅ |
| Moderation | ✅ | ✅ | ✅ (this PR) |
| ReactionRoles | ❌ | ❌ | ❌ |
| CommandAccess | ❌ | ❌ | ❌ |
| Onboarding | ❌ | ❌ | ❌ |
| Channels | ❌ | ❌ | ❌ |
| Roles | ❌ | ❌ | ❌ |

## Test plan
- [ ] CI passes (backend unit tests cover `GuildAutomationExecutionService`; moderation executor already tested in shared)
- [ ] `applyModerationModule` no longer calls legacy helpers directly — delegates to executor capture/diff/apply