### PR TITLE
chore(release): bump version to 2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.1] - 2026-05-28
+
+### Fixed
+- fix(backend): add primary redis cache read-through to `GuildAccessService.fetchUserGuilds` — every request was hitting Discord's `/users/@me/guilds` unconditionally, causing the 429 rate-limit storm (LUCKY-27, LUCKY-28) (#1078)
+- fix(bot): unarchive idle discord thread before syncing the ai-dev-toolkit board; skip cycle gracefully if unarchive is not permitted, preventing recurring `DiscordAPIError[50083]` (LUCKY-3G) (#1078)
+
 ## [2.15.0] - 2026-05-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.15.0",
+    "version": "2.15.1",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.15.0",
+    "version": "2.15.1",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.15.0",
+    "version": "2.15.1",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.15.0",
+    "version": "2.15.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.15.0",
+    "version": "2.15.1",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
Hotfix release bump — no logic changes.

Bumps all package versions `2.15.0 → 2.15.1` and adds the CHANGELOG entry for the fixes shipped in #1078 (discord 429 rate-limit storm + archived thread crash).