### PR TITLE
feat(autoplay): record selected mode on recommendation telemetry

### DIFF
--- a/packages/bot/src/services/musicRecommendation/recommendationTelemetry.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/recommendationTelemetry.spec.ts
@@ -89,6 +89,7 @@ describe('recommendationTelemetry', () => {
                     signals: input.basis.signals,
                     reason: 'spotify rec • preferred artist • completed before',
                     confidence: null,
+                    mode: null,
                 },
             })
         })

--- a/packages/bot/src/services/musicRecommendation/recommendationTelemetry.ts
+++ b/packages/bot/src/services/musicRecommendation/recommendationTelemetry.ts
@@ -16,6 +16,7 @@ export interface RecordPickInput {
     thumbnail?: string
     basis: RecommendationBasis
     confidence?: number
+    mode?: 'similar' | 'discover' | 'popular'
 }
 
 export interface RecordOutcomeArgs {
@@ -49,6 +50,7 @@ export async function recordRecommendationPick(
                 signals: input.basis.signals,
                 reason,
                 confidence: input.confidence ?? null,
+                mode: input.mode ?? null,
             },
         })
     } catch (err) {

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.spec.ts
@@ -582,6 +582,7 @@ describe('diversitySelector', () => {
                 expect.objectContaining({ source: 'spotify-rec' }),
                 'guild-id-123',
                 'requesting-user-id',
+                undefined,
             )
 
             // Without user ID
@@ -597,6 +598,87 @@ describe('diversitySelector', () => {
                 expect.any(Object),
                 'guild-id-123',
                 undefined,
+                undefined,
+            )
+        })
+
+        test('passes autoplay mode when provided', async () => {
+            const mockQueueWithAdd: Partial<GuildQueue> = {
+                ...mockQueue,
+                guild: { id: 'guild-id-123' },
+                tracks: { toArray: jest.fn(() => []) },
+                addTrack: jest.fn(),
+            }
+
+            const track: Partial<Track> = {
+                url: 'https://youtube.com/track1',
+                title: 'Track 1',
+                author: 'Artist 1',
+                id: 'track-1',
+            }
+
+            const selected = [
+                {
+                    track: track as Track,
+                    score: 0.8,
+                    basis: {
+                        source: 'spotify-rec' as const,
+                        signals: ['preferred artist'],
+                    },
+                },
+            ]
+
+            // Test with discover mode
+            await addSelectedTracks(
+                mockQueueWithAdd as GuildQueue,
+                selected,
+                new Set(),
+                new Set(),
+                'user-id',
+                'discover',
+            )
+            expect(markAndRecordAutoplayTrackMock).toHaveBeenCalledWith(
+                track,
+                expect.any(Object),
+                'guild-id-123',
+                'user-id',
+                'discover',
+            )
+
+            // Test with popular mode
+            jest.clearAllMocks()
+            await addSelectedTracks(
+                mockQueueWithAdd as GuildQueue,
+                selected,
+                new Set(),
+                new Set(),
+                'user-id',
+                'popular',
+            )
+            expect(markAndRecordAutoplayTrackMock).toHaveBeenCalledWith(
+                track,
+                expect.any(Object),
+                'guild-id-123',
+                'user-id',
+                'popular',
+            )
+
+            // Test with similar mode
+            jest.clearAllMocks()
+            await addSelectedTracks(
+                mockQueueWithAdd as GuildQueue,
+                selected,
+                new Set(),
+                new Set(),
+                'user-id',
+                'similar',
+            )
+            expect(markAndRecordAutoplayTrackMock).toHaveBeenCalledWith(
+                track,
+                expect.any(Object),
+                'guild-id-123',
+                'user-id',
+                'similar',
             )
         })
     })

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.ts
@@ -305,6 +305,7 @@ export async function addSelectedTracks(
     excludedUrls: Set<string>,
     excludedKeys: Set<string>,
     requestedById?: string,
+    mode?: 'similar' | 'discover' | 'popular',
 ): Promise<void> {
     const historyWrites: Promise<boolean>[] = []
     const telemetryWrites: Promise<void>[] = []
@@ -317,6 +318,7 @@ export async function addSelectedTracks(
                 candidate.basis,
                 guildId,
                 requestedById,
+                mode,
             ),
         )
         queue.addTrack(candidate.track)

