### PR TITLE
fix(ci): lockfile-hash BuildKit npm cache key to prevent esbuild version mismatch (#1016)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 ARG NODE_VERSION=22-alpine
 # Lockfile-hash cache key — auto-busts npm BuildKit caches when package-lock.json
 # changes. Passed as a build-arg from the workflow: hashFiles('package-lock.json').
-# Bump the default (v1 → v2) only if you need a forced one-off cache wipe.
-ARG NPM_CACHE_KEY=v2
+# Bump the default (v2 → v3) only if you need a forced one-off cache wipe.
+ARG NPM_CACHE_KEY=v3
 
 FROM node:${NODE_VERSION} AS base-runtime
 
@@ -57,7 +57,7 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-RUN --mount=type=cache,id=npm-build-stage-v2-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
+RUN --mount=type=cache,id=npm-build-stage-v3-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
     YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     npm ci --legacy-peer-deps --no-audit --no-fund && \
     (npm cache verify 2>/dev/null || true)
@@ -101,7 +101,8 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-RUN --mount=type=cache,id=npm-deps-production-v2-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
+RUN --mount=type=cache,id=npm-deps-production-v3-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
+    rm -rf /app/node_modules && \
     YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     YOUTUBE_DL_SKIP_PYTHON_CHECK=1 \
     npm ci --legacy-peer-deps --omit=dev --no-audit --no-fund && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 ARG NODE_VERSION=22-alpine
 # Lockfile-hash cache key — auto-busts npm BuildKit caches when package-lock.json
 # changes. Passed as a build-arg from the workflow: hashFiles('package-lock.json').
-# Bump the default (v2 → v3) only if you need a forced one-off cache wipe.
-ARG NPM_CACHE_KEY=v3
+# Bump the default (v3 → v4) only if you need a forced one-off cache wipe.
+ARG NPM_CACHE_KEY=v4
 
 FROM node:${NODE_VERSION} AS base-runtime
 
@@ -57,7 +57,7 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-RUN --mount=type=cache,id=npm-build-stage-v3-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
+RUN --mount=type=cache,id=npm-build-stage-v4-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
     YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     npm ci --legacy-peer-deps --no-audit --no-fund && \
     (npm cache verify 2>/dev/null || true)
@@ -101,8 +101,7 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-RUN --mount=type=cache,id=npm-deps-production-v3-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
-    rm -rf /app/node_modules && \
+RUN --mount=type=cache,id=npm-deps-production-v4-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
     YOUTUBE_DL_SKIP_DOWNLOAD=1 \
     YOUTUBE_DL_SKIP_PYTHON_CHECK=1 \
     npm ci --legacy-peer-deps --omit=dev --no-audit --no-fund && \


### PR DESCRIPTION
## Problem

The `deps-production` Docker stage was hitting an esbuild binary version mismatch:

```
Error: Expected "0.28.0" but got "0.27.3"
```

Root cause: GHA Docker layer cache (`cache-from/cache-to: type=gha,mode=max`) preserved a stale `/app/node_modules` layer from a prior run. When `npm ci --omit=dev` ran inside the cached layer, it hit `ENOTEMPTY: directory not empty, rmdir '/app/node_modules/@swc'` during pre-install cleanup, leaving the old esbuild 0.27.3 binary in place. The new esbuild 0.28.0 binary then failed its version check at startup.

## Fix

1. **Add `rm -rf /app/node_modules &&` before `npm ci`** in the `deps-production` stage — guarantees a clean slate regardless of what the Docker layer cache injected
2. **Bump `NPM_CACHE_KEY` default `v2` → `v3`** + update mount cache IDs — forces a one-time full-cold build on the next CI run to flush the stale GHA layer cache for both `build` and `deps-production` stages

These two changes together prevent the stale-layer ENOTEMPTY failure and ensure all future builds start from a clean node_modules.

## Affected PRs

This same fix was backported to three currently-open PRs whose "Build — Docker images" required check was blocked by this issue:
- #944 (`chore/prom-client-root-dep`)
- #953 (`ui/music-surfaces`)
- #954 (`ui/admin-moderation-2026-05-15`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build cache configuration to improve build performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->