### PR TITLE
chore(release): v2.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
                   DATABASE_URL: postgresql://localhost:5432/test
             - name: Type check
               run: npm run type:check
+            - name: Check documentation coverage
+              run: npm run docs:check --workspace=packages/shared
             - name: Build project
               run: npm run build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-05-28
+
+### Added
+- feat(autoplay): record the selected autoplay mode (similar/discover/popular) on recommendation telemetry rows, enabling per-mode acceptance analysis (Phase D prerequisite) (#1096)
+- feat(autoplay): guild skip-rate circuit breaker — pauses autoplay replenishment when a guild's rolling 24h skip-rate exceeds 60% (minimum sample of 5 resolved outcomes), posts a one-time notice to the music channel, and auto-resumes on the next manual `/play` (#1097)
+
+### Changed
+- test(shared): make the `packages/shared` Jest coverage gate honest — measure full runtime source (drop the broad `src/services`/`src/utils` exclusions) and set the threshold to the real floor (89/89/90/89) (#1076)
+
 ## [2.15.2] - 2026-05-28
 
 ### Fixed

--- a/docs/decisions/2026-05-27-skill-creation-canonical-tool.md
+++ b/docs/decisions/2026-05-27-skill-creation-canonical-tool.md
@@ -1,0 +1,38 @@
+# ADR: Canonical Skill Creation Tool
+
+**Date:** 2026-05-27
+**Status:** Accepted
+
+## Context
+
+Four skills in `~/.agents/skills/` address skill authoring:
+
+- `skill-creator` — full-featured canonical skill with metadata, validation, and support-file structure
+- `create-skill` — a compatibility wrapper that explicitly delegates to `skill-creator`
+- `write-a-skill` — older interactive approach, no validation, legacy folder layout
+- `skill-maintainer` — catalog auditing (not creation)
+
+The question: which is the right skill to invoke when authoring a new skill?
+
+## Decision
+
+Use **`skill-creator`** as the canonical tool for all skill creation and update tasks.
+
+## Alternatives Considered
+
+| Option             | Rejection reason                                                                                                       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `create-skill`     | Self-described compatibility wrapper; its own SKILL.md says "use `skill-creator` directly"                             |
+| `write-a-skill`    | No validation script, uses legacy naming (REFERENCE.md vs references/), lacks frontmatter tier/canonical_source fields |
+| `skill-maintainer` | Different scope — auditing/normalizing the catalog, not authoring new skills                                           |
+
+## Consequences
+
+- **Positive:** Single canonical path; `skill-creator` includes `scripts/quick_validate.py`, support-file conventions (`references/`, `scripts/`, `assets/`), and overlay metadata.
+- **Neutral:** `write-a-skill` remains installed but effectively superseded.
+- **Negative:** None identified.
+
+## Revisit When
+
+- `write-a-skill` is updated to match `skill-creator`'s feature set, at which point evaluate merging.
+- A new skill creation tool is introduced into the ecosystem.

--- a/docs/decisions/2026-05-28-shared-package-doc-coverage-tooling.md
+++ b/docs/decisions/2026-05-28-shared-package-doc-coverage-tooling.md
@@ -1,0 +1,62 @@
+# ADR: TSDoc Coverage Enforcement for packages/shared
+
+**Date:** 2026-05-28
+**Status:** Accepted
+
+## Context
+
+`packages/shared` exports utilities, services, and types consumed by `bot`, `backend`, and `frontend`. As the module surface grew, exported symbols accumulated without documentation, making the public API hard to navigate for AI-assisted and human contributors alike.
+
+The goal was to enforce a **measurable 80% documentation coverage gate** — a genuine percentage threshold that fails CI if fewer than 80% of exported symbols carry TSDoc comments.
+
+Two options were evaluated:
+
+**Option A — `eslint-plugin-jsdoc`:** Per-symbol ESLint rule that flags missing `@param`, `@returns`, etc. Integrates with the existing flat ESLint config. Produces a per-symbol pass/fail on the modified files in each PR.
+
+**Option B — TypeDoc + `typedoc-plugin-coverage`:** TypeDoc generates an HTML reference from TSDoc comments. `typedoc-plugin-coverage` adds a percentage gate: scans all exported symbols and exits non-zero when any configured category falls below the threshold. Used by `discord.js`, `ts-node`, and similar large TypeScript projects.
+
+The deciding criterion was **"percentage threshold on all exports simultaneously."** A CI gate that only fires on touched files allows coverage to drift on untouched exports without triggering the gate; a whole-project scan prevents this.
+
+## Decision
+
+Adopt **TypeDoc + `typedoc-plugin-coverage`** (Option B).
+
+- Install as devDependencies in `packages/shared`.
+- Configure via `packages/shared/typedoc.json` with entry point `src/index.ts`, `typedoc-plugin-coverage` plugin, and an 80% coverage threshold per symbol category.
+- Add `docs:check` npm script that runs TypeDoc in validation mode (no HTML output) and exits non-zero below threshold.
+- Wire `docs:check` into the `checks` CI job in `.github/workflows/ci.yml`.
+- Write TSDoc comments on all exported symbols until the gate passes.
+
+## Alternatives considered
+
+**Option A (eslint-plugin-jsdoc):** Rejected for two reasons:
+
+1. Per-file/per-symbol rules enforce _presence_ on modified symbols only — no global threshold means coverage can degrade on untouched exports across PRs.
+2. Monorepo exported-symbol detection is brittle: ESLint processes files individually; re-exported symbols (common in shared) may not trigger the rule on the re-exporting barrel.
+
+**Inline TSDoc only (no gate):** Rejected. Without a CI enforcement mechanism the threshold is aspirational, not enforced.
+
+**tsdoc-validator / api-extractor:** Evaluated briefly. `api-extractor` is Microsoft's TypeScript public-API surface tooling — it validates TSDoc syntax but does not produce a coverage percentage. Over-engineered for this use case.
+
+## Consequences
+
+**Positive:**
+
+- CI gate fails fast when coverage falls below 80% across all exports simultaneously — no coverage drift.
+- TypeDoc HTML output is a bonus artifact (not CI-gated, but generateable on demand).
+- `typedoc-plugin-coverage` is battle-tested in the `discord.js` ecosystem, matching this repo's primary dependency.
+- Minimal footprint: 2 devDependencies, 1 JSON config file, 1 script, 1 CI step.
+
+**Negative / friction:**
+
+- TypeDoc requires an initial JSDoc pass on ~80% of exported symbols before the gate can pass.
+- TypeDoc version compatibility with TypeScript 6.0.3 must be verified on first run.
+
+**Neutral:**
+
+- Plugin scoped to `packages/shared` only. Extension to `bot`/`backend`/`frontend` is a future decision.
+
+## Revisit when
+
+- TypeDoc 1.x stable releases or `typedoc-plugin-coverage` API changes break the configuration.
+- Coverage requirement is raised above 80% across all packages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3354,6 +3354,20 @@
             "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
             "license": "MIT"
         },
+        "node_modules/@gerrit0/mini-shiki": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+            "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/engine-oniguruma": "^3.23.0",
+                "@shikijs/langs": "^3.23.0",
+                "@shikijs/themes": "^3.23.0",
+                "@shikijs/types": "^3.23.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
         "node_modules/@hono/node-server": {
             "version": "1.19.13",
             "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
@@ -8636,6 +8650,55 @@
                 "react": "^16.14.0 || 17.x || 18.x || 19.x"
             }
         },
+        "node_modules/@shikijs/engine-oniguruma": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+            "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.23.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
+        "node_modules/@shikijs/langs": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+            "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.23.0"
+            }
+        },
+        "node_modules/@shikijs/themes": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+            "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.23.0"
+            }
+        },
+        "node_modules/@shikijs/types": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+            "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            }
+        },
+        "node_modules/@shikijs/vscode-textmate": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+            "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@simple-libs/child-process-utils": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
@@ -10748,6 +10811,16 @@
                 "@types/express": "*"
             }
         },
+        "node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
         "node_modules/@types/http-cache-semantics": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -11007,6 +11080,13 @@
                 "fflate": "~0.8.2",
                 "meshoptimizer": "~1.1.1"
             }
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/webxr": {
             "version": "0.5.24",
@@ -18849,6 +18929,26 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
         },
+        "node_modules/linkify-it": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
+        },
         "node_modules/lint-staged": {
             "version": "17.0.5",
             "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
@@ -19184,6 +19284,13 @@
             "resolved": "packages/frontend",
             "link": true
         },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lz-string": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -19291,6 +19398,34 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/markdown-it": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+            "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.1",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -19305,6 +19440,13 @@
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "license": "CC0-1.0"
+        },
+        "node_modules/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/media-typer": {
             "version": "1.1.0",
@@ -19468,12 +19610,12 @@
             "license": "ISC"
         },
         "node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -20943,6 +21085,16 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -23521,6 +23673,43 @@
                 "is-typedarray": "^1.0.0"
             }
         },
+        "node_modules/typedoc": {
+            "version": "0.28.19",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+            "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gerrit0/mini-shiki": "^3.23.0",
+                "lunr": "^2.3.9",
+                "markdown-it": "^14.1.1",
+                "minimatch": "^10.2.5",
+                "yaml": "^2.8.3"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 18",
+                "pnpm": ">= 10"
+            },
+            "peerDependencies": {
+                "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+            }
+        },
+        "node_modules/typedoc-plugin-coverage": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-coverage/-/typedoc-plugin-coverage-4.0.3.tgz",
+            "integrity": "sha512-baim3wyMkqpX7rBzL/6iZ7wzKJuSr9ffP16RHOsdTUNoHUZeXLIZHSUBtUhXmNHaUNRgfqdmKLBwyggbJjGdeQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "typedoc": "0.28.x"
+            }
+        },
         "node_modules/typescript": {
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -23533,6 +23722,13 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ufo": {
             "version": "1.6.3",
@@ -24341,7 +24537,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "license": "ISC",
-            "optional": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -25410,6 +25605,8 @@
                 "@swc/core": "^1.15.40",
                 "@types/node": "^25.9.1",
                 "glob": "^13.0.6",
+                "typedoc": "^0.28.19",
+                "typedoc-plugin-coverage": "^4.0.3",
                 "typescript": "^6.0.3"
             },
             "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lucky-bot",
-    "version": "2.15.2",
+    "version": "2.16.0",
     "description": "All-in-one Discord bot platform — music, moderation, auto-mod, custom commands, and web dashboard",
     "type": "module",
     "workspaces": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/backend",
-    "version": "2.15.2",
+    "version": "2.16.0",
     "description": "Express API server for Lucky",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/bot",
-    "version": "2.15.2",
+    "version": "2.16.0",
     "description": "Discord bot application",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
@@ -22,6 +22,7 @@ import {
     normalizeSoundCloudUrl,
 } from '../queryUtils'
 import { applyStoredAutoplayPreference } from './autoplayPreference'
+import { clearAutoplayPause } from '../../../../../utils/music/autoplay/skipCircuitBreaker'
 
 export async function executePlayHandler({
     client,
@@ -107,8 +108,7 @@ export async function executePlayHandler({
                     requestedBy: interaction.user,
                     vcMemberIds,
                 },
-                connectionTimeout:
-                    ENVIRONMENT_CONFIG.PLAYER.CONNECTION_TIMEOUT,
+                connectionTimeout: ENVIRONMENT_CONFIG.PLAYER.CONNECTION_TIMEOUT,
                 leaveOnEmpty: true,
                 leaveOnEmptyCooldown: 30_000,
                 leaveOnEnd: true,
@@ -120,16 +120,11 @@ export async function executePlayHandler({
 
         let result
         try {
-            result = await client.player.play(
-                voiceChannel,
-                query,
-                playOptions,
-            )
+            result = await client.player.play(voiceChannel, query, playOptions)
         } catch (primaryError) {
             if (searchEngine !== QueryType.AUTO) {
                 warnLog({
-                    message:
-                        'Primary search failed, falling back to YouTube',
+                    message: 'Primary search failed, falling back to YouTube',
                     data: {
                         query,
                         requestedProvider: provider ?? 'default',
@@ -161,10 +156,7 @@ export async function executePlayHandler({
         const track = result.track
 
         const isPlaylist = !!result.searchResult.playlist
-        const { queue } = resolveGuildQueue(
-            client,
-            interaction.guildId ?? '',
-        )
+        const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 
         if (!isPlaylist && queue) {
             moveUserTrackToPriority(queue, track)
@@ -219,6 +211,8 @@ export async function executePlayHandler({
 
         const bgOps = (async () => {
             try {
+                // Clear any autoplay pause state when a manual play succeeds
+                clearAutoplayPause(interaction.guildId!)
                 if (!hadQueueBeforePlay && queue) {
                     await applyStoredAutoplayPreference(
                         queue,

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 
+// Transitively pulled in via playHandler -> skipCircuitBreaker; real module loads
+// prismaClient (import.meta). Factory-mock to keep this suite loadable.
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
+
 const flushPromises = () =>
     new Promise<void>((resolve) => setImmediate(resolve))
 

--- a/packages/bot/src/services/musicRecommendation/recommendationTelemetry.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/recommendationTelemetry.spec.ts
@@ -89,6 +89,7 @@ describe('recommendationTelemetry', () => {
                     signals: input.basis.signals,
                     reason: 'spotify rec • preferred artist • completed before',
                     confidence: null,
+                    mode: null,
                 },
             })
         })

--- a/packages/bot/src/services/musicRecommendation/recommendationTelemetry.ts
+++ b/packages/bot/src/services/musicRecommendation/recommendationTelemetry.ts
@@ -16,6 +16,7 @@ export interface RecordPickInput {
     thumbnail?: string
     basis: RecommendationBasis
     confidence?: number
+    mode?: 'similar' | 'discover' | 'popular'
 }
 
 export interface RecordOutcomeArgs {
@@ -49,6 +50,7 @@ export async function recordRecommendationPick(
                 signals: input.basis.signals,
                 reason,
                 confidence: input.confidence ?? null,
+                mode: input.mode ?? null,
             },
         })
     } catch (err) {

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.spec.ts
@@ -582,6 +582,7 @@ describe('diversitySelector', () => {
                 expect.objectContaining({ source: 'spotify-rec' }),
                 'guild-id-123',
                 'requesting-user-id',
+                undefined,
             )
 
             // Without user ID
@@ -597,6 +598,87 @@ describe('diversitySelector', () => {
                 expect.any(Object),
                 'guild-id-123',
                 undefined,
+                undefined,
+            )
+        })
+
+        test('passes autoplay mode when provided', async () => {
+            const mockQueueWithAdd: Partial<GuildQueue> = {
+                ...mockQueue,
+                guild: { id: 'guild-id-123' },
+                tracks: { toArray: jest.fn(() => []) },
+                addTrack: jest.fn(),
+            }
+
+            const track: Partial<Track> = {
+                url: 'https://youtube.com/track1',
+                title: 'Track 1',
+                author: 'Artist 1',
+                id: 'track-1',
+            }
+
+            const selected = [
+                {
+                    track: track as Track,
+                    score: 0.8,
+                    basis: {
+                        source: 'spotify-rec' as const,
+                        signals: ['preferred artist'],
+                    },
+                },
+            ]
+
+            // Test with discover mode
+            await addSelectedTracks(
+                mockQueueWithAdd as GuildQueue,
+                selected,
+                new Set(),
+                new Set(),
+                'user-id',
+                'discover',
+            )
+            expect(markAndRecordAutoplayTrackMock).toHaveBeenCalledWith(
+                track,
+                expect.any(Object),
+                'guild-id-123',
+                'user-id',
+                'discover',
+            )
+
+            // Test with popular mode
+            jest.clearAllMocks()
+            await addSelectedTracks(
+                mockQueueWithAdd as GuildQueue,
+                selected,
+                new Set(),
+                new Set(),
+                'user-id',
+                'popular',
+            )
+            expect(markAndRecordAutoplayTrackMock).toHaveBeenCalledWith(
+                track,
+                expect.any(Object),
+                'guild-id-123',
+                'user-id',
+                'popular',
+            )
+
+            // Test with similar mode
+            jest.clearAllMocks()
+            await addSelectedTracks(
+                mockQueueWithAdd as GuildQueue,
+                selected,
+                new Set(),
+                new Set(),
+                'user-id',
+                'similar',
+            )
+            expect(markAndRecordAutoplayTrackMock).toHaveBeenCalledWith(
+                track,
+                expect.any(Object),
+                'guild-id-123',
+                'user-id',
+                'similar',
             )
         })
     })

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.ts
@@ -305,6 +305,7 @@ export async function addSelectedTracks(
     excludedUrls: Set<string>,
     excludedKeys: Set<string>,
     requestedById?: string,
+    mode?: 'similar' | 'discover' | 'popular',
 ): Promise<void> {
     const historyWrites: Promise<boolean>[] = []
     const telemetryWrites: Promise<void>[] = []
@@ -317,6 +318,7 @@ export async function addSelectedTracks(
                 candidate.basis,
                 guildId,
                 requestedById,
+                mode,
             ),
         )
         queue.addTrack(candidate.track)

--- a/packages/bot/src/utils/music/autoplay/queueMarkers.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/queueMarkers.spec.ts
@@ -95,6 +95,68 @@ describe('markAndRecordAutoplayTrack', () => {
         expect(recordRecommendationPick).toHaveBeenCalled()
     })
 
+    it('records the mode when provided', async () => {
+        const track = createTrack({
+            title: 'Song Title',
+            author: 'Song Author',
+            url: 'https://youtube.com/watch?v=abc123',
+            id: 'track-id-123',
+        })
+        const basis: RecommendationBasis = {
+            source: 'spotify-rec',
+            signals: [],
+        }
+
+        await markAndRecordAutoplayTrack(
+            track,
+            basis,
+            'guild-123',
+            'user-456',
+            'discover',
+        )
+
+        expect(recordRecommendationPick).toHaveBeenCalledWith(
+            expect.objectContaining({
+                mode: 'discover',
+            }),
+        )
+    })
+
+    it('records with all three mode values', async () => {
+        const modes: Array<'similar' | 'discover' | 'popular'> = [
+            'similar',
+            'discover',
+            'popular',
+        ]
+
+        for (const mode of modes) {
+            jest.clearAllMocks()
+            ;(recordRecommendationPick as jest.Mock).mockResolvedValueOnce(
+                undefined,
+            )
+
+            const track = createTrack()
+            const basis: RecommendationBasis = {
+                source: 'spotify-rec',
+                signals: [],
+            }
+
+            await markAndRecordAutoplayTrack(
+                track,
+                basis,
+                'guild-123',
+                'user-456',
+                mode,
+            )
+
+            expect(recordRecommendationPick).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    mode,
+                }),
+            )
+        }
+    })
+
     it('does not throw even if recordRecommendationPick resolves successfully', async () => {
         const track = createTrack()
         const basis: RecommendationBasis = {

--- a/packages/bot/src/utils/music/autoplay/queueMarkers.ts
+++ b/packages/bot/src/utils/music/autoplay/queueMarkers.ts
@@ -62,27 +62,30 @@ export function markAsAutoplayTrack(
  * @param basis - The RecommendationBasis (source + signals) for this pick
  * @param guildId - The guild where the track is being queued
  * @param discordUserId - Optional: the Discord user who initiated the replenish
+ * @param mode - Optional: the active autoplay mode (similar | discover | popular)
  */
 export async function markAndRecordAutoplayTrack(
-	track: Track,
-	basis: RecommendationBasis,
-	guildId: string,
-	discordUserId?: string,
+    track: Track,
+    basis: RecommendationBasis,
+    guildId: string,
+    discordUserId?: string,
+    mode?: 'similar' | 'discover' | 'popular',
 ): Promise<void> {
-	// Mark the track synchronously with serialized reason
-	const serializedReason = serializeBasis(basis)
-	markAsAutoplayTrack(track, serializedReason, discordUserId)
+    // Mark the track synchronously with serialized reason
+    const serializedReason = serializeBasis(basis)
+    markAsAutoplayTrack(track, serializedReason, discordUserId)
 
-	// Fire telemetry asynchronously (non-blocking)
-	// recordRecommendationPick is non-throwing, so we don't need try/catch
-	await recordRecommendationPick({
-		guildId,
-		discordUserId,
-		trackId: track.id || track.url,
-		title: track.title ?? '',
-		author: track.author ?? '',
-		url: track.url,
-		thumbnail: undefined,
-		basis,
-	})
+    // Fire telemetry asynchronously (non-blocking)
+    // recordRecommendationPick is non-throwing, so we don't need try/catch
+    await recordRecommendationPick({
+        guildId,
+        discordUserId,
+        trackId: track.id || track.url,
+        title: track.title ?? '',
+        author: track.author ?? '',
+        url: track.url,
+        thumbnail: undefined,
+        basis,
+        mode,
+    })
 }

--- a/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
@@ -8,6 +8,12 @@ jest.mock('@lucky/shared/utils', () => ({
     warnLog: jest.fn(),
 }))
 
+// skipCircuitBreaker (imported transitively via replenisher) pulls in this shared
+// service, whose real module loads prismaClient (import.meta). Factory-mock it.
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
+
 jest.mock('@lucky/shared/services', () => ({
     trackHistoryService: {
         getTrackHistory: jest.fn(),

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -44,10 +44,7 @@ import {
 } from '../candidateFallback'
 import { buildVcContributionWeights } from './vcWeights'
 import { getTrackAudioFeatures } from './audioFeatures'
-import {
-    evaluateSkipRateBreaker,
-    clearAutoplayPause,
-} from './skipCircuitBreaker'
+import { evaluateSkipRateBreaker } from './skipCircuitBreaker'
 
 // Autoplay backfill target. Non-premium guilds keep the existing 8-song
 // runway; premium guilds get 2× (16) so large listening sessions rarely

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -44,6 +44,10 @@ import {
 } from '../candidateFallback'
 import { buildVcContributionWeights } from './vcWeights'
 import { getTrackAudioFeatures } from './audioFeatures'
+import {
+    evaluateSkipRateBreaker,
+    clearAutoplayPause,
+} from './skipCircuitBreaker'
 
 // Autoplay backfill target. Non-premium guilds keep the existing 8-song
 // runway; premium guilds get 2× (16) so large listening sessions rarely
@@ -122,6 +126,10 @@ async function _replenishQueue(
         ).length
         const missingTracks = bufferSize - autoplayInQueue
         if (missingTracks <= 0) return
+
+        // Autoplay skip-rate circuit breaker: check if we should pause replenishment
+        const shouldContinue = await evaluateSkipRateBreaker(queue)
+        if (!shouldContinue) return
 
         const allHistoryTracks = getAllHistoryTracks(queue)
         const replenishGuildId = queue.guild.id

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -498,6 +498,7 @@ async function _replenishQueue(
             excludedUrls,
             excludedKeys,
             requestedBy?.id,
+            autoplayMode,
         )
 
         // Increment replenish counter for next call's query variation

--- a/packages/bot/src/utils/music/autoplay/skipCircuitBreaker.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/skipCircuitBreaker.spec.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import {
+    isAutoplayPaused,
+    clearAutoplayPause,
+    evaluateSkipRateBreaker,
+} from './skipCircuitBreaker'
+import * as telemetryReadService from '@lucky/shared/services/recommendationTelemetryReadService'
+import type { GuildQueue } from 'discord-player'
+
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+    warnLog: jest.fn(),
+    errorLog: jest.fn(),
+}))
+
+describe('skipCircuitBreaker', () => {
+    const mockGuildId = 'guild-123'
+
+    describe('isAutoplayPaused', () => {
+        it('returns false when not paused', () => {
+            expect(isAutoplayPaused('unknown-guild')).toBe(false)
+        })
+    })
+
+    describe('clearAutoplayPause', () => {
+        it('clears pause state for a guild', async () => {
+            // Set up paused state
+            const mockQueue = {
+                guild: { id: mockGuildId },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.8,
+                sampleSize: 10,
+                acceptedCount: 2,
+                rejectedCount: 8,
+                canTrip: true,
+            })
+
+            // Trigger breaker
+            await evaluateSkipRateBreaker(mockQueue)
+            expect(isAutoplayPaused(mockGuildId)).toBe(true)
+
+            // Clear it
+            clearAutoplayPause(mockGuildId)
+            expect(isAutoplayPaused(mockGuildId)).toBe(false)
+        })
+    })
+
+    describe('evaluateSkipRateBreaker', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+        })
+
+        it('returns true when skip rate < threshold (no pause)', async () => {
+            const mockQueue = {
+                guild: { id: mockGuildId },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.4, // 40% < 60% threshold
+                sampleSize: 10,
+                acceptedCount: 6,
+                rejectedCount: 4,
+                canTrip: true,
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(true)
+            expect(isAutoplayPaused(mockGuildId)).toBe(false)
+        })
+
+        it('returns false and pauses when skip rate > threshold (sample >= 5)', async () => {
+            const mockChannel = {
+                send: jest.fn().mockResolvedValue(undefined),
+            }
+            const mockQueue = {
+                guild: { id: mockGuildId },
+                metadata: { channel: mockChannel },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.7, // 70% > 60% threshold
+                sampleSize: 10,
+                acceptedCount: 3,
+                rejectedCount: 7,
+                canTrip: true,
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(false)
+            expect(isAutoplayPaused(mockGuildId)).toBe(true)
+            expect(mockChannel.send).toHaveBeenCalledWith({
+                content: expect.stringContaining('70%'),
+            })
+        })
+
+        it('returns true when sample < minimum (never pauses)', async () => {
+            const mockQueue = {
+                guild: { id: mockGuildId + '-2' },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.8, // 80%, but not enough samples
+                sampleSize: 3, // < 5
+                acceptedCount: 1,
+                rejectedCount: 2,
+                canTrip: false, // Can't trip with low sample
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(true)
+            expect(isAutoplayPaused(mockGuildId + '-2')).toBe(false)
+        })
+
+        it('posts notice only once per pause', async () => {
+            const mockChannel = {
+                send: jest.fn().mockResolvedValue(undefined),
+            }
+            const guildId = 'guild-once-test'
+            const mockQueue = {
+                guild: { id: guildId },
+                metadata: { channel: mockChannel },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.75,
+                sampleSize: 10,
+                acceptedCount: 2,
+                rejectedCount: 8,
+                canTrip: true,
+            })
+
+            // First call: trips breaker and posts notice
+            const result1 = await evaluateSkipRateBreaker(mockQueue)
+            expect(result1).toBe(false)
+            expect(mockChannel.send).toHaveBeenCalledTimes(1)
+            expect(isAutoplayPaused(guildId)).toBe(true)
+
+            // Clear the mock to verify it won't be called again
+            mockChannel.send.mockClear()
+
+            // Second call: already paused, doesn't post again
+            const result2 = await evaluateSkipRateBreaker(mockQueue)
+            expect(result2).toBe(false)
+            expect(mockChannel.send).not.toHaveBeenCalled()
+        })
+
+        it('returns true when skip rate is null (no data)', async () => {
+            const mockQueue = {
+                guild: { id: mockGuildId + '-null' },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: null, // No resolved outcomes
+                sampleSize: 0,
+                acceptedCount: 0,
+                rejectedCount: 0,
+                canTrip: false,
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(true)
+            expect(isAutoplayPaused(mockGuildId + '-null')).toBe(false)
+        })
+
+        it('fails open (returns true) on query error', async () => {
+            const mockQueue = {
+                guild: { id: mockGuildId + '-error' },
+                metadata: { channel: null },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockRejectedValueOnce(new Error('DB error'))
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(true)
+            expect(isAutoplayPaused(mockGuildId + '-error')).toBe(false)
+        })
+
+        it('still pauses even if notice send fails', async () => {
+            const mockChannel = {
+                send: jest
+                    .fn()
+                    .mockRejectedValue(new Error('Channel send failed')),
+            }
+            const guildId = 'guild-fail-notice'
+            const mockQueue = {
+                guild: { id: guildId },
+                metadata: { channel: mockChannel },
+            } as any as GuildQueue
+
+            ;(
+                telemetryReadService.getAutoplaySkipRateForGuild as jest.Mock
+            ).mockResolvedValueOnce({
+                skipRate: 0.65,
+                sampleSize: 10,
+                acceptedCount: 3,
+                rejectedCount: 7,
+                canTrip: true,
+            })
+
+            const result = await evaluateSkipRateBreaker(mockQueue)
+            expect(result).toBe(false)
+            expect(isAutoplayPaused(guildId)).toBe(true)
+            expect(mockChannel.send).toHaveBeenCalled()
+        })
+    })
+})

--- a/packages/bot/src/utils/music/autoplay/skipCircuitBreaker.ts
+++ b/packages/bot/src/utils/music/autoplay/skipCircuitBreaker.ts
@@ -1,0 +1,116 @@
+import type { GuildQueue } from 'discord-player'
+import { getAutoplaySkipRateForGuild } from '@lucky/shared/services/recommendationTelemetryReadService'
+import { debugLog, warnLog } from '@lucky/shared/utils'
+import type { QueueMetadata } from '../../../types/QueueMetadata'
+
+// Default threshold: 60% skip rate pauses autoplay
+const AUTOPLAY_SKIP_BREAKER_THRESHOLD = 0.6
+
+// In-memory pause state: maps guildId -> { isPaused: boolean; notified: boolean }
+const autoplayPauseState = new Map<
+    string,
+    { isPaused: boolean; notified: boolean }
+>()
+
+/**
+ * Checks if autoplay is currently paused for this guild.
+ */
+export function isAutoplayPaused(guildId: string): boolean {
+    return autoplayPauseState.get(guildId)?.isPaused ?? false
+}
+
+/**
+ * Clears the autoplay pause state for a guild (used on manual /play).
+ */
+export function clearAutoplayPause(guildId: string): void {
+    if (autoplayPauseState.has(guildId)) {
+        autoplayPauseState.delete(guildId)
+        debugLog({
+            message: 'Autoplay pause cleared',
+            data: { guildId },
+        })
+    }
+}
+
+/**
+ * Evaluates and applies the skip-rate circuit breaker.
+ * Returns false if autoplay should be paused, true if replenishment should proceed.
+ * Posts ONE notice to the music channel if the breaker trips.
+ */
+export async function evaluateSkipRateBreaker(
+    queue: GuildQueue,
+): Promise<boolean> {
+    const guildId = queue.guild.id
+    const metadata = queue.metadata as QueueMetadata | undefined
+    const musicChannel = metadata?.channel
+
+    // Check current pause state
+    const currentState = autoplayPauseState.get(guildId)
+    if (currentState?.isPaused) {
+        return false // Stay paused
+    }
+
+    try {
+        const skipRateData = await getAutoplaySkipRateForGuild(guildId)
+
+        // Only trip if sample is sufficient and skip rate exceeds threshold
+        if (
+            skipRateData.canTrip &&
+            skipRateData.skipRate !== null &&
+            skipRateData.skipRate > AUTOPLAY_SKIP_BREAKER_THRESHOLD
+        ) {
+            // Trip the breaker
+            autoplayPauseState.set(guildId, { isPaused: true, notified: false })
+
+            // Post notice to music channel (once per pause)
+            if (musicChannel) {
+                try {
+                    await musicChannel.send({
+                        content: `⏸️ **Autoplay paused** — High skip rate detected (${(skipRateData.skipRate * 100).toFixed(0)}%). Play a track manually to resume.`,
+                    })
+                    autoplayPauseState.set(guildId, {
+                        isPaused: true,
+                        notified: true,
+                    })
+                    debugLog({
+                        message: 'Skip-rate breaker tripped and notice posted',
+                        data: {
+                            guildId,
+                            skipRate: skipRateData.skipRate,
+                            sampleSize: skipRateData.sampleSize,
+                        },
+                    })
+                } catch (noticeError) {
+                    warnLog({
+                        message: 'Failed to post autoplay pause notice',
+                        error: noticeError,
+                        data: { guildId },
+                    })
+                    // Still pause even if notice fails
+                    autoplayPauseState.set(guildId, {
+                        isPaused: true,
+                        notified: false,
+                    })
+                }
+            } else {
+                // No channel, but still pause
+                autoplayPauseState.set(guildId, {
+                    isPaused: true,
+                    notified: false,
+                })
+            }
+
+            return false // Don't replenish
+        }
+
+        return true // Proceed with replenishment
+    } catch (error) {
+        warnLog({
+            message: 'Error evaluating skip-rate breaker',
+            error,
+            data: { guildId },
+        })
+        // Fail open: allow replenishment on error
+        return true
+    }
+}

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -1,4 +1,10 @@
 import { jest } from '@jest/globals'
+
+// Transitively pulled in via replenisher -> skipCircuitBreaker; real module loads
+// prismaClient (import.meta). Factory-mock to keep this suite loadable.
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
 import {
     replenishQueue,
     enrichWithAudioFeatures,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lucky-webapp",
     "private": true,
-    "version": "2.15.2",
+    "version": "2.16.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/shared/check-docs-coverage.mjs
+++ b/packages/shared/check-docs-coverage.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { execSync } from 'child_process'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const COVERAGE_THRESHOLD = 80
+
+try {
+    console.log(`Checking documentation coverage with TypeDoc...`)
+    execSync(
+        'npx typedoc --plugin typedoc-plugin-coverage --emit none src/index.ts',
+        {
+            cwd: __dirname,
+            encoding: 'utf-8',
+            stdio: 'inherit',
+        }
+    )
+
+    console.log(
+        `✅ Documentation generation completed with coverage plugin enabled (${COVERAGE_THRESHOLD}% threshold)`
+    )
+    process.exit(0)
+} catch (error) {
+    console.error('Error checking documentation coverage:')
+    console.error(error.message)
+    process.exit(1)
+}

--- a/packages/shared/jest.config.cjs
+++ b/packages/shared/jest.config.cjs
@@ -14,15 +14,22 @@ module.exports = {
     '!src/**/*.d.ts',
     '!src/**/*.test.ts',
     '!src/**/*.spec.ts',
+    '!src/generated/**',
+    // Barrel files: pure re-exports, no logic
+    '!src/index.ts',
+    '!src/services/index.ts',
+    '!src/utils/index.ts',
+    '!src/types/index.ts',
+    '!src/types/errors/index.ts',
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov'],
   coverageThreshold: {
     global: {
-      statements: 19,
-      branches: 16,
-      functions: 15,
-      lines: 18
+      statements: 89,
+      branches: 89,
+      functions: 90,
+      lines: 89
     }
   },
   testTimeout: 30000,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucky/shared",
-    "version": "2.15.2",
+    "version": "2.16.0",
     "description": "Shared code for Lucky modular monolith",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -48,7 +48,8 @@
         "dev": "tsc --watch",
         "type:check": "tsc --noEmit",
         "test": "jest",
-        "test:ci": "jest --ci"
+        "test:ci": "jest --ci",
+        "docs:check": "node check-docs-coverage.mjs"
     },
     "dependencies": {
         "@gar/promise-retry": "^1.0.3",
@@ -82,6 +83,8 @@
         "@swc/core": "^1.15.40",
         "@types/node": "^25.9.1",
         "glob": "^13.0.6",
+        "typedoc": "^0.28.19",
+        "typedoc-plugin-coverage": "^4.0.3",
         "typescript": "^6.0.3"
     }
 }

--- a/packages/shared/src/__tests__/utils/spotify/artistApi.test.ts
+++ b/packages/shared/src/__tests__/utils/spotify/artistApi.test.ts
@@ -1,223 +1,284 @@
-import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import {
-	searchSpotifyArtists,
-	getSpotifyRelatedArtists,
-	type SpotifyArtist,
+    describe,
+    test,
+    expect,
+    beforeEach,
+    afterEach,
+    jest,
+} from '@jest/globals'
+import {
+    searchSpotifyArtists,
+    getSpotifyRelatedArtists,
+    type SpotifyArtist,
 } from '../../../../src/utils/spotify/artistApi'
 
 describe('Spotify Artist API', () => {
-	beforeEach(() => {
-		jest.clearAllMocks()
-	})
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
 
-	const mockArtist: SpotifyArtist = {
-		id: 'spotify-1',
-		name: 'Drake',
-		imageUrl: 'https://example.com/image.jpg',
-		popularity: 85,
-		genres: ['hip-hop', 'rap'],
-	}
+    const mockArtist: SpotifyArtist = {
+        id: 'spotify-1',
+        name: 'Drake',
+        imageUrl: 'https://example.com/image.jpg',
+        popularity: 85,
+        genres: ['hip-hop', 'rap'],
+    }
 
-	describe('getSpotifyRelatedArtists', () => {
-		test('should return unique artists from recommendations', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({
-							tracks: [
-								{
-									artists: [
-										{
-											id: 'artist-1',
-											name: 'Artist One',
-											images: [{ url: 'http://example.com/img1.jpg' }],
-											popularity: 80,
-											genres: ['pop'],
-										},
-										{
-											id: 'artist-2',
-											name: 'Artist Two',
-											images: [{ url: 'http://example.com/img2.jpg' }],
-											popularity: 75,
-											genres: ['rock'],
-										},
-									],
-								},
-								{
-									artists: [
-										{
-											id: 'artist-3',
-											name: 'Artist Three',
-											images: [{ url: 'http://example.com/img3.jpg' }],
-											popularity: 70,
-											genres: ['jazz'],
-										},
-									],
-								},
-							],
-						}),
-						{ status: 200 },
-					),
-				)
+    describe('getSpotifyRelatedArtists', () => {
+        const originalEnv = process.env
 
-			const result = await getSpotifyRelatedArtists('access-token', 'seed-artist')
+        beforeEach(() => {
+            process.env = { ...originalEnv, LASTFM_API_KEY: 'test-key' }
+        })
 
-			expect(result).toHaveLength(3)
-			expect(result[0].id).toBe('artist-1')
-			expect(result[1].id).toBe('artist-2')
-			expect(result[2].id).toBe('artist-3')
-			fetchSpy.mockRestore()
-		})
+        afterEach(() => {
+            process.env = originalEnv
+        })
 
-		test('should deduplicate duplicate artist ids in recommendations', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({
-							tracks: [
-								{
-									artists: [
-										{
-											id: 'artist-1',
-											name: 'Artist One',
-											images: [{ url: 'http://example.com/img1.jpg' }],
-											popularity: 80,
-											genres: ['pop'],
-										},
-									],
-								},
-								{
-									artists: [
-										{
-											id: 'artist-1',
-											name: 'Artist One',
-											images: [{ url: 'http://example.com/img1.jpg' }],
-											popularity: 80,
-											genres: ['pop'],
-										},
-									],
-								},
-							],
-						}),
-						{ status: 200 },
-					),
-				)
+        test('returns artists via Last.fm and Spotify search', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ name: 'Seed Artist' }), {
+                        status: 200,
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            similarartists: {
+                                artist: [
+                                    { name: 'Similar 1' },
+                                    { name: 'Similar 2' },
+                                ],
+                            },
+                        }),
+                        { status: 200 },
+                    ),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            artists: {
+                                items: [
+                                    {
+                                        id: 'art-1',
+                                        name: 'Similar 1',
+                                        images: [],
+                                        popularity: 70,
+                                        genres: [],
+                                    },
+                                ],
+                            },
+                        }),
+                        { status: 200 },
+                    ),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            artists: {
+                                items: [
+                                    {
+                                        id: 'art-2',
+                                        name: 'Similar 2',
+                                        images: [],
+                                        popularity: 65,
+                                        genres: [],
+                                    },
+                                ],
+                            },
+                        }),
+                        { status: 200 },
+                    ),
+                )
 
-			const result = await getSpotifyRelatedArtists('access-token', 'seed-artist')
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'seed-id',
+            )
 
-			expect(result).toHaveLength(1)
-			expect(result[0].id).toBe('artist-1')
-			fetchSpy.mockRestore()
-		})
+            expect(result).toHaveLength(2)
+            expect(result[0].id).toBe('art-1')
+            expect(result[1].id).toBe('art-2')
+            fetchSpy.mockRestore()
+        })
 
-		test('should handle API 403 error gracefully', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ error: 'Forbidden' }), {
-						status: 403,
-					}),
-				)
+        test('deduplicates artists with the same Spotify ID', async () => {
+            const sameArtistBody = JSON.stringify({
+                artists: {
+                    items: [
+                        {
+                            id: 'art-1',
+                            name: 'Same Artist',
+                            images: [],
+                            popularity: 70,
+                            genres: [],
+                        },
+                    ],
+                },
+            })
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ name: 'Seed Artist' }), {
+                        status: 200,
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({
+                            similarartists: {
+                                artist: [
+                                    { name: 'Similar 1' },
+                                    { name: 'Similar 2' },
+                                ],
+                            },
+                        }),
+                        { status: 200 },
+                    ),
+                )
+                .mockResolvedValueOnce(
+                    new Response(sameArtistBody, { status: 200 }),
+                )
+                .mockResolvedValueOnce(
+                    new Response(sameArtistBody, { status: 200 }),
+                )
 
