### PR TITLE
fix: resolve discord 429 rate-limit storm and archived thread crash

### DIFF
--- a/packages/backend/src/services/GuildAccessService.ts
+++ b/packages/backend/src/services/GuildAccessService.ts
@@ -151,6 +151,11 @@ class GuildAccessService {
         options?: { allowCachedFallback?: boolean },
     ): Promise<DiscordGuild[]> {
         const allowCachedFallback = options?.allowCachedFallback ?? true
+        const cached = await this.getCachedGuilds(session)
+        if (cached) {
+            return cached
+        }
+
         const cacheKey = this.getCacheKey(session)
         const inFlight = this.userGuildsInFlight.get(cacheKey)
         if (inFlight) {

--- a/packages/backend/tests/unit/services/GuildAccessService.test.ts
+++ b/packages/backend/tests/unit/services/GuildAccessService.test.ts
@@ -9,7 +9,10 @@ const mockHasAdminPermission = jest.fn<
 >()
 
 class MockDiscordApiError extends Error {
-    constructor(public readonly statusCode: number, message = 'Discord API error') {
+    constructor(
+        public readonly statusCode: number,
+        message = 'Discord API error',
+    ) {
         super(message)
         this.name = 'DiscordApiError'
     }
@@ -40,8 +43,7 @@ jest.mock('../../../src/services/DiscordOAuthService', () => ({
         getUserGuilds: (...args: [string]) => mockGetUserGuilds(...args),
         hasAdminPermission: (
             ...args: [string | null | undefined, string | null | undefined]
-        ) =>
-            mockHasAdminPermission(...args),
+        ) => mockHasAdminPermission(...args),
     },
 }))
 
@@ -93,9 +95,7 @@ const MANAGE_ALL_ACCESS = {
     integrations: 'manage',
 }
 
-async function expectRbacStorageUnavailable(
-    operation: Promise<unknown>,
-) {
+async function expectRbacStorageUnavailable(operation: Promise<unknown>) {
     await expect(operation).rejects.toMatchObject({
         statusCode: 503,
         message:
@@ -244,7 +244,9 @@ describe('GuildAccessService', () => {
             new DiscordApiError(401, 'invalid token'),
         )
 
-        await expect(guildAccessService.listAuthorizedGuilds(SESSION)).rejects.toMatchObject({
+        await expect(
+            guildAccessService.listAuthorizedGuilds(SESSION),
+        ).rejects.toMatchObject({
             statusCode: 401,
             message: 'Discord session expired. Please sign in again.',
         })
@@ -256,9 +258,12 @@ describe('GuildAccessService', () => {
             message: 'missing scope',
         })
 
-        await expect(guildAccessService.listAuthorizedGuilds(SESSION)).rejects.toMatchObject({
+        await expect(
+            guildAccessService.listAuthorizedGuilds(SESSION),
+        ).rejects.toMatchObject({
             statusCode: 403,
-            message: 'Discord OAuth scope is missing. Re-authenticate and try again.',
+            message:
+                'Discord OAuth scope is missing. Re-authenticate and try again.',
         })
     })
 
@@ -288,7 +293,9 @@ describe('GuildAccessService', () => {
             message: 'rate limited',
         })
 
-        await expect(guildAccessService.listAuthorizedGuilds(SESSION)).rejects.toMatchObject({
+        await expect(
+            guildAccessService.listAuthorizedGuilds(SESSION),
+        ).rejects.toMatchObject({
             statusCode: 502,
             message: 'Discord API is temporarily unavailable. Please retry.',
         })
@@ -319,9 +326,9 @@ describe('GuildAccessService', () => {
         const unknownError = new Error('boom')
         mockGetUserGuilds.mockRejectedValue(unknownError)
 
-        await expect(guildAccessService.listAuthorizedGuilds(SESSION)).rejects.toBe(
-            unknownError,
-        )
+        await expect(
+            guildAccessService.listAuthorizedGuilds(SESSION),
+        ).rejects.toBe(unknownError)
     })
 
     test('listAuthorizedGuilds skips guild when access resolution throws', async () => {
@@ -330,12 +337,14 @@ describe('GuildAccessService', () => {
 
         mockGetUserGuilds.mockResolvedValue(guilds)
         mockHasBotInGuild.mockResolvedValue(true)
-        mockResolveEffectiveAccess.mockImplementation(async (guildId: string) => {
-            if (guildId === '202') {
-                throw new Error('policy lookup failed')
-            }
-            return adminAccess
-        })
+        mockResolveEffectiveAccess.mockImplementation(
+            async (guildId: string) => {
+                if (guildId === '202') {
+                    throw new Error('policy lookup failed')
+                }
+                return adminAccess
+            },
+        )
 
         const result = await guildAccessService.listAuthorizedGuilds(SESSION)
 
@@ -370,7 +379,9 @@ describe('GuildAccessService', () => {
             new Error('rbac dependency unavailable'),
         )
 
-        await expect(guildAccessService.listAuthorizedGuilds(SESSION)).rejects.toMatchObject({
+        await expect(
+            guildAccessService.listAuthorizedGuilds(SESSION),
+        ).rejects.toMatchObject({
             statusCode: 502,
             message: 'Unable to resolve server access right now. Please retry.',
         })
@@ -460,7 +471,9 @@ describe('GuildAccessService', () => {
             new Error('member context unavailable'),
         )
 
-        await expect(guildAccessService.listAuthorizedGuilds(SESSION)).rejects.toMatchObject({
+        await expect(
+            guildAccessService.listAuthorizedGuilds(SESSION),
+        ).rejects.toMatchObject({
             statusCode: 502,
             message: 'Unable to resolve server access right now. Please retry.',
         })
@@ -479,9 +492,9 @@ describe('GuildAccessService', () => {
             { ...guild, id: 'unknown-guild', hasBot: true },
         ])
 
-        await expect(guildAccessService.listAuthorizedGuilds(SESSION)).rejects.toThrow(
-            'Missing authorized context for guild unknown-guild',
-        )
+        await expect(
+            guildAccessService.listAuthorizedGuilds(SESSION),
+        ).rejects.toThrow('Missing authorized context for guild unknown-guild')
     })
 
     test('resolveGuildContext returns null when guild is not in user guild list', async () => {
@@ -596,13 +609,15 @@ describe('GuildAccessService', () => {
         const cachedGuilds = JSON.stringify([guild])
 
         mockRedisIsHealthy.mockReturnValue(true)
-        mockRedisGet.mockResolvedValue(cachedGuilds)
+        // First call: cache miss → Discord API populates it
+        mockRedisGet.mockResolvedValueOnce(null)
         mockGetUserGuilds.mockResolvedValueOnce([guild])
         mockResolveEffectiveAccess.mockResolvedValue(adminAccess)
         await guildAccessService.listAuthorizedGuilds(SESSION)
         expect(mockRedisSetex).toHaveBeenCalledTimes(1)
 
-        mockGetUserGuilds.mockRejectedValueOnce({ status: 429 })
+        // Second call: cache is populated — Discord is never called, no 429 possible
+        mockRedisGet.mockResolvedValue(cachedGuilds)
 
         await expect(
             guildAccessService.resolveGuildContext(SESSION, guild.id),
@@ -625,7 +640,9 @@ describe('GuildAccessService', () => {
 
         expect(mockRedisSetex).toHaveBeenCalledTimes(1)
         const redisKey = mockRedisSetex.mock.calls[0][0]
-        expect(redisKey).toContain(`guild-access:user-guilds:${SESSION.user.id}:`)
+        expect(redisKey).toContain(
+            `guild-access:user-guilds:${SESSION.user.id}:`,
+        )
         expect(redisKey).not.toContain(SESSION.accessToken)
         expect(redisKey).not.toContain(SESSION.accessToken.slice(0, 24))
     })

--- a/packages/bot/src/services/AiDevToolkitService.ts
+++ b/packages/bot/src/services/AiDevToolkitService.ts
@@ -1,4 +1,9 @@
-import { type Client, type TextChannel, type Message } from 'discord.js'
+import {
+    type Client,
+    type TextChannel,
+    type ThreadChannel,
+    type Message,
+} from 'discord.js'
 import { getPrismaClient } from '@lucky/shared/utils'
 import { infoLog, errorLog, debugLog } from '@lucky/shared/utils'
 
@@ -387,14 +392,27 @@ class AiDevToolkitService {
         const stored = await this.getStoredGuide()
 
         try {
-            const channel = (await client.channels.fetch(
-                CHANNEL_ID,
-            )) as TextChannel | null
+            const channel = (await client.channels.fetch(CHANNEL_ID)) as
+                | TextChannel
+                | ThreadChannel
+                | null
             if (!channel?.isTextBased()) {
                 errorLog({
                     message: `AiDevToolkitService: channel ${CHANNEL_ID} not found or not text-based`,
                 })
                 return
+            }
+
+            if (channel.isThread() && channel.archived) {
+                try {
+                    await channel.setArchived(false)
+                } catch (error) {
+                    errorLog({
+                        message: `AiDevToolkitService: cannot unarchive thread ${CHANNEL_ID}, skipping sync`,
+                        error,
+                    })
+                    return
+                }
             }
 
             const existingMessages: Message[] = []

--- a/packages/bot/tests/services/AiDevToolkitService.test.ts
+++ b/packages/bot/tests/services/AiDevToolkitService.test.ts
@@ -1,0 +1,133 @@
+import type { Client } from 'discord.js'
+
+const mockErrorLog = jest.fn()
+const mockInfoLog = jest.fn()
+const mockGetPrismaClient = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: (...args: unknown[]) => mockErrorLog(...args),
+    infoLog: (...args: unknown[]) => mockInfoLog(...args),
+    debugLog: jest.fn(),
+    getPrismaClient: () => mockGetPrismaClient(),
+}))
+
+import { aiDevToolkitService } from '../../src/services/AiDevToolkitService'
+
+function makeSnapshot() {
+    return {
+        commitSha: 'abc1234',
+        patterns: [],
+        lastUpdated: new Date().toISOString(),
+    }
+}
+
+function makeChannel(overrides: Record<string, unknown> = {}) {
+    return {
+        isTextBased: () => true,
+        isThread: () => false,
+        archived: false,
+        setArchived: jest
+            .fn<Promise<void>, [boolean]>()
+            .mockResolvedValue(undefined),
+        messages: {
+            fetch: jest.fn().mockRejectedValue(new Error('not found')),
+        },
+        send: jest.fn().mockResolvedValue({ id: 'msg-1' }),
+        ...overrides,
+    }
+}
+
+function makeClient(channel: ReturnType<typeof makeChannel> | null) {
+    return {
+        channels: { fetch: jest.fn().mockResolvedValue(channel) },
+    } as unknown as Client
+}
+
+describe('AiDevToolkitService', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const svc = aiDevToolkitService as any
+    let fetchSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        svc.lastCommitSha = null
+        fetchSpy = jest
+            .spyOn(svc, 'fetchRepoSnapshot')
+            .mockResolvedValue(makeSnapshot())
+        mockGetPrismaClient.mockReturnValue({
+            liveBoard: {
+                findUnique: jest.fn().mockResolvedValue(null),
+                upsert: jest.fn().mockResolvedValue({}),
+            },
+        })
+    })
+
+    afterEach(() => {
+        fetchSpy.mockRestore()
+    })
+
+    describe('syncBoard — archived thread guard', () => {
+        it('unarchives the thread before posting when it is archived', async () => {
+            const mockSetArchived = jest
+                .fn<Promise<void>, [boolean]>()
+                .mockResolvedValue(undefined)
+            const channel = makeChannel({
+                isThread: () => true,
+                archived: true,
+                setArchived: mockSetArchived,
+            })
+
+            await aiDevToolkitService.syncBoard(makeClient(channel))
+
+            expect(mockSetArchived).toHaveBeenCalledWith(false)
+            expect(channel.send).toHaveBeenCalled()
+        })
+
+        it('skips the sync cycle and logs error when unarchive fails', async () => {
+            const mockSetArchived = jest
+                .fn<Promise<void>, [boolean]>()
+                .mockRejectedValue(new Error('Missing Permissions'))
+            const channel = makeChannel({
+                isThread: () => true,
+                archived: true,
+                setArchived: mockSetArchived,
+            })
+
+            await aiDevToolkitService.syncBoard(makeClient(channel))
+
+            expect(mockSetArchived).toHaveBeenCalledWith(false)
+            expect(mockErrorLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining('cannot unarchive'),
+                }),
+            )
+            expect(channel.send).not.toHaveBeenCalled()
+        })
+
+        it('does not call setArchived when the thread is not archived', async () => {
+            const mockSetArchived = jest.fn()
+            const channel = makeChannel({
+                isThread: () => true,
+                archived: false,
+                setArchived: mockSetArchived,
+            })
+
+            await aiDevToolkitService.syncBoard(makeClient(channel))
+
+            expect(mockSetArchived).not.toHaveBeenCalled()
+            expect(channel.send).toHaveBeenCalled()
+        })
+
+        it('does not call setArchived for regular text channels', async () => {
+            const mockSetArchived = jest.fn()
+            const channel = makeChannel({
+                isThread: () => false,
+                setArchived: mockSetArchived,
+            })
+
+            await aiDevToolkitService.syncBoard(makeClient(channel))
+
+            expect(mockSetArchived).not.toHaveBeenCalled()
+        })
+    })
+})


### PR DESCRIPTION
## What

Fixes 3 escalating/regressed Sentry issues found in production.

## Issues fixed

### LUCKY-27 & LUCKY-28 — Discord 429 rate-limit storm (escalating)

**Root cause:** `GuildAccessService.fetchUserGuilds` had Redis caching implemented but never read the cache _before_ calling Discord. The `getCachedGuilds` call only existed inside the `catch` block as a 429 fallback. Every single authenticated request to any guild-protected endpoint called Discord's `/users/@me/guilds` unconditionally, causing the rate-limit storm (112 + 84 events, both escalating, firing minutes ago).

**Fix:** Add a primary cache read-through at the top of `fetchUserGuilds`. If Redis has a fresh guild list (30s TTL), return it immediately without touching Discord. The existing in-flight dedup and 429 fallback logic are preserved.

**Test:** Updated the 429-fallback test to reflect the improved behavior — with a warm cache, `resolveGuildContext` now returns from Redis directly and never reaches Discord at all.

### LUCKY-3G — `DiscordAPIError[50083]: Thread is archived` (regressed)

**Root cause:** `AiDevToolkitService.syncBoard` posts into a Discord thread (`CHANNEL_ID`). Discord auto-archives idle threads. When the thread is archived, `existingMessages[i].edit()` throws error 50083. The error was caught and logged (appearing as "handled" in Sentry) but the sync cycle aborted on every run — 85 events over 24 days.

**Fix:** After fetching the channel, check `channel.isThread() && channel.archived`. If archived, call `channel.setArchived(false)` before proceeding. If unarchiving fails, log and skip the sync cycle gracefully. Also widened the channel type cast from `TextChannel` to `TextChannel | ThreadChannel` so TypeScript narrows correctly inside `isThread()`.

## Files changed

- `packages/backend/src/services/GuildAccessService.ts` — primary cache read-through (+5 lines)
- `packages/backend/tests/unit/services/GuildAccessService.test.ts` — updated 429-fallback test
- `packages/bot/src/services/AiDevToolkitService.ts` — archived thread unarchive guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for thread channels in guide synchronization.

* **Performance**
  * Guild access queries now prioritize cached data when available for faster retrieval.

* **Tests**
  * Enhanced test patterns with explicit async/await assertions and improved cache-hit/miss scenario coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->