### PR TITLE
fix(shared): export ./utils/monitoring subpath — fixes lucky-bot crash-loop

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,6 +30,10 @@
             "types": "./dist/utils/index.d.ts",
             "default": "./dist/utils/index.js"
         },
+        "./utils/monitoring": {
+            "types": "./dist/utils/monitoring/index.d.ts",
+            "default": "./dist/utils/monitoring/index.js"
+        },
         "./utils/*": {
             "types": "./dist/utils/*.d.ts",
             "default": "./dist/utils/*.js"


### PR DESCRIPTION
## Incident
`lucky-bot` (`ghcr.io/lucassantana-dev/lucky-bot:latest`, built from `main@7d7e4f54`) is **crash-looping — 2500+ restarts**, the Discord bot is down. It dies at boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'/app/node_modules/@lucky/shared/dist/utils/monitoring.js'
imported from /app/packages/bot/dist/utils/music/queueResolver.js
```

## Root cause
`@lucky/shared`'s `exports` map has `"./utils/*": "./dist/utils/*.js"`. That wildcard resolves a subpath to a **file**: `@lucky/shared/utils/monitoring` → `dist/utils/monitoring.js`. But `utils/monitoring` is a **directory barrel** (`monitoring/index.js` re-exporting `sentry`/`heartbeat`), so the resolved file doesn't exist → ESM throws.

`monitoring` is the **only** util imported as a bare directory — `general` (×28), `error` (×7), `database` (×2) import *specific files* (`utils/general/log` → `general/log.js` ✓), so the wildcard resolves those fine. The `feat(observability)` work added the `monitoring/` barrel + the `queueResolver` import of `addBreadcrumb` from it.

## Fix
Add an explicit `"./utils/monitoring"` export → `monitoring/index.js`, exactly mirroring the existing `"./services/guildAutomation"` entry (same directory-barrel pattern). One 4-line addition.

**Verified:** `node` self-import of `@lucky/shared/utils/monitoring` against the built dist resolves `addBreadcrumb` as a `function`.

## Deploy
On merge, CI rebuilds + pushes `:latest`; the homelab then pulls + recreates `lucky-bot`, which should boot and connect to Discord again.