### PR TITLE
fix(ci): bust stale buildkit npm cache by prefixing ids with v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG NODE_VERSION=22-alpine
 # Lockfile-hash cache key — auto-busts npm BuildKit caches when package-lock.json
 # changes. Passed as a build-arg from the workflow: hashFiles('package-lock.json').
 # Bump the default (v1 → v2) only if you need a forced one-off cache wipe.
-ARG NPM_CACHE_KEY=v1
+ARG NPM_CACHE_KEY=v2
 
 FROM node:${NODE_VERSION} AS base-runtime
 
@@ -57,7 +57,7 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-RUN --mount=type=cache,id=npm-build-stage-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
+RUN --mount=type=cache,id=npm-build-stage-v2-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
     YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     npm ci --legacy-peer-deps --no-audit --no-fund && \
     (npm cache verify 2>/dev/null || true)
@@ -101,7 +101,7 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-RUN --mount=type=cache,id=npm-deps-production-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
+RUN --mount=type=cache,id=npm-deps-production-v2-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
     YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     YOUTUBE_DL_SKIP_PYTHON_CHECK=1 \
     npm ci --legacy-peer-deps --omit=dev --no-audit --no-fund && \


### PR DESCRIPTION
## Problem

BuildKit layer cache for the `npm-build-stage` and `npm-deps-production` stages was poisoned by a prior failed run that silently skipped the `@esbuild/linux-x64@0.28.0` optional tarball. Subsequent cached runs restored the partial state, leaving `tsx/node_modules/esbuild/install.js` to fall back to root `@esbuild/linux-x64@0.27.3` — a version mismatch that broke `esbuild`.

The `NPM_CACHE_KEY` build-arg exists precisely for forced one-off cache wipes (see the comment on line 8), but its default is `v1`. Changing the default to `v2` wipes both cache entries on the next build.

The static `v2-` prefix is also added to both cache IDs so that the next workflow run cannot accidentally re-hit the poisoned `v1` cache even when `NPM_CACHE_KEY` is not explicitly passed.

## Changes

- `ARG NPM_CACHE_KEY` default: `v1` → `v2`
- Build stage cache ID: `npm-build-stage-${NPM_CACHE_KEY}` → `npm-build-stage-v2-${NPM_CACHE_KEY}`
- Deps-production stage cache ID: `npm-deps-production-${NPM_CACHE_KEY}` → `npm-deps-production-v2-${NPM_CACHE_KEY}`

## Impact

Unblocks PRs #944, #953, #954 that were failing Docker builds due to the esbuild version mismatch.