### PR TITLE
fix(deps): sync package-lock.json – unblock Vercel @types/react build failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1859,7 +1859,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
             "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
@@ -1870,7 +1870,7 @@
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
             "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@clack/core": "0.5.0",
@@ -2629,14 +2629,14 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
             "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@electric-sql/pglite-socket": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
             "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "pglite-server": "dist/scripts/server.js"
@@ -2649,7 +2649,7 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
             "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@electric-sql/pglite": "0.4.1"
@@ -2659,7 +2659,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
             "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2671,7 +2670,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
             "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2682,7 +2680,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
             "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3345,7 +3342,7 @@
             "version": "1.19.13",
             "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
             "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18.14.1"
@@ -4226,7 +4223,7 @@
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
             "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@lucky/backend": {
@@ -4835,7 +4832,7 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
             "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -5472,7 +5469,7 @@
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
             "integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "c12": "3.3.4",
@@ -5491,7 +5488,7 @@
             "version": "0.24.3",
             "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
             "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "@electric-sql/pglite": "0.4.1",
@@ -5526,7 +5523,7 @@
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
             "integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5540,14 +5537,14 @@
             "version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
             "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
             "integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
             "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "7.8.0"
@@ -5557,7 +5554,7 @@
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
             "integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "7.8.0",
@@ -5569,7 +5566,7 @@
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
             "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "7.8.0"
@@ -5579,7 +5576,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
             "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "7.2.0"
@@ -5589,7 +5586,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
             "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/instrumentation": {
@@ -5649,14 +5646,14 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
             "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/streams-local": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
             "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^8.12.0",
@@ -5673,7 +5670,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
             "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -5686,7 +5683,7 @@
             "version": "0.27.3",
             "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
             "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@radix-ui/react-toggle": "1.1.10",
@@ -7237,7 +7234,7 @@
             "version": "1.1.10",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
             "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@radix-ui/primitive": "1.1.3",
@@ -7263,7 +7260,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
             "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@radix-ui/react-slot": "1.2.3"
@@ -7287,7 +7284,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
             "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@radix-ui/react-compose-refs": "1.1.2"
@@ -9697,7 +9694,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@standard-schema/utils": {
@@ -9710,7 +9707,7 @@
             "version": "1.15.40",
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
             "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -9955,14 +9952,14 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@swc/types": {
             "version": "0.1.26",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
             "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -10901,11 +10898,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/react": {
+            "version": "19.2.15",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+            "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.2.2"
+            }
+        },
         "node_modules/@types/react-dom": {
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -12199,7 +12206,7 @@
             "version": "8.20.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -12415,7 +12422,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
             "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0"
@@ -12648,7 +12655,7 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.7.0.tgz",
             "integrity": "sha512-7zrmXjAK8u8Z6SOe4R65XObOR5X+Y2I/VVku3t5cPOGQ8/WsBcfFmfnIPiEl5EBMDOzPHRwbiPbMtQBKYdw7RA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@clack/prompts": "^0.11.0"
@@ -13097,7 +13104,7 @@
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
             "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^5.0.0",
@@ -13126,7 +13133,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "readdirp": "^5.0.0"
@@ -13142,7 +13149,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
             "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 20.19.0"
@@ -13342,7 +13349,7 @@
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
             "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
@@ -13716,7 +13723,7 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
             "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/connect-redis": {
@@ -14007,7 +14014,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/dargs": {
@@ -14130,7 +14137,7 @@
             "version": "7.1.5",
             "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
             "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=16.0.0"
@@ -14153,7 +14160,7 @@
             "version": "6.1.7",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
             "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/delayed-stream": {
@@ -14203,7 +14210,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
             "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/detect-libc": {
@@ -14473,7 +14480,7 @@
             "version": "3.21.2",
             "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
             "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
@@ -14511,7 +14518,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
             "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14"
@@ -15239,7 +15246,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
             "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/ext-list": {
@@ -15273,7 +15280,7 @@
             "version": "3.23.2",
             "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
             "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "individual",
@@ -15296,7 +15303,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
             "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "individual",
@@ -15347,7 +15354,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
             "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -15641,7 +15648,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
             "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "cross-spawn": "^7.0.6",
@@ -15658,7 +15665,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -15898,7 +15905,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
             "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "is-property": "^1.0.2"
@@ -15984,7 +15991,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
             "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/get-proto": {
@@ -16017,7 +16024,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
             "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "bin": {
                 "giget": "dist/cli.mjs"
@@ -16204,14 +16211,14 @@
             "version": "3.1.12",
             "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
             "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/graphmatch": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
             "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/handlebars": {
@@ -16337,7 +16344,7 @@
             "version": "4.12.18",
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
             "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -16462,7 +16469,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
             "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/http2-wrapper": {
@@ -16846,7 +16853,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
             "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/is-stream": {
@@ -18364,7 +18371,7 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -18506,7 +18513,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
@@ -19158,7 +19165,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
             "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/lowercase-keys": {
@@ -19188,7 +19195,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
             "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "bun": ">=1.0.0",
@@ -19672,7 +19679,7 @@
             "version": "3.15.3",
             "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
             "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "aws-ssl-profiles": "^1.1.1",
@@ -19693,7 +19700,7 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -19721,7 +19728,7 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
             "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "lru.min": "^1.1.0"
@@ -19734,7 +19741,7 @@
             "version": "3.3.12",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
             "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -20019,7 +20026,7 @@
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
             "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/on-finished": {
@@ -20383,7 +20390,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
             "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/pg": {
@@ -20594,7 +20601,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
             "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "confbox": "^0.2.2",
@@ -20681,7 +20688,7 @@
             "version": "8.5.15",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
             "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -20764,7 +20771,7 @@
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
             "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Unlicense",
             "engines": {
                 "node": ">=12"
@@ -20873,7 +20880,7 @@
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
             "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -20938,7 +20945,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
             "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -20950,7 +20957,7 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
             "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -21098,7 +21105,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
             "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "defu": "^6.1.6",
@@ -21445,7 +21452,7 @@
             "version": "2.33.4",
             "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
             "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/remeda"
@@ -21909,7 +21916,7 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
             "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/serve-static": {
             "version": "2.2.1",
@@ -22096,7 +22103,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/slash": {
@@ -22362,7 +22369,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
             "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -22429,7 +22436,7 @@
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
             "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/streamx": {
@@ -22944,7 +22951,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
             "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/tailwindcss-animate": {
@@ -23471,7 +23477,7 @@
             "version": "4.22.3",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
             "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.28.0"
@@ -23932,7 +23938,7 @@
             "version": "0.28.0",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
             "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -24364,7 +24370,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
             "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peerDependencies": {
                 "typescript": ">=5"
@@ -24871,7 +24877,6 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
             "license": "ISC",
             "optional": true,
             "bin": {
@@ -25022,7 +25027,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
             "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "grammex": "^3.1.11",
@@ -25448,16 +25453,6 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": ">=7.24.0 <7.24.7"
-            }
-        },
-        "packages/frontend/node_modules/@types/react": {
-            "version": "19.2.15",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-            "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "csstype": "^3.2.2"
             }
         },
         "packages/frontend/node_modules/@vitest/coverage-v8": {


### PR DESCRIPTION
## Problem

Vercel builds have been failing since commit `34c309f8` (prom-client root dep hoisting) with:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @types/react@19.2.15 from lock file
```

## Root cause

The lockfile had `@types/react@19.2.15` stored at the workspace-local path (`packages/frontend/node_modules/@types/react`) rather than the root (`node_modules/@types/react`). When `34c309f8` ran `npm install` to add prom-client, npm's resolution algorithm changed the expected location (hoisting), but the lockfile structure didn't reflect this. `npm ci` enforces strict sync and fails when the lockfile diverges from what `npm install` would produce.

## Fix

Ran `npm install` from repo root to regenerate `package-lock.json` with the correct hoisted structure. `@types/react@19.2.15` is now at `node_modules/@types/react` (root-hoisted) and the workspace-local duplicate entry has been removed.

## Verification

- `node_modules/@types/react: 19.2.15` — present in lockfile ✓
- `packages/frontend/node_modules/@types/react` — removed (no longer needed) ✓
- Pre-commit type-check passed across all packages ✓