### PR TITLE
chore(bot): remove dead no-op handler export

### DIFF
--- a/packages/bot/src/handlers/clientHandler/index.ts
+++ b/packages/bot/src/handlers/clientHandler/index.ts
@@ -1,8 +1,10 @@
-import { createClient as createClientFunc, startClient as startClientFunc } from './service'
+import {
+    createClient as createClientFunc,
+    startClient as startClientFunc,
+} from './service'
 import type { CustomClient } from '../../types'
 import type {
     StartClientParams,
-    MapGuildIdsParams,
     CreateClientOptions,
     RegisterCommandsOptions,
 } from './types'
@@ -17,19 +19,12 @@ export const registerCommands = async (
     const { commands, token, clientId } = options
     const { REST, Routes } = await import('discord.js')
     const rest = new REST({ version: '10' }).setToken(token)
-    const commandsData = Array.from(commands).map((cmd: Command) => cmd.data.toJSON())
+    const commandsData = Array.from(commands).map((cmd: Command) =>
+        cmd.data.toJSON(),
+    )
     await rest.put(Routes.applicationCommands(clientId), {
         body: commandsData,
     })
 }
 
-export const mapGuildIds = async (_params: MapGuildIdsParams): Promise<void> => {
-    // Implementation can be added if needed
-}
-
-export type {
-    StartClientParams,
-    MapGuildIdsParams,
-    CreateClientOptions,
-    RegisterCommandsOptions,
-}
+export type { StartClientParams, CreateClientOptions, RegisterCommandsOptions }

--- a/packages/bot/src/handlers/clientHandler/types.ts
+++ b/packages/bot/src/handlers/clientHandler/types.ts
@@ -9,10 +9,6 @@ export type StartClientParams = {
     client: CustomClient
 }
 
-export type MapGuildIdsParams = {
-    client: CustomClient
-}
-
 export type CreateClientOptions = {
     intents: number[]
     presence: {


### PR DESCRIPTION
Removes the exported no-op `mapGuildIds` and its `MapGuildIdsParams` type from `clientHandler` — verified zero callers across the monorepo.

**Verified:** bot `tsc --noEmit` clean; 38 `clientHandler` tests pass (`service.spec` + `presence.spec`).

Part of the re-grounded dead-code cleanup (`.claude/plans/2026-05-31-dead-code-cleanup.md`). Note: the knip-reported "duplicate exports" are *not* acted on here — knip is not installed/wired in this repo, so its raw output isn't a trusted delete-list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed obsolete client initialization export and consolidated related type definitions to streamline the handler API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->