### PR TITLE
fix(codeql): resolve open codeql alerts

### DIFF
--- a/packages/backend/tests/unit/routes/artists.test.ts
+++ b/packages/backend/tests/unit/routes/artists.test.ts
@@ -5,7 +5,6 @@ import {
     searchSpotifyArtists,
     getSpotifyRelatedArtists,
     getPrismaClient,
-    errorLog,
 } from '@lucky/shared/utils'
 import {
     getSpotifyClientToken,

--- a/packages/bot/src/functions/general/commands/giveaway.ts
+++ b/packages/bot/src/functions/general/commands/giveaway.ts
@@ -8,7 +8,6 @@ import { requireGuild } from '../../../utils/command/commandValidations'
 import {
     createSuccessEmbed,
     createErrorEmbed,
-    createInfoEmbed,
 } from '../../../utils/general/embeds'
 import { errorLog } from '@lucky/shared/utils'
 

--- a/packages/bot/src/services/musicRecommendation/recommendationEngine.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/recommendationEngine.spec.ts
@@ -169,11 +169,6 @@ describe('recommendationEngine', () => {
             calculateVectorSimilarityMock.mockReturnValue(0.8)
             generateRecommendationReasonsMock.mockReturnValue(['Similar'])
 
-            const allRecs = availableTracks.map((track, idx) => ({
-                track,
-                score: 0.775 - idx * 0.01,
-                reasons: ['Similar'],
-            }))
             // Diversity filter removes duplicates
             const filteredRecs = [
                 {

--- a/packages/bot/src/utils/music/autoplay/candidateCollector.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.ts
@@ -10,7 +10,6 @@ import {
 } from './spotifyRecommender'
 import { calculateRecommendationScore } from './candidateScorer'
 import { normalizeTrackKey } from './scoringUtils'
-import { isDuplicateCandidate } from './diversitySelector'
 import {
     shouldIncludeCandidate,
     upsertScoredCandidate,

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -114,12 +114,6 @@ export async function collectBroadFallbackCandidates(
         `${ctx.currentTrack.author} popular`,
     ].filter(Boolean)
 
-    // Obtain Spotify token once for the whole fallback pass — used to enrich
-    // genre tags when Last.fm is not linked (getArtistTags returns []).
-    // Promise.resolve() guards against stubs that return undefined rather than
-    // a Promise (matches the pattern used throughout replenisher.ts).
-    const spotifyToken = null // Will be obtained from context if needed
-
     for (const query of fallbackQueries) {
         try {
             const result = await ctx.queue.player.search(query, {
@@ -156,23 +150,6 @@ export async function collectBroadFallbackCandidates(
                         return [] as string[]
                     },
                 )
-                // When Last.fm returns nothing (not linked or artist unknown),
-                // use Spotify's genre data so the cross-locale Spanish veto in
-                // candidateScorer can still fire for Spanish gospel artists
-                // that have non-Spanish-looking artist names / titles.
-                if (candidateTags.length === 0 && spotifyToken) {
-                    candidateTags = await getArtistGenres(
-                        spotifyToken,
-                        track.author,
-                    ).catch((err: unknown) => {
-                        logAndSwallow(
-                            err,
-                            'candidateFallback.getArtistGenres.spotifyFallback',
-                            { author: track.author },
-                        )
-                        return [] as string[]
-                    }) // NOSONAR — track.author used as URLSearchParams search query inside getArtistGenres; no raw URL interpolation
-                }
                 const rec = calculateRecommendationScore({
                     candidate: track,
                     currentTrack: ctx.currentTrack,

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -42,13 +42,6 @@ const QueryType = {
     SPOTIFY_SEARCH: 'spotifySearch',
 } as const
 
-const QueueRepeatMode = {
-    OFF: 0,
-    TRACK: 1,
-    QUEUE: 2,
-    AUTOPLAY: 3,
-} as const
-
 type GuildQueue = any
 type Track = any
 

--- a/packages/bot/src/utils/music/service.spec.ts
+++ b/packages/bot/src/utils/music/service.spec.ts
@@ -39,7 +39,6 @@ import * as queueStateMgr from './queueStateManager'
 import { trackHistoryService } from '@lucky/shared/services'
 
 const queueOpsMock = queueOps as unknown as Record<string, jest.Mock>
-const queueStateMgrMock = queueStateMgr as unknown as Record<string, jest.Mock>
 const trackHistoryServiceMock = trackHistoryService as unknown as Record<
     string,
     jest.Mock

--- a/packages/bot/src/utils/music/titleComparison/service.spec.ts
+++ b/packages/bot/src/utils/music/titleComparison/service.spec.ts
@@ -191,7 +191,7 @@ describe('TitleComparisonService', () => {
         })
 
         it('should set up cache cleanup interval with logging', () => {
-            const svc = new TitleComparisonService()
+            new TitleComparisonService()
             expect(safeSetIntervalMock).toHaveBeenCalledWith(
                 expect.any(Function),
                 600000,

--- a/packages/bot/src/utils/music/trackNormalization.spec.ts
+++ b/packages/bot/src/utils/music/trackNormalization.spec.ts
@@ -11,7 +11,6 @@ jest.mock('./searchQueryCleaner', () => ({
 import {
     normalizeText,
     normalizeTrackKey,
-    FUZZY_TITLE_THRESHOLD,
     getGenreFamilies,
     calculateGenreFamilyPenalty,
 } from './trackNormalization'

--- a/packages/bot/src/utils/music/trackUtils/index.spec.ts
+++ b/packages/bot/src/utils/music/trackUtils/index.spec.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import {
     TrackUtils,
-    trackUtils,
     getTrackInfo,
     getTrackCacheKey,
     categorizeTracks,

--- a/packages/shared/src/services/guildAutomation/GuildAutomationRepository.ts
+++ b/packages/shared/src/services/guildAutomation/GuildAutomationRepository.ts
@@ -258,37 +258,33 @@ export class GuildAutomationRepository implements IGuildAutomationRepository {
         checklist: unknown[],
         initiatedBy?: string,
     ) {
-        const { manifestRow, run } = await this.prisma.$transaction(
-            async (tx) => {
-                const manifestRow = await tx.guildAutomationManifest.update({
-                    where: { guildId },
-                    data: {
-                        version: nextManifest.version,
-                        manifest: toJsonValue(nextManifest),
-                    },
-                })
+        const { run } = await this.prisma.$transaction(async (tx) => {
+            const manifestRow = await tx.guildAutomationManifest.update({
+                where: { guildId },
+                data: {
+                    version: nextManifest.version,
+                    manifest: toJsonValue(nextManifest),
+                },
+            })
 
-                const run = await tx.guildAutomationRun.create({
-                    data: {
-                        guildId,
-                        manifestId: manifestRow.id,
-                        type: 'cutover',
-                        status: 'completed',
-                        summary: toJsonValue({
-                            checklistComplete: true,
-                            checklist:
-                                nextManifest.parity?.checklist ?? checklist,
-                            externalBots:
-                                nextManifest.parity?.externalBots ?? [],
-                        }),
-                        initiatedBy,
-                        completedAt: new Date(),
-                    },
-                })
+            const run = await tx.guildAutomationRun.create({
+                data: {
+                    guildId,
+                    manifestId: manifestRow.id,
+                    type: 'cutover',
+                    status: 'completed',
+                    summary: toJsonValue({
+                        checklistComplete: true,
+                        checklist: nextManifest.parity?.checklist ?? checklist,
+                        externalBots: nextManifest.parity?.externalBots ?? [],
+                    }),
+                    initiatedBy,
+                    completedAt: new Date(),
+                },
+            })
 
-                return { manifestRow, run }
-            },
-        )
+            return { manifestRow, run }
+        })
 
         return {
             id: run.id,


### PR DESCRIPTION
Resolves all 11 open CodeQL alerts.

**1 warning — `js/trivial-conditional`**
- `candidateFallback.ts`: `spotifyToken` was permanently `null` (deferred stub), making the entire `if (candidateTags.length === 0 && spotifyToken)` block unreachable. Removed the dead block.

**10 notes — `js/unused-local-variable`**
- `GuildAutomationRepository.ts`: `manifestRow` destructured but unused in `runCutover`
- `giveaway.ts`: `createInfoEmbed` import never referenced
- `candidateCollector.ts`: `isDuplicateCandidate` import never referenced
- Specs: unused imports (`FUZZY_TITLE_THRESHOLD`, `trackUtils`, `errorLog`) and unused locals (`QueueRepeatMode` const, `queueStateMgrMock`, `allRecs`)
- `titleComparison/service.spec.ts`: `const svc = new TitleComparisonService()` → bare constructor call (side-effect only)

All changes verified: `type:check` clean across all packages; 7 bot test suites (185 tests) + 2 backend test suites (63 tests) pass.