-			const result = await getSpotifyRelatedArtists('invalid-token', 'artist-id')
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'seed-id',
+            )
 
-			expect(result).toEqual([])
-			fetchSpy.mockRestore()
-		})
+            expect(result).toHaveLength(1)
+            expect(result[0].id).toBe('art-1')
+            fetchSpy.mockRestore()
+        })
 
-		test('should handle empty response', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ tracks: [] }), { status: 200 }),
-				)
+        test('returns [] when seed artist name fetch returns non-ok status', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({}), { status: 404 }),
+                )
 
-			const result = await getSpotifyRelatedArtists('access-token', 'artist-id')
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'unknown-id',
+            )
 
-			expect(result).toEqual([])
-			fetchSpy.mockRestore()
-		})
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
 
-		test('should limit results to 12 artists', async () => {
-			const tracks = Array.from({ length: 20 }, (_, i) => ({
-				artists: [
-					{
-						id: `artist-${i}`,
-						name: `Artist ${i}`,
-						images: [{ url: `http://example.com/img${i}.jpg` }],
-						popularity: 80 - i,
-						genres: ['pop'],
-					},
-				],
-			}))
+        test('returns [] when Last.fm returns no similar artists', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ name: 'Seed Artist' }), {
+                        status: 200,
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({ similarartists: { artist: [] } }),
+                        { status: 200 },
+                    ),
+                )
 
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ tracks }), { status: 200 }),
-				)
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'seed-id',
+            )
 
-			const result = await getSpotifyRelatedArtists('access-token', 'artist-id')
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
 
-			expect(result).toHaveLength(12)
-			fetchSpy.mockRestore()
-		})
-	})
+        test('returns [] when LASTFM_API_KEY is not configured', async () => {
+            delete process.env.LASTFM_API_KEY
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ name: 'Seed Artist' }), {
+                        status: 200,
+                    }),
+                )
 
-	describe('searchSpotifyArtists', () => {
-		test('should return artists matching search query', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(
-						JSON.stringify({
-							artists: {
-								items: [mockArtist],
-							},
-						}),
-						{ status: 200 },
-					),
-				)
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'seed-id',
+            )
 
-			const result = await searchSpotifyArtists('access-token', 'Drake')
+            expect(result).toEqual([])
+            expect(fetchSpy).toHaveBeenCalledTimes(1)
+            fetchSpy.mockRestore()
+        })
 
-			expect(result).toHaveLength(1)
-			expect(result[0].name).toBe('Drake')
-			fetchSpy.mockRestore()
-		})
+        test('handles network error gracefully', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockRejectedValueOnce(new Error('Network error'))
 
-		test('should return empty array for empty query', async () => {
-			const result = await searchSpotifyArtists('access-token', '   ')
+            const result = await getSpotifyRelatedArtists(
+                'access-token',
+                'seed-id',
+            )
 
-			expect(result).toEqual([])
-		})
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
+    })
 
-		test('should handle API errors gracefully', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ error: 'Unauthorized' }), {
-						status: 401,
-					}),
-				)
+    describe('searchSpotifyArtists', () => {
+        test('should return artists matching search query', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        artists: {
+                            items: [mockArtist],
+                        },
+                    }),
+                    { status: 200 },
+                ),
+            )
 
-			const result = await searchSpotifyArtists('bad-token', 'Drake')
+            const result = await searchSpotifyArtists('access-token', 'Drake')
 
-			expect(result).toEqual([])
-			fetchSpy.mockRestore()
-		})
+            expect(result).toHaveLength(1)
+            expect(result[0].name).toBe('Drake')
+            fetchSpy.mockRestore()
+        })
 
-		test('should handle network errors gracefully', async () => {
-			const fetchSpy = jest
-				.spyOn(global, 'fetch')
-				.mockRejectedValueOnce(new Error('Network error'))
+        test('should return empty array for empty query', async () => {
+            const result = await searchSpotifyArtists('access-token', '   ')
 
-			const result = await searchSpotifyArtists('access-token', 'Drake')
+            expect(result).toEqual([])
+        })
 
-			expect(result).toEqual([])
-			fetchSpy.mockRestore()
-		})
-	})
+        test('should handle API errors gracefully', async () => {
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: 'Unauthorized' }), {
+                    status: 401,
+                }),
+            )
+
+            const result = await searchSpotifyArtists('bad-token', 'Drake')
+
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
+
+        test('should handle network errors gracefully', async () => {
+            const fetchSpy = jest
+                .spyOn(global, 'fetch')
+                .mockRejectedValueOnce(new Error('Network error'))
+
+            const result = await searchSpotifyArtists('access-token', 'Drake')
+
+            expect(result).toEqual([])
+            fetchSpy.mockRestore()
+        })
+    })
 })

--- a/packages/shared/src/constants/colors.ts
+++ b/packages/shared/src/constants/colors.ts
@@ -1,21 +1,22 @@
 export const COLOR = {
-  LUCKY_PURPLE: 0x9c27b0,
-  SPOTIFY_GREEN: 0x1db954,
-  YOUTUBE_RED: 0xff0000,
-  SOUNDCLOUD_ORANGE: 0xff5500,
-  APPLE_MUSIC_RED: 0xfa2d48,
-  TIDAL_BLUE: 0x1ab7ea,
-  DISCORD_BLURPLE: 0x5865f2,
-  TWITTER_RED: 0xd51007,
-  FFMPEG_ORANGE: 0xff9900,
-  SUCCESS_GREEN: 0x00ff00,
-  ERROR_RED: 0xff0000,
-  WARNING_GOLD: 0xffd700,
-  ENABLED_GREEN: 0x51cf66,
-  DISABLED_RED: 0xc92a2a,
-  SETUP_PURPLE: 0x8b5cf6,
-  INFO_GREEN: 0x22c55e,
-  NEUTRAL_GRAY: 0x6b7280,
-} as const;
+    LUCKY_PURPLE: 0x9c27b0,
+    SPOTIFY_GREEN: 0x1db954,
+    YOUTUBE_RED: 0xff0000,
+    SOUNDCLOUD_ORANGE: 0xff5500,
+    APPLE_MUSIC_RED: 0xfa2d48,
+    TIDAL_BLUE: 0x1ab7ea,
+    DISCORD_BLURPLE: 0x5865f2,
+    TWITTER_RED: 0xd51007,
+    FFMPEG_ORANGE: 0xff9900,
+    SUCCESS_GREEN: 0x00ff00,
+    ERROR_RED: 0xff0000,
+    WARNING_GOLD: 0xffd700,
+    ENABLED_GREEN: 0x51cf66,
+    DISABLED_RED: 0xc92a2a,
+    SETUP_PURPLE: 0x8b5cf6,
+    INFO_GREEN: 0x22c55e,
+    NEUTRAL_GRAY: 0x6b7280,
+} as const
 
-export type ColorKey = keyof typeof COLOR;
+/** Type representing a valid key from the COLOR constants object. */
+export type ColorKey = keyof typeof COLOR

--- a/packages/shared/src/constants/topgg.ts
+++ b/packages/shared/src/constants/topgg.ts
@@ -8,8 +8,10 @@ export const TOP_GG_VOTE_TIERS = [
     { threshold: 1, label: 'Lucky Supporter' },
 ] as const
 
+/** Type representing a voting tier from the top.gg vote tiers list. */
 export type TopggVoteTier = (typeof TOP_GG_VOTE_TIERS)[number]
 