--- a/packages/bot/src/utils/music/autoplay/queueMarkers.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/queueMarkers.spec.ts
@@ -95,6 +95,68 @@ describe('markAndRecordAutoplayTrack', () => {
         expect(recordRecommendationPick).toHaveBeenCalled()
     })
 
+    it('records the mode when provided', async () => {
+        const track = createTrack({
+            title: 'Song Title',
+            author: 'Song Author',
+            url: 'https://youtube.com/watch?v=abc123',
+            id: 'track-id-123',
+        })
+        const basis: RecommendationBasis = {
+            source: 'spotify-rec',
+            signals: [],
+        }
+
+        await markAndRecordAutoplayTrack(
+            track,
+            basis,
+            'guild-123',
+            'user-456',
+            'discover',
+        )
+
+        expect(recordRecommendationPick).toHaveBeenCalledWith(
+            expect.objectContaining({
+                mode: 'discover',
+            }),
+        )
+    })
+
+    it('records with all three mode values', async () => {
+        const modes: Array<'similar' | 'discover' | 'popular'> = [
+            'similar',
+            'discover',
+            'popular',
+        ]
+
+        for (const mode of modes) {
+            jest.clearAllMocks()
+            ;(recordRecommendationPick as jest.Mock).mockResolvedValueOnce(
+                undefined,
+            )
+
+            const track = createTrack()
+            const basis: RecommendationBasis = {
+                source: 'spotify-rec',
+                signals: [],
+            }
+
+            await markAndRecordAutoplayTrack(
+                track,
+                basis,
+                'guild-123',
+                'user-456',
+                mode,
+            )
+
+            expect(recordRecommendationPick).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    mode,
+                }),
+            )
+        }
+    })
+
     it('does not throw even if recordRecommendationPick resolves successfully', async () => {
         const track = createTrack()
         const basis: RecommendationBasis = {

--- a/packages/bot/src/utils/music/autoplay/queueMarkers.ts
+++ b/packages/bot/src/utils/music/autoplay/queueMarkers.ts
@@ -62,27 +62,30 @@ export function markAsAutoplayTrack(
  * @param basis - The RecommendationBasis (source + signals) for this pick
  * @param guildId - The guild where the track is being queued
  * @param discordUserId - Optional: the Discord user who initiated the replenish
+ * @param mode - Optional: the active autoplay mode (similar | discover | popular)
  */
 export async function markAndRecordAutoplayTrack(
-	track: Track,
-	basis: RecommendationBasis,
-	guildId: string,
-	discordUserId?: string,
+    track: Track,
+    basis: RecommendationBasis,
+    guildId: string,
+    discordUserId?: string,
+    mode?: 'similar' | 'discover' | 'popular',
 ): Promise<void> {
-	// Mark the track synchronously with serialized reason
-	const serializedReason = serializeBasis(basis)
-	markAsAutoplayTrack(track, serializedReason, discordUserId)
+    // Mark the track synchronously with serialized reason
+    const serializedReason = serializeBasis(basis)
+    markAsAutoplayTrack(track, serializedReason, discordUserId)
 
-	// Fire telemetry asynchronously (non-blocking)
-	// recordRecommendationPick is non-throwing, so we don't need try/catch
-	await recordRecommendationPick({
-		guildId,
-		discordUserId,
-		trackId: track.id || track.url,
-		title: track.title ?? '',
-		author: track.author ?? '',
-		url: track.url,
-		thumbnail: undefined,
-		basis,
-	})
+    // Fire telemetry asynchronously (non-blocking)
+    // recordRecommendationPick is non-throwing, so we don't need try/catch
+    await recordRecommendationPick({
+        guildId,
+        discordUserId,
+        trackId: track.id || track.url,
+        title: track.title ?? '',
+        author: track.author ?? '',
+        url: track.url,
+        thumbnail: undefined,
+        basis,
+        mode,
+    })
 }

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -498,6 +498,7 @@ async function _replenishQueue(
             excludedUrls,
             excludedKeys,
             requestedBy?.id,
+            autoplayMode,
         )
 
         // Increment replenish counter for next call's query variation

--- a/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
@@ -14,8 +14,10 @@ jest.mock('../utils/database/prismaClient', () => ({
 // Now import the module under test
 import {
     getPerSourceAcceptance,
+    getPerModeAcceptance,
     getSummary,
     type PerSourceRow,
+    type PerModeRow,
     type Summary,
 } from './recommendationTelemetryReadService'
 
@@ -220,6 +222,150 @@ describe('recommendationTelemetryReadService', () => {
             mockCount.mockResolvedValue({ count: 0 })
 
             await getPerSourceAcceptance('guild-123')
+
+            const call = mockGroupBy.mock.calls[0][0] as any
+            const minus7Days = Date.now() - 7 * 86_400_000
+            expect(call.where.createdAt.gte.getTime()).toBeCloseTo(
+                minus7Days,
+                -2,
+            )
+        })
+    })
+
+    describe('getPerModeAcceptance', () => {
+        it('returns empty array when guild has no recommendations', async () => {
+            mockGroupBy.mockResolvedValue([])
+
+            const result = await getPerModeAcceptance('guild-123')
+
+            expect(result).toEqual([])
+            expect(mockGroupBy).toHaveBeenCalled()
+        })
+
+        it('returns rows for all three modes', async () => {
+            const mockGroupResult = [
+                { mode: 'similar', _count: { id: 10 } },
+                { mode: 'discover', _count: { id: 8 } },
+                { mode: 'popular', _count: { id: 6 } },
+            ]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            // similar: 7 accepted, 2 rejected, 1 pending
+            mockCount
+                .mockResolvedValueOnce({ count: 7 })
+                .mockResolvedValueOnce({ count: 2 })
+                .mockResolvedValueOnce({ count: 1 })
+                // discover: 5 accepted, 2 rejected, 1 pending
+                .mockResolvedValueOnce({ count: 5 })
+                .mockResolvedValueOnce({ count: 2 })
+                .mockResolvedValueOnce({ count: 1 })
+                // popular: 4 accepted, 1 rejected, 1 pending
+                .mockResolvedValueOnce({ count: 4 })
+                .mockResolvedValueOnce({ count: 1 })
+                .mockResolvedValueOnce({ count: 1 })
+
+            const result = await getPerModeAcceptance('guild-123')
+
+            expect(result).toHaveLength(3)
+            expect(result[0]).toEqual({
+                mode: 'similar',
+                count: 10,
+                acceptedCount: 7,
+                rejectedCount: 2,
+                pendingCount: 1,
+                acceptanceRate: 7 / 9,
+            })
+            expect(result[1]).toEqual({
+                mode: 'discover',
+                count: 8,
+                acceptedCount: 5,
+                rejectedCount: 2,
+                pendingCount: 1,
+                acceptanceRate: 5 / 7,
+            })
+            expect(result[2]).toEqual({
+                mode: 'popular',
+                count: 6,
+                acceptedCount: 4,
+                rejectedCount: 1,
+                pendingCount: 1,
+                acceptanceRate: 4 / 5,
+            })
+        })
+
+        it('handles null mode value (pre-migration rows)', async () => {
+            const mockGroupResult = [
+                { mode: null, _count: { id: 2 } },
+                { mode: 'similar', _count: { id: 5 } },
+            ]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            mockCount
+                .mockResolvedValueOnce({ count: 1 }) // null: accepted
+                .mockResolvedValueOnce({ count: 1 }) // null: rejected
+                .mockResolvedValueOnce({ count: 0 }) // null: pending
+                .mockResolvedValueOnce({ count: 4 }) // similar: accepted
+                .mockResolvedValueOnce({ count: 1 }) // similar: rejected
+                .mockResolvedValueOnce({ count: 0 }) // similar: pending
+
+            const result = await getPerModeAcceptance('guild-123')
+
+            expect(result).toHaveLength(2)
+            expect(result[0].mode).toBeNull()
+            expect(result[0].acceptanceRate).toBe(0.5) // 1/(1+1)
+            expect(result[1].mode).toBe('similar')
+        })
+
+        it('returns null acceptanceRate when all pending', async () => {
+            const mockGroupResult = [{ mode: 'similar', _count: { id: 5 } }]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            mockCount
+                .mockResolvedValueOnce({ count: 0 }) // accepted
+                .mockResolvedValueOnce({ count: 0 }) // rejected
+                .mockResolvedValueOnce({ count: 5 }) // pending
+
+            const result = await getPerModeAcceptance('guild-123')
+
+            expect(result[0].acceptanceRate).toBeNull()
+        })
+
+        it('clamps days to [1, 30] range', async () => {
+            mockGroupBy.mockResolvedValue([])
+            mockCount.mockResolvedValue({ count: 0 })
+
+            // Test with days: 0 (should clamp to 1)
+            await getPerModeAcceptance('guild-123', 0)
+            const firstCall = mockGroupBy.mock.calls[0][0] as any
+            const minusOneDay = Date.now() - 1 * 86_400_000
+            expect(firstCall.where.createdAt.gte.getTime()).toBeCloseTo(
+                minusOneDay,
+                -2,
+            )
+
+            jest.clearAllMocks()
+            mockGetPrismaClient.mockReturnValue({
+                recommendation: {
+                    groupBy: mockGroupBy,
+                    count: mockCount,
+                },
+            })
+
+            // Test with days: 999 (should clamp to 30)
+            await getPerModeAcceptance('guild-123', 999)
+            const secondCall = mockGroupBy.mock.calls[0][0] as any
+            const minus30Days = Date.now() - 30 * 86_400_000
+            expect(secondCall.where.createdAt.gte.getTime()).toBeCloseTo(
+                minus30Days,
+                -2,
+            )
+        })
+
+        it('defaults to 7 days when days is undefined', async () => {
+            mockGroupBy.mockResolvedValue([])
+            mockCount.mockResolvedValue({ count: 0 })
+
+            await getPerModeAcceptance('guild-123')
 
             const call = mockGroupBy.mock.calls[0][0] as any
             const minus7Days = Date.now() - 7 * 86_400_000

--- a/packages/shared/src/services/recommendationTelemetryReadService.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.ts
@@ -10,6 +10,17 @@ export interface PerSourceRow {
     acceptanceRate: number | null
 }
 
+export interface PerModeRow {
+    // Loose typing intentional: read aggregation may encounter pre-migration
+    // null rows or unexpected values; the strict union is enforced at write time.
+    mode: string | null
+    count: number
+    acceptedCount: number
+    rejectedCount: number
+    pendingCount: number
+    acceptanceRate: number | null
+}
+
 export interface Summary {
     totalPicks: number
     accepted: number
@@ -114,6 +125,97 @@ export async function getPerSourceAcceptance(
 
         rows.push({
             source,
+            count,
+            acceptedCount,
+            rejectedCount,
+            pendingCount,
+            acceptanceRate,
+        })
+    }
+
+    return rows
+}
+
+/**
+ * Returns one row per distinct mode value seen in the Recommendation table
+ * for this guild within the window. Null mode is its own row.
+ */
+export async function getPerModeAcceptance(
+    guildId: string,
+    days?: number,
+): Promise<PerModeRow[]> {
+    const prisma = getPrismaClient()
+    const createdAtGte = getCreatedAtCutoff(days)
+
+    // Group by mode to get distinct modes and total count per mode
+    const groupByResult = await prisma.recommendation.groupBy({
+        by: ['mode'],
+        where: {
+            guildId,
+            createdAt: {
+                gte: createdAtGte,
+            },
+        },
+        _count: {
+            id: true,
+        },
+    })
+
+    // For each mode, fetch accepted, rejected, and pending counts
+    const rows: PerModeRow[] = []
+    for (const group of groupByResult) {
+        const mode = group.mode
+        const count = group._count.id
+
+        const getCountValue = (result: any): number =>
+            typeof result === 'number' ? result : result.count
+
+        const acceptedCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    mode,
+                    isAccepted: true,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const rejectedCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    mode,
+                    isRejected: true,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const pendingCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    mode,
+                    isAccepted: null,
+                    isRejected: null,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const denominator = acceptedCount + rejectedCount
+        const acceptanceRate =
+            denominator === 0 ? null : acceptedCount / denominator
+
+        rows.push({
+            mode,
             count,
             acceptedCount,
             rejectedCount,

--- a/prisma/migrations/20260528000000_add_autoplay_mode_to_recommendations/migration.sql
+++ b/prisma/migrations/20260528000000_add_autoplay_mode_to_recommendations/migration.sql
@@ -1,0 +1,14 @@
+-- Phase D prerequisite: record the active autoplay mode at recommendation pick time.
+-- See GitHub issue #1081 and docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md
+--
+-- This allows future Phase D analysis to slice acceptance rate by mode (similar, discover, popular)
+-- enabling mode-specific tuning of the candidate scoring logic.
+--
+-- The field is nullable to accommodate pre-migration rows (backfill not required);
+-- forward writes will populate the mode for all three mode values.
+
+ALTER TABLE "recommendations" ADD COLUMN "mode" TEXT;
+
+-- Index for grouping/aggregating acceptance by mode and guild.
+CREATE INDEX "recommendations_guildId_mode_createdAt_idx"
+    ON "recommendations" ("guildId", "mode", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -429,6 +429,9 @@ model Recommendation {
   // Denormalized human-readable serialization of source + signals. Computed
   // by serializeBasis(). Kept for Discord display and ad-hoc query inspection.
   reason     String?
+  // Phase D: active autoplay mode at pick time (similar | discover | popular).
+  // Nullable for forward-compatibility with pre-migration rows.
+  mode       String?
 
   // Phase B closed-loop outcome
   isAccepted Boolean?
@@ -440,6 +443,7 @@ model Recommendation {
 
   @@index([guildId, createdAt])
   @@index([guildId, source, createdAt])
+  @@index([guildId, mode, createdAt])
   @@map("recommendations")
 }
 


### PR DESCRIPTION
Closes #1081.

## What
Records the active autoplay mode (`similar` | `discover` | `popular`) on each recommendation telemetry row at pick time, so a future **Phase D** can slice acceptance by mode. Today the mode is dropped before the telemetry write, which blocks Phase D entirely.

## Changes
- **Prisma:** nullable `mode` column on `Recommendation` + index `(guildId, mode, createdAt)`. Migration created (NOT deployed — `prisma migrate deploy` against Supabase happens at release).
- **Write path:** mode threaded `replenisher.ts` → `addSelectedTracks` (diversitySelector) → `markAndRecordAutoplayTrack` (queueMarkers) → `recordRecommendationPick`. Source already exists as `guildSettings.autoplayMode`.
- **Read path:** `getPerModeAcceptance()` in `recommendationTelemetryReadService.ts`, mirroring `getPerSourceAcceptance()`.
- Telemetry write still swallows DB errors (unchanged). No change to candidate scoring.

## Tests
- bot: queueMarkers (+3 mode tests, incl. all 3 values), diversitySelector (+mode threading)
- shared: `getPerModeAcceptance` (+6, real aggregation), write-path `mode: null` assertion
- All green; bot + shared typecheck clean.

## Context
Phase D prerequisite per ADR `docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md` (revisit 2026-05-29). Without the `mode` dimension Phase D cannot compute per-mode acceptance.