### PR TITLE
fix(play): isolate post-play background ops (#1085)

### DIFF
--- a/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
@@ -1,5 +1,5 @@
 import type { GuildMember, ChatInputCommandInteraction } from 'discord.js'
-import { QueueRepeatMode, QueryType } from 'discord-player'
+import { QueryType } from 'discord-player'
 import type { CommandExecuteParams } from '../../../../../types/CommandData'
 import type { CustomClient } from '../../../../../types'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
@@ -9,10 +9,7 @@ import { createErrorEmbed } from '../../../../../utils/general/embeds'
 import { interactionReply } from '../../../../../utils/general/interactionReply'
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
 import { collaborativePlaylistService } from '../../../../../utils/music/collaborativePlaylist'
-import {
-    moveUserTrackToPriority,
-    blendAutoplayTracks,
-} from '../../../../../utils/music/queueManipulation'
+import { moveUserTrackToPriority } from '../../../../../utils/music/queueManipulation'
 import { buildPlayResponseEmbed } from '../../../../../utils/music/nowPlayingEmbed'
 import { registerNowPlayingMessage } from '../../../../../handlers/player/trackNowPlaying'
 import { resolveGuildQueue } from '../../../../../utils/music/queueResolver'
@@ -21,8 +18,7 @@ import {
     resolveSearchEngine,
     normalizeSoundCloudUrl,
 } from '../queryUtils'
-import { applyStoredAutoplayPreference } from './autoplayPreference'
-import { clearAutoplayPause } from '../../../../../utils/music/autoplay/skipCircuitBreaker'
+import { runPostPlayBackgroundOps } from './postPlayBackgroundOps'
 
 export async function executePlayHandler({
     client,
@@ -209,32 +205,15 @@ export async function executePlayHandler({
             content: { embeds: [embed] },
         })
 
-        const bgOps = (async () => {
-            try {
-                // Clear any autoplay pause state when a manual play succeeds
-                clearAutoplayPause(interaction.guildId!)
-                if (!hadQueueBeforePlay && queue) {
-                    await applyStoredAutoplayPreference(
-                        queue,
-                        interaction.guildId!,
-                    )
-                }
-                if (
-                    !isPlaylist &&
-                    queue &&
-                    queue.repeatMode === QueueRepeatMode.AUTOPLAY
-                ) {
-                    await blendAutoplayTracks(queue, track)
-                }
-            } catch (bgError) {
-                errorLog({
-                    message: 'Post-play background ops failed',
-                    error: bgError,
-                    data: { guildId: interaction.guildId },
-                })
-            }
-        })()
-        void bgOps
+        // Fire-and-forget: each op is isolated inside runPostPlayBackgroundOps so a
+        // single failure never silently skips the others (#1085).
+        void runPostPlayBackgroundOps({
+            queue,
+            guildId: interaction.guildId!,
+            track,
+            hadQueueBeforePlay,
+            isPlaylist,
+        })
     } catch (error) {
         if (isUnknownInteractionError(error)) {
             debugLog({

--- a/packages/bot/src/functions/music/commands/play/handlers/postPlayBackgroundOps.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/postPlayBackgroundOps.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
+import { QueueRepeatMode } from 'discord-player'
+import type { GuildQueue, Track } from 'discord-player'
+
+const clearAutoplayPause = jest.fn<(guildId: string) => void>()
+const applyStoredAutoplayPreference =
+    jest.fn<(queue: unknown, guildId: string) => Promise<void>>()
+const blendAutoplayTracks =
+    jest.fn<(queue: unknown, track: unknown) => Promise<void>>()
+const addBreadcrumb = jest.fn()
+const errorLog = jest.fn()
+
+jest.mock('../../../../../utils/music/autoplay/skipCircuitBreaker', () => ({
+    clearAutoplayPause: (id: string) => clearAutoplayPause(id),
+}))
+jest.mock('./autoplayPreference', () => ({
+    applyStoredAutoplayPreference: (q: unknown, id: string) =>
+        applyStoredAutoplayPreference(q, id),
+}))
+jest.mock('../../../../../utils/music/queueManipulation', () => ({
+    blendAutoplayTracks: (q: unknown, t: unknown) => blendAutoplayTracks(q, t),
+}))
+jest.mock('@lucky/shared/utils/monitoring', () => ({
+    addBreadcrumb: (...args: unknown[]) => addBreadcrumb(...args),
+}))
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: (...args: unknown[]) => errorLog(...args),
+}))
+
+import { runPostPlayBackgroundOps } from './postPlayBackgroundOps'
+
+const guildId = 'guild-1'
+const track = { title: 't' } as unknown as Track
+const autoplayQueue = {
+    repeatMode: QueueRepeatMode.AUTOPLAY,
+} as unknown as GuildQueue
+
+function failedOps(): string[] {
+    return addBreadcrumb.mock.calls
+        .filter((c) => c[0] === 'post_play_bg_op_failed')
+        .map((c) => (c[3] as { op: string }).op)
+}
+
+describe('runPostPlayBackgroundOps', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        applyStoredAutoplayPreference.mockResolvedValue(undefined)
+        blendAutoplayTracks.mockResolvedValue(undefined)
+    })
+
+    it('runs all three ops on the happy path with no failure breadcrumb', async () => {
+        await runPostPlayBackgroundOps({
+            queue: autoplayQueue,
+            guildId,
+            track,
+            hadQueueBeforePlay: false,
+            isPlaylist: false,
+        })
+
+        expect(clearAutoplayPause).toHaveBeenCalledWith(guildId)
+        expect(applyStoredAutoplayPreference).toHaveBeenCalledTimes(1)
+        expect(blendAutoplayTracks).toHaveBeenCalledTimes(1)
+        expect(failedOps()).toEqual([])
+    })
+
+    it('isolates a clearAutoplayPause failure — the other ops still run', async () => {
+        clearAutoplayPause.mockImplementation(() => {
+            throw new Error('boom')
+        })
+
+        await runPostPlayBackgroundOps({
+            queue: autoplayQueue,
+            guildId,
+            track,
+            hadQueueBeforePlay: false,
+            isPlaylist: false,
+        })
+
+        // cascade is broken: preference + blend still execute
+        expect(applyStoredAutoplayPreference).toHaveBeenCalledTimes(1)
+        expect(blendAutoplayTracks).toHaveBeenCalledTimes(1)
+        expect(failedOps()).toEqual(['clearAutoplayPause'])
+    })
+
+    it('retries a transient applyStoredAutoplayPreference failure then succeeds', async () => {
+        applyStoredAutoplayPreference
+            .mockRejectedValueOnce(new Error('transient'))
+            .mockResolvedValueOnce(undefined)
+
+        await runPostPlayBackgroundOps({
+            queue: autoplayQueue,
+            guildId,
+            track,
+            hadQueueBeforePlay: false,
+            isPlaylist: false,
+        })
+
+        expect(applyStoredAutoplayPreference).toHaveBeenCalledTimes(2)
+        expect(blendAutoplayTracks).toHaveBeenCalledTimes(1)
+        expect(failedOps()).toEqual([])
+    })
+
+    it('records a breadcrumb when the preference op fails both attempts, and still blends', async () => {
+        applyStoredAutoplayPreference.mockRejectedValue(new Error('down'))
+
+        await runPostPlayBackgroundOps({
+            queue: autoplayQueue,
+            guildId,
+            track,
+            hadQueueBeforePlay: false,
+            isPlaylist: false,
+        })
+
+        expect(applyStoredAutoplayPreference).toHaveBeenCalledTimes(2)
+        expect(failedOps()).toEqual(['applyStoredAutoplayPreference'])
+        expect(blendAutoplayTracks).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips preference when a queue already existed, and skips blend off-autoplay', async () => {
+        await runPostPlayBackgroundOps({
+            queue: { repeatMode: QueueRepeatMode.OFF } as unknown as GuildQueue,
+            guildId,
+            track,
+            hadQueueBeforePlay: true,
+            isPlaylist: false,
+        })
+
+        expect(clearAutoplayPause).toHaveBeenCalledTimes(1)
+        expect(applyStoredAutoplayPreference).not.toHaveBeenCalled()
+        expect(blendAutoplayTracks).not.toHaveBeenCalled()
+    })
+
+    it('skips blend for a playlist', async () => {
+        await runPostPlayBackgroundOps({
+            queue: autoplayQueue,
+            guildId,
+            track,
+            hadQueueBeforePlay: false,
+            isPlaylist: true,
+        })
+
+        expect(blendAutoplayTracks).not.toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/functions/music/commands/play/handlers/postPlayBackgroundOps.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/postPlayBackgroundOps.ts
@@ -1,0 +1,91 @@
+import type { GuildQueue, Track } from 'discord-player'
+import { QueueRepeatMode } from 'discord-player'
+import { errorLog } from '@lucky/shared/utils'
+import { addBreadcrumb } from '@lucky/shared/utils/monitoring'
+import { blendAutoplayTracks } from '../../../../../utils/music/queueManipulation'
+import { applyStoredAutoplayPreference } from './autoplayPreference'
+import { clearAutoplayPause } from '../../../../../utils/music/autoplay/skipCircuitBreaker'
+
+export interface PostPlayBackgroundOpsInput {
+    queue: GuildQueue | null | undefined
+    guildId: string
+    track: Track
+    hadQueueBeforePlay: boolean
+    isPlaylist: boolean
+}
+
+const AUTOPLAY_PREFERENCE_RETRY_DELAY_MS = 150
+
+/**
+ * Runs one post-play background op in isolation. A failure is recorded (telemetry
+ * breadcrumb + error log) but NEVER cascades to the other ops — fixing #1085, where
+ * a single shared try/catch meant a `clearAutoplayPause` or preference-load failure
+ * silently skipped the remaining work.
+ */
+async function runIsolated(
+    op: string,
+    guildId: string,
+    fn: () => void | Promise<void>,
+): Promise<void> {
+    try {
+        await fn()
+    } catch (error) {
+        try {
+            addBreadcrumb('post_play_bg_op_failed', 'play', 'warning', {
+                op,
+                guildId,
+            })
+        } catch {
+            // Observability must never break the handler.
+        }
+        errorLog({
+            message: `Post-play background op failed: ${op}`,
+            error,
+            data: { guildId, op },
+        })
+    }
+}
+
+/**
+ * Retries a transient op once (2 attempts total) with a short backoff. Used for the
+ * stored-autoplay-preference read, which can fail transiently on a slow DB. The final
+ * failure (if any) is surfaced to the caller's `runIsolated`.
+ */
+async function withSingleRetry(fn: () => Promise<void>): Promise<void> {
+    try {
+        await fn()
+    } catch {
+        await new Promise((resolve) =>
+            setTimeout(resolve, AUTOPLAY_PREFERENCE_RETRY_DELAY_MS),
+        )
+        await fn()
+    }
+}
+
+/**
+ * Post-play background work, dispatched fire-and-forget by the play handler. Each op
+ * is isolated so one failure never silently skips the others.
+ */
+export async function runPostPlayBackgroundOps(
+    input: PostPlayBackgroundOpsInput,
+): Promise<void> {
+    const { queue, guildId, track, hadQueueBeforePlay, isPlaylist } = input
+
+    await runIsolated('clearAutoplayPause', guildId, () =>
+        clearAutoplayPause(guildId),
+    )
+
+    if (!hadQueueBeforePlay && queue) {
+        await runIsolated('applyStoredAutoplayPreference', guildId, () =>
+            withSingleRetry(() =>
+                applyStoredAutoplayPreference(queue, guildId),
+            ),
+        )
+    }
+
+    if (!isPlaylist && queue && queue.repeatMode === QueueRepeatMode.AUTOPLAY) {
+        await runIsolated('blendAutoplayTracks', guildId, () =>
+            blendAutoplayTracks(queue, track),
+        )
+    }
+}

--- a/packages/bot/src/functions/music/commands/play/index.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/index.spec.ts
@@ -669,10 +669,11 @@ describe('play command', () => {
             expect.anything(),
             track,
         )
-        // Blending error is now logged as "Post-play background ops failed" in background task
+        // Each post-play bg op is isolated; a blend failure is logged per-op
+        // (see runPostPlayBackgroundOps) rather than as one shared catch.
         expect(errorLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: 'Post-play background ops failed',
+                message: 'Post-play background op failed: blendAutoplayTracks',
             }),
         )
         expect(interactionReplyMock).toHaveBeenCalledWith(


### PR DESCRIPTION
Closes #1085.

## Bug
The post-play background block ran `clearAutoplayPause` → `applyStoredAutoplayPreference` → `blendAutoplayTracks` under **one shared try/catch**, so any single failure aborted the rest and only logged — e.g. a transient preference-load error silently skipped, and a clearAutoplayPause throw skipped both following ops.

## Fix (approach C+A+B, per /research-and-decide)
- Extract to **`runPostPlayBackgroundOps`** — each op isolated in its own try/catch (no cascade).
- **Observability:** `addBreadcrumb('post_play_bg_op_failed', …)` per failed op (reuses #1084's monitoring).
- **Bounded retry** (2 attempts) on `applyStoredAutoplayPreference` (the transient DB read).
- Rejected moving to sync — backgrounding is intentional for play-response latency.

## Tests
New `postPlayBackgroundOps.spec.ts` (6: cascade-isolation, retry, retry-exhaustion+breadcrumb, condition guards). Full bot suite 2463 pass; typecheck clean. Removed the 4 now-unused imports from playHandler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error resilience in post-play background operations to prevent one failure from blocking others.

* **Tests**
  * Added comprehensive test coverage for post-play background operation scenarios and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LucasSantana-Dev/Lucky/pull/1101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->