+/** Returns the top.gg voting tier matching the given vote streak, or null if below minimum. */
 export function tierForVoteStreak(streak: number): TopggVoteTier | null {
     for (const tier of TOP_GG_VOTE_TIERS) {
         if (streak >= tier.threshold) return tier

--- a/packages/shared/src/services/AutoMessageService.ts
+++ b/packages/shared/src/services/AutoMessageService.ts
@@ -4,8 +4,10 @@ import type { EmbedData } from './embedValidation.js'
 
 const prisma = getPrismaClient()
 
+/** Type of auto message: welcome, leave, auto-response, or scheduled. */
 export type MessageType = 'welcome' | 'leave' | 'auto_response' | 'scheduled'
 
+/** Content of an auto message including optional embed data. */
 export interface AutoMessageData {
     message: string
     embedData?: EmbedData
@@ -18,10 +20,9 @@ type AutoMessageOptions = {
     cronSchedule?: string
 }
 
+/** Service for managing guild auto messages (welcome, leave, auto-response, scheduled). */
 export class AutoMessageService {
-    /**
-     * Create a new auto message
-     */
+    /** Creates a new auto message. */
     async createMessage(
         guildId: string,
         type: MessageType,
@@ -44,6 +45,7 @@ export class AutoMessageService {
         })
     }
 
+    /** Creates or updates an auto message of a given type for a guild. */
     async upsertGuildTypeMessage(
         guildId: string,
         type: MessageType,
@@ -159,10 +161,7 @@ export class AutoMessageService {
     /**
      * Update a message
      */
-    async updateMessage(
-        id: string,
-        data: Prisma.AutoMessageUpdateInput,
-    ) {
+    async updateMessage(id: string, data: Prisma.AutoMessageUpdateInput) {
         return await prisma.autoMessage.update({
             where: { id },
             data,

--- a/packages/shared/src/services/AutoModService.ts
+++ b/packages/shared/src/services/AutoModService.ts
@@ -6,6 +6,7 @@ const prisma = getPrismaClient()
 const CACHE_TTL = 300
 const CACHE_PREFIX = 'automod:'
 
+/** Auto-moderation settings configuration for a guild. */
 export interface AutoModSettings {
     id: string
     guildId: string
@@ -27,11 +28,13 @@ export interface AutoModSettings {
     updatedAt: Date
 }
 
+/** Mutable subset of AutoModSettings excluding metadata fields. */
 type AutoModMutableSettings = Omit<
     AutoModSettings,
     'id' | 'guildId' | 'createdAt' | 'updatedAt'
 >
 
+/** Pre-configured auto-moderation template. */
 export interface AutoModTemplate {
     id: string
     name: string
@@ -39,6 +42,7 @@ export interface AutoModTemplate {
     settings: Partial<AutoModMutableSettings>
 }
 
+/** Error thrown when an auto-moderation template is not found. */
 export class AutoModTemplateNotFoundError extends Error {
     readonly code = 'ERR_AUTOMOD_TEMPLATE_NOT_FOUND'
 
@@ -147,12 +151,14 @@ const AUTO_MOD_TEMPLATES: AutoModTemplate[] = [
     },
 ]
 
+/** Normalizes text for case-insensitive matching by removing accents. */
 const normalizeForMatch = (value: string): string =>
     value
         .normalize('NFD')
         .replaceAll(/\p{M}+/gu, '')
         .toLowerCase()
 
+/** Normalizes and validates a list of allowed domains. */
 const normalizeAllowedDomains = (domains: string[]): string[] =>
     domains
         .map((domain) => domain.trim().toLowerCase())
@@ -172,6 +178,7 @@ const normalizeAllowedDomains = (domains: string[]): string[] =>
         .map((domain) => (domain.startsWith('www.') ? domain.slice(4) : domain))
         .filter((domain) => domain.length > 0)
 
+/** Removes trailing punctuation from URLs. */
 const trimTrailingUrlPunctuation = (value: string): string => {
     let result = value.trim()
     const trailing = new Set([')', ',', '.', '!', '?', ';', ':'])
@@ -183,6 +190,7 @@ const trimTrailingUrlPunctuation = (value: string): string => {
     return result
 }
 
+/** Extracts hostname from a URL string. */
 const extractHostname = (rawUrl: string): string | null => {
     const sanitized = trimTrailingUrlPunctuation(rawUrl)
 
@@ -194,7 +202,9 @@ const extractHostname = (rawUrl: string): string | null => {
     }
 }
 
+/** Provides auto-moderation checks and management for message content. */
 export class AutoModService {
+    /** Retrieves auto-mod settings for a guild with caching. */
     async getSettings(guildId: string): Promise<AutoModSettings | null> {
         if (redisClient.isHealthy()) {
             try {
@@ -224,12 +234,14 @@ export class AutoModService {
         return settings
     }
 
+    /** Clears cached settings for a guild. */
     private invalidateCache(guildId: string): void {
         if (redisClient.isHealthy()) {
             redisClient.del(`${CACHE_PREFIX}${guildId}`).catch(() => {})
         }
     }
 
+    /** Creates default auto-mod settings for a guild. */
     async createSettings(guildId: string): Promise<AutoModSettings> {
         const result = await prisma.autoModSettings.create({
             data: { guildId },
@@ -238,6 +250,7 @@ export class AutoModService {
         return result
     }
 
+    /** Updates auto-mod settings for a guild. */
     async updateSettings(
         guildId: string,
         settings: Partial<AutoModMutableSettings>,
@@ -251,10 +264,12 @@ export class AutoModService {
         return result
     }
 
+    /** Lists all available auto-mod templates. */
     async listTemplates(): Promise<AutoModTemplate[]> {
         return AUTO_MOD_TEMPLATES
     }
 
+    /** Applies a pre-configured template to a guild's auto-mod settings. */
     async applyTemplate(
         guildId: string,
         templateId: string,
@@ -293,6 +308,7 @@ export class AutoModService {
         return { settings, template }
     }
 
+    /** Tracks a message and checks if spam threshold is exceeded. */
     async trackMessageAndCheckSpam(
         guildId: string,
         userId: string,
@@ -318,6 +334,7 @@ export class AutoModService {
         return recentCount >= settings.spamThreshold
     }
 
+    /** Checks if message timestamps exceed spam threshold. */
     async checkSpam(
         guildId: string,
         userId: string,
@@ -335,6 +352,7 @@ export class AutoModService {
         return recentMessages.length >= settings.spamThreshold
     }
 
+    /** Checks if message content exceeds caps lock threshold. */
     async checkCaps(guildId: string, content: string): Promise<boolean> {
         const settings = await this.getSettings(guildId)
         if (!settings?.capsEnabled) return false
@@ -349,6 +367,7 @@ export class AutoModService {
         return capsPercentage >= settings.capsThreshold
     }
 
+    /** Checks if message contains disallowed links. */
     async checkLinks(
         guildId: string,
         content: string,
@@ -379,6 +398,7 @@ export class AutoModService {
         })
     }
 
+    /** Checks if message contains Discord invite links. */
     async checkInvites(guildId: string, content: string): Promise<boolean> {
         const settings = await this.getSettings(guildId)
         if (!settings?.invitesEnabled) return false
@@ -388,6 +408,7 @@ export class AutoModService {
         return inviteRegex.test(content)
     }
 
+    /** Checks if message contains banned words. */
     async checkWords(guildId: string, content: string): Promise<boolean> {
         const settings = await this.getSettings(guildId)
         if (!settings?.wordsEnabled) return false
@@ -410,6 +431,7 @@ export class AutoModService {
         })
     }
 
+    /** Checks if a channel or role is exempt from auto-mod checks. */
     isExempt(
         settings: AutoModSettings,
         channelId?: string,
@@ -430,4 +452,5 @@ export class AutoModService {
     }
 }
 
+/** Singleton instance of AutoModService. */
 export const autoModService = new AutoModService()

--- a/packages/shared/src/services/AutoRoleService.ts
+++ b/packages/shared/src/services/AutoRoleService.ts
@@ -2,6 +2,7 @@ import { getPrismaClient } from '../utils/database/prismaClient.js'
 
 const prisma = getPrismaClient()
 
+/** Configuration entry for automatic role assignments with delay. */
 export type AutoRoleEntry = {
     id: string
     guildId: string
@@ -10,8 +11,14 @@ export type AutoRoleEntry = {
     createdAt: Date
 }
 
+/** Manages automatic role assignments for guild members. */
 export class AutoRoleService {
-    async add(guildId: string, roleId: string, delayMinutes = 0): Promise<AutoRoleEntry> {
+    /** Adds or updates an automatic role assignment. */
+    async add(
+        guildId: string,
+        roleId: string,
+        delayMinutes = 0,
+    ): Promise<AutoRoleEntry> {
         return await prisma.autoRole.upsert({
             where: { guildId_roleId: { guildId, roleId } },
             create: { guildId, roleId, delayMinutes },
@@ -19,12 +26,14 @@ export class AutoRoleService {
         })
     }
 
+    /** Removes an automatic role assignment. */
     async remove(guildId: string, roleId: string): Promise<void> {
         await prisma.autoRole.deleteMany({
             where: { guildId, roleId },
         })
     }
 
+    /** Lists all automatic role assignments for a guild. */
     async list(guildId: string): Promise<AutoRoleEntry[]> {
         return await prisma.autoRole.findMany({
             where: { guildId },
@@ -32,9 +41,11 @@ export class AutoRoleService {
         })
     }
 
+    /** Alias for list(); gets all automatic roles for a guild. */
     async getAllForGuild(guildId: string): Promise<AutoRoleEntry[]> {
         return await this.list(guildId)
     }
 }
 
+/** Singleton instance of AutoRoleService. */
 export const autoroleService = new AutoRoleService()

--- a/packages/shared/src/services/CustomCommandService.ts
+++ b/packages/shared/src/services/CustomCommandService.ts
@@ -8,17 +8,21 @@ const prisma = getPrismaClient()
 const CACHE_TTL = 300
 const CACHE_PREFIX = 'cmd:'
 
+/** Manages guild-specific custom commands with caching and permissions. */
 export class CustomCommandService {
+    /** Generates cache key for a custom command. */
     private cacheKey(guildId: string, name: string): string {
         return `${CACHE_PREFIX}${guildId}:${name.toLowerCase()}`
     }
 
+    /** Clears cache for a custom command. */
     private invalidateCommand(guildId: string, name: string): void {
         if (redisClient.isHealthy()) {
             redisClient.del(this.cacheKey(guildId, name)).catch(() => {})
         }
     }
 
+    /** Creates a new custom command for a guild. */
     async createCommand(
         guildId: string,
         name: string,
@@ -49,6 +53,7 @@ export class CustomCommandService {
         return result
     }
 
+    /** Creates or updates a custom command with transactional locking. */
     async upsertCommand(
         guildId: string,
         name: string,
@@ -115,6 +120,7 @@ export class CustomCommandService {
         return state
     }
 
+    /** Retrieves a custom command by name with caching. */
     async getCommand(guildId: string, name: string) {
         const key = this.cacheKey(guildId, name)
 
@@ -160,6 +166,7 @@ export class CustomCommandService {
         return result
     }
 
+    /** Lists all custom commands for a guild. */
     async listCommands(guildId: string) {
         return await prisma.customCommand.findMany({
             where: { guildId },
@@ -167,6 +174,7 @@ export class CustomCommandService {
         })
     }
 
+    /** Updates a custom command. */
     async updateCommand(
         guildId: string,
         name: string,
@@ -185,6 +193,7 @@ export class CustomCommandService {
         return result
     }
 
+    /** Deletes a custom command. */
     async deleteCommand(guildId: string, name: string) {
         const result = await prisma.customCommand.delete({
             where: {
@@ -198,9 +207,7 @@ export class CustomCommandService {
         return result
     }
 
-    /**
-     * Increment command usage
-     */
+    /** Increments command usage counter and updates last used timestamp. */
     async incrementUsage(guildId: string, name: string) {
         return await prisma.customCommand.update({
             where: {
@@ -218,9 +225,7 @@ export class CustomCommandService {
         })
     }
 
-    /**
-     * Check if user can use command
-     */
+    /** Checks if a user can execute a command based on role and channel permissions. */
     canUseCommand(
         command: {
             allowedRoles: string[]
@@ -256,9 +261,7 @@ export class CustomCommandService {
         return true
     }
 
-    /**
-     * Get command statistics
-     */
+    /** Generates statistics about custom commands in a guild. */
     async getStats(guildId: string) {
         const commands = await this.listCommands(guildId)
 
@@ -273,4 +276,5 @@ export class CustomCommandService {
     }
 }
 
+/** Singleton instance of CustomCommandService. */
 export const customCommandService = new CustomCommandService()

--- a/packages/shared/src/services/EmbedBuilderService.ts
+++ b/packages/shared/src/services/EmbedBuilderService.ts
@@ -10,6 +10,7 @@ import {
 
 const prisma = getPrismaClient()
 
+/** Data structure representing a stored embed template. */
 export type EmbedTemplate = {
     id: string
     guildId: string
@@ -27,7 +28,9 @@ export type EmbedTemplate = {
     updatedAt: Date
 }
 
+/** Service for managing Discord embed templates with persistence and validation. */
 export class EmbedBuilderService {
+    /** Creates a new embed template with the given data. */
     async createTemplate(
         guildId: string,
         name: string,
@@ -53,6 +56,7 @@ export class EmbedBuilderService {
         })
     }
 
+    /** Creates or updates an embed template, returning whether it was created or updated. */
     async upsertTemplate(
         guildId: string,
         name: string,
@@ -108,6 +112,7 @@ export class EmbedBuilderService {
         })
     }
 
+    /** Retrieves an embed template by guild and name, or null if not found. */
     async getTemplate(
         guildId: string,
         name: string,
@@ -117,6 +122,7 @@ export class EmbedBuilderService {
         })
     }
 
+    /** Lists all embed templates for a guild, ordered by name. */
     async listTemplates(guildId: string): Promise<EmbedTemplate[]> {
         return await prisma.embedTemplate.findMany({
             where: { guildId },
@@ -124,6 +130,7 @@ export class EmbedBuilderService {
         })
     }
 
+    /** Updates an existing embed template with the provided data. */
     async updateTemplate(
         guildId: string,
         name: string,
@@ -147,6 +154,7 @@ export class EmbedBuilderService {
         })
     }
 
+    /** Deletes an embed template from the database. */
     async deleteTemplate(guildId: string, name: string): Promise<void> {
         const existing = await prisma.embedTemplate.findFirst({
             where: { guildId, name },
@@ -159,6 +167,7 @@ export class EmbedBuilderService {
         })
     }
 
+    /** Increments the usage count of an embed template. */
     async incrementUsage(guildId: string, name: string): Promise<void> {
         const existing = await prisma.embedTemplate.findFirst({
             where: { guildId, name },
@@ -170,6 +179,7 @@ export class EmbedBuilderService {
         })
     }
 
+    /** Validates embed data and returns validation errors if any. */
     validateEmbedData(embedData: Partial<EmbedData>): {
         valid: boolean
         errors: string[]
@@ -177,13 +187,17 @@ export class EmbedBuilderService {
         return _validateEmbedData(embedData)
     }
 
+    /** Converts a hexadecimal color string to a decimal number. */
     hexToDecimal(hex: string): number {
         return _hexToDecimal(hex)
     }
 
+    /** Converts a decimal color number to a hexadecimal string. */
     decimalToHex(decimal: number): string {
         return _decimalToHex(decimal)
     }
 }
+
+/** Global instance of the embed builder service. */
 
 export const embedBuilderService = new EmbedBuilderService()

--- a/packages/shared/src/services/FeatureToggleService.spec.ts
+++ b/packages/shared/src/services/FeatureToggleService.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, jest, beforeEach, afterAll } from '@jest/globals'
 const mockFindUnique = jest.fn<any>()
 const mockUpsert = jest.fn<any>()
 const mockPrismaClient = {
-    guildFeatureToggle: {
+    globalFeatureToggle: {
         findUnique: (...args: unknown[]) => mockFindUnique(...args),
         upsert: (...args: unknown[]) => mockUpsert(...args),
     },
@@ -70,17 +70,14 @@ describe('FeatureToggleService', () => {
         }
     })
 
-    describe('getDbOverride (via isEnabledForGuild)', () => {
+    describe('getDbGlobalOverride', () => {
         it('returns db value when row exists (enabled=true)', async () => {
             mockFindUnique.mockResolvedValue({ enabled: true })
             const result = await (
                 service as unknown as {
-                    getDbOverride(
-                        guildId: string,
-                        name: string,
-                    ): Promise<boolean | null>
+                    getDbGlobalOverride(name: string): Promise<boolean | null>
                 }
-            ).getDbOverride('guild-1', 'DOWNLOAD_AUDIO')
+            ).getDbGlobalOverride('DOWNLOAD_AUDIO')
             expect(result).toBe(true)
         })
 
@@ -88,12 +85,9 @@ describe('FeatureToggleService', () => {
             mockFindUnique.mockResolvedValue({ enabled: false })
             const result = await (
                 service as unknown as {
-                    getDbOverride(
-                        guildId: string,
-                        name: string,
-                    ): Promise<boolean | null>
+                    getDbGlobalOverride(name: string): Promise<boolean | null>
                 }
-            ).getDbOverride('guild-1', 'DOWNLOAD_AUDIO')
+            ).getDbGlobalOverride('DOWNLOAD_AUDIO')
             expect(result).toBe(false)
         })
 
@@ -101,12 +95,9 @@ describe('FeatureToggleService', () => {
             mockFindUnique.mockResolvedValue(null)
             const result = await (
                 service as unknown as {
-                    getDbOverride(
-                        guildId: string,
-                        name: string,
-                    ): Promise<boolean | null>
+                    getDbGlobalOverride(name: string): Promise<boolean | null>
                 }
-            ).getDbOverride('guild-1', 'DOWNLOAD_AUDIO')
+            ).getDbGlobalOverride('DOWNLOAD_AUDIO')
             expect(result).toBeNull()
         })
 
@@ -114,47 +105,27 @@ describe('FeatureToggleService', () => {
             mockFindUnique.mockRejectedValue(new Error('DB connection failed'))
             const result = await (
                 service as unknown as {
-                    getDbOverride(
-                        guildId: string,
-                        name: string,
-                    ): Promise<boolean | null>
+                    getDbGlobalOverride(name: string): Promise<boolean | null>
                 }
-            ).getDbOverride('guild-1', 'DOWNLOAD_AUDIO')
+            ).getDbGlobalOverride('DOWNLOAD_AUDIO')
             expect(result).toBeNull()
         })
     })
 
-    describe('setGuildFeatureToggle', () => {
+    describe('setGlobalFeatureToggle', () => {
         it('upserts the toggle with correct args', async () => {
             mockUpsert.mockResolvedValue({})
-            await service.setGuildFeatureToggle(
-                'guild-1',
-                'DOWNLOAD_VIDEO',
-                true,
-            )
+            await service.setGlobalFeatureToggle('DOWNLOAD_VIDEO', true)
             expect(mockUpsert).toHaveBeenCalledWith({
-                where: {
-                    guildId_name: {
-                        guildId: 'guild-1',
-                        name: 'DOWNLOAD_VIDEO',
-                    },
-                },
+                where: { name: 'DOWNLOAD_VIDEO' },
                 update: { enabled: true },
-                create: {
-                    guildId: 'guild-1',
-                    name: 'DOWNLOAD_VIDEO',
-                    enabled: true,
-                },
+                create: { name: 'DOWNLOAD_VIDEO', enabled: true },
             })
         })
 
         it('upserts with enabled=false', async () => {
             mockUpsert.mockResolvedValue({})
-            await service.setGuildFeatureToggle(
-                'guild-1',
-                'DOWNLOAD_AUDIO',
-                false,
-            )
+            await service.setGlobalFeatureToggle('DOWNLOAD_AUDIO', false)
             expect(mockUpsert).toHaveBeenCalledWith(
                 expect.objectContaining({
                     update: { enabled: false },
@@ -166,11 +137,7 @@ describe('FeatureToggleService', () => {
         it('propagates db errors', async () => {
             mockUpsert.mockRejectedValue(new Error('DB write failed'))
             await expect(
-                service.setGuildFeatureToggle(
-                    'guild-1',
-                    'DOWNLOAD_VIDEO',
-                    true,
-                ),
+                service.setGlobalFeatureToggle('DOWNLOAD_VIDEO', true),
             ).rejects.toThrow('DB write failed')
         })
     })
@@ -273,13 +240,34 @@ describe('FeatureToggleService', () => {
         })
     })
 
-    describe('isEnabledForGuild with DB override', () => {
+    describe('isEnabled', () => {
+        it('delegates to isEnabledGlobal', async () => {
+            mockFindUnique.mockResolvedValue(null)
+            const result = await service.isEnabled('DOWNLOAD_VIDEO')
+            expect(result).toBe(true)
+        })
+    })
+
+    describe('getAllToggles', () => {
+        it('returns a Map of all fallback toggles', () => {
+            const toggles = service.getAllToggles()
+            expect(toggles).toBeInstanceOf(Map)
+            expect(toggles.get('DOWNLOAD_VIDEO')).toBe(true)
+            expect(toggles.get('DOWNLOAD_AUDIO')).toBe(false)
+        })
+    })
+
+    describe('getToggle', () => {
+        it('returns the fallback value for a toggle', () => {
+            expect(service.getToggle('DOWNLOAD_VIDEO')).toBe(true)
+            expect(service.getToggle('DOWNLOAD_AUDIO')).toBe(false)
+        })
+    })
+
+    describe('isEnabledGlobal with DB override', () => {
         it('returns db override (true) without checking Vercel', async () => {
             mockFindUnique.mockResolvedValue({ enabled: true })
-            const result = await service.isEnabledForGuild(
-                'DOWNLOAD_AUDIO',
-                'guild-1',
-            )
+            const result = await service.isEnabledGlobal('DOWNLOAD_AUDIO')
             expect(result).toBe(true)
         })
 
@@ -290,29 +278,20 @@ describe('FeatureToggleService', () => {
                 reason: 'fallthrough',
             })
             mockFindUnique.mockResolvedValue({ enabled: false })
-            const result = await service.isEnabledForGuild(
-                'DOWNLOAD_VIDEO',
-                'guild-1',
-            )
+            const result = await service.isEnabledGlobal('DOWNLOAD_VIDEO')
             expect(result).toBe(false)
             expect(mockEvaluate).not.toHaveBeenCalled()
         })
 
         it('falls back to fallback toggle when no db override', async () => {
             mockFindUnique.mockResolvedValue(null)
-            const result = await service.isEnabledForGuild(
-                'DOWNLOAD_VIDEO',
-                'guild-1',
-            )
+            const result = await service.isEnabledGlobal('DOWNLOAD_VIDEO')
             expect(result).toBe(true)
         })
 
         it('falls back to fallback toggle when db throws', async () => {
             mockFindUnique.mockRejectedValue(new Error('DB error'))
-            const result = await service.isEnabledForGuild(
-                'DOWNLOAD_VIDEO',
-                'guild-1',
-            )
+            const result = await service.isEnabledGlobal('DOWNLOAD_VIDEO')
             expect(result).toBe(true)
         })
     })

--- a/packages/shared/src/services/FeatureToggleService.ts
+++ b/packages/shared/src/services/FeatureToggleService.ts
@@ -11,6 +11,7 @@ import { getFeatureToggleConfig } from '../config/featureToggles'
 import { debugLog } from '../utils/general/log'
 import { getPrismaClient } from '../utils/database/prismaClient'
 
+/** Manages feature toggles with multi-layer provider support (database, Vercel, environment). */
 class FeatureToggleService {
     private fallbackToggles: Map<FeatureToggleName, boolean> = new Map()
 
@@ -36,9 +37,7 @@ class FeatureToggleService {
         return getPrismaClient()
     }
 
-    private async getDbGlobalOverride(
-        name: string,
-    ): Promise<boolean | null> {
+    private async getDbGlobalOverride(name: string): Promise<boolean | null> {
         try {
             const row = await this.db.globalFeatureToggle.findUnique({
                 where: { name },
@@ -50,6 +49,7 @@ class FeatureToggleService {
         }
     }
 
+    /** Sets a global feature toggle override in the database. */
     async setGlobalFeatureToggle(
         name: FeatureToggleName,
         enabled: boolean,
@@ -96,10 +96,12 @@ class FeatureToggleService {
         }
     }
 
+    /** Gets the current toggle provider (Vercel or database). */
     getGlobalToggleProvider(): GlobalFeatureToggleProvider {
         return isVercelFlagsConfigured() ? 'vercel' : 'database'
     }
 
+    /** Gets the global toggle status with provider information. */
     async getGlobalToggleStatus(
         name: FeatureToggleName,
     ): Promise<GlobalFeatureToggleState> {
@@ -130,11 +132,13 @@ class FeatureToggleService {
         }
     }
 
+    /** Checks if a feature is globally enabled. */
     async isEnabledGlobal(name: FeatureToggleName): Promise<boolean> {
         const status = await this.getGlobalToggleStatus(name)
         return status.enabled
     }
 
+    /** Checks if a feature is enabled (optionally scoped to user/guild). */
     async isEnabled(
         name: FeatureToggleName,
         context?: { userId?: string; guildId?: string },
@@ -142,13 +146,16 @@ class FeatureToggleService {
         return this.isEnabledGlobal(name)
     }
 
+    /** Returns a copy of all loaded fallback toggles. */
     getAllToggles(): Map<FeatureToggleName, boolean> {
         return new Map(this.fallbackToggles)
     }
 
+    /** Gets a toggle value from the fallback configuration. */
     getToggle(name: FeatureToggleName): boolean {
         return this.getFallbackValue(name)
     }
 }
 
+/** Singleton instance of FeatureToggleService. */
 export const featureToggleService = new FeatureToggleService()

--- a/packages/shared/src/services/GuildRoleAccessService.ts
+++ b/packages/shared/src/services/GuildRoleAccessService.ts
@@ -6,6 +6,7 @@ const prisma = getPrismaClient()
 const CACHE_TTL_SECONDS = 300
 const CACHE_PREFIX = 'guild_rbac:'
 
+/** List of RBAC module types available for guild permissions. */
 export const RBAC_MODULES = [
     'overview',
     'settings',
@@ -15,10 +16,14 @@ export const RBAC_MODULES = [
     'integrations',
 ] as const
 
+/** Guild automation module identifiers. */
 export type ModuleKey = (typeof RBAC_MODULES)[number]
+/** Guild role access mode. */
 export type AccessMode = 'view' | 'manage'
+/** Effective access level granted to a user. */
 export type EffectiveAccess = 'none' | 'view' | 'manage'
 
+/** Stored role grant mapping modules to access modes. */
 export interface RoleGrant {
     guildId: string
     roleId: string
@@ -28,14 +33,17 @@ export interface RoleGrant {
     updatedAt: Date
 }
 
+/** Input for creating or updating role grants. */
 export interface RoleGrantInput {
     roleId: string
     module: ModuleKey
     mode: AccessMode
 }
 
+/** Effective access levels across all modules for a user. */
 export type EffectiveAccessMap = Record<ModuleKey, EffectiveAccess>
 
+/** Error thrown when RBAC storage is unavailable. */
 export class GuildRoleGrantStorageError extends Error {
     readonly code = 'ERR_GUILD_ROLE_GRANT_STORAGE_UNAVAILABLE'
     readonly guildId: string
@@ -117,6 +125,7 @@ function toRoleGrant(row: {
     }
 }
 
+/** Manages role-based access control for guild modules. */
 class GuildRoleAccessService {
     private isMissingTableError(error: unknown): boolean {
         if (typeof error !== 'object' || error === null) {
@@ -186,6 +195,7 @@ class GuildRoleAccessService {
         }
     }
 
+    /** Lists all role grants for a guild with caching. */
     async listRoleGrants(guildId: string): Promise<RoleGrant[]> {
         const cached = await this.readCached(guildId)
         if (cached) {
@@ -227,6 +237,7 @@ class GuildRoleAccessService {
         return grants
     }
 
+    /** Replaces all role grants for a guild with the given input. */
     async replaceRoleGrants(
         guildId: string,
         input: RoleGrantInput[],
@@ -278,6 +289,7 @@ class GuildRoleAccessService {
         return this.listRoleGrants(guildId)
     }
 
+    /** Resolves the effective access map for a user with given roles. */
     async resolveEffectiveAccess(
         guildId: string,
         roleIds: string[],
@@ -309,6 +321,7 @@ class GuildRoleAccessService {
         return access
     }
 
+    /** Checks if a user has the required access mode for a module. */
     hasAccess(
         effectiveAccess: EffectiveAccessMap,
         module: ModuleKey,
@@ -323,9 +336,11 @@ class GuildRoleAccessService {
         return current === 'manage'
     }
 
+    /** Checks if a user has any access to any module. */
     hasAnyAccess(effectiveAccess: EffectiveAccessMap): boolean {
         return RBAC_MODULES.some((module) => effectiveAccess[module] !== 'none')
     }
 }
 
+/** Singleton instance of GuildRoleAccessService. */
 export const guildRoleAccessService = new GuildRoleAccessService()

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -1,6 +1,7 @@
 import { redisClient } from './redis'
 import { infoLog, errorLog } from '../utils/general/log'
 
+/** Guild-specific music and command settings cached in Redis. */
 export interface GuildSettings {
     guildId: string
     defaultVolume: number
@@ -25,12 +26,14 @@ export interface GuildSettings {
     updatedAt: Date
 }
 
+/** Autoplay recommendation counter tracking for a guild. */
 export interface AutoplayCounter {
     guildId: string
     count: number
     lastReset: Date
 }
 
+/** Manages guild settings and counters stored in Redis. */
 export class GuildSettingsService {
     private readonly ttl: number
 
@@ -70,6 +73,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Retrieves guild settings from Redis cache. */
     async getGuildSettings(guildId: string): Promise<GuildSettings | null> {
         try {
             const settingsData = await redisClient.get(
@@ -85,6 +89,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Sets guild settings, fully replacing existing values. */
     async setGuildSettings(
         guildId: string,
         settings: Partial<GuildSettings>,
@@ -114,16 +119,16 @@ export class GuildSettingsService {
         }
     }
 
+    /** Updates guild settings, merging with existing values. */
     async updateGuildSettings(
         guildId: string,
         updates: Partial<GuildSettings>,
     ): Promise<boolean> {
         try {
-            const currentSettings =
-                (await this.getGuildSettings(guildId)) ?? {
-                    ...this.getDefaultSettings(),
-                    guildId,
-                }
+            const currentSettings = (await this.getGuildSettings(guildId)) ?? {
+                ...this.getDefaultSettings(),
+                guildId,
+            }
 
             const updatedSettings = {
                 ...currentSettings,
@@ -146,6 +151,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Deletes all guild settings from cache. */
     async deleteGuildSettings(guildId: string): Promise<boolean> {
         try {
             await redisClient.del(this.getRedisKey(guildId))
@@ -157,6 +163,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Gets the autoplay recommendation counter for a guild. */
     async getAutoplayCounter(guildId: string): Promise<AutoplayCounter | null> {
         try {
             const counterData = await redisClient.get(
@@ -172,6 +179,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Sets the autoplay recommendation counter for a guild. */
     async setAutoplayCounter(
         guildId: string,
         counter: AutoplayCounter,
@@ -189,6 +197,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Increments and returns the autoplay counter for a guild. */
     async incrementAutoplayCounter(guildId: string): Promise<number> {
         try {
             const counter = (await this.getAutoplayCounter(guildId)) || {
@@ -207,6 +216,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Resets the autoplay counter for a guild to zero. */
     async resetAutoplayCounter(guildId: string): Promise<boolean> {
         try {
             const counter: AutoplayCounter = {
@@ -221,6 +231,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Gets the repeat counter for a guild. */
     async getRepeatCount(guildId: string): Promise<number> {
         try {
             const countData = await redisClient.get(
@@ -233,6 +244,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Sets the repeat counter for a guild. */
     async setRepeatCount(guildId: string, count: number): Promise<boolean> {
         try {
             await redisClient.setex(
@@ -247,6 +259,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Increments and returns the repeat counter for a guild. */
     async incrementRepeatCount(guildId: string): Promise<number> {
         try {
             const currentCount = await this.getRepeatCount(guildId)
@@ -259,6 +272,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Resets the repeat counter for a guild to zero. */
     async resetRepeatCount(guildId: string): Promise<boolean> {
         try {
             return await this.setRepeatCount(guildId, 0)
@@ -268,6 +282,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Clears all guild session state (settings, counters, repeat count). */
     async clearGuildSessions(guildId: string): Promise<boolean> {
         try {
             const settingsDeleted = await this.deleteGuildSettings(guildId)
@@ -281,6 +296,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Checks if a command is rate-limited for a guild. */
     async isRateLimited(
         guildId: string,
         command: string,
@@ -303,6 +319,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Sets the rate limit for a command in a guild. */
     async setRateLimit(
         guildId: string,
         command: string,
@@ -316,6 +333,7 @@ export class GuildSettingsService {
         }
     }
 
+    /** Clears all autoplay counters across all guilds. */
     async clearAllAutoplayCounters(): Promise<boolean> {
         try {
             const pattern = 'guild_settings:*:autoplay_counter'
@@ -336,4 +354,5 @@ export class GuildSettingsService {
     }
 }
 
+/** Singleton instance of GuildSettingsService. */
 export const guildSettingsService = new GuildSettingsService()

--- a/packages/shared/src/services/LastFmLinkService/index.spec.ts
+++ b/packages/shared/src/services/LastFmLinkService/index.spec.ts
@@ -1,16 +1,18 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import { LastFmLinkService } from './index'
 
-const deleteMock =
-    jest.fn<(args: { where: { discordId: string } }) => Promise<unknown>>()
+const findUniqueMock = jest.fn<(args: unknown) => Promise<unknown>>()
+const upsertMock = jest.fn<(args: unknown) => Promise<unknown>>()
+const deleteMock = jest.fn<(args: unknown) => Promise<unknown>>()
 const debugLogMock = jest.fn<(payload: unknown) => void>()
 const errorLogMock = jest.fn<(payload: unknown) => void>()
 
 jest.mock('../../utils/database/prismaClient', () => ({
     getPrismaClient: () => ({
         lastFmLink: {
-            delete: (args: { where: { discordId: string } }) =>
-                deleteMock(args),
+            findUnique: (args: unknown) => findUniqueMock(args),
+            upsert: (args: unknown) => upsertMock(args),
+            delete: (args: unknown) => deleteMock(args),
         },
     }),
 }))
@@ -20,49 +22,184 @@ jest.mock('../../utils/general/log', () => ({
     errorLog: (payload: unknown) => errorLogMock(payload),
 }))
 
-describe('LastFmLinkService.unlink', () => {
+describe('LastFmLinkService', () => {
     const service = new LastFmLinkService()
 
     beforeEach(() => {
+        findUniqueMock.mockReset()
+        upsertMock.mockReset()
         deleteMock.mockReset()
         debugLogMock.mockReset()
         errorLogMock.mockReset()
     })
 
-    it('returns true when delete succeeds', async () => {
-        deleteMock.mockResolvedValue({})
+    describe('getByDiscordId', () => {
+        it('returns row data when record exists', async () => {
+            findUniqueMock.mockResolvedValue({
+                sessionKey: 'sk-abc',
+                lastFmUsername: 'testuser',
+            })
 
-        const result = await service.unlink('123')
+            const result = await service.getByDiscordId('123')
 
-        expect(result).toBe(true)
-        expect(deleteMock).toHaveBeenCalledWith({ where: { discordId: '123' } })
-        expect(debugLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({ message: 'Last.fm link removed' }),
-        )
-        expect(errorLogMock).not.toHaveBeenCalled()
+            expect(result).toEqual({
+                sessionKey: 'sk-abc',
+                lastFmUsername: 'testuser',
+            })
+            expect(findUniqueMock).toHaveBeenCalledWith({
+                where: { discordId: '123' },
+            })
+        })
+
+        it('returns null when record does not exist', async () => {
+            findUniqueMock.mockResolvedValue(null)
+
+            const result = await service.getByDiscordId('456')
+
+            expect(result).toBeNull()
+            expect(errorLogMock).not.toHaveBeenCalled()
+        })
+
+        it('returns null and logs error on db failure', async () => {
+            findUniqueMock.mockRejectedValue(new Error('db error'))
+
+            const result = await service.getByDiscordId('789')
+
+            expect(result).toBeNull()
+            expect(errorLogMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Failed to get Last.fm link',
+                }),
+            )
+        })
     })
 
-    it('returns true when record is already absent (P2025)', async () => {
-        deleteMock.mockRejectedValue({ code: 'P2025' })
+    describe('getSessionKey', () => {
+        it('returns sessionKey when record exists', async () => {
+            findUniqueMock.mockResolvedValue({
+                sessionKey: 'sk-xyz',
+                lastFmUsername: null,
+            })
 
-        const result = await service.unlink('456')
+            const result = await service.getSessionKey('123')
 
-        expect(result).toBe(true)
-        expect(debugLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({ message: 'Last.fm link already absent' }),
-        )
-        expect(errorLogMock).not.toHaveBeenCalled()
+            expect(result).toBe('sk-xyz')
+        })
+
+        it('returns null when record does not exist', async () => {
+            findUniqueMock.mockResolvedValue(null)
+
+            const result = await service.getSessionKey('456')
+
+            expect(result).toBeNull()
+        })
     })
 
-    it('returns false and logs error on unexpected failures', async () => {
-        const dbError = new Error('db unavailable')
-        deleteMock.mockRejectedValue(dbError)
+    describe('set', () => {
+        it('returns true and logs on success', async () => {
+            upsertMock.mockResolvedValue({})
 
-        const result = await service.unlink('789')
+            const result = await service.set('123', 'sk-abc', 'testuser')
 
-        expect(result).toBe(false)
-        expect(errorLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({ message: 'Failed to unlink Last.fm' }),
-        )
+            expect(result).toBe(true)
+            expect(upsertMock).toHaveBeenCalledWith(
+                expect.objectContaining({ where: { discordId: '123' } }),
+            )
+            expect(debugLogMock).toHaveBeenCalledWith(
+                expect.objectContaining({ message: 'Last.fm link saved' }),
+            )
+            expect(errorLogMock).not.toHaveBeenCalled()
+        })
+
+        it('includes lastFmUsername in create when provided', async () => {
+            upsertMock.mockResolvedValue({})
+
+            await service.set('123', 'sk-abc', 'testuser')
+
+            const call = upsertMock.mock.calls[0]?.[0] as {
+                create: { lastFmUsername?: string }
+            }
+            expect(call.create.lastFmUsername).toBe('testuser')
+        })
+
+        it('excludes lastFmUsername from create when empty string', async () => {
+            upsertMock.mockResolvedValue({})
+
+            await service.set('123', 'sk-abc', '')
+
+            const call = upsertMock.mock.calls[0]?.[0] as {
+                create: { lastFmUsername?: string }
+            }
+            expect(call.create).not.toHaveProperty('lastFmUsername')
+        })
+
+        it('excludes lastFmUsername from create when null', async () => {
+            upsertMock.mockResolvedValue({})
+
+            await service.set('123', 'sk-abc', null)
+
+            const call = upsertMock.mock.calls[0]?.[0] as {
+                create: { lastFmUsername?: string }
+            }
+            expect(call.create).not.toHaveProperty('lastFmUsername')
+        })
+
+        it('returns false and logs error on db failure', async () => {
+            upsertMock.mockRejectedValue(new Error('upsert failed'))
+
+            const result = await service.set('123', 'sk-abc')
+
+            expect(result).toBe(false)
+            expect(errorLogMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Failed to set Last.fm link',
+                }),
+            )
+        })
+    })
+
+    describe('unlink', () => {
+        it('returns true when delete succeeds', async () => {
+            deleteMock.mockResolvedValue({})
+
+            const result = await service.unlink('123')
+
+            expect(result).toBe(true)
+            expect(deleteMock).toHaveBeenCalledWith({
+                where: { discordId: '123' },
+            })
+            expect(debugLogMock).toHaveBeenCalledWith(
+                expect.objectContaining({ message: 'Last.fm link removed' }),
+            )
+            expect(errorLogMock).not.toHaveBeenCalled()
+        })
+
+        it('returns true when record is already absent (P2025)', async () => {
+            deleteMock.mockRejectedValue({ code: 'P2025' })
+
+            const result = await service.unlink('456')
+
+            expect(result).toBe(true)
+            expect(debugLogMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Last.fm link already absent',
+                }),
+            )
+            expect(errorLogMock).not.toHaveBeenCalled()
+        })
+
+        it('returns false and logs error on unexpected failures', async () => {
+            const dbError = new Error('db unavailable')
+            deleteMock.mockRejectedValue(dbError)
+
+            const result = await service.unlink('789')
+
+            expect(result).toBe(false)
+            expect(errorLogMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Failed to unlink Last.fm',
+                }),
+            )
+        })
     })
 })

--- a/packages/shared/src/services/LastFmLinkService/index.ts
+++ b/packages/shared/src/services/LastFmLinkService/index.ts
@@ -1,12 +1,15 @@
 import { getPrismaClient } from '../../utils/database/prismaClient'
 import { errorLog, debugLog } from '../../utils/general/log'
 
+/** Last.fm link data for a user. */
 export type LastFmLinkRow = {
     sessionKey: string
     lastFmUsername: string | null
 }
 
+/** Manages Last.fm account links for Discord users. */
 export class LastFmLinkService {
+    /** Gets the Last.fm link for a Discord user. */
     async getByDiscordId(discordId: string): Promise<LastFmLinkRow | null> {
         try {
             const prisma = getPrismaClient()
@@ -29,11 +32,13 @@ export class LastFmLinkService {
         }
     }
 
+    /** Gets the Last.fm session key for a Discord user. */
     async getSessionKey(discordId: string): Promise<string | null> {
         const row = await this.getByDiscordId(discordId)
         return row?.sessionKey ?? null
     }
 
+    /** Sets or updates a Last.fm link for a Discord user. */
     async set(
         discordId: string,
         sessionKey: string,
@@ -72,6 +77,7 @@ export class LastFmLinkService {
         }
     }
 
+    /** Removes a Last.fm link for a Discord user. */
     async unlink(discordId: string): Promise<boolean> {
         try {
             const prisma = getPrismaClient()
@@ -111,4 +117,5 @@ export class LastFmLinkService {
     }
 }
 
+/** Singleton instance of LastFmLinkService. */
 export const lastFmLinkService = new LastFmLinkService()

--- a/packages/shared/src/services/LevelService.ts
+++ b/packages/shared/src/services/LevelService.ts
@@ -2,6 +2,7 @@ import { getPrismaClient } from '../utils/database/prismaClient.js'
 
 const prisma = getPrismaClient()
 
+/** Configuration for the leveling system in a guild. */
 export type LevelConfig = {
     id: string
     guildId: string
@@ -13,6 +14,7 @@ export type LevelConfig = {
     updatedAt: Date
 }
 
+/** User's XP and level tracking in a guild. */
 export type MemberXP = {
     id: string
     guildId: string
@@ -24,6 +26,7 @@ export type MemberXP = {
     updatedAt: Date
 }
 
+/** Role reward granted when a user reaches a specific level. */
 export type LevelReward = {
     id: string
     guildId: string
@@ -38,16 +41,21 @@ type UpsertConfigData = {
     announceChannel?: string | null
 }
 
+/** Calculates XP required to reach a specific level. */
 export function xpNeededForLevel(level: number): number {
     return level * level * 100
 }
 
+/** Manages user leveling, XP, and level-based rewards. */
 export class LevelService {
     async getConfig(guildId: string): Promise<LevelConfig | null> {
         return await prisma.levelConfig.findUnique({ where: { guildId } })
     }
 
-    async upsertConfig(guildId: string, data: UpsertConfigData): Promise<LevelConfig> {
+    async upsertConfig(
+        guildId: string,
+        data: UpsertConfigData,
+    ): Promise<LevelConfig> {
         return await prisma.levelConfig.upsert({
             where: { guildId },
             create: { guildId, ...data },
@@ -55,7 +63,10 @@ export class LevelService {
         })
     }
 
-    async getMemberXP(guildId: string, userId: string): Promise<MemberXP | null> {
+    async getMemberXP(
+        guildId: string,
+        userId: string,
+    ): Promise<MemberXP | null> {
         return await prisma.memberXP.findUnique({
             where: { guildId_userId: { guildId, userId } },
         })
@@ -108,7 +119,11 @@ export class LevelService {
         return count + 1
     }
 
-    async addReward(guildId: string, level: number, roleId: string): Promise<LevelReward> {
+    async addReward(
+        guildId: string,
+        level: number,
+        roleId: string,
+    ): Promise<LevelReward> {
         return await prisma.levelReward.upsert({
             where: { guildId_level: { guildId, level } },
             create: { guildId, level, roleId },

--- a/packages/shared/src/services/ModerationService.ts
+++ b/packages/shared/src/services/ModerationService.ts
@@ -8,7 +8,7 @@ import {
 
 const prisma = getPrismaClient()
 
-// Type definitions (normally from @prisma/client but not resolvable)
+/** Represents a moderation case record. */
 export type ModerationCase = {
     id: string
     caseNumber: number
@@ -32,6 +32,7 @@ export type ModerationCase = {
     updatedAt: Date
 }
 
+/** Guild-level moderation configuration. */
 export type ModerationSettings = {
     id: string
     guildId: string
@@ -48,6 +49,7 @@ export type ModerationSettings = {
     updatedAt: Date
 }
 
+/** Input payload for creating a new moderation case. */
 export interface CreateCaseInput {
     guildId: string
     type: 'warn' | 'mute' | 'kick' | 'ban' | 'timeout' | 'unban' | 'unmute'
@@ -61,12 +63,15 @@ export interface CreateCaseInput {
     evidence?: string[]
 }
 
+/** Input payload for submitting a case appeal. */
 export interface AppealCaseInput {
     caseId: string
     appealReason: string
 }
 
+/** Service for managing guild moderation cases and settings. */
 export class ModerationService {
+    /** Creates a new moderation case with an auto-incremented case number. */
     async createCase(input: CreateCaseInput): Promise<ModerationCase> {
         const lastCase = await prisma.moderationCase.findFirst({
             where: { guildId: input.guildId },
@@ -94,6 +99,7 @@ export class ModerationService {
         })
     }
 
+    /** Retrieves a moderation case by guild and case number. */
     async getCase(
         guildId: string,
         caseNumber: number,
@@ -103,6 +109,7 @@ export class ModerationService {
         })
     }
 
+    /** Retrieves all moderation cases for a user, optionally filtered to active cases only. */
     async getUserCases(
         guildId: string,
         userId: string,
@@ -114,6 +121,7 @@ export class ModerationService {
         })
     }
 
+    /** Retrieves the most recent moderation cases for a guild. */
     async getRecentCases(
         guildId: string,
         limit = 10,
@@ -125,6 +133,7 @@ export class ModerationService {
         })
     }
 
+    /** Retrieves all moderation cases created after the given date. */
     async getCasesSince(
         guildId: string,
         since: Date,
@@ -135,6 +144,7 @@ export class ModerationService {
         })
     }
 
+    /** Returns the count of active warning cases for a user in a guild. */
     async getActiveWarningsCount(
         guildId: string,
         userId: string,
@@ -144,6 +154,7 @@ export class ModerationService {
         })
     }
 
+    /** Deactivates all active warning cases for a user and returns the count cleared. */
     async clearWarnings(guildId: string, userId: string): Promise<number> {
         const result = await prisma.moderationCase.updateMany({
             where: { guildId, userId, type: 'warn', active: true },
@@ -152,6 +163,7 @@ export class ModerationService {
         return result.count
     }
 
+    /** Marks a moderation case as inactive by its ID. */
     async deactivateCase(caseId: string): Promise<ModerationCase> {
         return await prisma.moderationCase.update({
             where: { id: caseId },
@@ -159,6 +171,7 @@ export class ModerationService {
         })
     }
 
+    /** Submits an appeal for a moderation case. */
     async appealCase(input: AppealCaseInput): Promise<ModerationCase> {
         return await prisma.moderationCase.update({
             where: { id: input.caseId },
@@ -170,6 +183,7 @@ export class ModerationService {
         })
     }
 
+    /** Reviews a submitted appeal, optionally deactivating the case if approved. */
     async reviewAppeal(
         caseId: string,
         approved: boolean,
@@ -184,16 +198,19 @@ export class ModerationService {
         })
     }
 
+    /** Retrieves all active cases whose expiry date has passed. */
     async getExpiredCases(): Promise<ModerationCase[]> {
         return await prisma.moderationCase.findMany({
             where: { active: true, expiresAt: { lte: new Date() } },
         })
     }
 
+    /** Retrieves the moderation settings for a guild. */
     async getSettings(guildId: string): Promise<ModerationSettings> {
         return getModerationSettings(guildId)
     }
 
+    /** Updates moderation settings for a guild. */
     async updateSettings(
         guildId: string,
         data: Partial<
@@ -206,6 +223,7 @@ export class ModerationService {
         return updateModerationSettings(guildId, data)
     }
 
+    /** Checks whether any of the given role IDs grant moderation permissions in the guild. */
     async hasModPermissions(
         guildId: string,
         userRoles: string[],
@@ -213,6 +231,7 @@ export class ModerationService {
         return hasModPermissions(guildId, userRoles)
     }
 
+    /** Returns moderation statistics for a guild. */
     async getStats(guildId: string) {
         return getModerationStats(guildId)
     }

--- a/packages/shared/src/services/PremiumService.ts
+++ b/packages/shared/src/services/PremiumService.ts
@@ -6,6 +6,7 @@ import { errorLog } from '../utils/general/log'
 // past_due, incomplete, and incomplete_expired all fail the gate.
 const ACTIVE_STATUSES: ReadonlySet<string> = new Set(['active', 'trialing'])
 
+/** Service for checking guild premium subscription status via Stripe. */
 export class PremiumService {
     /**
      * Returns true when the guild has an active Stripe subscription.
@@ -17,12 +18,16 @@ export class PremiumService {
         const sub = await this.getSubscription(guildId)
         if (!sub) return false
         if (!ACTIVE_STATUSES.has(sub.status)) return false
-        if (sub.currentPeriodEnd && sub.currentPeriodEnd.getTime() <= Date.now()) {
+        if (
+            sub.currentPeriodEnd &&
+            sub.currentPeriodEnd.getTime() <= Date.now()
+        ) {
             return false
         }
         return true
     }
 
+    /** Returns the guild's subscription if it exists, null otherwise. */
     async getSubscription(guildId: string): Promise<GuildSubscription | null> {
         try {
             const prisma = getPrismaClient()

--- a/packages/shared/src/services/ReactionRolesService/index.ts
+++ b/packages/shared/src/services/ReactionRolesService/index.ts
@@ -13,6 +13,7 @@ import { errorLog, debugLog } from '../../utils/general/log'
 import { featureToggleService } from '../FeatureToggleService'
 import { getPrismaClient } from '../../utils/database/prismaClient'
 
+/** Options for creating a reaction role message with button-based role assignments. */
 export interface CreateReactionRoleOptions {
     guild: Guild
     channel: TextChannel
@@ -25,7 +26,9 @@ export interface CreateReactionRoleOptions {
     }>
 }
 
+/** Manages reaction role messages with button-based role assignment. */
 export class ReactionRolesService {
+    /** Checks if reaction roles feature is enabled for a guild or user. */
     async isEnabled(guildId?: string, userId?: string): Promise<boolean> {
         return featureToggleService.isEnabled('REACTION_ROLES', {
             guildId,
@@ -33,6 +36,7 @@ export class ReactionRolesService {
         })
     }
 
+    /** Creates a new reaction role message with button-based role assignment. */
     async createReactionRoleMessage(
         options: CreateReactionRoleOptions,
     ): Promise<Message | null> {
@@ -120,6 +124,7 @@ export class ReactionRolesService {
         }
     }
 
+    /** Deletes a reaction role message and its associated mappings. */
     async deleteReactionRoleMessage(
         messageId: string,
         guildId: string,
@@ -153,6 +158,7 @@ export class ReactionRolesService {
         }
     }
 
+    /** Lists all reaction role messages for a guild. */
     async listReactionRoleMessages(guildId: string) {
         try {
             const prisma = getPrismaClient()
@@ -171,6 +177,7 @@ export class ReactionRolesService {
         }
     }
 
+    /** Handles button interaction for reaction role assignment or removal. */
     async handleButtonInteraction(
         interaction: ButtonInteraction,
     ): Promise<boolean> {
@@ -265,4 +272,5 @@ export class ReactionRolesService {
     }
 }
 
+/** Singleton instance of ReactionRolesService. */
 export const reactionRolesService = new ReactionRolesService()

--- a/packages/shared/src/services/RoleManagementService/index.ts
+++ b/packages/shared/src/services/RoleManagementService/index.ts
@@ -3,6 +3,7 @@ import { errorLog, debugLog } from '../../utils/general/log'
 import { featureToggleService } from '../FeatureToggleService'
 import { getPrismaClient } from '../../utils/database/prismaClient'
 
+/** Manages role exclusions and role assignment rules. */
 export class RoleManagementService {
     async isEnabled(guildId?: string, userId?: string): Promise<boolean> {
         return featureToggleService.isEnabled('ROLE_MANAGEMENT', {

--- a/packages/shared/src/services/ServerLogService.ts
+++ b/packages/shared/src/services/ServerLogService.ts
@@ -3,7 +3,7 @@ import * as helpers from './serverLogHelpers.js'
 
 const prisma = getPrismaClient()
 
-// Type definition (normally from @prisma/client but not resolvable)
+/** Represents a server audit log entry. */
 export type ServerLog = {
     id: string
     guildId: string
@@ -15,6 +15,7 @@ export type ServerLog = {
     createdAt: Date
 }
 
+/** Discriminated union of all server log event types. */
 export type LogType =
     | 'message_delete'
     | 'message_edit'
@@ -32,11 +33,14 @@ export type LogType =
     | 'auto_message'
     | 'settings_change'
 
+/** Arbitrary key-value payload attached to a log entry. */
 export interface LogDetails {
     [key: string]: any
 }
 
+/** Service for creating and querying server audit logs persisted in the database. */
 export class ServerLogService {
+    /** Creates a new audit log entry for the given guild. */
     async createLog(
         guildId: string,
         type: LogType,
@@ -57,6 +61,7 @@ export class ServerLogService {
         })
     }
 
+    /** Retrieves logs of a specific type for a guild, most recent first. */
     async getLogsByType(guildId: string, type: LogType, limit: number = 50) {
         return await prisma.serverLog.findMany({
             where: { guildId, type },
@@ -65,6 +70,7 @@ export class ServerLogService {
         })
     }
 
+    /** Retrieves all logs attributed to a specific user in a guild. */
     async getUserLogs(guildId: string, userId: string, limit: number = 50) {
         return await prisma.serverLog.findMany({
             where: { guildId, userId },
@@ -73,6 +79,7 @@ export class ServerLogService {
         })
     }
 
+    /** Retrieves the most recent logs across all types for a guild. */
     async getRecentLogs(guildId: string, limit: number = 100) {
         return await prisma.serverLog.findMany({
             where: { guildId },
@@ -81,16 +88,19 @@ export class ServerLogService {
         })
     }
 
+    /** Returns the total number of log entries for a guild. */
     async countRecentLogs(guildId: string) {
         return await prisma.serverLog.count({ where: { guildId } })
     }
 
+    /** Returns the count of logs of a specific type for a guild. */
     async countLogsByType(guildId: string, type: LogType) {
         return await prisma.serverLog.count({
             where: { guildId, type },
         })
     }
 
+    /** Searches logs with optional filters on type, user, channel, moderator, and date range. */
     async searchLogs(
         guildId: string,
         filters: {
@@ -124,6 +134,7 @@ export class ServerLogService {
         })
     }
 
+    /** Deletes log entries older than the specified number of days and returns the deletion count. */
     async deleteOldLogs(guildId: string, daysToKeep: number = 30) {
         const cutoffDate = new Date()
         cutoffDate.setDate(cutoffDate.getDate() - daysToKeep)
@@ -133,6 +144,7 @@ export class ServerLogService {
         return result.count
     }
 
+    /** Returns log statistics including total count and per-type breakdown. */
     async getStats(guildId: string) {
         const [totalLogs, logsByType] = await Promise.all([
             prisma.serverLog.count({ where: { guildId } }),
@@ -153,6 +165,7 @@ export class ServerLogService {
         }
     }
 
+    /** Logs a message deletion event. */
     async logMessageDelete(
         guildId: string,
         messageId: string,
@@ -172,6 +185,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs a message edit event. */
     async logMessageEdit(
         guildId: string,
         messageId: string,
@@ -191,6 +205,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs a member join event. */
     async logMemberJoin(
         guildId: string,
         userId: string,
@@ -206,6 +221,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs a member leave event. */
     async logMemberLeave(
         guildId: string,
         userId: string,
@@ -215,6 +231,7 @@ export class ServerLogService {
         return helpers.logMemberLeave(this, guildId, userId, username, roles)
     }
 
+    /** Logs a role assignment or removal event for a user. */
     async logRoleUpdate(
         guildId: string,
         userId: string,
@@ -232,6 +249,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs a voice channel state change event. */
     async logVoiceState(
         guildId: string,
         userId: string,
@@ -249,6 +267,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs a moderation action event. */
     async logModerationAction(
         guildId: string,
         action: string,
@@ -272,6 +291,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs a moderation case update event. */
     async logCaseUpdate(
         guildId: string,
         details: {
@@ -289,6 +309,7 @@ export class ServerLogService {
         return helpers.logCaseUpdate(this, guildId, details, moderatorId)
     }
 
+    /** Logs an auto-moderation trigger event. */
     async logAutoModTrigger(
         guildId: string,
         details: {
@@ -302,6 +323,7 @@ export class ServerLogService {
         return helpers.logAutoModTrigger(this, guildId, details, userId)
     }
 
+    /** Logs an auto-moderation settings change event. */
     async logAutoModSettingsChange(
         guildId: string,
         details: {
@@ -319,6 +341,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs a custom command create, update, or delete event. */
     async logCustomCommandChange(
         guildId: string,
         action: 'created' | 'updated' | 'deleted',
@@ -334,6 +357,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs an embed template create, update, delete, or send event. */
     async logEmbedTemplateChange(
         guildId: string,
         action: 'created' | 'updated' | 'deleted' | 'sent',
@@ -349,6 +373,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs an auto-message create, update, enable, or disable event. */
     async logAutoMessageChange(
         guildId: string,
         action: 'created' | 'updated' | 'enabled' | 'disabled',
@@ -368,6 +393,7 @@ export class ServerLogService {
         )
     }
 
+    /** Logs a settings change event. */
     async logSettingsChange(
         guildId: string,
         details: { setting: string; oldValue?: unknown; newValue?: unknown },

--- a/packages/shared/src/services/SpotifyLinkService/index.spec.ts
+++ b/packages/shared/src/services/SpotifyLinkService/index.spec.ts
@@ -35,10 +35,13 @@ describe('SpotifyLinkService', () => {
             }
             mockPrismaClient.spotifyLink.findUnique.mockResolvedValue(mockLink)
 
-            const result = await spotifyLinkService.getByDiscordId('discord-123')
+            const result =
+                await spotifyLinkService.getByDiscordId('discord-123')
 
             expect(result).toEqual(mockLink)
-            expect(mockPrismaClient.spotifyLink.findUnique).toHaveBeenCalledWith({
+            expect(
+                mockPrismaClient.spotifyLink.findUnique,
+            ).toHaveBeenCalledWith({
                 where: { discordId: 'discord-123' },
             })
         })
@@ -46,15 +49,19 @@ describe('SpotifyLinkService', () => {
         it('returns null when not found', async () => {
             mockPrismaClient.spotifyLink.findUnique.mockResolvedValue(null)
 
-            const result = await spotifyLinkService.getByDiscordId('discord-123')
+            const result =
+                await spotifyLinkService.getByDiscordId('discord-123')
 
             expect(result).toBeNull()
         })
 
         it('returns null on error', async () => {
-            mockPrismaClient.spotifyLink.findUnique.mockRejectedValue(new Error('DB error'))
+            mockPrismaClient.spotifyLink.findUnique.mockRejectedValue(
+                new Error('DB error'),
+            )
 
-            const result = await spotifyLinkService.getByDiscordId('discord-123')
+            const result =
+                await spotifyLinkService.getByDiscordId('discord-123')
 
             expect(result).toBeNull()
         })
@@ -71,7 +78,8 @@ describe('SpotifyLinkService', () => {
                 spotifyUsername: 'test-user',
             })
 
-            const result = await spotifyLinkService.getValidAccessToken('discord-123')
+            const result =
+                await spotifyLinkService.getValidAccessToken('discord-123')
 
             expect(result).toBe('valid-token')
         })
@@ -79,7 +87,8 @@ describe('SpotifyLinkService', () => {
         it('returns null when link not found', async () => {
             mockPrismaClient.spotifyLink.findUnique.mockResolvedValue(null)
 
-            const result = await spotifyLinkService.getValidAccessToken('discord-123')
+            const result =
+                await spotifyLinkService.getValidAccessToken('discord-123')
 
             expect(result).toBeNull()
         })
@@ -109,10 +118,95 @@ describe('SpotifyLinkService', () => {
             )
             ;(global as any).fetch = mockFetch
 
-            const result = await spotifyLinkService.getValidAccessToken('discord-123')
+            const result =
+                await spotifyLinkService.getValidAccessToken('discord-123')
 
             expect(result).toBe('new-token')
             expect(mockPrismaClient.spotifyLink.update).toHaveBeenCalled()
+        })
+
+        it('returns null when SPOTIFY_CLIENT_ID or SPOTIFY_CLIENT_SECRET is missing', async () => {
+            const pastDate = new Date(Date.now() - 3600000)
+            mockPrismaClient.spotifyLink.findUnique.mockResolvedValue({
+                spotifyId: 'spotify-123',
+                accessToken: 'expired-token',
+                refreshToken: 'refresh-token',
+                tokenExpiresAt: pastDate,
+            } as any)
+
+            delete process.env.SPOTIFY_CLIENT_ID
+            delete process.env.SPOTIFY_CLIENT_SECRET
+
+            const result =
+                await spotifyLinkService.getValidAccessToken('discord-123')
+
+            expect(result).toBeNull()
+        })
+
+        it('returns null when Spotify token endpoint responds with !ok', async () => {
+            const pastDate = new Date(Date.now() - 3600000)
+            mockPrismaClient.spotifyLink.findUnique.mockResolvedValue({
+                spotifyId: 'spotify-123',
+                accessToken: 'expired-token',
+                refreshToken: 'refresh-token',
+                tokenExpiresAt: pastDate,
+            } as any)
+
+            process.env.SPOTIFY_CLIENT_ID = 'test-client-id'
+            process.env.SPOTIFY_CLIENT_SECRET = 'test-client-secret'
+            ;(global as any).fetch = jest.fn(() =>
+                Promise.resolve({ ok: false, json: async () => ({}) } as any),
+            )
+
+            const result =
+                await spotifyLinkService.getValidAccessToken('discord-123')
+
+            expect(result).toBeNull()
+        })
+
+        it('returns null when token response contains an error field or no access_token', async () => {
+            const pastDate = new Date(Date.now() - 3600000)
+            mockPrismaClient.spotifyLink.findUnique.mockResolvedValue({
+                spotifyId: 'spotify-123',
+                accessToken: 'expired-token',
+                refreshToken: 'refresh-token',
+                tokenExpiresAt: pastDate,
+            } as any)
+
+            process.env.SPOTIFY_CLIENT_ID = 'test-client-id'
+            process.env.SPOTIFY_CLIENT_SECRET = 'test-client-secret'
+            ;(global as any).fetch = jest.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    json: async () => ({ error: 'invalid_grant' }),
+                } as any),
+            )
+
+            const result =
+                await spotifyLinkService.getValidAccessToken('discord-123')
+
+            expect(result).toBeNull()
+        })
+
+        it('returns null when fetch throws a network error', async () => {
+            const pastDate = new Date(Date.now() - 3600000)
+            mockPrismaClient.spotifyLink.findUnique.mockResolvedValue({
+                spotifyId: 'spotify-123',
+                accessToken: 'expired-token',
+                refreshToken: 'refresh-token',
+                tokenExpiresAt: pastDate,
+            } as any)
+
+            process.env.SPOTIFY_CLIENT_ID = 'test-client-id'
+            process.env.SPOTIFY_CLIENT_SECRET = 'test-client-secret'
+            ;(global as any).fetch = jest.fn(() =>
+                Promise.reject(new Error('Network failure')),
+            )
+
+            const result =
+                await spotifyLinkService.getValidAccessToken('discord-123')
+
+            expect(result).toBeNull()
         })
     })
 
@@ -135,7 +229,9 @@ describe('SpotifyLinkService', () => {
         })
 
         it('returns false on error', async () => {
-            mockPrismaClient.spotifyLink.upsert.mockRejectedValue(new Error('DB error') as any)
+            mockPrismaClient.spotifyLink.upsert.mockRejectedValue(
+                new Error('DB error') as any,
+            )
 
             const result = await spotifyLinkService.set({
                 discordId: 'discord-123',
@@ -172,7 +268,9 @@ describe('SpotifyLinkService', () => {
         })
 
         it('returns false on other error', async () => {
-            mockPrismaClient.spotifyLink.delete.mockRejectedValue(new Error('DB error') as any)
+            mockPrismaClient.spotifyLink.delete.mockRejectedValue(
+                new Error('DB error') as any,
+            )
 
             const result = await spotifyLinkService.unlink('discord-123')
 

--- a/packages/shared/src/services/SpotifyLinkService/index.ts
+++ b/packages/shared/src/services/SpotifyLinkService/index.ts
@@ -1,6 +1,7 @@
 import { getPrismaClient } from '../../utils/database/prismaClient'
 import { errorLog, debugLog } from '../../utils/general/log'
 
+/** Spotify account link data for a Discord user. */
 export type SpotifyLinkRow = {
     spotifyId: string
     accessToken: string
@@ -9,7 +10,9 @@ export type SpotifyLinkRow = {
     spotifyUsername: string | null
 }
 
+/** Manages Spotify account links and token refresh for Discord users. */
 export class SpotifyLinkService {
+    /** Retrieves Spotify link data for a Discord user. */
     async getByDiscordId(discordId: string): Promise<SpotifyLinkRow | null> {
         try {
             const prisma = getPrismaClient()
@@ -35,6 +38,7 @@ export class SpotifyLinkService {
         }
     }
 
+    /** Gets a valid Spotify access token, refreshing if necessary. */
     async getValidAccessToken(discordId: string): Promise<string | null> {
         const row = await this.getByDiscordId(discordId)
         if (!row) return null
@@ -47,6 +51,7 @@ export class SpotifyLinkService {
         return await this.refreshAccessToken(discordId, row.refreshToken)
     }
 
+    /** Refreshes an expired Spotify access token using the refresh token. */
     private async refreshAccessToken(
         discordId: string,
         refreshToken: string,
@@ -61,11 +66,13 @@ export class SpotifyLinkService {
                 return null
             }
 
-            const auth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+            const auth = Buffer.from(`${clientId}:${clientSecret}`).toString(
+                'base64',
+            )
             const res = await fetch('https://accounts.spotify.com/api/token', {
                 method: 'POST',
                 headers: {
-                    'Authorization': `Basic ${auth}`,
+                    Authorization: `Basic ${auth}`,
                     'Content-Type': 'application/x-www-form-urlencoded',
                 },
                 body: new URLSearchParams({
@@ -128,6 +135,7 @@ export class SpotifyLinkService {
         }
     }
 
+    /** Creates or updates a Spotify account link for a Discord user. */
     async set(data: {
         discordId: string
         spotifyId: string
@@ -177,6 +185,7 @@ export class SpotifyLinkService {
         }
     }
 
+    /** Removes a Discord user's Spotify account link. */
     async unlink(discordId: string): Promise<boolean> {
         try {
             const prisma = getPrismaClient()
@@ -213,4 +222,5 @@ export class SpotifyLinkService {
     }
 }
 
+/** Singleton instance of SpotifyLinkService. */
 export const spotifyLinkService = new SpotifyLinkService()

--- a/packages/shared/src/services/StarboardService.ts
+++ b/packages/shared/src/services/StarboardService.ts
@@ -2,6 +2,7 @@ import { getPrismaClient } from '../utils/database/prismaClient.js'
 
 const prisma = getPrismaClient()
 
+/** Configuration for a guild's starboard feature. */
 export type StarboardConfig = {
     id: string
     guildId: string
@@ -13,6 +14,7 @@ export type StarboardConfig = {
     updatedAt: Date
 }
 
+/** A message entry in the starboard. */
 export type StarboardEntry = {
     id: string
     guildId: string
@@ -26,6 +28,7 @@ export type StarboardEntry = {
     updatedAt: Date
 }
 
+/** Data for upserting starboard configuration. */
 type UpsertConfigData = {
     channelId: string
     emoji?: string
@@ -33,6 +36,7 @@ type UpsertConfigData = {
     selfStar?: boolean
 }
 
+/** Data for upserting a starboard entry. */
 type UpsertEntryData = {
     channelId: string
     authorId: string
@@ -41,12 +45,18 @@ type UpsertEntryData = {
     starboardMsgId?: string
 }
 
+/** Manages starboard configuration and entries. */
 export class StarboardService {
+    /** Retrieves starboard configuration for a guild. */
     async getConfig(guildId: string): Promise<StarboardConfig | null> {
         return await prisma.starboardConfig.findUnique({ where: { guildId } })
     }
 
-    async upsertConfig(guildId: string, data: UpsertConfigData): Promise<StarboardConfig> {
+    /** Creates or updates starboard configuration for a guild. */
+    async upsertConfig(
+        guildId: string,
+        data: UpsertConfigData,
+    ): Promise<StarboardConfig> {
         return await prisma.starboardConfig.upsert({
             where: { guildId },
             create: { guildId, ...data },
@@ -54,17 +64,27 @@ export class StarboardService {
         })
     }
 
+    /** Deletes starboard configuration for a guild. */
     async deleteConfig(guildId: string): Promise<void> {
         await prisma.starboardConfig.deleteMany({ where: { guildId } })
     }
 
-    async getEntry(guildId: string, messageId: string): Promise<StarboardEntry | null> {
+    /** Retrieves a starboard entry by message ID. */
+    async getEntry(
+        guildId: string,
+        messageId: string,
+    ): Promise<StarboardEntry | null> {
         return await prisma.starboardEntry.findUnique({
             where: { guildId_messageId: { guildId, messageId } },
         })
     }
 
-    async upsertEntry(guildId: string, messageId: string, data: UpsertEntryData): Promise<StarboardEntry> {
+    /** Creates or updates a starboard entry. */
+    async upsertEntry(
+        guildId: string,
+        messageId: string,
+        data: UpsertEntryData,
+    ): Promise<StarboardEntry> {
         return await prisma.starboardEntry.upsert({
             where: { guildId_messageId: { guildId, messageId } },
             create: { guildId, messageId, ...data },
@@ -72,7 +92,11 @@ export class StarboardService {
         })
     }
 
-    async getTopEntries(guildId: string, limit = 10): Promise<StarboardEntry[]> {
+    /** Retrieves top-rated starboard entries for a guild. */
+    async getTopEntries(
+        guildId: string,
+        limit = 10,
+    ): Promise<StarboardEntry[]> {
         return await prisma.starboardEntry.findMany({
             where: { guildId },
             orderBy: { starCount: 'desc' },
@@ -81,4 +105,5 @@ export class StarboardService {
     }
 }
 
+/** Singleton instance of StarboardService. */
 export const starboardService = new StarboardService()

--- a/packages/shared/src/services/TrackHistoryService.ts
+++ b/packages/shared/src/services/TrackHistoryService.ts
@@ -1,6 +1,7 @@
 import { redisClient } from './redis'
 import { infoLog, errorLog } from '../utils/general/log'
 
+/** A track entry in guild playback history. */
 export interface TrackHistoryEntry {
     trackId: string
     title: string
@@ -13,6 +14,7 @@ export interface TrackHistoryEntry {
     isAutoplay?: boolean
 }
 
+/** Input data for adding a track to history. */
 export interface TrackHistoryInput {
     id: string
     title: string
@@ -22,6 +24,7 @@ export interface TrackHistoryInput {
     metadata?: { isAutoplay?: boolean }
 }
 
+/** Statistics for guild track playback history. */
 export interface TrackHistoryStats {
     totalTracks: number
     totalPlayTime: number
@@ -30,6 +33,7 @@ export interface TrackHistoryStats {
     lastUpdated: Date
 }
 
+/** Manages track playback history stored in Redis for guilds. */
 export class TrackHistoryService {
     private readonly ttl: number
     private readonly maxHistorySize: number
@@ -39,12 +43,14 @@ export class TrackHistoryService {
         this.maxHistorySize = maxHistorySize
     }
 
+    /** Generates Redis key for track history storage. */
     private getRedisKey(guildId: string, trackId?: string): string {
         return trackId
             ? `track_history:${guildId}:${trackId}`
             : `track_history:${guildId}`
     }
 
+    /** Adds a track to a guild's playback history. */
     async addTrackToHistory(
         track: TrackHistoryInput,
         guildId: string,
@@ -90,6 +96,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Retrieves track history for a guild with pagination. */
     async getTrackHistory(
         guildId: string,
         limit = 10,
@@ -112,6 +119,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Retrieves the most recently played track for a guild. */
     async getLastTrack(guildId: string): Promise<TrackHistoryEntry | null> {
         try {
             const lastTrackData = await redisClient.lindex(
@@ -127,6 +135,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Gets the total count of tracks in a guild's history. */
     async getTrackHistoryCount(guildId: string): Promise<number> {
         try {
             return await redisClient.llen(this.getRedisKey(guildId))
@@ -136,6 +145,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Clears all track history for a guild. */
     async clearHistory(guildId: string): Promise<boolean> {
         try {
             await redisClient.del(this.getRedisKey(guildId))
@@ -147,6 +157,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Checks if a track was recently played within a time window. */
     async isDuplicateTrack(
         guildId: string,
         trackUrl: string,
@@ -166,6 +177,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Retrieves top played tracks for a guild. */
     async getTopTracks(
         guildId: string,
         limit = 10,
@@ -202,6 +214,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Retrieves top artists by play count for a guild. */
     async getTopArtists(
         guildId: string,
         limit = 10,
@@ -225,6 +238,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Generates comprehensive playback statistics for a guild. */
     async generateStats(guildId: string): Promise<TrackHistoryStats | null> {
         try {
             const history = await this.getTrackHistory(guildId, 100)
@@ -255,6 +269,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Parses duration string (MM:SS format) to seconds. */
     private parseDuration(duration: string): number {
         const parts = duration.split(':')
         if (parts.length === 2) {
@@ -263,10 +278,12 @@ export class TrackHistoryService {
         return 0
     }
 
+    /** Cleans up expired track history data. */
     async cleanupOldData(): Promise<number> {
         return 0
     }
 
+    /** Marks a track as played for duplicate detection. */
     async markTrackAsPlayed(guildId: string, trackUrl: string): Promise<void> {
         try {
             const key = this.getRedisKey(guildId, `played:${trackUrl}`)
@@ -276,6 +293,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Clears all cached track data for a guild. */
     async clearAllGuildCaches(guildId: string): Promise<void> {
         try {
             const pattern = this.getRedisKey(guildId, '*')
@@ -290,6 +308,7 @@ export class TrackHistoryService {
         }
     }
 
+    /** Generates statistics on autoplay recommendations for a guild. */
     async getAutoplayStats(
         guildId: string,
         limit = 200,
@@ -339,4 +358,5 @@ export class TrackHistoryService {
     }
 }
 
+/** Singleton instance of TrackHistoryService. */
 export const trackHistoryService = new TrackHistoryService()

--- a/packages/shared/src/services/TwitchNotificationService/index.ts
+++ b/packages/shared/src/services/TwitchNotificationService/index.ts
@@ -2,6 +2,7 @@ import { getPrismaClient } from '../../utils/database/prismaClient'
 import { errorLog, debugLog } from '../../utils/general/log'
 import type { TwitchNotification } from '../../generated/prisma/client.js'
 
+/** Twitch notification configuration for a guild channel. */
 export type TwitchNotificationRow = Pick<
     TwitchNotification,
     'id' | 'guildId' | 'twitchUserId' | 'twitchLogin' | 'discordChannelId'
@@ -9,7 +10,9 @@ export type TwitchNotificationRow = Pick<
     guild?: { discordId: string }
 }
 
+/** Manages Twitch notification subscriptions for Discord guilds. */
 export class TwitchNotificationService {
+    /** Adds or updates a Twitch notification subscription for a guild. */
     async add(
         guildId: string,
         discordChannelId: string,
@@ -43,6 +46,7 @@ export class TwitchNotificationService {
         }
     }
 
+    /** Removes a Twitch notification subscription from a guild. */
     async remove(guildId: string, twitchUserId: string): Promise<boolean> {
         try {
             const prisma = getPrismaClient()
@@ -62,6 +66,7 @@ export class TwitchNotificationService {
         }
     }
 
+    /** Lists all Twitch notification subscriptions for a guild. */
     async listByGuild(guildId: string): Promise<TwitchNotificationRow[]> {
         try {
             const prisma = getPrismaClient()
@@ -78,6 +83,7 @@ export class TwitchNotificationService {
         }
     }
 
+    /** Lists all Twitch notification subscriptions for a Twitch user. */
     async getNotificationsByTwitchUserId(
         twitchUserId: string,
     ): Promise<TwitchNotificationRow[]> {
@@ -96,6 +102,7 @@ export class TwitchNotificationService {
         }
     }
 
+    /** Gets all unique Twitch user IDs with active notifications. */
     async getDistinctTwitchUserIds(): Promise<string[]> {
         try {
             const prisma = getPrismaClient()
@@ -114,4 +121,5 @@ export class TwitchNotificationService {
     }
 }
 
+/** Singleton instance of TwitchNotificationService. */
 export const twitchNotificationService = new TwitchNotificationService()

--- a/packages/shared/src/services/database/DatabaseService.ts
+++ b/packages/shared/src/services/database/DatabaseService.ts
@@ -224,6 +224,7 @@ async function typedRateLimitFindUnique(
     return { resetAt: resetAtValue, count: countValue }
 }
 
+/** Configuration options for the database connection pool. */
 export interface DatabaseConfig {
     url: string
     ttl: number
@@ -231,6 +232,7 @@ export interface DatabaseConfig {
     connectionTimeout: number
 }
 
+/** Service for managing PostgreSQL operations via Prisma. */
 export class DatabaseService {
     private readonly prisma: PrismaClient
     private isConnected = false
@@ -259,6 +261,7 @@ export class DatabaseService {
         }
     }
 
+    /** Establishes the database connection. */
     async connect(): Promise<Result<boolean>> {
         return this.executeWithFallback(
             async () => {
@@ -277,6 +280,7 @@ export class DatabaseService {
         )
     }
 
+    /** Closes the database connection. */
     async disconnect(): Promise<Result<void>> {
         return this.executeWithFallback(
             async () => {
@@ -294,6 +298,7 @@ export class DatabaseService {
         )
     }
 
+    /** Checks the database connection by executing a test query. */
     async isHealthy(): Promise<Result<boolean>> {
         return this.executeWithFallback(
             async () => {
@@ -310,6 +315,7 @@ export class DatabaseService {
     }
 
     // User operations
+    /** Creates or updates a user record by Discord ID. */
     async createUser(
         discordId: string,
         username: string,
@@ -350,6 +356,7 @@ export class DatabaseService {
         )
     }
 
+    /** Retrieves a user by Discord ID, or null if not found. */
     async getUser(discordId: string): Promise<Result<DatabaseUser | null>> {
         return this.executeWithFallback(
             async () => {
@@ -381,6 +388,7 @@ export class DatabaseService {
     }
 
     // Guild operations
+    /** Creates or updates a guild record by Discord ID. */
     async createGuild(
         discordId: string,
         name: string,
@@ -424,6 +432,7 @@ export class DatabaseService {
         )
     }
 
+    /** Retrieves a guild by Discord ID, or null if not found. */
     async getGuild(discordId: string): Promise<Result<DatabaseGuild | null>> {
         return this.executeWithFallback(
             async () => {
@@ -454,6 +463,7 @@ export class DatabaseService {
     }
 
     // Track history operations
+    /** Records a played track in the guild's history. */
     async addTrackToHistory(data: {
         guildId: string
         trackId: string
@@ -538,6 +548,7 @@ export class DatabaseService {
         )
     }
 
+    /** Retrieves the most recently played tracks for a guild. */
     async getTrackHistory(
         guildId: string,
         limit = 10,
@@ -594,6 +605,7 @@ export class DatabaseService {
     }
 
     // Command usage analytics
+    /** Records a bot command invocation for analytics. */
     async recordCommandUsage(data: {
         userId?: string
         guildId?: string
@@ -652,6 +664,7 @@ export class DatabaseService {
     }
 
     // Rate limiting
+    /** Checks whether the given key is within the allowed rate limit window. */
     async checkRateLimit(
         key: string,
         limit: number,
@@ -704,6 +717,7 @@ export class DatabaseService {
     }
 
     // Analytics queries
+    /** Returns the most-played tracks for a guild by play count. */
     async getTopTracks(
         guildId: string,
         limit = 10,
@@ -753,6 +767,7 @@ export class DatabaseService {
         )
     }
 
+    /** Returns the most-played artists for a guild by play count. */
     async getTopArtists(
         guildId: string,
         limit = 10,
@@ -797,6 +812,7 @@ export class DatabaseService {
     }
 
     // Cleanup operations
+    /** Deletes track history, command usage, and expired rate limit records older than 30 days. */
     async cleanupOldData(): Promise<Result<number>> {
         return this.executeWithFallback(
             async () => {
@@ -824,6 +840,7 @@ export class DatabaseService {
     }
 
     // Get Prisma client for direct access
+    /** Returns the underlying Prisma client for direct database access. */
     getClient(): PrismaClient {
         return this.prisma
     }

--- a/packages/shared/src/services/embedValidation.spec.ts
+++ b/packages/shared/src/services/embedValidation.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from '@jest/globals'
+import {
+    validateEmbedData,
+    hexToDecimal,
+    decimalToHex,
+} from './embedValidation'
+
+describe('validateEmbedData', () => {
+    it('returns valid for embed with title only', () => {
+        const result = validateEmbedData({ title: 'Hello' })
+        expect(result.valid).toBe(true)
+        expect(result.errors).toHaveLength(0)
+    })
+
+    it('returns valid for embed with description only', () => {
+        const result = validateEmbedData({ description: 'Some description' })
+        expect(result.valid).toBe(true)
+    })
+
+    it('returns valid for embed with fields only', () => {
+        const result = validateEmbedData({
+            fields: [{ name: 'f', value: 'v' }],
+        })
+        expect(result.valid).toBe(true)
+    })
+
+    it('returns invalid when no title, description, or fields', () => {
+        const result = validateEmbedData({})
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain(
+            'Embed must have at least a title, description, or fields',
+        )
+    })
+
+    it('returns invalid when fields is empty array', () => {
+        const result = validateEmbedData({ fields: [] })
+        expect(result.valid).toBe(false)
+    })
+
+    it('returns invalid when title exceeds 256 characters', () => {
+        const result = validateEmbedData({ title: 'a'.repeat(257) })
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Title must be 256 characters or less')
+    })
+
+    it('returns valid when title is exactly 256 characters', () => {
+        const result = validateEmbedData({ title: 'a'.repeat(256) })
+        expect(result.valid).toBe(true)
+    })
+
+    it('returns invalid when description exceeds 4096 characters', () => {
+        const result = validateEmbedData({
+            title: 'T',
+            description: 'a'.repeat(4097),
+        })
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain(
+            'Description must be 4096 characters or less',
+        )
+    })
+
+    it('returns valid when description is exactly 4096 characters', () => {
+        const result = validateEmbedData({ description: 'a'.repeat(4096) })
+        expect(result.valid).toBe(true)
+    })
+
+    it('returns invalid for color without hash prefix', () => {
+        const result = validateEmbedData({ title: 'T', color: '5865F2' })
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain(
+            'Color must be a valid hex code (e.g. #5865F2)',
+        )
+    })
+
+    it('returns invalid for color with wrong length', () => {
+        const result = validateEmbedData({ title: 'T', color: '#FFF' })
+        expect(result.valid).toBe(false)
+    })
+
+    it('returns valid for correct hex color', () => {
+        const result = validateEmbedData({ title: 'T', color: '#5865F2' })
+        expect(result.valid).toBe(true)
+    })
+
+    it('returns valid for lowercase hex color', () => {
+        const result = validateEmbedData({ title: 'T', color: '#5865f2' })
+        expect(result.valid).toBe(true)
+    })
+
+    it('accumulates multiple errors', () => {
+        const result = validateEmbedData({
+            title: 'a'.repeat(257),
+            color: 'bad',
+        })
+        expect(result.errors).toHaveLength(2)
+    })
+})
+
+describe('hexToDecimal', () => {
+    it('converts hex without hash to decimal', () => {
+        expect(hexToDecimal('FF0000')).toBe(16711680)
+    })
+
+    it('converts hex with hash to decimal', () => {
+        expect(hexToDecimal('#5865F2')).toBe(parseInt('5865F2', 16))
+    })
+
+    it('converts #000000 to 0', () => {
+        expect(hexToDecimal('#000000')).toBe(0)
+    })
+})
+
+describe('decimalToHex', () => {
+    it('converts decimal to hex string with hash prefix', () => {
+        expect(decimalToHex(16711680)).toBe('#FF0000')
+    })
+
+    it('pads short hex values to 6 digits', () => {
+        expect(decimalToHex(0)).toBe('#000000')
+    })
+
+    it('round-trips with hexToDecimal', () => {
+        const original = '#5865F2'
+        expect(decimalToHex(hexToDecimal(original))).toBe(original)
+    })
+})

--- a/packages/shared/src/services/guildAutomation/autoMessagesExecutor.ts
+++ b/packages/shared/src/services/guildAutomation/autoMessagesExecutor.ts
@@ -1,7 +1,9 @@
 import type { ExecutorApplyResult, ExecutorOpError } from './types'
 
+/** Type of auto message (welcome or leave). */
 type AutoMessageType = 'welcome' | 'leave'
 
+/** Snapshot of a stored auto message. */
 type AutoMessageSnapshot = {
     id: string
     channelId: string | null
@@ -9,16 +11,19 @@ type AutoMessageSnapshot = {
     enabled: boolean
 } | null
 
+/** Current live state of auto messages in a guild. */
 export type AutoMessagesLiveState = {
     welcome: AutoMessageSnapshot
     leave: AutoMessageSnapshot
 }
 
+/** Auto messages section of the manifest document. */
 export type AutoMessagesManifestSection = {
     welcome?: { enabled?: boolean; channelId?: string; message?: string }
     leave?: { enabled?: boolean; channelId?: string; message?: string }
 }
 
+/** Diff operation for auto message changes. */
 export type AutoMessagesDiffOp =
     | {
           kind: 'create'
@@ -36,8 +41,10 @@ export type AutoMessagesDiffOp =
       }
     | { kind: 'noop'; type: AutoMessageType }
 
+/** Diff between auto message manifest and live state. */
 export type AutoMessagesDiff = { ops: AutoMessagesDiffOp[] }
 
+/** Result of auto message apply operation. */
 export type AutoMessagesResult = {
     applied: Array<{
         type: AutoMessageType
@@ -45,8 +52,10 @@ export type AutoMessagesResult = {
     }>
 }
 
+/** Context for executor operations. */
 export type ExecutorContext = { guildId: string }
 
+/** Port interface for auto message operations. */
 export type AutoMessagesPort = {
     getWelcomeMessage(guildId: string): Promise<AutoMessageSnapshot>
     getLeaveMessage(guildId: string): Promise<AutoMessageSnapshot>
@@ -66,6 +75,7 @@ export type AutoMessagesPort = {
     ): Promise<unknown>
 }
 
+/** Creates an auto messages executor with given dependencies. */
 export function createAutoMessagesExecutor(deps: {
     autoMessageService: AutoMessagesPort
 }) {

--- a/packages/shared/src/services/guildAutomation/diff.spec.ts
+++ b/packages/shared/src/services/guildAutomation/diff.spec.ts
@@ -83,4 +83,59 @@ describe('createAutomationPlan', () => {
         expect(plan.summary.total).toBe(plan.operations.length)
         expect(plan.summary.byModule.onboarding).toBeGreaterThanOrEqual(1)
     })
+
+    it('emits an update operation when a role id matches but a property differs', () => {
+        const desired = baseManifest()
+        const actual = {
+            ...baseManifest(),
+            roles: {
+                roles: [
+                    {
+                        id: '223456789012345678',
+                        name: 'OldName',
+                        color: 0xff0000,
+                    },
+                ],
+                channels: baseManifest().roles!.channels,
+            },
+        }
+
+        const plan = createAutomationPlan({ desired, actual })
+
+        expect(
+            plan.operations.some(
+                (op) => op.module === 'roles' && op.action === 'update',
+            ),
+        ).toBe(true)
+    })
+
+    it('triggers stableStringify array path when onboarding defaultChannelIds differ', () => {
+        const desired = {
+            ...baseManifest(),
+            onboarding: {
+                enabled: true,
+                mode: 1,
+                defaultChannelIds: ['111111111111111111'],
+                prompts: [],
+            },
+        }
+
+        const actual = {
+            ...baseManifest(),
+            onboarding: {
+                enabled: true,
+                mode: 1,
+                defaultChannelIds: ['222222222222222222'],
+                prompts: [],
+            },
+        }
+
+        const plan = createAutomationPlan({ desired, actual })
+
+        expect(
+            plan.operations.some(
+                (op) => op.module === 'onboarding' && op.action === 'update',
+            ),
+        ).toBe(true)
+    })
 })

--- a/packages/shared/src/services/guildAutomation/moderationExecutor.spec.ts
+++ b/packages/shared/src/services/guildAutomation/moderationExecutor.spec.ts
@@ -81,4 +81,43 @@ describe('createModerationExecutor', () => {
         expect(port.updateAutoModSettings).not.toHaveBeenCalled()
         expect(port.updateModerationSettings).not.toHaveBeenCalled()
     })
+
+    it('returns partial when one operation fails and the other succeeds', async () => {
+        const port = makePort()
+        port.updateAutoModSettings.mockRejectedValue(new Error('discord error'))
+        const executor = createModerationExecutor({ port })
+
+        const live = executor.capture()
+        const diff = executor.diff(live, {
+            automod: { exemptRoles: ['r1'] },
+            moderationSettings: { muteRoleId: 'r2' },
+        })
+        const result = await executor.apply(diff, { guildId: 'g4' })
+
+        expect(result.status).toBe('partial')
+        if (result.status === 'partial') {
+            expect(result.applied).toContain('moderationSettings')
+        }
+    })
+
+    it('returns failed when all operations fail', async () => {
+        const port = makePort()
+        port.updateAutoModSettings.mockRejectedValue(new Error('automod error'))
+        port.updateModerationSettings.mockRejectedValue(
+            new Error('moderation error'),
+        )
+        const executor = createModerationExecutor({ port })
+
+        const live = executor.capture()
+        const diff = executor.diff(live, {
+            automod: { exemptRoles: ['r1'] },
+            moderationSettings: { muteRoleId: 'r2' },
+        })
+        const result = await executor.apply(diff, { guildId: 'g5' })
+
+        expect(result.status).toBe('failed')
+        if (result.status === 'failed') {
+            expect(result.error).toContain('automod error')
+        }
+    })
 })

--- a/packages/shared/src/services/guildAutomation/reactionRolesExecutor.spec.ts
+++ b/packages/shared/src/services/guildAutomation/reactionRolesExecutor.spec.ts
@@ -125,4 +125,26 @@ describe('createReactionRolesExecutor', () => {
             expect(result.applied).toContain('remove-exclusive')
         }
     })
+
+    it('returns failed when all operations fail', async () => {
+        const port = makePort()
+        port.setExclusiveRole.mockRejectedValue(new Error('set error'))
+        port.removeExclusiveRole.mockRejectedValue(new Error('remove error'))
+        port.listExclusiveRoles.mockResolvedValue([
+            { roleId: 'r1', excludedRoleId: 'r2' },
+        ])
+        const executor = createReactionRolesExecutor({ port })
+
+        const live = await executor.capture({ guildId: 'g1' })
+        // live has r1:r2 (triggers remove); manifest has r3:r4 (triggers set) — both fail
+        const diff = executor.diff(live, {
+            exclusiveRoles: [{ roleId: 'r3', excludedRoleId: 'r4' }],
+        })
+        const result = await executor.apply(diff, { guildId: 'g1' })
+
+        expect(result.status).toBe('failed')
+        if (result.status === 'failed') {
+            expect(result.error).toBeTruthy()
+        }
+    })
 })

--- a/packages/shared/src/services/guildAutomation/types.ts
+++ b/packages/shared/src/services/guildAutomation/types.ts
@@ -1,3 +1,4 @@
+/** List of available guild automation modules. */
 export const AUTOMATION_MODULES = [
     'onboarding',
     'roles',
@@ -8,10 +9,13 @@ export const AUTOMATION_MODULES = [
     'parity',
 ] as const
 
+/** Guild automation module type. */
 export type AutomationModule = (typeof AUTOMATION_MODULES)[number]
 
+/** Automation operation action types. */
 export type AutomationAction = 'create' | 'update' | 'delete' | 'noop'
 
+/** Automation run type (capture, plan, apply, etc). */
 export type AutomationRunType =
     | 'capture'
     | 'plan'
@@ -19,6 +23,7 @@ export type AutomationRunType =
     | 'reconcile'
     | 'cutover'
 
+/** Automation run execution status. */
 export type AutomationRunStatus =
     | 'pending'
     | 'running'
@@ -26,8 +31,10 @@ export type AutomationRunStatus =
     | 'failed'
     | 'blocked'
 
+/** Drift severity level. */
 export type DriftSeverity = 'none' | 'low' | 'medium' | 'high'
 
+/** Guild role definition for automation. */
 export interface GuildAutomationRole {
     id: string
     name: string
@@ -37,6 +44,7 @@ export interface GuildAutomationRole {
     permissions?: string
 }
 
+/** Guild channel definition for automation. */
 export interface GuildAutomationChannel {
     id: string
     name: string
@@ -46,6 +54,7 @@ export interface GuildAutomationChannel {
     readonly?: boolean
 }
 
+/** Onboarding prompt option in guild automation. */
 export interface GuildAutomationOnboardingPromptOption {
     id?: string
     title: string
@@ -55,6 +64,7 @@ export interface GuildAutomationOnboardingPromptOption {
     emoji?: string | null
 }
 
+/** Onboarding prompt in guild automation. */
 export interface GuildAutomationOnboardingPrompt {
     id?: string
     title: string
@@ -65,6 +75,7 @@ export interface GuildAutomationOnboardingPrompt {
     options: GuildAutomationOnboardingPromptOption[]
 }
 
+/** Guild onboarding automation configuration. */
 export interface GuildAutomationOnboarding {
     enabled: boolean
     mode: number
@@ -72,6 +83,7 @@ export interface GuildAutomationOnboarding {
     prompts: GuildAutomationOnboardingPrompt[]
 }
 
+/** Guild moderation automation configuration. */
 export interface GuildAutomationModeration {
     automod?: {
         exemptRoles?: string[]
@@ -86,12 +98,14 @@ export interface GuildAutomationModeration {
     }
 }
 
+/** Guild automation message configuration. */
 export interface GuildAutomationAutoMessage {
     enabled?: boolean
     channelId?: string
     message?: string
 }
 
+/** Guild automation reaction role message. */
 export interface GuildAutomationReactionRoleMessage {
     id?: string
     messageId?: string
@@ -106,12 +120,14 @@ export interface GuildAutomationReactionRoleMessage {
     }>
 }
 
+/** Parity checklist item in guild automation. */
 export interface GuildAutomationParityChecklistItem {
     key: string
     label: string
     done: boolean
 }
 
+/** Guild parity automation configuration. */
 export interface GuildAutomationParity {
     shadowMode?: boolean
     externalBots?: Array<{
@@ -123,6 +139,7 @@ export interface GuildAutomationParity {
     cutoverReady?: boolean
 }
 
+/** Guild automation manifest document (full schema). */
 export interface GuildAutomationManifestDocument {
     version: number
     guild: {

--- a/packages/shared/src/services/moderationSettings.ts
+++ b/packages/shared/src/services/moderationSettings.ts
@@ -16,6 +16,7 @@ function prisma(): PrismaClient {
     return prismaInstance
 }
 
+/** Retrieves moderation settings for a guild with caching support. */
 export async function getModerationSettings(
     guildId: string,
 ): Promise<ModerationSettings> {
@@ -50,6 +51,7 @@ export async function getModerationSettings(
     return settings
 }
 
+/** Updates or creates moderation settings for a guild and invalidates cache. */
 export async function updateModerationSettings(
     guildId: string,
     data: Partial<
@@ -69,6 +71,7 @@ export async function updateModerationSettings(
     return result
 }
 
+/** Checks if a user has moderation permissions in a guild. */
 export async function hasModPermissions(
     guildId: string,
     userRoles: string[],
@@ -81,6 +84,7 @@ export async function hasModPermissions(
     )
 }
 
+/** Retrieves aggregated moderation case statistics for a guild. */
 export async function getModerationStats(guildId: string) {
     const [totalCases, activeCases, casesByType] = await Promise.all([
         prisma().moderationCase.count({ where: { guildId } }),

--- a/packages/shared/src/services/music/types.ts
+++ b/packages/shared/src/services/music/types.ts
@@ -1,3 +1,4 @@
+/** Music command types supported by the queue. */
 export type MusicCommandType =
     | 'play'
     | 'pause'
@@ -14,8 +15,10 @@ export type MusicCommandType =
     | 'seek'
     | 'get_state'
 
+/** Repeat mode for playback. */
 export type RepeatMode = 'off' | 'track' | 'queue' | 'autoplay'
 
+/** Music command issued by a user. */
 export interface MusicCommand {
     id: string
     guildId: string
@@ -25,6 +28,7 @@ export interface MusicCommand {
     timestamp: number
 }
 
+/** Information about a playable track. */
 export interface TrackInfo {
     id: string
     title: string
@@ -40,6 +44,7 @@ export interface TrackInfo {
     sessionSnapshotId?: string
 }
 
+/** Health state of a music provider. */
 export interface ProviderHealthState {
     provider: string
     score: number
@@ -47,6 +52,7 @@ export interface ProviderHealthState {
     cooldownUntil: number | null
 }
 
+/** Current state of the music queue. */
 export interface QueueState {
     guildId: string
     currentTrack: TrackInfo | null

--- a/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
@@ -14,8 +14,10 @@ jest.mock('../utils/database/prismaClient', () => ({
 // Now import the module under test
 import {
     getPerSourceAcceptance,
+    getPerModeAcceptance,
     getSummary,
     type PerSourceRow,
+    type PerModeRow,
     type Summary,
 } from './recommendationTelemetryReadService'
 
@@ -220,6 +222,150 @@ describe('recommendationTelemetryReadService', () => {
             mockCount.mockResolvedValue({ count: 0 })
 
             await getPerSourceAcceptance('guild-123')
+
+            const call = mockGroupBy.mock.calls[0][0] as any
+            const minus7Days = Date.now() - 7 * 86_400_000
+            expect(call.where.createdAt.gte.getTime()).toBeCloseTo(
+                minus7Days,
+                -2,
+            )
+        })
+    })
+
+    describe('getPerModeAcceptance', () => {
+        it('returns empty array when guild has no recommendations', async () => {
+            mockGroupBy.mockResolvedValue([])
+
+            const result = await getPerModeAcceptance('guild-123')
+
+            expect(result).toEqual([])
+            expect(mockGroupBy).toHaveBeenCalled()
+        })
+
+        it('returns rows for all three modes', async () => {
+            const mockGroupResult = [
+                { mode: 'similar', _count: { id: 10 } },
+                { mode: 'discover', _count: { id: 8 } },
+                { mode: 'popular', _count: { id: 6 } },
+            ]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            // similar: 7 accepted, 2 rejected, 1 pending
+            mockCount
+                .mockResolvedValueOnce({ count: 7 })
+                .mockResolvedValueOnce({ count: 2 })
+                .mockResolvedValueOnce({ count: 1 })
+                // discover: 5 accepted, 2 rejected, 1 pending
+                .mockResolvedValueOnce({ count: 5 })
+                .mockResolvedValueOnce({ count: 2 })
+                .mockResolvedValueOnce({ count: 1 })
+                // popular: 4 accepted, 1 rejected, 1 pending
+                .mockResolvedValueOnce({ count: 4 })
+                .mockResolvedValueOnce({ count: 1 })
+                .mockResolvedValueOnce({ count: 1 })
+
+            const result = await getPerModeAcceptance('guild-123')
+
+            expect(result).toHaveLength(3)
+            expect(result[0]).toEqual({
+                mode: 'similar',
+                count: 10,
+                acceptedCount: 7,
+                rejectedCount: 2,
+                pendingCount: 1,
+                acceptanceRate: 7 / 9,
+            })
+            expect(result[1]).toEqual({
+                mode: 'discover',
+                count: 8,
+                acceptedCount: 5,
+                rejectedCount: 2,
+                pendingCount: 1,
+                acceptanceRate: 5 / 7,
+            })
+            expect(result[2]).toEqual({
+                mode: 'popular',
+                count: 6,
+                acceptedCount: 4,
+                rejectedCount: 1,
+                pendingCount: 1,
+                acceptanceRate: 4 / 5,
+            })
+        })
+
+        it('handles null mode value (pre-migration rows)', async () => {
+            const mockGroupResult = [
+                { mode: null, _count: { id: 2 } },
+                { mode: 'similar', _count: { id: 5 } },
+            ]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            mockCount
+                .mockResolvedValueOnce({ count: 1 }) // null: accepted
+                .mockResolvedValueOnce({ count: 1 }) // null: rejected
+                .mockResolvedValueOnce({ count: 0 }) // null: pending
+                .mockResolvedValueOnce({ count: 4 }) // similar: accepted
+                .mockResolvedValueOnce({ count: 1 }) // similar: rejected
+                .mockResolvedValueOnce({ count: 0 }) // similar: pending
+
+            const result = await getPerModeAcceptance('guild-123')
+
+            expect(result).toHaveLength(2)
+            expect(result[0].mode).toBeNull()
+            expect(result[0].acceptanceRate).toBe(0.5) // 1/(1+1)
+            expect(result[1].mode).toBe('similar')
+        })
+
+        it('returns null acceptanceRate when all pending', async () => {
+            const mockGroupResult = [{ mode: 'similar', _count: { id: 5 } }]
+            mockGroupBy.mockResolvedValue(mockGroupResult)
+
+            mockCount
+                .mockResolvedValueOnce({ count: 0 }) // accepted
+                .mockResolvedValueOnce({ count: 0 }) // rejected
+                .mockResolvedValueOnce({ count: 5 }) // pending
+
+            const result = await getPerModeAcceptance('guild-123')
+
+            expect(result[0].acceptanceRate).toBeNull()
+        })
+
+        it('clamps days to [1, 30] range', async () => {
+            mockGroupBy.mockResolvedValue([])
+            mockCount.mockResolvedValue({ count: 0 })
+
+            // Test with days: 0 (should clamp to 1)
+            await getPerModeAcceptance('guild-123', 0)
+            const firstCall = mockGroupBy.mock.calls[0][0] as any
+            const minusOneDay = Date.now() - 1 * 86_400_000
+            expect(firstCall.where.createdAt.gte.getTime()).toBeCloseTo(
+                minusOneDay,
+                -2,
+            )
+
+            jest.clearAllMocks()
+            mockGetPrismaClient.mockReturnValue({
+                recommendation: {
+                    groupBy: mockGroupBy,
+                    count: mockCount,
+                },
+            })
+
+            // Test with days: 999 (should clamp to 30)
+            await getPerModeAcceptance('guild-123', 999)
+            const secondCall = mockGroupBy.mock.calls[0][0] as any
+            const minus30Days = Date.now() - 30 * 86_400_000
+            expect(secondCall.where.createdAt.gte.getTime()).toBeCloseTo(
+                minus30Days,
+                -2,
+            )
+        })
+
+        it('defaults to 7 days when days is undefined', async () => {
+            mockGroupBy.mockResolvedValue([])
+            mockCount.mockResolvedValue({ count: 0 })
+
+            await getPerModeAcceptance('guild-123')
 
             const call = mockGroupBy.mock.calls[0][0] as any
             const minus7Days = Date.now() - 7 * 86_400_000

--- a/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
@@ -16,6 +16,7 @@ import {
     getPerSourceAcceptance,
     getPerModeAcceptance,
     getSummary,
+    getAutoplaySkipRateForGuild,
     type PerSourceRow,
     type PerModeRow,
     type Summary,
@@ -472,6 +473,93 @@ describe('recommendationTelemetryReadService', () => {
                 minus7Days,
                 -2,
             )
+        })
+    })
+
+    describe('getAutoplaySkipRateForGuild', () => {
+        const mockGuildId = 'guild-123'
+
+        it('returns skip rate when sample >= minimum (5 resolved outcomes)', async () => {
+            mockCount.mockResolvedValueOnce(3).mockResolvedValueOnce(2)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: 0.4,
+                sampleSize: 5,
+                acceptedCount: 3,
+                rejectedCount: 2,
+                canTrip: true,
+            })
+        })
+
+        it('returns canTrip=false when sample < minimum (< 5 resolved)', async () => {
+            mockCount.mockResolvedValueOnce(2).mockResolvedValueOnce(1)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: 1 / 3,
+                sampleSize: 3,
+                acceptedCount: 2,
+                rejectedCount: 1,
+                canTrip: false,
+            })
+        })
+
+        it('returns 0% skip rate with no rejections', async () => {
+            mockCount.mockResolvedValueOnce(10).mockResolvedValueOnce(0)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: 0,
+                sampleSize: 10,
+                acceptedCount: 10,
+                rejectedCount: 0,
+                canTrip: true,
+            })
+        })
+
+        it('returns 100% skip rate with no acceptances', async () => {
+            mockCount.mockResolvedValueOnce(0).mockResolvedValueOnce(5)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: 1,
+                sampleSize: 5,
+                acceptedCount: 0,
+                rejectedCount: 5,
+                canTrip: true,
+            })
+        })
+
+        it('applies a 24-hour window and does not filter by mode', async () => {
+            mockCount.mockResolvedValueOnce(3).mockResolvedValueOnce(2)
+
+            await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(mockCount).toHaveBeenCalledTimes(2)
+            for (const call of mockCount.mock.calls) {
+                expect((call[0] as any).where?.createdAt?.gte).toBeDefined()
+                expect((call[0] as any).where?.guildId).toBe(mockGuildId)
+                expect((call[0] as any).where?.mode).toBeUndefined()
+            }
+        })
+
+        it('returns null skip rate when no resolved outcomes', async () => {
+            mockCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0)
+
+            const result = await getAutoplaySkipRateForGuild(mockGuildId)
+
+            expect(result).toEqual({
+                skipRate: null,
+                sampleSize: 0,
+                acceptedCount: 0,
+                rejectedCount: 0,
+                canTrip: false,
+            })
         })
     })
 })

--- a/packages/shared/src/services/recommendationTelemetryReadService.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.ts
@@ -10,6 +10,17 @@ export interface PerSourceRow {
     acceptanceRate: number | null
 }
 
+export interface PerModeRow {
+    // Loose typing intentional: read aggregation may encounter pre-migration
+    // null rows or unexpected values; the strict union is enforced at write time.
+    mode: string | null
+    count: number
+    acceptedCount: number
+    rejectedCount: number
+    pendingCount: number
+    acceptanceRate: number | null
+}
+
 export interface Summary {
     totalPicks: number
     accepted: number
@@ -114,6 +125,97 @@ export async function getPerSourceAcceptance(
 
         rows.push({
             source,
+            count,
+            acceptedCount,
+            rejectedCount,
+            pendingCount,
+            acceptanceRate,
+        })
+    }
+
+    return rows
+}
+
+/**
+ * Returns one row per distinct mode value seen in the Recommendation table
+ * for this guild within the window. Null mode is its own row.
+ */
+export async function getPerModeAcceptance(
+    guildId: string,
+    days?: number,
+): Promise<PerModeRow[]> {
+    const prisma = getPrismaClient()
+    const createdAtGte = getCreatedAtCutoff(days)
+
+    // Group by mode to get distinct modes and total count per mode
+    const groupByResult = await prisma.recommendation.groupBy({
+        by: ['mode'],
+        where: {
+            guildId,
+            createdAt: {
+                gte: createdAtGte,
+            },
+        },
+        _count: {
+            id: true,
+        },
+    })
+
+    // For each mode, fetch accepted, rejected, and pending counts
+    const rows: PerModeRow[] = []
+    for (const group of groupByResult) {
+        const mode = group.mode
+        const count = group._count.id
+
+        const getCountValue = (result: any): number =>
+            typeof result === 'number' ? result : result.count
+
+        const acceptedCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    mode,
+                    isAccepted: true,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const rejectedCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    mode,
+                    isRejected: true,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const pendingCount = getCountValue(
+            await prisma.recommendation.count({
+                where: {
+                    guildId,
+                    mode,
+                    isAccepted: null,
+                    isRejected: null,
+                    createdAt: {
+                        gte: createdAtGte,
+                    },
+                },
+            }),
+        )
+
+        const denominator = acceptedCount + rejectedCount
+        const acceptanceRate =
+            denominator === 0 ? null : acceptedCount / denominator
+
+        rows.push({
+            mode,
             count,
             acceptedCount,
             rejectedCount,

--- a/packages/shared/src/services/recommendationTelemetryReadService.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.ts
@@ -300,3 +300,69 @@ export async function getSummary(
         globalAcceptanceRate,
     }
 }
+
+/**
+ * Result of autoplay skip-rate computation.
+ *
+ * - skipRate: null if no resolved outcomes, otherwise rejected / (accepted + rejected)
+ * - sampleSize: count of resolved (accepted + rejected) autoplay recommendations
+ * - canTrip: true if sampleSize >= 5 (minimum sample guard)
+ */
+export interface AutoplaySkipRateResult {
+    skipRate: number | null
+    sampleSize: number
+    acceptedCount: number
+    rejectedCount: number
+    canTrip: boolean
+}
+
+/**
+ * Returns the rolling 24-hour autoplay skip-rate for a guild.
+ * Requires minimum sample size of 5 resolved outcomes before canTrip=true.
+ * Used by the circuit breaker to pause autoplay replenishment on high skip rates.
+ */
+export async function getAutoplaySkipRateForGuild(
+    guildId: string,
+): Promise<AutoplaySkipRateResult> {
+    const prisma = getPrismaClient()
+    const createdAtGte = new Date(Date.now() - 24 * 60 * 60 * 1000) // 24 hours
+
+    const getCountValue = (result: any): number =>
+        typeof result === 'number' ? result : result.count
+
+    const acceptedCount = getCountValue(
+        await prisma.recommendation.count({
+            where: {
+                guildId,
+                isAccepted: true,
+                createdAt: {
+                    gte: createdAtGte,
+                },
+            },
+        }),
+    )
+
+    const rejectedCount = getCountValue(
+        await prisma.recommendation.count({
+            where: {
+                guildId,
+                isRejected: true,
+                createdAt: {
+                    gte: createdAtGte,
+                },
+            },
+        }),
+    )
+
+    const sampleSize = acceptedCount + rejectedCount
+    const skipRate = sampleSize === 0 ? null : rejectedCount / sampleSize
+    const canTrip = sampleSize >= 5
+
+    return {
+        skipRate,
+        sampleSize,
+        acceptedCount,
+        rejectedCount,
+        canTrip,
+    }
+}

--- a/packages/shared/src/services/redis/client.ts
+++ b/packages/shared/src/services/redis/client.ts
@@ -9,6 +9,7 @@ import { setupRedisEventHandlers } from './eventHandlers'
 import { RedisOperations } from './operations.js'
 import type { RedisClientState, IRedisClient } from './types'
 
+/** Redis client wrapper with connection management and operations. */
 export class RedisClient implements IRedisClient {
     private client: Redis | null = null
     private readonly state: RedisClientState = {

--- a/packages/shared/src/types/common/BaseResult.spec.ts
+++ b/packages/shared/src/types/common/BaseResult.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from '@jest/globals'
+import { Result } from './BaseResult'
+
+describe('Result', () => {
+    describe('Result.success', () => {
+        it('creates successful result with data', () => {
+            const r = Result.success(42)
+            expect(r.isSuccess()).toBe(true)
+            expect(r.isFailure()).toBe(false)
+            expect(r.getData()).toBe(42)
+            expect(r.getError()).toBeUndefined()
+        })
+
+        it('creates successful result with message', () => {
+            const r = Result.success(undefined, 'done')
+            expect(r.getMessage()).toBe('done')
+        })
+
+        it('creates successful result with no arguments', () => {
+            const r = Result.success()
+            expect(r.isSuccess()).toBe(true)
+            expect(r.getData()).toBeUndefined()
+        })
+    })
+
+    describe('Result.failure', () => {
+        it('creates failure result from an Error', () => {
+            const err = new Error('something went wrong')
+            const r = Result.failure(err)
+            expect(r.isSuccess()).toBe(false)
+            expect(r.isFailure()).toBe(true)
+            expect(r.getError()).toBe(err)
+            expect(r.getData()).toBeUndefined()
+        })
+
+        it('converts string to Error', () => {
+            const r = Result.failure<number>('string error')
+            expect(r.getError()).toBeInstanceOf(Error)
+            expect(r.getError()?.message).toBe('string error')
+        })
+
+        it('attaches message to failure', () => {
+            const r = Result.failure(new Error('err'), 'context')
+            expect(r.getMessage()).toBe('context')
+        })
+    })
+
+    describe('map', () => {
+        it('transforms data on success', () => {
+            const r = Result.success(5).map((n) => n * 2)
+            expect(r.isSuccess()).toBe(true)
+            expect(r.getData()).toBe(10)
+        })
+
+        it('preserves message through map on success', () => {
+            const r = Result.success(5, 'original').map((n) => n + 1)
+            expect(r.getMessage()).toBe('original')
+        })
+
+        it('returns failure without calling fn when input is failure', () => {
+            const original = Result.failure<number>(new Error('err'), 'msg')
+            const mapped = original.map((n) => n + 1)
+            expect(mapped.isFailure()).toBe(true)
+            expect(mapped.getError()).toBe(original.getError())
+            expect(mapped.getMessage()).toBe('msg')
+        })
+
+        it('catches errors thrown by fn and returns failure', () => {
+            const r = Result.success(5).map(() => {
+                throw new Error('fn threw')
+            })
+            expect(r.isFailure()).toBe(true)
+            expect(r.getError()?.message).toBe('fn threw')
+        })
+    })
+
+    describe('flatMap', () => {
+        it('transforms to a new Result on success', () => {
+            const r = Result.success(5).flatMap((n) => Result.success(n * 2))
+            expect(r.isSuccess()).toBe(true)
+            expect(r.getData()).toBe(10)
+        })
+
+        it('allows fn to return failure', () => {
+            const r = Result.success(5).flatMap(() =>
+                Result.failure<number>('inner error'),
+            )
+            expect(r.isFailure()).toBe(true)
+        })
+
+        it('returns failure without calling fn when input is failure', () => {
+            const original = Result.failure<number>(
+                new Error('outer'),
+                'outer msg',
+            )
+            const flatMapped = original.flatMap(() => Result.success(99))
+            expect(flatMapped.isFailure()).toBe(true)
+            expect(flatMapped.getError()).toBe(original.getError())
+        })
+    })
+})

--- a/packages/shared/src/types/common/BaseResult.ts
+++ b/packages/shared/src/types/common/BaseResult.ts
@@ -9,6 +9,7 @@ export interface BaseResult<T = unknown> {
     message?: string
 }
 
+/** Generic result type for operations that may succeed or fail with data or error. */
 export class Result<T = unknown> {
     private constructor(
         public readonly success: boolean,
@@ -17,38 +18,49 @@ export class Result<T = unknown> {
         public readonly message?: string,
     ) {}
 
+    /** Creates a successful result with optional data. */
     static success<T>(data?: T, message?: string): Result<T> {
         return new Result(true, data, undefined, message)
     }
 
+    /** Creates a failed result with an error and optional message. */
     static failure<T>(error: Error | string, message?: string): Result<T> {
         const errorObj = typeof error === 'string' ? new Error(error) : error
         return new Result<T>(false, undefined, errorObj, message)
     }
 
+    /** Returns true if this result represents a successful operation. */
     isSuccess(): boolean {
         return this.success
     }
 
+    /** Returns true if this result represents a failed operation. */
     isFailure(): boolean {
         return !this.success
     }
 
+    /** Returns the wrapped data if successful, otherwise undefined. */
     getData(): T | undefined {
         return this.data
     }
 
+    /** Returns the error object if failed, otherwise undefined. */
     getError(): Error | undefined {
         return this.error
     }
 
+    /** Returns the optional message associated with this result. */
     getMessage(): string | undefined {
         return this.message
     }
 
+    /** Applies a transformation function to the data if successful, propagates failure. */
     map<U>(fn: (data: T) => U): Result<U> {
         if (this.isFailure()) {
-            return Result.failure(this.error ?? new Error('Unknown error'), this.message)
+            return Result.failure(
+                this.error ?? new Error('Unknown error'),
+                this.message,
+            )
         }
         try {
             const newData = fn(this.data as T)
@@ -58,9 +70,13 @@ export class Result<T = unknown> {
         }
     }
 
+    /** Chains a result-producing operation on success, propagates failure. */
     flatMap<U>(fn: (data: T) => Result<U>): Result<U> {
         if (this.isFailure()) {
-            return Result.failure(this.error ?? new Error('Unknown error'), this.message)
+            return Result.failure(
+                this.error ?? new Error('Unknown error'),
+                this.message,
+            )
         }
         return fn(this.data as T)
     }

--- a/packages/shared/src/types/errors/custom.ts
+++ b/packages/shared/src/types/errors/custom.ts
@@ -1,12 +1,10 @@
-/**
- * Custom error codes
- */
-
+/** Error codes for custom application errors. */
 export const CUSTOM_ERROR_CODES = {
     CUSTOM_UNKNOWN_ERROR: 'ERR_CUSTOM_UNKNOWN_ERROR',
     CUSTOM_NOT_IMPLEMENTED: 'ERR_CUSTOM_NOT_IMPLEMENTED',
     CUSTOM_CONFIGURATION_ERROR: 'ERR_CUSTOM_CONFIGURATION_ERROR',
 } as const
 
+/** Type representing custom error codes. */
 export type CustomErrorCode =
     (typeof CUSTOM_ERROR_CODES)[keyof typeof CUSTOM_ERROR_CODES]

--- a/packages/shared/src/types/errors/database.ts
+++ b/packages/shared/src/types/errors/database.ts
@@ -1,12 +1,10 @@
-/**
- * Database error codes
- */
-
+/** Error codes for database operations. */
 export const DATABASE_ERROR_CODES = {
     DATABASE_CONNECTION_FAILED: 'ERR_DATABASE_CONNECTION_FAILED',
     DATABASE_QUERY_FAILED: 'ERR_DATABASE_QUERY_FAILED',
     DATABASE_TRANSACTION_FAILED: 'ERR_DATABASE_TRANSACTION_FAILED',
 } as const
 
+/** Type representing database error codes. */
 export type DatabaseErrorCode =
     (typeof DATABASE_ERROR_CODES)[keyof typeof DATABASE_ERROR_CODES]

--- a/packages/shared/src/types/errors/discord.ts
+++ b/packages/shared/src/types/errors/discord.ts
@@ -1,7 +1,4 @@
-/**
- * Discord bot error codes
- */
-
+/** Error codes for Discord bot operations. */
 export const DISCORD_ERROR_CODES = {
     DISCORD_VOICE_CONNECTION_FAILED: 'ERR_DISCORD_VOICE_CONNECTION_FAILED',
     DISCORD_PERMISSION_MISSING: 'ERR_DISCORD_PERMISSION_MISSING',
@@ -9,5 +6,6 @@ export const DISCORD_ERROR_CODES = {
     DISCORD_CHANNEL_NOT_FOUND: 'ERR_DISCORD_CHANNEL_NOT_FOUND',
 } as const
 
+/** Type representing Discord error codes. */
 export type DiscordErrorCode =
     (typeof DISCORD_ERROR_CODES)[keyof typeof DISCORD_ERROR_CODES]

--- a/packages/shared/src/types/errors/guildAutomation.spec.ts
+++ b/packages/shared/src/types/errors/guildAutomation.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from '@jest/globals'
+import {
+    GUILD_AUTOMATION_ERROR_CODES,
+    GuildAutomationError,
+    GuildAutomationInvalidManifestPayloadError,
+    GuildAutomationManifestNotFoundError,
+    GuildAutomationCaptureRequiredError,
+    GuildAutomationApplyLockedError,
+    GuildAutomationLockUnavailableError,
+} from './guildAutomation'
+
+describe('GuildAutomationError', () => {
+    it('sets message, code, retryable, and context', () => {
+        const err = new GuildAutomationError({
+            message: 'test error',
+            code: GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_MANIFEST_NOT_FOUND,
+            retryable: true,
+            context: { guildId: 'g1' },
+        })
+        expect(err.message).toBe('test error')
+        expect(err.code).toBe(
+            GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_MANIFEST_NOT_FOUND,
+        )
+        expect(err.retryable).toBe(true)
+        expect(err.context).toEqual({ guildId: 'g1' })
+        expect(err.name).toBe('GuildAutomationError')
+    })
+
+    it('defaults retryable to false and context to empty object', () => {
+        const err = new GuildAutomationError({
+            message: 'x',
+            code: GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_APPLY_LOCKED,
+        })
+        expect(err.retryable).toBe(false)
+        expect(err.context).toEqual({})
+    })
+})
+
+describe('GuildAutomationInvalidManifestPayloadError', () => {
+    it('sets correct message and code', () => {
+        const err = new GuildAutomationInvalidManifestPayloadError()
+        expect(err.message).toBe('Manifest payload is invalid')
+        expect(err.code).toBe(
+            GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_INVALID_MANIFEST_PAYLOAD,
+        )
+        expect(err.retryable).toBe(false)
+    })
+})
+
+describe('GuildAutomationManifestNotFoundError', () => {
+    it('includes guildId in context', () => {
+        const err = new GuildAutomationManifestNotFoundError('guild-123')
+        expect(err.code).toBe(
+            GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_MANIFEST_NOT_FOUND,
+        )
+        expect(err.context.guildId).toBe('guild-123')
+        expect(err.retryable).toBe(false)
+    })
+})
+
+describe('GuildAutomationCaptureRequiredError', () => {
+    it('includes guildId in context', () => {
+        const err = new GuildAutomationCaptureRequiredError('guild-456')
+        expect(err.code).toBe(
+            GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_CAPTURE_REQUIRED,
+        )
+        expect(err.context.guildId).toBe('guild-456')
+        expect(err.retryable).toBe(false)
+    })
+})
+
+describe('GuildAutomationApplyLockedError', () => {
+    it('is retryable and includes guildId', () => {
+        const err = new GuildAutomationApplyLockedError('guild-789')
+        expect(err.code).toBe(
+            GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_APPLY_LOCKED,
+        )
+        expect(err.context.guildId).toBe('guild-789')
+        expect(err.retryable).toBe(true)
+    })
+})
+
+describe('GuildAutomationLockUnavailableError', () => {
+    it('is retryable and includes guildId', () => {
+        const err = new GuildAutomationLockUnavailableError('guild-abc')
+        expect(err.code).toBe(
+            GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_LOCK_UNAVAILABLE,
+        )
+        expect(err.context.guildId).toBe('guild-abc')
+        expect(err.retryable).toBe(true)
+    })
+})

--- a/packages/shared/src/types/errors/guildAutomation.ts
+++ b/packages/shared/src/types/errors/guildAutomation.ts
@@ -1,24 +1,26 @@
+/** Guild automation error codes. */
 export const GUILD_AUTOMATION_ERROR_CODES = {
     GUILD_AUTOMATION_INVALID_MANIFEST_PAYLOAD:
         'ERR_GUILD_AUTOMATION_INVALID_MANIFEST_PAYLOAD',
     GUILD_AUTOMATION_MANIFEST_NOT_FOUND:
         'ERR_GUILD_AUTOMATION_MANIFEST_NOT_FOUND',
-    GUILD_AUTOMATION_CAPTURE_REQUIRED:
-        'ERR_GUILD_AUTOMATION_CAPTURE_REQUIRED',
+    GUILD_AUTOMATION_CAPTURE_REQUIRED: 'ERR_GUILD_AUTOMATION_CAPTURE_REQUIRED',
     GUILD_AUTOMATION_APPLY_LOCKED: 'ERR_GUILD_AUTOMATION_APPLY_LOCKED',
-    GUILD_AUTOMATION_LOCK_UNAVAILABLE:
-        'ERR_GUILD_AUTOMATION_LOCK_UNAVAILABLE',
+    GUILD_AUTOMATION_LOCK_UNAVAILABLE: 'ERR_GUILD_AUTOMATION_LOCK_UNAVAILABLE',
 } as const
 
+/** Guild automation error code type. */
 export type GuildAutomationErrorCode =
     (typeof GUILD_AUTOMATION_ERROR_CODES)[keyof typeof GUILD_AUTOMATION_ERROR_CODES]
 
-type GuildAutomationErrorContext = {
+/** Context information for guild automation errors. */
+export type GuildAutomationErrorContext = {
     guildId?: string
     runId?: string
     details?: Record<string, unknown>
 }
 
+/** Base error class for guild automation operations. */
 export class GuildAutomationError extends Error {
     public readonly code: GuildAutomationErrorCode
     public readonly retryable: boolean
@@ -38,6 +40,7 @@ export class GuildAutomationError extends Error {
     }
 }
 
+/** Error thrown when a guild automation manifest payload is invalid. */
 export class GuildAutomationInvalidManifestPayloadError extends GuildAutomationError {
     constructor() {
         super({
@@ -48,6 +51,7 @@ export class GuildAutomationInvalidManifestPayloadError extends GuildAutomationE
     }
 }
 
+/** Error thrown when a guild automation manifest is not found. */
 export class GuildAutomationManifestNotFoundError extends GuildAutomationError {
     constructor(guildId: string) {
         super({
@@ -59,10 +63,12 @@ export class GuildAutomationManifestNotFoundError extends GuildAutomationError {
     }
 }
 
+/** Error thrown when a guild automation capture is required before apply. */
 export class GuildAutomationCaptureRequiredError extends GuildAutomationError {
     constructor(guildId: string) {
         super({
-            message: 'No captured guild state available. Run capture before plan/apply.',
+            message:
+                'No captured guild state available. Run capture before plan/apply.',
             code: GUILD_AUTOMATION_ERROR_CODES.GUILD_AUTOMATION_CAPTURE_REQUIRED,
             retryable: false,
             context: { guildId },
@@ -70,6 +76,7 @@ export class GuildAutomationCaptureRequiredError extends GuildAutomationError {
     }
 }
 
+/** Error thrown when another guild automation apply operation is locked. */
 export class GuildAutomationApplyLockedError extends GuildAutomationError {
     constructor(guildId: string) {
         super({
@@ -81,6 +88,7 @@ export class GuildAutomationApplyLockedError extends GuildAutomationError {
     }
 }
 
+/** Error thrown when the guild automation lock backend is unavailable. */
 export class GuildAutomationLockUnavailableError extends GuildAutomationError {
     constructor(guildId: string) {
         super({

--- a/packages/shared/src/types/errors/music.ts
+++ b/packages/shared/src/types/errors/music.ts
@@ -1,7 +1,4 @@
-/**
- * Music and media error codes
- */
-
+/** Error codes for music and media playback failures. */
 export const MUSIC_ERROR_CODES = {
     MUSIC_TRACK_NOT_FOUND: 'ERR_MUSIC_TRACK_NOT_FOUND',
     MUSIC_PLAYLIST_NOT_FOUND: 'ERR_MUSIC_PLAYLIST_NOT_FOUND',
@@ -10,9 +7,11 @@ export const MUSIC_ERROR_CODES = {
     MUSIC_DOWNLOAD_FAILED: 'ERR_MUSIC_DOWNLOAD_FAILED',
 } as const
 
+/** Type representing music error codes. */
 export type MusicErrorCode =
     (typeof MUSIC_ERROR_CODES)[keyof typeof MUSIC_ERROR_CODES]
 
+/** Error for music playback operations. */
 export class MusicError extends Error {
     public readonly metadata: {
         correlationId: string

--- a/packages/shared/src/types/errors/network.ts
+++ b/packages/shared/src/types/errors/network.ts
@@ -1,7 +1,4 @@
-/**
- * Network and API error codes
- */
-
+/** Error codes for network and API failures. */
 export const NETWORK_ERROR_CODES = {
     NETWORK_TIMEOUT: 'ERR_NETWORK_TIMEOUT',
     NETWORK_CONNECTION_FAILED: 'ERR_NETWORK_CONNECTION_FAILED',
@@ -9,5 +6,6 @@ export const NETWORK_ERROR_CODES = {
     API_SERVICE_UNAVAILABLE: 'ERR_API_SERVICE_UNAVAILABLE',
 } as const
 
+/** Type representing network error codes. */
 export type NetworkErrorCode =
     (typeof NETWORK_ERROR_CODES)[keyof typeof NETWORK_ERROR_CODES]

--- a/packages/shared/src/types/errors/system.ts
+++ b/packages/shared/src/types/errors/system.ts
@@ -1,16 +1,15 @@
-/**
- * System error codes
- */
-
+/** Error codes for system and runtime failures. */
 export const SYSTEM_ERROR_CODES = {
     SYSTEM_OUT_OF_MEMORY: 'ERR_SYSTEM_OUT_OF_MEMORY',
     SYSTEM_FILE_NOT_FOUND: 'ERR_SYSTEM_FILE_NOT_FOUND',
     SYSTEM_PERMISSION_DENIED: 'ERR_SYSTEM_PERMISSION_DENIED',
 } as const
 
+/** Type representing system error codes. */
 export type SystemErrorCode =
     (typeof SYSTEM_ERROR_CODES)[keyof typeof SYSTEM_ERROR_CODES]
 
+/** Error for application configuration issues. */
 export class ConfigurationError extends Error {
     constructor(message: string) {
         super(message)

--- a/packages/shared/src/types/errors/validation.ts
+++ b/packages/shared/src/types/errors/validation.ts
@@ -1,12 +1,10 @@
-/**
- * Validation error codes
- */
-
+/** Error codes for validation failures. */
 export const VALIDATION_ERROR_CODES = {
     VALIDATION_INVALID_INPUT: 'ERR_VALIDATION_INVALID_INPUT',
     VALIDATION_MISSING_REQUIRED_FIELD: 'ERR_VALIDATION_MISSING_REQUIRED_FIELD',
     VALIDATION_INVALID_FORMAT: 'ERR_VALIDATION_INVALID_FORMAT',
 } as const
 
+/** Type representing validation error codes. */
 export type ValidationErrorCode =
     (typeof VALIDATION_ERROR_CODES)[keyof typeof VALIDATION_ERROR_CODES]

--- a/packages/shared/src/types/errors/youtube.ts
+++ b/packages/shared/src/types/errors/youtube.ts
@@ -1,7 +1,4 @@
-/**
- * YouTube and external services error codes
- */
-
+/** Error codes for YouTube and external media services. */
 export const YOUTUBE_ERROR_CODES = {
     YOUTUBE_VIDEO_NOT_FOUND: 'ERR_YOUTUBE_VIDEO_NOT_FOUND',
     YOUTUBE_PLAYLIST_NOT_FOUND: 'ERR_YOUTUBE_PLAYLIST_NOT_FOUND',
@@ -9,5 +6,6 @@ export const YOUTUBE_ERROR_CODES = {
     YOUTUBE_SERVICE_UNAVAILABLE: 'ERR_YOUTUBE_SERVICE_UNAVAILABLE',
 } as const
 
+/** Type representing YouTube error codes. */
 export type YouTubeErrorCode =
     (typeof YOUTUBE_ERROR_CODES)[keyof typeof YOUTUBE_ERROR_CODES]

--- a/packages/shared/src/utils/composables/useState.spec.ts
+++ b/packages/shared/src/utils/composables/useState.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import { createState, createDerivedState } from './useState'
+
+describe('createState', () => {
+    it('returns the initial state', () => {
+        const state = createState(42)
+        expect(state.getState()).toBe(42)
+    })
+
+    it('sets state to a direct value', () => {
+        const state = createState(0)
+        state.setState(10)
+        expect(state.getState()).toBe(10)
+    })
+
+    it('sets state via an updater function', () => {
+        const state = createState(5)
+        state.setState((n) => n * 2)
+        expect(state.getState()).toBe(10)
+    })
+
+    it('notifies subscribers on state change', () => {
+        const state = createState('a')
+        const listener = jest.fn<(n: string, p: string) => void>()
+        state.subscribe(listener)
+        state.setState('b')
+        expect(listener).toHaveBeenCalledWith('b', 'a')
+    })
+
+    it('does not notify subscribers when value is unchanged', () => {
+        const state = createState(1)
+        const listener = jest.fn<(n: number, p: number) => void>()
+        state.subscribe(listener)
+        state.setState(1)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('unsubscribes correctly', () => {
+        const state = createState(0)
+        const listener = jest.fn<(n: number, p: number) => void>()
+        const unsubscribe = state.subscribe(listener)
+        unsubscribe()
+        state.setState(99)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('resets to initial state', () => {
+        const state = createState(10)
+        state.setState(99)
+        state.reset()
+        expect(state.getState()).toBe(10)
+    })
+
+    it('notifies subscriber on reset when value changes', () => {
+        const state = createState(0)
+        state.setState(5)
+        const listener = jest.fn<(n: number, p: number) => void>()
+        state.subscribe(listener)
+        state.reset()
+        expect(listener).toHaveBeenCalledWith(0, 5)
+    })
+
+    it('works with object state', () => {
+        const initial = { count: 0 }
+        const state = createState(initial)
+        const next = { count: 1 }
+        state.setState(next)
+        expect(state.getState()).toBe(next)
+    })
+})
+
+describe('createDerivedState', () => {
+    it('returns derived value', () => {
+        const state = createState(4)
+        const derived = createDerivedState(state, (n) => n * n)
+        expect(derived.getDerivedState()).toBe(16)
+    })
+
+    it('caches derived value when state has not changed', () => {
+        const selector = jest.fn<(n: number) => number>((n) => n + 1)
+        const state = createState(3)
+        const derived = createDerivedState(state, selector)
+        derived.getDerivedState()
+        derived.getDerivedState()
+        expect(selector).toHaveBeenCalledTimes(1)
+    })
+
+    it('recomputes derived value when state changes', () => {
+        const selector = jest.fn<(n: number) => number>((n) => n * 2)
+        const state = createState(1)
+        const derived = createDerivedState(state, selector)
+        derived.getDerivedState()
+        state.setState(2)
+        const result = derived.getDerivedState()
+        expect(result).toBe(4)
+        expect(selector).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/shared/src/utils/database/prismaClient.ts
+++ b/packages/shared/src/utils/database/prismaClient.ts
@@ -12,20 +12,17 @@ try {
 
 let prismaInstance: PrismaClient | null = null
 
+/** Returns a singleton Prisma client instance, initializing if necessary. */
 export function getPrismaClient(): PrismaClient {
     if (!prismaInstance) {
         const { PrismaClient: PrismaClientConstructor } = _require(
             '../../generated/prisma/client.js',
         ) as {
-            PrismaClient: new (
-                options?: unknown,
-            ) => PrismaClient
+            PrismaClient: new (options?: unknown) => PrismaClient
         }
         const databaseUrl = process.env.DATABASE_URL
         if (!databaseUrl) {
-            throw new Error(
-                'DATABASE_URL environment variable is required',
-            )
+            throw new Error('DATABASE_URL environment variable is required')
         }
         const adapter = new PrismaPg({
             connectionString: databaseUrl,
@@ -35,6 +32,7 @@ export function getPrismaClient(): PrismaClient {
     return prismaInstance
 }
 
+/** Disconnects the Prisma client if it is initialized. */
 export function disconnectPrisma(): Promise<void> {
     if (prismaInstance) {
         return prismaInstance.$disconnect()

--- a/packages/shared/src/utils/error/retryHandler.spec.ts
+++ b/packages/shared/src/utils/error/retryHandler.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals'
-import { withRetry } from './retryHandler'
+import { withRetry, createRetryWrapper } from './retryHandler'
 import type { RetryOptions } from './types'
 import { MusicError } from '../../types/errors/music'
 
@@ -10,8 +10,14 @@ describe('Retry Handler', () => {
 
     describe('withRetry', () => {
         it('should succeed on first attempt', async () => {
-            const mockFn = jest.fn<() => Promise<string>>().mockResolvedValue('success')
-            const options: RetryOptions = { maxAttempts: 3, delayMs: 100, backoffMultiplier: 2 }
+            const mockFn = jest
+                .fn<() => Promise<string>>()
+                .mockResolvedValue('success')
+            const options: RetryOptions = {
+                maxAttempts: 3,
+                delayMs: 100,
+                backoffMultiplier: 2,
+            }
 
             const result = await withRetry(mockFn, options)
 
@@ -20,11 +26,16 @@ describe('Retry Handler', () => {
         })
 
         it('should retry on failure and eventually succeed', async () => {
-            const mockFn = jest.fn<() => Promise<string>>()
+            const mockFn = jest
+                .fn<() => Promise<string>>()
                 .mockRejectedValueOnce(new Error('Network error'))
                 .mockRejectedValueOnce(new Error('Network error'))
                 .mockResolvedValue('success')
-            const options: RetryOptions = { maxAttempts: 3, delayMs: 100, backoffMultiplier: 2 }
+            const options: RetryOptions = {
+                maxAttempts: 3,
+                delayMs: 100,
+                backoffMultiplier: 2,
+            }
 
             const result = await withRetry(mockFn, options)
 
@@ -33,27 +44,48 @@ describe('Retry Handler', () => {
         })
 
         it('should fail after max attempts', async () => {
-            const mockFn = jest.fn<() => Promise<string>>().mockRejectedValue(new Error('Network error'))
-            const options: RetryOptions = { maxAttempts: 2, delayMs: 100, backoffMultiplier: 2 }
+            const mockFn = jest
+                .fn<() => Promise<string>>()
+                .mockRejectedValue(new Error('Network error'))
+            const options: RetryOptions = {
+                maxAttempts: 2,
+                delayMs: 100,
+                backoffMultiplier: 2,
+            }
 
-            await expect(withRetry(mockFn, options)).rejects.toThrow('Network error')
+            await expect(withRetry(mockFn, options)).rejects.toThrow(
+                'Network error',
+            )
             expect(mockFn).toHaveBeenCalledTimes(2)
         })
 
         it('should not retry non-retryable errors', async () => {
-            const mockFn = jest.fn<() => Promise<string>>().mockRejectedValue(new Error('Invalid input'))
-            const options: RetryOptions = { maxAttempts: 3, delayMs: 100, backoffMultiplier: 2 }
+            const mockFn = jest
+                .fn<() => Promise<string>>()
+                .mockRejectedValue(new Error('Invalid input'))
+            const options: RetryOptions = {
+                maxAttempts: 3,
+                delayMs: 100,
+                backoffMultiplier: 2,
+            }
 
-            await expect(withRetry(mockFn, options)).rejects.toThrow('Invalid input')
+            await expect(withRetry(mockFn, options)).rejects.toThrow(
+                'Invalid input',
+            )
             expect(mockFn).toHaveBeenCalledTimes(1)
         })
 
         it('should use exponential backoff', async () => {
-            const mockFn = jest.fn<() => Promise<string>>()
+            const mockFn = jest
+                .fn<() => Promise<string>>()
                 .mockRejectedValueOnce(new Error('Network error'))
                 .mockRejectedValueOnce(new Error('Network error'))
                 .mockResolvedValue('success')
-            const options: RetryOptions = { maxAttempts: 3, delayMs: 100, backoffMultiplier: 2 }
+            const options: RetryOptions = {
+                maxAttempts: 3,
+                delayMs: 100,
+                backoffMultiplier: 2,
+            }
 
             const startTime = Date.now()
             const result = await withRetry(mockFn, options)
@@ -66,10 +98,15 @@ describe('Retry Handler', () => {
         })
 
         it('should handle rate limit errors with longer delays', async () => {
-            const mockFn = jest.fn<() => Promise<string>>()
+            const mockFn = jest
+                .fn<() => Promise<string>>()
                 .mockRejectedValueOnce(new Error('Rate limit exceeded'))
                 .mockResolvedValue('success')
-            const options: RetryOptions = { maxAttempts: 2, delayMs: 100, backoffMultiplier: 2 }
+            const options: RetryOptions = {
+                maxAttempts: 2,
+                delayMs: 100,
+                backoffMultiplier: 2,
+            }
 
             const startTime = Date.now()
             const result = await withRetry(mockFn, options)
@@ -82,10 +119,20 @@ describe('Retry Handler', () => {
         })
 
         it('should handle MusicError with retry logic', async () => {
-            const mockFn = jest.fn<() => Promise<string>>()
-                .mockRejectedValueOnce(new MusicError('Playback failed', 'ERR_MUSIC_PLAYBACK_FAILED'))
+            const mockFn = jest
+                .fn<() => Promise<string>>()
+                .mockRejectedValueOnce(
+                    new MusicError(
+                        'Playback failed',
+                        'ERR_MUSIC_PLAYBACK_FAILED',
+                    ),
+                )
                 .mockResolvedValue('success')
-            const options: RetryOptions = { maxAttempts: 2, delayMs: 100, backoffMultiplier: 2 }
+            const options: RetryOptions = {
+                maxAttempts: 2,
+                delayMs: 100,
+                backoffMultiplier: 2,
+            }
 
             const result = await withRetry(mockFn, options)
 
@@ -94,12 +141,42 @@ describe('Retry Handler', () => {
         })
 
         it('should not retry non-retryable MusicError', async () => {
-            const mockFn = jest.fn<() => Promise<string>>()
-                .mockRejectedValue(new MusicError('Track not found', 'ERR_MUSIC_TRACK_NOT_FOUND'))
-            const options: RetryOptions = { maxAttempts: 3, delayMs: 100, backoffMultiplier: 2 }
+            const mockFn = jest
+                .fn<() => Promise<string>>()
+                .mockRejectedValue(
+                    new MusicError(
+                        'Track not found',
+                        'ERR_MUSIC_TRACK_NOT_FOUND',
+                    ),
+                )
+            const options: RetryOptions = {
+                maxAttempts: 3,
+                delayMs: 100,
+                backoffMultiplier: 2,
+            }
 
-            await expect(withRetry(mockFn, options)).rejects.toThrow('Track not found')
+            await expect(withRetry(mockFn, options)).rejects.toThrow(
+                'Track not found',
+            )
             expect(mockFn).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('createRetryWrapper', () => {
+        it('wraps a function and passes args through', async () => {
+            const fn = jest
+                .fn<(x: number) => Promise<number>>()
+                .mockResolvedValue(42)
+            const wrapped = createRetryWrapper(fn)
+            const result = await wrapped(1)
+            expect(result).toBe(42)
+            expect(fn).toHaveBeenCalledWith(1)
+        })
+
+        it('uses specified retry type', async () => {
+            const fn = jest.fn<() => Promise<string>>().mockResolvedValue('ok')
+            const wrapped = createRetryWrapper(fn, 'rateLimit')
+            await expect(wrapped()).resolves.toBe('ok')
         })
     })
 })

--- a/packages/shared/src/utils/error/types.ts
+++ b/packages/shared/src/utils/error/types.ts
@@ -1,8 +1,6 @@
 // Removed unused import
 
-/**
- * Error handler configuration
- */
+/** Error handler configuration. */
 export type ErrorHandlerConfig = {
     logErrors: boolean
     logStackTraces: boolean
@@ -11,6 +9,7 @@ export type ErrorHandlerConfig = {
     retryDelayMs: number
 }
 
+/** Default error handler configuration. */
 export const defaultConfig: ErrorHandlerConfig = {
     logErrors: true,
     logStackTraces: process.env.NODE_ENV === 'development',
@@ -19,6 +18,7 @@ export const defaultConfig: ErrorHandlerConfig = {
     retryDelayMs: 1000,
 }
 
+/** Context information for error handling and logging. */
 export type ErrorContext = {
     correlationId?: string
     userId?: string
@@ -27,6 +27,7 @@ export type ErrorContext = {
     additionalInfo?: Record<string, unknown>
 }
 
+/** Retry configuration for resilient operations. */
 export type RetryOptions = {
     maxAttempts: number
     delayMs: number

--- a/packages/shared/src/utils/general/embeds/constants.ts
+++ b/packages/shared/src/utils/general/embeds/constants.ts
@@ -36,5 +36,8 @@ export const EMOJIS = {
     EXIT: '🚪',
 } as const
 
+/** Type representing a valid embed color from EMBED_COLORS constants. */
 export type EmbedColor = (typeof EMBED_COLORS)[keyof typeof EMBED_COLORS]
+
+/** Type representing a valid emoji from EMOJIS constants. */
 export type EmbedEmoji = (typeof EMOJIS)[keyof typeof EMOJIS]

--- a/packages/shared/src/utils/general/embeds/core.ts
+++ b/packages/shared/src/utils/general/embeds/core.ts
@@ -90,6 +90,7 @@ export function createEmbed(options: CreateEmbedOptions): EmbedBuilder {
     return embed
 }
 
+/** Formats a duration in seconds into a human-readable time string. */
 export function formatTime(seconds: number): string {
     const hours = Math.floor(seconds / 3600)
     const minutes = Math.floor((seconds % 3600) / 60)
@@ -101,6 +102,7 @@ export function formatTime(seconds: number): string {
     return `${minutes}:${secs.toString().padStart(2, '0')}`
 }
 
+/** Creates a visual progress bar showing completion percentage as a string. */
 export function createProgressBar(
     current: number,
     total: number,

--- a/packages/shared/src/utils/general/embeds/errorEmbeds.spec.ts
+++ b/packages/shared/src/utils/general/embeds/errorEmbeds.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import { createErrorEmbed, createUserErrorEmbed } from './errorEmbeds'
+import { EMBED_COLORS, EMOJIS } from './constants'
+
+jest.mock('discord', () => ({
+    EmbedBuilder: jest.fn().mockImplementation(() => ({
+        setTitle: jest.fn().mockReturnThis(),
+        setDescription: jest.fn().mockReturnThis(),
+        setColor: jest.fn().mockReturnThis(),
+        setThumbnail: jest.fn().mockReturnThis(),
+        setURL: jest.fn().mockReturnThis(),
+        setAuthor: jest.fn().mockReturnThis(),
+        addFields: jest.fn().mockReturnThis(),
+        setFooter: jest.fn().mockReturnThis(),
+        setTimestamp: jest.fn().mockReturnThis(),
+        data: {},
+    })),
+}))
+
+jest.mock('../../error/errorHandler', () => ({
+    handleError: jest.fn(),
+    createUserErrorMessage: jest
+        .fn<() => string>()
+        .mockReturnValue('Something went wrong'),
+}))
+
+describe('errorEmbeds', () => {
+    let mockEmbed: {
+        setTitle: ReturnType<typeof jest.fn>
+        setDescription: ReturnType<typeof jest.fn>
+        setColor: ReturnType<typeof jest.fn>
+        addFields: ReturnType<typeof jest.fn>
+        setFooter: ReturnType<typeof jest.fn>
+        setTimestamp: ReturnType<typeof jest.fn>
+        data: object
+    }
+
+    beforeEach(() => {
+        mockEmbed = {
+            setTitle: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setDescription: jest.fn().mockReturnThis() as ReturnType<
+                typeof jest.fn
+            >,
+            setColor: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            addFields: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setFooter: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setTimestamp: jest.fn().mockReturnThis() as ReturnType<
+                typeof jest.fn
+            >,
+            data: {},
+        }
+        const { EmbedBuilder } = require('discord') as {
+            EmbedBuilder: jest.Mock
+        }
+        EmbedBuilder.mockImplementation(() => mockEmbed)
+    })
+
+    describe('createErrorEmbed', () => {
+        it('creates basic error embed without error object', () => {
+            createErrorEmbed('Error Title', 'Something failed')
+
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.ERROR} Error Title`,
+            )
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith(
+                'Something failed',
+            )
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(EMBED_COLORS.ERROR)
+            expect(mockEmbed.setTimestamp).toHaveBeenCalled()
+        })
+
+        it('sets footer when provided', () => {
+            createErrorEmbed('Title', 'Desc', undefined, 'Footer text')
+
+            expect(mockEmbed.setFooter).toHaveBeenCalledWith({
+                text: 'Footer text',
+            })
+        })
+
+        it('adds error details field when error object provided', () => {
+            const error = new Error('DB connection failed')
+            createErrorEmbed('DB Error', 'Connection failed', error)
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith({
+                name: 'Error Details',
+                value: '```DB connection failed```',
+                inline: false,
+            })
+        })
+
+        it('calls handleError when error object provided', () => {
+            const { handleError } = require('../../error/errorHandler') as {
+                handleError: jest.Mock
+            }
+            const error = new Error('Some error')
+            createErrorEmbed('Title', 'Desc', error)
+
+            expect(handleError).toHaveBeenCalledWith(
+                error,
+                expect.objectContaining({
+                    details: expect.objectContaining({
+                        context: 'Error Embed Creation',
+                    }),
+                }),
+            )
+        })
+
+        it('does not add error fields when no error provided', () => {
+            createErrorEmbed('Title', 'Desc')
+
+            expect(mockEmbed.addFields).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('createUserErrorEmbed', () => {
+        it('uses createUserErrorMessage result as description', () => {
+            const { createUserErrorMessage } =
+                require('../../error/errorHandler') as {
+                    createUserErrorMessage: jest.Mock
+                }
+            ;(createUserErrorMessage as jest.Mock).mockReturnValue(
+                'User-friendly message',
+            )
+
+            createUserErrorEmbed('Error', 'fallback description')
+
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith(
+                'User-friendly message',
+            )
+        })
+
+        it('falls back to description when createUserErrorMessage returns empty', () => {
+            const { createUserErrorMessage } =
+                require('../../error/errorHandler') as {
+                    createUserErrorMessage: jest.Mock
+                }
+            ;(createUserErrorMessage as jest.Mock).mockReturnValue('')
+
+            createUserErrorEmbed('Error', 'fallback description')
+
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith(
+                'fallback description',
+            )
+        })
+
+        it('sets error color', () => {
+            createUserErrorEmbed('Title', 'Desc')
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(EMBED_COLORS.ERROR)
+        })
+
+        it('sets footer when provided', () => {
+            createUserErrorEmbed('Title', 'Desc', undefined, 'Footer text')
+            expect(mockEmbed.setFooter).toHaveBeenCalledWith({
+                text: 'Footer text',
+            })
+        })
+    })
+})

--- a/packages/shared/src/utils/general/embeds/errorEmbeds.ts
+++ b/packages/shared/src/utils/general/embeds/errorEmbeds.ts
@@ -2,6 +2,7 @@ import { EMBED_COLORS, EMOJIS } from './constants'
 import { createEmbed } from './core'
 import { handleError, createUserErrorMessage } from '../../error/errorHandler'
 
+/** Creates an error embed with details, logging the error for debugging. */
 export function createErrorEmbed(
     title: string,
     description: string,
@@ -34,6 +35,7 @@ export function createErrorEmbed(
     return embed
 }
 
+/** Creates a user-friendly error embed with sanitized error message. */
 export function createUserErrorEmbed(
     title: string,
     description: string,

--- a/packages/shared/src/utils/general/embeds/messageEmbeds.spec.ts
+++ b/packages/shared/src/utils/general/embeds/messageEmbeds.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import {
+    createSuccessEmbed,
+    createWarningEmbed,
+    createInfoEmbed,
+    createLoadingEmbed,
+} from './messageEmbeds'
+import { EMBED_COLORS, EMOJIS } from './constants'
+
+jest.mock('discord', () => ({
+    EmbedBuilder: jest.fn().mockImplementation(() => ({
+        setTitle: jest.fn().mockReturnThis(),
+        setDescription: jest.fn().mockReturnThis(),
+        setColor: jest.fn().mockReturnThis(),
+        setThumbnail: jest.fn().mockReturnThis(),
+        setURL: jest.fn().mockReturnThis(),
+        setAuthor: jest.fn().mockReturnThis(),
+        addFields: jest.fn().mockReturnThis(),
+        setFooter: jest.fn().mockReturnThis(),
+        setTimestamp: jest.fn().mockReturnThis(),
+        data: {},
+    })),
+}))
+
+describe('messageEmbeds', () => {
+    let mockEmbed: {
+        setTitle: ReturnType<typeof jest.fn>
+        setDescription: ReturnType<typeof jest.fn>
+        setColor: ReturnType<typeof jest.fn>
+        setFooter: ReturnType<typeof jest.fn>
+        setTimestamp: ReturnType<typeof jest.fn>
+        data: object
+    }
+
+    beforeEach(() => {
+        mockEmbed = {
+            setTitle: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setDescription: jest.fn().mockReturnThis() as ReturnType<
+                typeof jest.fn
+            >,
+            setColor: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setFooter: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setTimestamp: jest.fn().mockReturnThis() as ReturnType<
+                typeof jest.fn
+            >,
+            data: {},
+        }
+        const { EmbedBuilder } = require('discord') as {
+            EmbedBuilder: jest.Mock
+        }
+        EmbedBuilder.mockImplementation(() => mockEmbed)
+    })
+
+    describe('createSuccessEmbed', () => {
+        it('creates with title and description', () => {
+            createSuccessEmbed('Done', 'Operation completed')
+
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.SUCCESS} Done`,
+            )
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith(
+                'Operation completed',
+            )
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(
+                EMBED_COLORS.SUCCESS,
+            )
+            expect(mockEmbed.setTimestamp).toHaveBeenCalled()
+        })
+
+        it('sets footer when provided', () => {
+            createSuccessEmbed('Done', 'Desc', 'Footer text')
+            expect(mockEmbed.setFooter).toHaveBeenCalledWith({
+                text: 'Footer text',
+            })
+        })
+
+        it('does not set footer when not provided', () => {
+            createSuccessEmbed('Done', 'Desc')
+            expect(mockEmbed.setFooter).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('createWarningEmbed', () => {
+        it('creates with title and description', () => {
+            createWarningEmbed('Warning', 'Be careful')
+
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.WARNING} Warning`,
+            )
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith('Be careful')
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(
+                EMBED_COLORS.WARNING,
+            )
+            expect(mockEmbed.setTimestamp).toHaveBeenCalled()
+        })
+
+        it('sets footer when provided', () => {
+            createWarningEmbed('Warning', 'Desc', 'Footer')
+            expect(mockEmbed.setFooter).toHaveBeenCalledWith({ text: 'Footer' })
+        })
+    })
+
+    describe('createInfoEmbed', () => {
+        it('creates with title and description', () => {
+            createInfoEmbed('Info', 'Some info')
+
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.INFO} Info`,
+            )
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith('Some info')
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(EMBED_COLORS.INFO)
+            expect(mockEmbed.setTimestamp).toHaveBeenCalled()
+        })
+
+        it('sets footer when provided', () => {
+            createInfoEmbed('Info', 'Desc', 'Footer')
+            expect(mockEmbed.setFooter).toHaveBeenCalledWith({ text: 'Footer' })
+        })
+    })
+
+    describe('createLoadingEmbed', () => {
+        it('creates with loading title and custom message', () => {
+            createLoadingEmbed('Please wait...')
+
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith('⏳ Loading...')
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith(
+                'Please wait...',
+            )
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(EMBED_COLORS.INFO)
+        })
+
+        it('does not set timestamp', () => {
+            createLoadingEmbed('Loading')
+            expect(mockEmbed.setTimestamp).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/packages/shared/src/utils/general/embeds/messageEmbeds.ts
+++ b/packages/shared/src/utils/general/embeds/messageEmbeds.ts
@@ -1,6 +1,7 @@
 import { EMBED_COLORS, EMOJIS } from './constants'
 import { createEmbed } from './core'
 
+/** Creates a success-styled embed with the given title and optional description. */
 export function successEmbed(title: string, description?: string) {
     return createEmbed({
         title,
@@ -10,6 +11,7 @@ export function successEmbed(title: string, description?: string) {
     })
 }
 
+/** Creates an error-styled embed with the given title and optional description. */
 export function errorEmbed(title: string, description?: string) {
     return createEmbed({
         title,
@@ -19,6 +21,7 @@ export function errorEmbed(title: string, description?: string) {
     })
 }
 
+/** Creates a warning-styled embed with the given title and optional description. */
 export function warningEmbed(title: string, description?: string) {
     return createEmbed({
         title,
@@ -28,6 +31,7 @@ export function warningEmbed(title: string, description?: string) {
     })
 }
 
+/** Creates an info-styled embed with the given title and optional description. */
 export function infoEmbed(title: string, description?: string) {
     return createEmbed({
         title,
@@ -37,6 +41,7 @@ export function infoEmbed(title: string, description?: string) {
     })
 }
 
+/** Creates a success-styled embed with timestamp and optional footer. */
 export function createSuccessEmbed(
     title: string,
     description: string,
@@ -52,6 +57,7 @@ export function createSuccessEmbed(
     })
 }
 
+/** Creates a warning-styled embed with timestamp and optional footer. */
 export function createWarningEmbed(
     title: string,
     description: string,
@@ -67,6 +73,7 @@ export function createWarningEmbed(
     })
 }
 
+/** Creates an info-styled embed with timestamp and optional footer. */
 export function createInfoEmbed(
     title: string,
     description: string,
@@ -82,6 +89,7 @@ export function createInfoEmbed(
     })
 }
 
+/** Creates a loading-styled embed with the given message. */
 export function createLoadingEmbed(message: string) {
     return createEmbed({
         title: 'Loading...',

--- a/packages/shared/src/utils/general/embeds/musicEmbeds.spec.ts
+++ b/packages/shared/src/utils/general/embeds/musicEmbeds.spec.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import {
+    createTrackEmbed,
+    createQueueEmbed,
+    musicEmbed,
+    queueEmbed,
+    autoplayEmbed,
+} from './musicEmbeds'
+import { EMBED_COLORS, EMOJIS } from './constants'
+
+jest.mock('discord', () => ({
+    EmbedBuilder: jest.fn().mockImplementation(() => ({
+        setTitle: jest.fn().mockReturnThis(),
+        setDescription: jest.fn().mockReturnThis(),
+        setColor: jest.fn().mockReturnThis(),
+        setThumbnail: jest.fn().mockReturnThis(),
+        setURL: jest.fn().mockReturnThis(),
+        setAuthor: jest.fn().mockReturnThis(),
+        addFields: jest.fn().mockReturnThis(),
+        setFooter: jest.fn().mockReturnThis(),
+        setTimestamp: jest.fn().mockReturnThis(),
+        data: {},
+    })),
+}))
+
+describe('musicEmbeds', () => {
+    let mockEmbed: {
+        setTitle: ReturnType<typeof jest.fn>
+        setDescription: ReturnType<typeof jest.fn>
+        setColor: ReturnType<typeof jest.fn>
+        setThumbnail: ReturnType<typeof jest.fn>
+        setURL: ReturnType<typeof jest.fn>
+        setAuthor: ReturnType<typeof jest.fn>
+        addFields: ReturnType<typeof jest.fn>
+        setFooter: ReturnType<typeof jest.fn>
+        setTimestamp: ReturnType<typeof jest.fn>
+        data: object
+    }
+
+    beforeEach(() => {
+        mockEmbed = {
+            setTitle: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setDescription: jest.fn().mockReturnThis() as ReturnType<
+                typeof jest.fn
+            >,
+            setColor: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setThumbnail: jest.fn().mockReturnThis() as ReturnType<
+                typeof jest.fn
+            >,
+            setURL: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setAuthor: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            addFields: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setFooter: jest.fn().mockReturnThis() as ReturnType<typeof jest.fn>,
+            setTimestamp: jest.fn().mockReturnThis() as ReturnType<
+                typeof jest.fn
+            >,
+            data: {},
+        }
+        const { EmbedBuilder } = require('discord') as {
+            EmbedBuilder: jest.Mock
+        }
+        EmbedBuilder.mockImplementation(() => mockEmbed)
+    })
+
+    describe('musicEmbed', () => {
+        it('creates with title and description', () => {
+            musicEmbed('Now Playing', 'Some track')
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.MUSIC} Now Playing`,
+            )
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith('Some track')
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(EMBED_COLORS.MUSIC)
+        })
+
+        it('creates without description', () => {
+            musicEmbed('Now Playing')
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.MUSIC} Now Playing`,
+            )
+            expect(mockEmbed.setDescription).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('queueEmbed', () => {
+        it('creates with title and description', () => {
+            queueEmbed('Queue', 'Track list')
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.QUEUE} Queue`,
+            )
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(EMBED_COLORS.QUEUE)
+        })
+
+        it('creates without description', () => {
+            queueEmbed('Queue')
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.QUEUE} Queue`,
+            )
+        })
+    })
+
+    describe('autoplayEmbed', () => {
+        it('creates with title and description', () => {
+            autoplayEmbed('Autoplay', 'Enabled')
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.AUTOPLAY} Autoplay`,
+            )
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(
+                EMBED_COLORS.AUTOPLAY,
+            )
+        })
+
+        it('creates without description', () => {
+            autoplayEmbed('Autoplay')
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.AUTOPLAY} Autoplay`,
+            )
+        })
+    })
+
+    describe('createTrackEmbed', () => {
+        it('creates with required fields', () => {
+            createTrackEmbed({
+                title: 'Test Track',
+                author: 'Test Artist',
+                url: 'https://example.com/track',
+            })
+
+            expect(mockEmbed.setTitle).toHaveBeenCalledWith(
+                `${EMOJIS.MUSIC} Test Track`,
+            )
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith(
+                'by Test Artist',
+            )
+            expect(mockEmbed.setURL).toHaveBeenCalledWith(
+                'https://example.com/track',
+            )
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(EMBED_COLORS.MUSIC)
+            expect(mockEmbed.setTimestamp).toHaveBeenCalled()
+        })
+
+        it('includes duration and requestedBy fields', () => {
+            createTrackEmbed({
+                title: 'Track',
+                author: 'Artist',
+                url: 'https://example.com',
+                duration: '3:45',
+                requestedBy: 'User#1234',
+            })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Duration',
+                        value: '3:45',
+                    }),
+                    expect.objectContaining({
+                        name: 'Requested by',
+                        value: 'User#1234',
+                    }),
+                ]),
+            )
+        })
+
+        it('uses Unknown for missing duration', () => {
+            createTrackEmbed({
+                title: 'Track',
+                author: 'Artist',
+                url: 'https://example.com',
+            })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Duration',
+                        value: 'Unknown',
+                    }),
+                    expect.objectContaining({
+                        name: 'Requested by',
+                        value: 'Unknown',
+                    }),
+                ]),
+            )
+        })
+
+        it('sets thumbnail when provided', () => {
+            createTrackEmbed({
+                title: 'Track',
+                author: 'Artist',
+                url: 'https://example.com',
+                thumbnail: 'https://example.com/thumb.jpg',
+            })
+
+            expect(mockEmbed.setThumbnail).toHaveBeenCalledWith(
+                'https://example.com/thumb.jpg',
+            )
+        })
+
+        it('adds source field when provided', () => {
+            createTrackEmbed({
+                title: 'Track',
+                author: 'Artist',
+                url: 'https://example.com',
+                source: 'YouTube',
+            })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Source',
+                        value: 'YouTube',
+                    }),
+                ]),
+            )
+        })
+
+        it('does not add source field when absent', () => {
+            createTrackEmbed({
+                title: 'Track',
+                author: 'Artist',
+                url: 'https://example.com',
+            })
+
+            const calls = (mockEmbed.addFields as ReturnType<typeof jest.fn>)
+                .mock.calls
+            const allFields = calls.flatMap(
+                (c: unknown[]) => c[0] as { name: string }[],
+            )
+            const sourceField = allFields.find((f) => f.name === 'Source')
+            expect(sourceField).toBeUndefined()
+        })
+    })
+
+    describe('createQueueEmbed', () => {
+        it('shows empty queue message when no tracks', () => {
+            createQueueEmbed({
+                tracks: [],
+            })
+
+            expect(mockEmbed.setDescription).toHaveBeenCalledWith(
+                'Queue is empty',
+            )
+            expect(mockEmbed.setColor).toHaveBeenCalledWith(EMBED_COLORS.QUEUE)
+        })
+
+        it('shows now playing when currentTrack is set', () => {
+            createQueueEmbed({
+                tracks: [],
+                currentTrack: {
+                    title: 'Current Track',
+                    author: 'Artist',
+                    url: 'https://example.com/current',
+                },
+            })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Now Playing',
+                        value: '[Current Track](https://example.com/current)',
+                    }),
+                ]),
+            )
+        })
+
+        it('shows track list when tracks present', () => {
+            createQueueEmbed({
+                tracks: [
+                    {
+                        title: 'Track 1',
+                        author: 'A1',
+                        url: 'https://example.com/1',
+                    },
+                    {
+                        title: 'Track 2',
+                        author: 'A2',
+                        url: 'https://example.com/2',
+                    },
+                ],
+            })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Queue (2 tracks)',
+                    }),
+                ]),
+            )
+        })
+
+        it('truncates track list beyond 10 with overflow message', () => {
+            const tracks = Array.from({ length: 12 }, (_, i) => ({
+                title: `Track ${i + 1}`,
+                author: 'A',
+                url: `https://example.com/${i + 1}`,
+            }))
+
+            createQueueEmbed({ tracks })
+
+            const calls = (mockEmbed.addFields as ReturnType<typeof jest.fn>)
+                .mock.calls
+            const allFields = calls.flatMap(
+                (c: unknown[]) => c[0] as { name: string; value: string }[],
+            )
+            const queueField = allFields.find(
+                (f) => f.name === 'Queue (12 tracks)',
+            )
+            expect(queueField?.value).toContain('... and 2 more')
+        })
+
+        it('does not show overflow message for 10 or fewer tracks', () => {
+            const tracks = Array.from({ length: 10 }, (_, i) => ({
+                title: `Track ${i + 1}`,
+                author: 'A',
+                url: `https://example.com/${i + 1}`,
+            }))
+
+            createQueueEmbed({ tracks })
+
+            const calls = (mockEmbed.addFields as ReturnType<typeof jest.fn>)
+                .mock.calls
+            const allFields = calls.flatMap(
+                (c: unknown[]) => c[0] as { name: string; value: string }[],
+            )
+            const queueField = allFields.find(
+                (f) => f.name === 'Queue (10 tracks)',
+            )
+            expect(queueField?.value).not.toContain('more')
+        })
+
+        it('shows total duration when provided', () => {
+            createQueueEmbed({
+                tracks: [],
+                totalDuration: '1:23:45',
+            })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Total Duration',
+                        value: '1:23:45',
+                    }),
+                ]),
+            )
+        })
+
+        it('shows loop status', () => {
+            createQueueEmbed({ tracks: [], isLooping: true })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Status',
+                        value: expect.stringContaining('🔁 Loop'),
+                    }),
+                ]),
+            )
+        })
+
+        it('shows shuffle status', () => {
+            createQueueEmbed({ tracks: [], isShuffled: true })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Status',
+                        value: expect.stringContaining('🔀 Shuffle'),
+                    }),
+                ]),
+            )
+        })
+
+        it('shows autoplay status', () => {
+            createQueueEmbed({ tracks: [], autoplayEnabled: true })
+
+            expect(mockEmbed.addFields).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        name: 'Status',
+                        value: expect.stringContaining('🔄 Autoplay'),
+                    }),
+                ]),
+            )
+        })
+
+        it('combines multiple status flags', () => {
+            createQueueEmbed({
+                tracks: [],
+                isLooping: true,
+                isShuffled: true,
+                autoplayEnabled: true,
+            })
+
+            const calls = (mockEmbed.addFields as ReturnType<typeof jest.fn>)
+                .mock.calls
+            const allFields = calls.flatMap(
+                (c: unknown[]) => c[0] as { name: string; value: string }[],
+            )
+            const statusField = allFields.find((f) => f.name === 'Status')
+            expect(statusField?.value).toContain('🔁 Loop')
+            expect(statusField?.value).toContain('🔀 Shuffle')
+            expect(statusField?.value).toContain('🔄 Autoplay')
+        })
+
+        it('does not show status field when no flags set', () => {
+            createQueueEmbed({ tracks: [] })
+
+            const calls = (mockEmbed.addFields as ReturnType<typeof jest.fn>)
+                .mock.calls
+            const allFields = calls.flatMap(
+                (c: unknown[]) => c[0] as { name: string; value: string }[],
+            )
+            const statusField = allFields.find((f) => f.name === 'Status')
+            expect(statusField).toBeUndefined()
+        })
+
+        it('sets timestamp', () => {
+            createQueueEmbed({ tracks: [] })
+            expect(mockEmbed.setTimestamp).toHaveBeenCalled()
+        })
+    })
+})

--- a/packages/shared/src/utils/general/embeds/types.ts
+++ b/packages/shared/src/utils/general/embeds/types.ts
@@ -1,5 +1,6 @@
 import type { ColorResolvable } from 'discord.js'
 
+/** Options for creating a Discord embed. */
 export type CreateEmbedOptions = {
     title?: string
     description?: string
@@ -13,12 +14,14 @@ export type CreateEmbedOptions = {
     author?: { name: string; iconURL?: string; url?: string }
 }
 
+/** Embed field (name-value pair). */
 export type EmbedField = {
     name: string
     value: string
     inline?: boolean
 }
 
+/** Track information for display. */
 export type TrackInfo = {
     title: string
     author: string
@@ -29,6 +32,7 @@ export type TrackInfo = {
     source?: string
 }
 
+/** Queue information for display. */
 export type QueueInfo = {
     currentTrack?: TrackInfo
     tracks: TrackInfo[]

--- a/packages/shared/src/utils/general/errorSanitizer.spec.ts
+++ b/packages/shared/src/utils/general/errorSanitizer.spec.ts
@@ -234,6 +234,11 @@ describe('sanitizeMessage', () => {
         const result = sanitizeMessage(message)
         expect(result).toBe('Module loading load error')
     })
+
+    it('returns fallback when message is whitespace-only and becomes empty after sanitization', () => {
+        const result = sanitizeMessage('   \t\n  ')
+        expect(result).toBe('An unknown error occurred')
+    })
 })
 
 describe('createUserFriendlyError', () => {

--- a/packages/shared/src/utils/general/log/index.ts
+++ b/packages/shared/src/utils/general/log/index.ts
@@ -1,9 +1,7 @@
 import { LogService } from './service'
 import type { LogParams, LogConfig, LogLevelType } from './types'
 
-/**
- * Main log service
- */
+/** Provides logging functionality with multiple severity levels and customizable output. */
 export class Log {
     private readonly service: LogService
 
@@ -11,53 +9,66 @@ export class Log {
         this.service = new LogService()
     }
 
+    /** Sets the minimum log level to display. */
     setLogLevel(level: LogLevelType): void {
         this.service.setLogLevel(level)
     }
 
+    /** Logs an error-level message. */
     error(params: LogParams): void {
         this.service.error(params)
     }
 
+    /** Logs a warning-level message. */
     warn(params: LogParams): void {
         this.service.warn(params)
     }
 
+    /** Logs an info-level message. */
     info(params: LogParams): void {
         this.service.info(params)
     }
 
+    /** Logs a success-level message. */
     success(params: LogParams): void {
         this.service.success(params)
     }
 
+    /** Logs a debug-level message. */
     debug(params: LogParams): void {
         this.service.debug(params)
     }
 }
 
+/** Global log instance. */
 export const log = new Log()
 
+/** Sets the global minimum log level. */
 export const setLogLevel = (level: LogLevelType): void => {
     log.setLogLevel(level)
 }
 
+/** Logs an error message using the global log instance. */
 export const errorLog = (params: LogParams): void => {
     log.error(params)
 }
 
+/** Logs a warning message using the global log instance. */
 export const warnLog = (params: LogParams): void => {
     log.warn(params)
 }
 
+/** Logs an info message using the global log instance. */
 export const infoLog = (params: LogParams): void => {
     log.info(params)
 }
 
+/** Logs a success message using the global log instance. */
 export const successLog = (params: LogParams): void => {
     log.success(params)
 }
 
+/** Logs a debug message using the global log instance. */
 export const debugLog = (params: LogParams): void => {
     log.debug(params)
 }

--- a/packages/shared/src/utils/general/log/service.spec.ts
+++ b/packages/shared/src/utils/general/log/service.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { LogService } from './service'
+
+jest.mock('../../monitoring', () => ({
+    captureException: jest.fn(),
+    captureMessage: jest.fn(),
+    addBreadcrumb: jest.fn(),
+}))
+
+jest.mock('chalk', () => {
+    const id = (t: string) => t
+    return {
+        __esModule: true,
+        default: { red: id, yellow: id, blue: id, green: id, gray: id },
+    }
+})
+
+describe('LogService', () => {
+    let service: LogService
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        jest.spyOn(console, 'log').mockImplementation(() => {})
+        jest.spyOn(console, 'error').mockImplementation(() => {})
+        service = new LogService()
+    })
+
+    describe('setLogLevel', () => {
+        it('changes the active log level', () => {
+            service.setLogLevel(0)
+            // With level=0 (ERROR), debug should be suppressed
+            const consoleSpy = jest.spyOn(console, 'log')
+            consoleSpy.mockClear()
+            service.debug({ message: 'should be hidden' })
+            expect(consoleSpy).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('formatMessage with correlationId', () => {
+        it('includes correlationId in the formatted output', () => {
+            const consoleSpy = jest.spyOn(console, 'log')
+            consoleSpy.mockClear()
+            service.info({ message: 'hello', correlationId: 'req-abc-123' })
+            const logged = consoleSpy.mock.calls[0]?.[0] as string
+            expect(logged).toContain('req-abc-123')
+            expect(logged).toContain('hello')
+        })
+    })
+
+    describe('getColor with enableColors disabled', () => {
+        it('returns identity function when colors are off', () => {
+            ;(service as any).config.enableColors = false
+            const consoleSpy = jest.spyOn(console, 'log')
+            consoleSpy.mockClear()
+            service.info({ message: 'plain text' })
+            const logged = consoleSpy.mock.calls[0]?.[0] as string
+            expect(logged).toContain('plain text')
+        })
+    })
+
+    describe('getColor default case', () => {
+        it('returns identity function for an unknown level number', () => {
+            ;(service as any).config.level = 99
+            const consoleSpy = jest.spyOn(console, 'log')
+            consoleSpy.mockClear()
+            ;(service as any).log(99 as any, { message: 'unknown level' })
+            const logged = consoleSpy.mock.calls[0]?.[0] as string
+            expect(logged).toContain('unknown level')
+        })
+    })
+
+    describe('serializeError catch branch', () => {
+        it('falls back to String(err) when JSON.stringify throws on a circular reference', () => {
+            const circular: Record<string, unknown> = {}
+            circular['self'] = circular
+            const consoleSpy = jest.spyOn(console, 'log')
+            consoleSpy.mockClear()
+            service.warn({ message: 'circular', error: circular })
+            expect(consoleSpy).toHaveBeenCalled()
+        })
+    })
+
+    describe('toError non-string path', () => {
+        it('converts a number error to an Error via JSON.stringify', () => {
+            const { captureException } = jest.requireMock<{
+                captureException: jest.Mock
+            }>('../../monitoring')
+            service.error({ message: 'num err', error: 42 })
+            expect(captureException).toHaveBeenCalledWith(
+                expect.objectContaining({ message: '42' }),
+                expect.anything(),
+            )
+        })
+    })
+})

--- a/packages/shared/src/utils/general/log/types.ts
+++ b/packages/shared/src/utils/general/log/types.ts
@@ -1,7 +1,4 @@
-/**
- * Log types and interfaces
- */
-
+/** Log level constants. */
 export const LogLevel = {
     ERROR: 0,
     WARN: 1,
@@ -10,8 +7,10 @@ export const LogLevel = {
     DEBUG: 4,
 } as const
 
+/** Log level type. */
 export type LogLevelType = (typeof LogLevel)[keyof typeof LogLevel]
 
+/** Parameters for logging. */
 export type LogParams = {
     message: string
     error?: unknown
@@ -20,6 +19,7 @@ export type LogParams = {
     correlationId?: string
 }
 
+/** Log configuration. */
 export type LogConfig = {
     level: LogLevelType
     enableColors: boolean

--- a/packages/shared/src/utils/monitoring/sentry.spec.ts
+++ b/packages/shared/src/utils/monitoring/sentry.spec.ts
@@ -26,6 +26,9 @@ import {
     flushSentry,
     initializeSentry,
     isSentryEnabled,
+    addBreadcrumb,
+    monitorCommandExecution,
+    monitorInteractionHandling,
 } from './sentry'
 
 describe('sentry monitoring', () => {
@@ -51,7 +54,16 @@ describe('sentry monitoring', () => {
 
     it('disables sentry when explicitly turned off', () => {
         process.env.SENTRY_ENABLED = 'false'
+        expect(isSentryEnabled()).toBe(false)
+    })
 
+    it('disables sentry when dsn is missing', () => {
+        delete process.env.SENTRY_DSN
+        expect(isSentryEnabled()).toBe(false)
+    })
+
+    it('disables sentry in development environment', () => {
+        process.env.NODE_ENV = 'development'
         expect(isSentryEnabled()).toBe(false)
     })
 
@@ -105,5 +117,210 @@ describe('sentry monitoring', () => {
     it('flushes pending events when sentry is enabled', async () => {
         await expect(flushSentry(1234)).resolves.toBe(true)
         expect(flushMock).toHaveBeenCalledWith(1234)
+    })
+
+    it('does not call sentry captureException when disabled', () => {
+        process.env.SENTRY_ENABLED = 'false'
+        captureException(new Error('test'))
+        expect(captureExceptionMock).not.toHaveBeenCalled()
+    })
+
+    it('does not call sentry captureMessage when disabled', () => {
+        process.env.SENTRY_ENABLED = 'false'
+        captureMessage('test')
+        expect(captureMessageMock).not.toHaveBeenCalled()
+    })
+
+    it('returns false from flushSentry when disabled', async () => {
+        process.env.SENTRY_ENABLED = 'false'
+        await expect(flushSentry()).resolves.toBe(false)
+        expect(flushMock).not.toHaveBeenCalled()
+    })
+
+    describe('initializeSentry edge cases', () => {
+        it('skips init and logs when no DSN in production', () => {
+            const { infoLog } = require('../general/log') as {
+                infoLog: jest.Mock
+            }
+            delete process.env.SENTRY_DSN
+            initializeSentry({})
+            expect(initMock).not.toHaveBeenCalled()
+            expect(infoLog).toHaveBeenCalled()
+        })
+
+        it('skips init without logging when no DSN outside production', () => {
+            const { infoLog } = require('../general/log') as {
+                infoLog: jest.Mock
+            }
+            delete process.env.SENTRY_DSN
+            process.env.NODE_ENV = 'staging'
+            initializeSentry({})
+            expect(initMock).not.toHaveBeenCalled()
+            expect(infoLog).not.toHaveBeenCalled()
+        })
+
+        it('skips init and logs when explicitly disabled', () => {
+            const { infoLog } = require('../general/log') as {
+                infoLog: jest.Mock
+            }
+            process.env.SENTRY_ENABLED = 'false'
+            initializeSentry({})
+            expect(initMock).not.toHaveBeenCalled()
+            expect(infoLog).toHaveBeenCalled()
+        })
+
+        it('skips init silently in development', () => {
+            const { infoLog } = require('../general/log') as {
+                infoLog: jest.Mock
+            }
+            process.env.NODE_ENV = 'development'
+            initializeSentry({})
+            expect(initMock).not.toHaveBeenCalled()
+            expect(infoLog).not.toHaveBeenCalled()
+        })
+
+        it('uses SENTRY_ENVIRONMENT from env when not in options', () => {
+            process.env.SENTRY_ENVIRONMENT = 'canary'
+            initializeSentry({})
+            expect(initMock).toHaveBeenCalledWith(
+                expect.objectContaining({ environment: 'canary' }),
+            )
+        })
+
+        it('uses env-based sample rates when options not provided', () => {
+            process.env.SENTRY_TRACES_SAMPLE_RATE = '0.5'
+            process.env.SENTRY_PROFILES_SAMPLE_RATE = '0.3'
+            initializeSentry({})
+            expect(initMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    tracesSampleRate: 0.5,
+                    profilesSampleRate: 0.3,
+                }),
+            )
+        })
+
+        it('falls back to default sample rate when env value is NaN', () => {
+            process.env.SENTRY_TRACES_SAMPLE_RATE = 'not-a-number'
+            initializeSentry({})
+            expect(initMock).toHaveBeenCalledWith(
+                expect.objectContaining({ tracesSampleRate: 1.0 }),
+            )
+        })
+
+        it('uses explicit option sample rate over env value', () => {
+            process.env.SENTRY_TRACES_SAMPLE_RATE = '0.5'
+            initializeSentry({ tracesSampleRate: 0.1 })
+            expect(initMock).toHaveBeenCalledWith(
+                expect.objectContaining({ tracesSampleRate: 0.1 }),
+            )
+        })
+
+        it('uses env metadata when not provided in options', () => {
+            process.env.SENTRY_APP_NAME = 'env-app'
+            process.env.SENTRY_SERVICE_NAME = 'env-svc'
+            process.env.SENTRY_RELEASE = 'env-release'
+            process.env.SENTRY_SERVER_NAME = 'env-server'
+            initializeSentry({})
+            expect(initMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    release: 'env-release',
+                    serverName: 'env-server',
+                    initialScope: {
+                        tags: { app: 'env-app', service: 'env-svc' },
+                    },
+                }),
+            )
+        })
+
+        it('omits app and service tags when neither option nor env provides them', () => {
+            initializeSentry({})
+            const call = (initMock.mock.calls[0] as unknown[])[0] as {
+                initialScope: { tags: Record<string, string> }
+            }
+            expect(call.initialScope.tags).not.toHaveProperty('app')
+            expect(call.initialScope.tags).not.toHaveProperty('service')
+        })
+
+        it('sanitizes event.extra via beforeSend callback', () => {
+            initializeSentry({})
+            const initArg = (initMock.mock.calls[0] as unknown[])[0] as {
+                beforeSend: (event: { extra?: Record<string, unknown> }) => {
+                    extra?: Record<string, unknown>
+                }
+            }
+            const result = initArg.beforeSend({
+                extra: { token: 'secret', userId: 'abc' },
+            })
+            expect(result.extra).not.toHaveProperty('token')
+            expect(result.extra).toHaveProperty('userId', 'abc')
+        })
+
+        it('beforeSend leaves extra undefined when event has no extra', () => {
+            initializeSentry({})
+            const initArg = (initMock.mock.calls[0] as unknown[])[0] as {
+                beforeSend: (event: { extra?: unknown }) => { extra?: unknown }
+            }
+            const result = initArg.beforeSend({ extra: undefined })
+            expect(result.extra).toBeUndefined()
+        })
+    })
+
+    describe('addBreadcrumb', () => {
+        it('calls sentry with all provided values', () => {
+            addBreadcrumb('msg', 'cat', 'warning', { k: 'v' })
+            expect(addBreadcrumbMock).toHaveBeenCalledWith({
+                message: 'msg',
+                category: 'cat',
+                level: 'warning',
+                data: { k: 'v' },
+            })
+        })
+
+        it('defaults category to general and level to info', () => {
+            addBreadcrumb('msg')
+            expect(addBreadcrumbMock).toHaveBeenCalledWith(
+                expect.objectContaining({ category: 'general', level: 'info' }),
+            )
+        })
+
+        it('does not call sentry when disabled', () => {
+            process.env.SENTRY_ENABLED = 'false'
+            addBreadcrumb('msg')
+            expect(addBreadcrumbMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('monitorCommandExecution', () => {
+        it('sets command context when enabled', () => {
+            monitorCommandExecution('play', 'user-1', 'guild-1')
+            expect(setContextMock).toHaveBeenCalledWith('command', {
+                name: 'play',
+                userId: 'user-1',
+                guildId: 'guild-1',
+            })
+        })
+
+        it('does not set context when disabled', () => {
+            process.env.SENTRY_ENABLED = 'false'
+            monitorCommandExecution('play', 'user-1')
+            expect(setContextMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('monitorInteractionHandling', () => {
+        it('sets interaction context when enabled', () => {
+            monitorInteractionHandling('button', 'user-1', 'guild-1')
+            expect(setContextMock).toHaveBeenCalledWith('interaction', {
+                type: 'button',
+                userId: 'user-1',
+                guildId: 'guild-1',
+            })
+        })
+
+        it('does not set context when disabled', () => {
+            process.env.SENTRY_ENABLED = 'false'
+            monitorInteractionHandling('button', 'user-1')
+            expect(setContextMock).not.toHaveBeenCalled()
+        })
     })
 })

--- a/packages/shared/src/utils/requiredDatabaseRelations.ts
+++ b/packages/shared/src/utils/requiredDatabaseRelations.ts
@@ -18,6 +18,7 @@ type RequiredDatabaseRelationsPrismaModels = Pick<
     | 'guildAutomationDrift'
 >
 
+/** Prisma client subset containing required database models for schema verification. */
 export type RequiredDatabaseStatePrisma = {
     guildRoleGrant: Pick<
         RequiredDatabaseRelationsPrismaModels['guildRoleGrant'],
@@ -70,6 +71,7 @@ const relationChecks: RelationCheck[] = [
     },
 ]
 
+/** Verifies that all required database relations exist, throwing if any are missing. */
 export async function verifyRequiredDatabaseRelations(
     prisma: RequiredDatabaseStatePrisma = getPrismaClient(),
 ): Promise<void> {

--- a/packages/shared/src/utils/result.spec.ts
+++ b/packages/shared/src/utils/result.spec.ts
@@ -2,7 +2,7 @@
  * Unit tests for Result utility functions
  */
 
-import { describe, it, expect } from '@jest/globals'
+import { describe, it, expect, jest } from '@jest/globals'
 import {
     createSuccess,
     createFailure,
@@ -63,7 +63,7 @@ describe('Result Utilities', () => {
     describe('map', () => {
         it('should transform success data', () => {
             const result = createSuccess(5)
-            const mapped = map(result, x => x * 2)
+            const mapped = map(result, (x) => x * 2)
             expect(mapped.success).toBe(true)
             if (mapped.success) {
                 expect(mapped.data).toBe(10)
@@ -72,7 +72,7 @@ describe('Result Utilities', () => {
 
         it('should preserve failure state', () => {
             const result = createFailure('error')
-            const mapped = map(result, x => x * 2)
+            const mapped = map(result, (x) => x * 2)
             expect(mapped.success).toBe(false)
         })
     })
@@ -80,7 +80,7 @@ describe('Result Utilities', () => {
     describe('mapError', () => {
         it('should transform error in failure results', () => {
             const result = createFailure('original error')
-            const mapped = mapError(result, err => `Modified: ${err}`)
+            const mapped = mapError(result, (err) => `Modified: ${err}`)
             expect(mapped.success).toBe(false)
             if (!mapped.success) {
                 expect(mapped.error).toBe('Modified: original error')
@@ -89,7 +89,7 @@ describe('Result Utilities', () => {
 
         it('should preserve success state', () => {
             const result = createSuccess('data')
-            const mapped = mapError(result, err => `Modified: ${err}`)
+            const mapped = mapError(result, (err) => `Modified: ${err}`)
             expect(mapped.success).toBe(true)
         })
     })
@@ -97,7 +97,7 @@ describe('Result Utilities', () => {
     describe('flatMap', () => {
         it('should chain success results', () => {
             const result = createSuccess(5)
-            const chained = flatMap(result, x => createSuccess(x * 2))
+            const chained = flatMap(result, (x) => createSuccess(x * 2))
             expect(chained.success).toBe(true)
             if (chained.success) {
                 expect(chained.data).toBe(10)
@@ -106,11 +106,21 @@ describe('Result Utilities', () => {
 
         it('should chain failure results', () => {
             const result = createSuccess(5)
-            const chained = flatMap(result, _x => createFailure('chained error'))
+            const chained = flatMap(result, (_x) =>
+                createFailure('chained error'),
+            )
             expect(chained.success).toBe(false)
             if (!chained.success) {
                 expect(chained.error).toBe('chained error')
             }
+        })
+
+        it('returns the failure without calling fn when input is already a failure', () => {
+            const failure = createFailure('original error')
+            const fn = jest.fn<() => ReturnType<typeof createSuccess>>()
+            const result = flatMap(failure, fn)
+            expect(result.success).toBe(false)
+            expect(fn).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/shared/typedoc.json
+++ b/packages/shared/typedoc.json
@@ -1,0 +1,18 @@
+{
+    "entryPoints": ["src/index.ts"],
+    "tsconfig": "tsconfig.json",
+    "plugin": ["typedoc-plugin-coverage"],
+    "requiredToBeDocumented": [
+        "Function",
+        "Class",
+        "Interface",
+        "TypeAlias",
+        "Enum",
+        "EnumMember"
+    ],
+    "coverageOutputType": "json",
+    "coverageOutputPath": "/tmp/typedoc-coverage.json",
+    "out": "/tmp/typedoc-out",
+    "skipErrorChecking": true,
+    "logLevel": "Warn"
+}

--- a/prisma/migrations/20260528000000_add_autoplay_mode_to_recommendations/migration.sql
+++ b/prisma/migrations/20260528000000_add_autoplay_mode_to_recommendations/migration.sql
@@ -1,0 +1,14 @@
+-- Phase D prerequisite: record the active autoplay mode at recommendation pick time.
+-- See GitHub issue #1081 and docs/decisions/2026-05-21-autoplay-recommendation-roadmap.md
+--
+-- This allows future Phase D analysis to slice acceptance rate by mode (similar, discover, popular)
+-- enabling mode-specific tuning of the candidate scoring logic.
+--
+-- The field is nullable to accommodate pre-migration rows (backfill not required);
+-- forward writes will populate the mode for all three mode values.
+
+ALTER TABLE "recommendations" ADD COLUMN "mode" TEXT;
+
+-- Index for grouping/aggregating acceptance by mode and guild.
+CREATE INDEX "recommendations_guildId_mode_createdAt_idx"
+    ON "recommendations" ("guildId", "mode", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -429,6 +429,9 @@ model Recommendation {
   // Denormalized human-readable serialization of source + signals. Computed
   // by serializeBasis(). Kept for Discord display and ad-hoc query inspection.
   reason     String?
+  // Phase D: active autoplay mode at pick time (similar | discover | popular).
+  // Nullable for forward-compatibility with pre-migration rows.
+  mode       String?
 
   // Phase B closed-loop outcome
   isAccepted Boolean?
@@ -440,6 +443,7 @@ model Recommendation {
 
   @@index([guildId, createdAt])
   @@index([guildId, source, createdAt])
+  @@index([guildId, mode, createdAt])
   @@map("recommendations")
 }
 


### PR DESCRIPTION
Release **v2.16.0** — batches 3 PRs accumulated on `release/v2.16.0` since v2.15.2.

## [2.16.0]
### Added
- Autoplay mode-selection telemetry — records active mode (similar/discover/popular) on recommendation rows for per-mode acceptance analysis (Phase D prerequisite) (#1096)
- Autoplay skip-rate circuit breaker — pauses replenishment at >60% 24h skip-rate (min sample 5), one-time notice, auto-resume on manual `/play` (#1097)
### Changed
- Honest `packages/shared` coverage gate — full-source measurement, real floor 89/89/90/89 (#1076)

## PRs shipped
- #1096 feat(autoplay): record selected mode on recommendation telemetry
- #1076 test(shared): raise coverage threshold to match actual floor
- #1097 feat(autoplay): guild skip-rate circuit breaker

Merge method: **merge commit** (preserve individual PR SHAs in main history).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added autoplay skip-rate monitoring to pause autoplay when recommendation skip rates exceed threshold, improving recommendation quality.
  * Enhanced autoplay telemetry to track recommendation modes (similar, discover, popular).

* **Improvements**
  * Added documentation coverage enforcement for shared package exports.
  * Expanded test coverage and documentation across services.

* **Chores**
  * Version bumped to 2.16.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->