### PR TITLE
ci(madge): --ignore-scripts to skip the yt-dlp postinstall flake

### DIFF
--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -31,7 +31,13 @@ jobs:
                   node-version: '22'
 
             - name: Install madge
-              run: npm install --no-save madge@^7
+              # --ignore-scripts: this static-analysis job needs only the source
+              # tree, not any postinstall binaries. Without it, the full install
+              # runs youtube-dl-exec's postinstall, which fetches the yt-dlp
+              # binary from GitHub releases unauthenticated and flakes on the
+              # ~60/hr anonymous rate limit (blocked #1105). Matches the
+              # --ignore-scripts convention already used throughout ci.yml.
+              run: npm install --no-save madge@^7 --ignore-scripts
 
             - name: Run madge --circular on packages/bot/src
               run: |


### PR DESCRIPTION
The `madge` job's `npm install --no-save madge@^7` triggers `youtube-dl-exec`'s postinstall (full install in a fresh checkout), which fetches the yt-dlp binary from GitHub releases **unauthenticated** → flakes on the ~60/hr anonymous rate limit. This **blocked the required `madge / packages/bot` check on #1105**.

Static analysis needs only the source tree, so `--ignore-scripts` skips all postinstalls — matching the convention **already used throughout `ci.yml`** (every `npm ci --ignore-scripts`). The runtime yt-dlp binary is unaffected (installed via pip in the Dockerfile; `ci.yml`, `bundle-size.yml`, `release.yml` already mitigate their own installs).