### PR TITLE
fix(frontend): healthcheck uses busybox wget, not bash /dev/tcp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,10 @@ COPY nginx/frontend.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 8080
 
+# nginx-unprivileged is alpine/busybox: its `sh` (ash) has no /dev/tcp (a bash
+# builtin), so the previous probe could never run -> false-positive "unhealthy".
+# busybox wget is present and reaches the unprivileged :8080 listener.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD sh -c 'exec 3<>/dev/tcp/127.0.0.1/8080 && echo -e "GET / HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" >&3 && head -1 <&3 | grep -q "200" || exit 1'
+    CMD wget -q --spider http://127.0.0.1:8080/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Problem
`lucky-frontend` reports a permanent **false-positive `unhealthy`** (the app serves fine). Its `Dockerfile` HEALTHCHECK (production-frontend stage, `nginx-unprivileged:1.31-alpine`) uses `sh -c 'exec 3<>/dev/tcp/127.0.0.1/8080 …'` — but `/dev/tcp` is a **bash builtin**, and alpine's `sh` is busybox `ash`, which has no `/dev/tcp`. So the probe could never run.

## Fix
Use busybox `wget` (present at `/usr/bin/wget`) against the unprivileged `:8080` listener: `wget -q --spider http://127.0.0.1:8080/`. **Validated live** in the running container (`WGET_SPIDER_OK`).

Part of the same healthcheck-probe-mismatch class as homelab PR #173 + ADR-0018 and the lucky-bot fix #1105.