### PR TITLE
feat(autoplay): guild skip-rate circuit breaker

### DIFF
--- a/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
@@ -22,6 +22,7 @@ import {
     normalizeSoundCloudUrl,
 } from '../queryUtils'
 import { applyStoredAutoplayPreference } from './autoplayPreference'
+import { clearAutoplayPause } from '../../../../../utils/music/autoplay/skipCircuitBreaker'
 
 export async function executePlayHandler({
     client,
@@ -107,8 +108,7 @@ export async function executePlayHandler({
                     requestedBy: interaction.user,
                     vcMemberIds,
                 },
-                connectionTimeout:
-                    ENVIRONMENT_CONFIG.PLAYER.CONNECTION_TIMEOUT,
+                connectionTimeout: ENVIRONMENT_CONFIG.PLAYER.CONNECTION_TIMEOUT,
                 leaveOnEmpty: true,
                 leaveOnEmptyCooldown: 30_000,
                 leaveOnEnd: true,
@@ -120,16 +120,11 @@ export async function executePlayHandler({
 
         let result
         try {
-            result = await client.player.play(
-                voiceChannel,
-                query,
-                playOptions,
-            )
+            result = await client.player.play(voiceChannel, query, playOptions)
         } catch (primaryError) {
             if (searchEngine !== QueryType.AUTO) {
                 warnLog({
-                    message:
-                        'Primary search failed, falling back to YouTube',
+                    message: 'Primary search failed, falling back to YouTube',
                     data: {
                         query,
                         requestedProvider: provider ?? 'default',
@@ -161,10 +156,7 @@ export async function executePlayHandler({
         const track = result.track
 
         const isPlaylist = !!result.searchResult.playlist
-        const { queue } = resolveGuildQueue(
-            client,
-            interaction.guildId ?? '',
-        )
+        const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 
         if (!isPlaylist && queue) {
             moveUserTrackToPriority(queue, track)
@@ -219,6 +211,8 @@ export async function executePlayHandler({
 
         const bgOps = (async () => {
             try {
+                // Clear any autoplay pause state when a manual play succeeds
+                clearAutoplayPause(interaction.guildId!)
                 if (!hadQueueBeforePlay && queue) {
                     await applyStoredAutoplayPreference(
                         queue,

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 
+// Transitively pulled in via playHandler -> skipCircuitBreaker; real module loads
+// prismaClient (import.meta). Factory-mock to keep this suite loadable.
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
+
 const flushPromises = () =>
     new Promise<void>((resolve) => setImmediate(resolve))
 

--- a/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
@@ -8,6 +8,12 @@ jest.mock('@lucky/shared/utils', () => ({
     warnLog: jest.fn(),
 }))
 
+// skipCircuitBreaker (imported transitively via replenisher) pulls in this shared
+// service, whose real module loads prismaClient (import.meta). Factory-mock it.
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
+
 jest.mock('@lucky/shared/services', () => ({
     trackHistoryService: {
         getTrackHistory: jest.fn(),

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -44,6 +44,10 @@ import {
 } from '../candidateFallback'
 import { buildVcContributionWeights } from './vcWeights'
 import { getTrackAudioFeatures } from './audioFeatures'
+import {
+    evaluateSkipRateBreaker,
+    clearAutoplayPause,
+} from './skipCircuitBreaker'
 
 // Autoplay backfill target. Non-premium guilds keep the existing 8-song
 // runway; premium guilds get 2× (16) so large listening sessions rarely
@@ -122,6 +126,10 @@ async function _replenishQueue(
         ).length
         const missingTracks = bufferSize - autoplayInQueue
         if (missingTracks <= 0) return
+
+        // Autoplay skip-rate circuit breaker: check if we should pause replenishment
+        const shouldContinue = await evaluateSkipRateBreaker(queue)
+        if (!shouldContinue) return
 
         const allHistoryTracks = getAllHistoryTracks(queue)
         const replenishGuildId = queue.guild.id

--- a/packages/bot/src/utils/music/autoplay/skipCircuitBreaker.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/skipCircuitBreaker.spec.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import {
+    isAutoplayPaused,
+    clearAutoplayPause,
+    evaluateSkipRateBreaker,
+} from './skipCircuitBreaker'
+import * as telemetryReadService from '@lucky/shared/services/recommendationTelemetryReadService'
+import type { GuildQueue } from 'discord-player'
+
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+    warnLog: jest.fn(),
+    errorLog: jest.fn(),
+}))
+
+describe('skipCircuitBreaker', () => {
+    const mockGuildId = 'guild-123'
+
+    describe('isAutoplayPaused', () => {
+        it('returns false when not paused', () => {
+            expect(isAutoplayPaused('unknown-guild')).toBe(false)
+        })
+    })
+
+    describe('clearAutoplayPause', () => {
+        it('clears pause state for a guild', async () => {
+            // Set up paused state
+            const mockQueue = {
+                guild: { id: mockGuildId },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.8,
+                sampleSize: 10,
+                acceptedCount: 2,
+                rejectedCount: 8,
+                canTrip: true,
+            })
+
+            // Trigger breaker
+            await evaluateSkipRateBreaker(mockQueue)
+            expect(isAutoplayPaused(mockGuildId)).toBe(true)
+
+            // Clear it
+            clearAutoplayPause(mockGuildId)
+            expect(isAutoplayPaused(mockGuildId)).toBe(false)
+        })
+    })
+
+    describe('evaluateSkipRateBreaker', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+        })
+
+        it('returns true when skip rate < threshold (no pause)', async () => {
+            const mockQueue = {
+                guild: { id: mockGuildId },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.4, // 40% < 60% threshold
+                sampleSize: 10,
+                acceptedCount: 6,
+                rejectedCount: 4,
+                canTrip: true,
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(true)
+            expect(isAutoplayPaused(mockGuildId)).toBe(false)
+        })
+
+        it('returns false and pauses when skip rate > threshold (sample >= 5)', async () => {
+            const mockChannel = {
+                send: jest.fn().mockResolvedValue(undefined),
+            }
+            const mockQueue = {
+                guild: { id: mockGuildId },
+                metadata: { channel: mockChannel },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.7, // 70% > 60% threshold
+                sampleSize: 10,
+                acceptedCount: 3,
+                rejectedCount: 7,
+                canTrip: true,
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(false)
+            expect(isAutoplayPaused(mockGuildId)).toBe(true)
+            expect(mockChannel.send).toHaveBeenCalledWith({
+                content: expect.stringContaining('70%'),
+            })
+        })
+
+        it('returns true when sample < minimum (never pauses)', async () => {
+            const mockQueue = {
+                guild: { id: mockGuildId + '-2' },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.8, // 80%, but not enough samples
+                sampleSize: 3, // < 5
+                acceptedCount: 1,
+                rejectedCount: 2,
+                canTrip: false, // Can't trip with low sample
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(true)
+            expect(isAutoplayPaused(mockGuildId + '-2')).toBe(false)
+        })
+
+        it('posts notice only once per pause', async () => {
+            const mockChannel = {
+                send: jest.fn().mockResolvedValue(undefined),
+            }
+            const guildId = 'guild-once-test'
+            const mockQueue = {
+                guild: { id: guildId },
+                metadata: { channel: mockChannel },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.75,
+                sampleSize: 10,
+                acceptedCount: 2,
+                rejectedCount: 8,
+                canTrip: true,
+            })
+
+            // First call: trips breaker and posts notice
+            const result1 = await evaluateSkipRateBreaker(mockQueue)
+            expect(result1).toBe(false)
+            expect(mockChannel.send).toHaveBeenCalledTimes(1)
+            expect(isAutoplayPaused(guildId)).toBe(true)
+
+            // Clear the mock to verify it won't be called again
+            mockChannel.send.mockClear()
+
+            // Second call: already paused, doesn't post again
+            const result2 = await evaluateSkipRateBreaker(mockQueue)
+            expect(result2).toBe(false)
+            expect(mockChannel.send).not.toHaveBeenCalled()
+        })
+
+        it('returns true when skip rate is null (no data)', async () => {
+            const mockQueue = {
+                guild: { id: mockGuildId + '-null' },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: null, // No resolved outcomes
+                sampleSize: 0,
+                acceptedCount: 0,
+                rejectedCount: 0,
+                canTrip: false,
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(true)
+            expect(isAutoplayPaused(mockGuildId + '-null')).toBe(false)
+        })
+
+        it('fails open (returns true) on query error', async () => {
+            const mockQueue = {
+                guild: { id: mockGuildId + '-error' },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockRejectedValueOnce(new Error('DB error'))
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(true)
+            expect(isAutoplayPaused(mockGuildId + '-error')).toBe(false)
+        })
+
+        it('still pauses even if notice send fails', async () => {
+            const mockChannel = {
+                send: jest
+                    .fn()
+                    .mockRejectedValue(new Error('Channel send failed')),
+            }
+            const guildId = 'guild-fail-notice'
+            const mockQueue = {
+                guild: { id: guildId },
+                metadata: { channel: mockChannel },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.65,
+                sampleSize: 10,
+                acceptedCount: 3,
+                rejectedCount: 7,
+                canTrip: true,
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(false)
+            expect(isAutoplayPaused(guildId)).toBe(true)
+            expect(mockChannel.send).toHaveBeenCalled()
+        })
+    })
+})

--- a/packages/bot/src/utils/music/autoplay/skipCircuitBreaker.ts
+++ b/packages/bot/src/utils/music/autoplay/skipCircuitBreaker.ts
@@ -1,0 +1,116 @@
+import type { GuildQueue } from 'discord-player'
+import { getAutoplaySkipRateForGuild } from '@lucky/shared/services/recommendationTelemetryReadService'
+import { debugLog, warnLog } from '@lucky/shared/utils'
+import type { QueueMetadata } from '../../../types/QueueMetadata'
+
+// Default threshold: 60% skip rate pauses autoplay
+const AUTOPLAY_SKIP_BREAKER_THRESHOLD = 0.6
+
+// In-memory pause state: maps guildId -> { isPaused: boolean; notified: boolean }
+const autoplayPauseState = new Map<
+    string,
+    { isPaused: boolean; notified: boolean }
+>()
+
+/**
+ * Checks if autoplay is currently paused for this guild.
+ */
+export function isAutoplayPaused(guildId: string): boolean {
+    return autoplayPauseState.get(guildId)?.isPaused ?? false
+}
+
+/**
+ * Clears the autoplay pause state for a guild (used on manual /play).
+ */
+export function clearAutoplayPause(guildId: string): void {
+    if (autoplayPauseState.has(guildId)) {
+        autoplayPauseState.delete(guildId)
+        debugLog({
+            message: 'Autoplay pause cleared',
+            data: { guildId },
+        })
+    }
+}
+
+/**
+ * Evaluates and applies the skip-rate circuit breaker.
+ * Returns false if autoplay should be paused, true if replenishment should proceed.
+ * Posts ONE notice to the music channel if the breaker trips.
+ */
+export async function evaluateSkipRateBreaker(
+    queue: GuildQueue,
+): Promise<boolean> {
+    const guildId = queue.guild.id
+    const metadata = queue.metadata as QueueMetadata | undefined
+    const musicChannel = metadata?.channel
+
+    // Check current pause state
+    const currentState = autoplayPauseState.get(guildId)
+    if (currentState?.isPaused) {
+        return false // Stay paused
+    }
+
+    try {
+        const skipRateData = await getAutoplaySkipRateForGuild(guildId)
+
+        // Only trip if sample is sufficient and skip rate exceeds threshold
+        if (
+            skipRateData.canTrip &&
+            skipRateData.skipRate !== null &&
+            skipRateData.skipRate > AUTOPLAY_SKIP_BREAKER_THRESHOLD
+        ) {
+            // Trip the breaker
+            autoplayPauseState.set(guildId, { isPaused: true, notified: false })
+
+            // Post notice to music channel (once per pause)
+            if (musicChannel) {
+                try {
+                    await musicChannel.send({
+                        content: `⏸️ **Autoplay paused** — High skip rate detected (${(skipRateData.skipRate * 100).toFixed(0)}%). Play a track manually to resume.`,
+                    })
+                    autoplayPauseState.set(guildId, {
+                        isPaused: true,
+                        notified: true,
+                    })
+                    debugLog({
+                        message: 'Skip-rate breaker tripped and notice posted',
+                        data: {
+                            guildId,
+                            skipRate: skipRateData.skipRate,
+                            sampleSize: skipRateData.sampleSize,
+                        },
+                    })
+                } catch (noticeError) {
+                    warnLog({
+                        message: 'Failed to post autoplay pause notice',
+                        error: noticeError,
+                        data: { guildId },
+                    })
+                    // Still pause even if notice fails
+                    autoplayPauseState.set(guildId, {
+                        isPaused: true,
+                        notified: false,
+                    })
+                }
+            } else {
+                // No channel, but still pause
+                autoplayPauseState.set(guildId, {
+                    isPaused: true,
+                    notified: false,
+                })
+            }
+
+            return false // Don't replenish
+        }
+
+        return true // Proceed with replenishment
+    } catch (error) {
+        warnLog({
+            message: 'Error evaluating skip-rate breaker',
+            error,
+            data: { guildId },
+        })
+        // Fail open: allow replenishment on error
+        return true
+    }
+}

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -1,4 +1,10 @@
 import { jest } from '@jest/globals'
+
+// Transitively pulled in via replenisher -> skipCircuitBreaker; real module loads
+// prismaClient (import.meta). Factory-mock to keep this suite loadable.
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
 import {
     replenishQueue,
     enrichWithAudioFeatures,

--- a/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
@@ -16,6 +16,7 @@ import {
     getPerSourceAcceptance,
     getPerModeAcceptance,
     getSummary,
+    getAutoplaySkipRateForGuild,
     type PerSourceRow,
     type PerModeRow,
     type Summary,
@@ -472,6 +473,93 @@ describe('recommendationTelemetryReadService', () => {
                 minus7Days,
                 -2,
             )
+        })
+    })
+
+    describe('getAutoplaySkipRateForGuild', () => {
+        const mockGuildId = 'guild-123'
+
+        it('returns skip rate when sample >= minimum (5 resolved outcomes)', async () => {
+            mockCount.mockResolvedValueOnce(3).mockResolvedValueOnce(2)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: 0.4,
+                sampleSize: 5,
+                acceptedCount: 3,
+                rejectedCount: 2,
+                canTrip: true,
+            })
+        })
+
+        it('returns canTrip=false when sample < minimum (< 5 resolved)', async () => {
+            mockCount.mockResolvedValueOnce(2).mockResolvedValueOnce(1)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: 1 / 3,
+                sampleSize: 3,
+                acceptedCount: 2,
+                rejectedCount: 1,
+                canTrip: false,
+            })
+        })
+
+        it('returns 0% skip rate with no rejections', async () => {
+            mockCount.mockResolvedValueOnce(10).mockResolvedValueOnce(0)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: 0,
+                sampleSize: 10,
+                acceptedCount: 10,
+                rejectedCount: 0,
+                canTrip: true,
+            })
+        })
+
+        it('returns 100% skip rate with no acceptances', async () => {
+            mockCount.mockResolvedValueOnce(0).mockResolvedValueOnce(5)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: 1,
+                sampleSize: 5,
+                acceptedCount: 0,
+                rejectedCount: 5,
+                canTrip: true,
+            })
+        })
+
+        it('applies a 24-hour window and does not filter by mode', async () => {
+            mockCount.mockResolvedValueOnce(3).mockResolvedValueOnce(2)
+
+            await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(mockCount).toHaveBeenCalledTimes(2)
+            for (const call of mockCount.mock.calls) {
+                expect((call[0] as any).where?.createdAt?.gte).toBeDefined()
+                expect((call[0] as any).where?.guildId).toBe(mockGuildId)
+                expect((call[0] as any).where?.mode).toBeUndefined()
+            }
+        })
+
+        it('returns null skip rate when no resolved outcomes', async () => {
+            mockCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: null,
+                sampleSize: 0,
+                acceptedCount: 0,
+                rejectedCount: 0,
+                canTrip: false,
+            })
         })
     })
 })

--- a/packages/shared/src/services/recommendationTelemetryReadService.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.ts
@@ -300,3 +300,69 @@ export async function getSummary(
         globalAcceptanceRate,
     }
 }
+
+/**
+ * Result of autoplay skip-rate computation.
+ *
+ * - skipRate: null if no resolved outcomes, otherwise rejected / (accepted + rejected)
+ * - sampleSize: count of resolved (accepted + rejected) autoplay recommendations
+ * - canTrip: true if sampleSize >= 5 (minimum sample guard)
+ */
+export interface AutoplaySkipRateResult {
+    skipRate: number | null
+    sampleSize: number
+    acceptedCount: number
+    rejectedCount: number
+    canTrip: boolean
+}
+
+/**
+ * Returns the rolling 24-hour autoplay skip-rate for a guild.
+ * Requires minimum sample size of 5 resolved outcomes before canTrip=true.
+ * Used by the circuit breaker to pause autoplay replenishment on high skip rates.
+ */
+export async function getAutoplaySkipRateForGuild(
+    guildId: string,
+): Promise<AutoplaySkipRateResult> {
+    const prisma = getPrismaClient()
+    const createdAtGte = new Date(Date.now() - 24 * 60 * 60 * 1000) // 24 hours
+
+    const getCountValue = (result: any): number =>
+        typeof result === 'number' ? result : result.count
+
+    const acceptedCount = getCountValue(
+        await prisma.recommendation.count({
+            where: {
+                guildId,
+                isAccepted: true,
+                createdAt: {
+                    gte: createdAtGte,
+                },
+            },
+        }),
+    )
+
+    const rejectedCount = getCountValue(
+        await prisma.recommendation.count({
+            where: {
+                guildId,
+                isRejected: true,
+                createdAt: {
+                    gte: createdAtGte,
+                },
+            },
+        }),
+    )
+
+    const sampleSize = acceptedCount + rejectedCount
+    const skipRate = sampleSize === 0 ? null : rejectedCount / sampleSize
+    const canTrip = sampleSize >= 5
+
+    return {
+        skipRate,
+        sampleSize,
+        acceptedCount,
+        rejectedCount,
+        canTrip,
+    }
+}


### PR DESCRIPTION
Closes #1082.

## What
Pauses autoplay replenishment for a guild when its rolling **24h** autoplay skip-rate exceeds **60%** (min sample ≥5 resolved outcomes), posts one notice to the music channel, and auto-resumes on the next manual `/play`. Prevents skip-storm spirals that burn provider quota on rejected tracks.

## How
- **Skip-rate** computed from existing `Recommendation` telemetry (no new schema/migration): `getAutoplaySkipRateForGuild()` over a 24h window, across all autoplay rows (no mode filter), with a ≥5-sample guard so it can't trip on 1–2 skips.
- **Gate** in `replenisher._replenishQueue` — early-return when paused.
- **Pause state** in-memory per-guild (mirrors `sessionMoodCache`); tracks a `notified` flag so the channel notice fires once per pause.
- **Resume** clears the flag on a successful manual `/play` (`playHandler`).

## Tests
- shared: `getAutoplaySkipRateForGuild` (6 — sample guard, 0/100%/null, 24h window, no mode filter); existing read-service tests preserved (24 total).
- bot: `skipCircuitBreaker` (9 — under/over threshold, sample<5, once-only notice, resume, fail-open).
- Both packages typecheck clean; shared via ts-jest.

## Builds on
#1096 (autoplay mode telemetry), already merged to release/v2.16.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Autoplay now includes a smart pause feature that automatically pauses automatic track addition when member skip rates exceed a threshold, with notices sent to the music channel.
  * Manual music plays automatically clear any active autoplay pause state, resuming automatic recommendations.

* **Tests**
  * Added comprehensive test coverage for autoplay pause/resume behavior and skip-rate telemetry tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1097?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->