### PR TITLE
refactor(bot): store music session snapshots in postgres, not redis

### DIFF
--- a/packages/bot/src/utils/music/sessionSnapshots.spec.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.spec.ts
@@ -1,22 +1,12 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import type { GuildQueue } from 'discord-player'
+import { getPrismaClient } from '@lucky/shared/utils'
 import { MusicSessionSnapshotService } from './sessionSnapshots'
 
-const getMock = jest.fn()
-const setexMock = jest.fn()
-const delMock = jest.fn()
-
 jest.mock('@lucky/shared/utils', () => ({
+    getPrismaClient: jest.fn(),
     debugLog: jest.fn(),
     errorLog: jest.fn(),
-}))
-
-jest.mock('@lucky/shared/services', () => ({
-    redisClient: {
-        get: (...args: unknown[]) => getMock(...args),
-        setex: (...args: unknown[]) => setexMock(...args),
-        del: (...args: unknown[]) => delMock(...args),
-    },
 }))
 
 jest.mock('@lucky/shared/config', () => ({
@@ -29,597 +19,410 @@ jest.mock('discord-player', () => ({
     QueryType: { AUTO: 'auto' },
 }))
 
+const mockGetPrismaClient = jest.mocked(getPrismaClient)
+const mockFindUnique = jest.fn<any>()
+const mockDeleteMany = jest.fn<any>()
+const mockCreate = jest.fn<any>()
+
+/** Builds a `music_session_snapshots` row for mock returns. */
+function snapshotRow(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'row-1',
+        guildId: 'guild-1',
+        sessionSnapshotId: 'snap-1',
+        savedAt: new Date(),
+        currentTrack: null,
+        upcomingTracks: [
+            {
+                title: 'Recovered Song',
+                author: 'Recovered Artist',
+                url: 'https://example.com/recovered',
+                duration: '3:00',
+                source: 'youtube',
+            },
+        ],
+        voiceChannelId: null,
+        ...overrides,
+    }
+}
+
+function restoringQueue(guildId: string, searchResult?: unknown) {
+    const addTrack = jest.fn()
+    return {
+        guild: { id: guildId },
+        currentTrack: null,
+        tracks: { size: 0 },
+        addTrack,
+        clear: jest.fn(),
+        node: {
+            isPlaying: () => false,
+            play: jest.fn(async () => undefined),
+        },
+        player: {
+            search: jest.fn(
+                async () =>
+                    searchResult ?? {
+                        tracks: [
+                            {
+                                title: 'Recovered Song',
+                                author: 'Recovered Artist',
+                                url: 'https://example.com/recovered',
+                                metadata: null,
+                                setMetadata: jest.fn(function (
+                                    this: { metadata: unknown },
+                                    m: unknown,
+                                ) {
+                                    this.metadata = m
+                                }),
+                            },
+                        ],
+                    },
+            ),
+        },
+    } as unknown as GuildQueue
+}
+
 describe('MusicSessionSnapshotService', () => {
     beforeEach(() => {
         jest.clearAllMocks()
-    })
-
-    it('saves queue snapshot to redis', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const queue = {
-            guild: { id: 'guild-1' },
-            currentTrack: {
-                title: 'Now Song',
-                author: 'Now Artist',
-                url: 'https://example.com/now',
-                duration: '3:10',
-                source: 'youtube',
+        mockGetPrismaClient.mockReturnValue({
+            musicSessionSnapshot: {
+                findUnique: mockFindUnique,
+                deleteMany: mockDeleteMany,
+                create: mockCreate,
             },
-            tracks: {
-                toArray: () => [
-                    {
-                        title: 'Next Song',
-                        author: 'Next Artist',
-                        url: 'https://example.com/next',
-                        duration: '2:40',
-                        source: 'youtube',
-                    },
-                ],
-            },
-            metadata: { channel: { id: 'channel-1' } },
-        } as unknown as GuildQueue
-
-        await service.saveSnapshot(queue)
-
-        expect(setexMock).toHaveBeenCalledTimes(1)
-        expect(setexMock.mock.calls[0]?.[0]).toContain('music:session:guild-1')
+        } as any)
+        mockFindUnique.mockResolvedValue(null)
+        mockDeleteMany.mockResolvedValue({ count: 1 })
+        mockCreate.mockResolvedValue(snapshotRow())
     })
 
-    it('returns null when queue is empty and does not write to redis', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const queue = {
-            guild: { id: 'guild-empty' },
-            currentTrack: null,
-            tracks: { toArray: () => [] },
-        } as unknown as GuildQueue
-
-        const result = await service.saveSnapshot(queue)
-
-        expect(result).toBeNull()
-        expect(setexMock).not.toHaveBeenCalled()
-    })
-
-    it('restores tracks from snapshot by searching and adding to queue', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const snapshot = {
-            sessionSnapshotId: 'snap-1',
-            guildId: 'guild-2',
-            savedAt: Date.now(),
-            currentTrack: null,
-            upcomingTracks: [
-                {
-                    title: 'Recovered Song',
-                    author: 'Recovered Artist',
-                    url: 'https://example.com/recovered',
-                    duration: '3:00',
+    describe('saveSnapshot', () => {
+        it('overwrites the guild snapshot (delete + create) and returns it', async () => {
+            const service = new MusicSessionSnapshotService()
+            const queue = {
+                guild: { id: 'guild-1' },
+                currentTrack: {
+                    title: 'Now Song',
+                    author: 'Now Artist',
+                    url: 'https://example.com/now',
+                    duration: '3:10',
                     source: 'youtube',
                 },
-            ],
-        }
-        getMock.mockResolvedValue(JSON.stringify(snapshot))
-        delMock.mockResolvedValue(1)
-
-        const addTrack = jest.fn()
-        const queue = {
-            guild: { id: 'guild-2' },
-            currentTrack: null,
-            tracks: { size: 0 },
-            addTrack,
-            node: {
-                isPlaying: () => false,
-                play: jest.fn().mockResolvedValue(undefined),
-            },
-            player: {
-                search: jest.fn().mockResolvedValue({
-                    tracks: [
-                        {
-                            title: 'Recovered Song',
-                            author: 'Recovered Artist',
-                            url: 'https://example.com/recovered',
-                            metadata: null,
-                            setMetadata: jest.fn(function (
-                                this: { metadata: unknown },
-                                m: unknown,
-                            ) {
-                                this.metadata = m
-                            }),
-                        },
-                    ],
-                }),
-            },
-        } as unknown as GuildQueue
-
-        const result = await service.restoreSnapshot(queue)
-
-        expect(result.restoredCount).toBe(1)
-        expect(addTrack).toHaveBeenCalledTimes(1)
-        // Snapshot must be cleared after restore (Gap 3 fix)
-        expect(delMock).toHaveBeenCalledWith('music:session:guild-2')
-    })
-
-    it('also restores currentTrack prepended to the queue (Gap 4 fix)', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const snapshot = {
-            sessionSnapshotId: 'snap-ct',
-            guildId: 'guild-ct',
-            savedAt: Date.now(),
-            currentTrack: {
-                title: 'Was Playing',
-                author: 'Artist A',
-                url: 'https://example.com/current',
-                duration: '3:00',
-                source: 'youtube',
-            },
-            upcomingTracks: [
-                {
-                    title: 'Next Up',
-                    author: 'Artist B',
-                    url: 'https://example.com/next',
-                    duration: '2:30',
-                    source: 'youtube',
-                },
-            ],
-        }
-        getMock.mockResolvedValue(JSON.stringify(snapshot))
-        delMock.mockResolvedValue(1)
-
-        const addTrack = jest.fn()
-        const queue = {
-            guild: { id: 'guild-ct' },
-            currentTrack: null,
-            tracks: { size: 0 },
-            addTrack,
-            node: {
-                isPlaying: () => false,
-                play: jest.fn().mockResolvedValue(undefined),
-            },
-            player: {
-                search: jest.fn().mockImplementation(async (query: unknown) => {
-                    const t: {
-                        title: string
-                        author: string
-                        url: unknown
-                        metadata: unknown
-                        setMetadata: (m: unknown) => void
-                    } = {
-                        title: String(query).split(' ')[0],
-                        author: 'resolved',
-                        url: query,
-                        metadata: null,
-                        setMetadata(m) {
-                            this.metadata = m
-                        },
-                    }
-                    return { tracks: [t] }
-                }),
-            },
-        } as unknown as GuildQueue
-
-        const result = await service.restoreSnapshot(queue)
-
-        // currentTrack + 1 upcoming = 2 tracks
-        expect(result.restoredCount).toBe(2)
-        expect(addTrack).toHaveBeenCalledTimes(2)
-    })
-
-    it('rejects snapshot older than maxAgeMs (Gap 2 staleness guard)', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const staleSnapshot = {
-            sessionSnapshotId: 'snap-stale',
-            guildId: 'guild-stale',
-            savedAt: Date.now() - 60 * 60 * 1_000, // 1 hour ago
-            currentTrack: null,
-            upcomingTracks: [
-                {
-                    title: 'Old Song',
-                    author: 'Old Artist',
-                    url: 'https://example.com/old',
-                    duration: '3:00',
-                    source: 'youtube',
-                },
-            ],
-        }
-        getMock.mockResolvedValue(JSON.stringify(staleSnapshot))
-
-        const addTrack = jest.fn()
-        const queue = {
-            guild: { id: 'guild-stale' },
-            currentTrack: null,
-            tracks: { size: 0 },
-            addTrack,
-            node: { isPlaying: () => false, play: jest.fn() },
-            player: { search: jest.fn() },
-        } as unknown as GuildQueue
-
-        // Use 30-min maxAge (default)
-        const result = await service.restoreSnapshot(queue, undefined, {
-            maxAgeMs: 30 * 60 * 1_000,
-        })
-
-        expect(result.restoredCount).toBe(0)
-        expect(result.sessionSnapshotId).toBeNull()
-        expect(addTrack).not.toHaveBeenCalled()
-        // Should NOT delete the stale snapshot (so TTL can still expire it naturally)
-        expect(delMock).not.toHaveBeenCalled()
-    })
-
-    it('accepts snapshot within maxAgeMs window', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const freshSnapshot = {
-            sessionSnapshotId: 'snap-fresh',
-            guildId: 'guild-fresh',
-            savedAt: Date.now() - 5 * 60 * 1_000, // 5 min ago
-            currentTrack: null,
-            upcomingTracks: [
-                {
-                    title: 'Fresh Song',
-                    author: 'Fresh Artist',
-                    url: 'https://example.com/fresh',
-                    duration: '3:00',
-                    source: 'youtube',
-                },
-            ],
-        }
-        getMock.mockResolvedValue(JSON.stringify(freshSnapshot))
-        delMock.mockResolvedValue(1)
-
-        const addTrack = jest.fn()
-        const queue = {
-            guild: { id: 'guild-fresh' },
-            currentTrack: null,
-            tracks: { size: 0 },
-            addTrack,
-            node: {
-                isPlaying: () => false,
-                play: jest.fn().mockResolvedValue(undefined),
-            },
-            player: {
-                search: jest.fn().mockResolvedValue({
-                    tracks: [
-                        {
-                            title: 'Fresh Song',
-                            author: 'Fresh Artist',
-                            url: 'https://example.com/fresh',
-                            metadata: null,
-                            setMetadata: jest.fn(function (
-                                this: { metadata: unknown },
-                                m: unknown,
-                            ) {
-                                this.metadata = m
-                            }),
-                        },
-                    ],
-                }),
-            },
-        } as unknown as GuildQueue
-
-        const result = await service.restoreSnapshot(queue, undefined, {
-            maxAgeMs: 30 * 60 * 1_000,
-        })
-
-        expect(result.restoredCount).toBe(1)
-        expect(delMock).toHaveBeenCalledWith('music:session:guild-fresh')
-    })
-
-    it('preserves autoplay metadata when restoring snapshot tracks', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const snapshot = {
-            sessionSnapshotId: 'snap-autoplay',
-            guildId: 'guild-autoplay',
-            savedAt: Date.now(),
-            currentTrack: null,
-            upcomingTracks: [
-                {
-                    title: 'Recommended Song',
-                    author: 'Recommended Artist',
-                    url: 'https://example.com/recommended',
-                    duration: '3:00',
-                    source: 'youtube',
-                    recommendationReason: 'Because you listened to Test Song',
-                    isAutoplay: true,
-                    requestedById: 'user-1',
-                },
-            ],
-        }
-        getMock.mockResolvedValue(JSON.stringify(snapshot))
-        delMock.mockResolvedValue(1)
-
-        const addTrack = jest.fn()
-        const restoredTrack: {
-            title: string
-            author: string
-            url: string
-            metadata: unknown
-            setMetadata: (m: unknown) => void
-        } = {
-            title: 'Recommended Song',
-            author: 'Recommended Artist',
-            url: 'https://example.com/recommended',
-            metadata: null,
-            setMetadata(m) {
-                this.metadata = m
-            },
-        }
-
-        const queue = {
-            guild: { id: 'guild-autoplay' },
-            currentTrack: null,
-            tracks: { size: 0 },
-            addTrack,
-            node: {
-                isPlaying: () => false,
-                play: jest.fn().mockResolvedValue(undefined),
-            },
-            player: {
-                search: jest.fn().mockResolvedValue({
-                    tracks: [restoredTrack],
-                }),
-            },
-        } as unknown as GuildQueue
-
-        await service.restoreSnapshot(queue)
-
-        expect(addTrack).toHaveBeenCalledWith(
-            expect.objectContaining({
-                metadata: expect.objectContaining({
-                    isAutoplay: true,
-                    requestedById: 'user-1',
-                    recommendationReason: 'Because you listened to Test Song',
-                }),
-            }),
-        )
-    })
-
-    it('returns early when queue already has tracks', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const queue = {
-            guild: { id: 'guild-busy' },
-            currentTrack: { title: 'Playing Now' },
-            tracks: { size: 2 },
-        } as unknown as GuildQueue
-
-        const result = await service.restoreSnapshot(queue)
-
-        expect(result.restoredCount).toBe(0)
-        expect(getMock).not.toHaveBeenCalled()
-    })
-
-    it('does not delete snapshot when no tracks are restored', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const snapshot = {
-            sessionSnapshotId: 'snap-noresult',
-            guildId: 'guild-noresult',
-            savedAt: Date.now(),
-            currentTrack: null,
-            upcomingTracks: [
-                {
-                    title: 'Ghost Track',
-                    author: 'Ghost',
-                    url: 'https://example.com/ghost',
-                    duration: '3:00',
-                    source: 'youtube',
-                },
-            ],
-        }
-        getMock.mockResolvedValue(JSON.stringify(snapshot))
-
-        const addTrack = jest.fn()
-        const queue = {
-            guild: { id: 'guild-noresult' },
-            currentTrack: null,
-            tracks: { size: 0 },
-            addTrack,
-            node: { isPlaying: () => false, play: jest.fn() },
-            player: {
-                search: jest.fn().mockResolvedValue({ tracks: [] }), // no results
-            },
-        } as unknown as GuildQueue
-
-        const result = await service.restoreSnapshot(queue)
-
-        expect(result.restoredCount).toBe(0)
-        expect(delMock).not.toHaveBeenCalled()
-    })
-})
-
-    it('skips current track when skipCurrentTrack option is true', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const snapshot = {
-            sessionSnapshotId: 'snap-skip-current',
-            guildId: 'guild-skip',
-            savedAt: Date.now(),
-            currentTrack: {
-                title: 'Same Song',
-                author: 'Artist',
-                url: 'https://example.com/same',
-                duration: '3:00',
-                source: 'youtube',
-            },
-            upcomingTracks: [
-                {
-                    title: 'Next Song',
-                    author: 'Next Artist',
-                    url: 'https://example.com/next',
-                    duration: '3:00',
-                    source: 'youtube',
-                },
-            ],
-        }
-        getMock.mockResolvedValue(JSON.stringify(snapshot))
-        delMock.mockResolvedValue(1)
-
-        const addTrack = jest.fn()
-        const queue = {
-            guild: { id: 'guild-skip' },
-            currentTrack: null,
-            tracks: { size: 0 },
-            addTrack,
-            node: {
-                isPlaying: () => false,
-                play: jest.fn().mockResolvedValue(undefined),
-            },
-            player: {
-                search: jest.fn().mockResolvedValue({
-                    tracks: [
+                tracks: {
+                    toArray: () => [
                         {
                             title: 'Next Song',
                             author: 'Next Artist',
                             url: 'https://example.com/next',
-                            metadata: null,
-                            setMetadata: jest.fn(),
+                            duration: '2:40',
+                            source: 'youtube',
                         },
                     ],
+                },
+                channel: { id: 'channel-1' },
+            } as unknown as GuildQueue
+
+            const result = await service.saveSnapshot(queue)
+
+            expect(result).not.toBeNull()
+            expect(mockDeleteMany).toHaveBeenCalledWith({
+                where: { guildId: 'guild-1' },
+            })
+            expect(mockCreate).toHaveBeenCalledWith({
+                data: expect.objectContaining({
+                    guildId: 'guild-1',
+                    voiceChannelId: 'channel-1',
+                    sessionSnapshotId: expect.any(String),
+                    upcomingTracks: expect.any(Array),
                 }),
-            },
-        } as unknown as GuildQueue
+            })
+        })
 
-        await service.restoreSnapshot(queue, undefined, { skipCurrentTrack: true })
+        it('returns null when queue is empty and does not write', async () => {
+            const service = new MusicSessionSnapshotService()
+            const queue = {
+                guild: { id: 'guild-empty' },
+                currentTrack: null,
+                tracks: { toArray: () => [] },
+            } as unknown as GuildQueue
 
-        expect(addTrack).toHaveBeenCalledTimes(1)
-        expect(addTrack.mock.calls[0]?.[0]).toMatchObject({
-            title: 'Next Song',
+            const result = await service.saveSnapshot(queue)
+
+            expect(result).toBeNull()
+            expect(mockCreate).not.toHaveBeenCalled()
+        })
+
+        it('returns null on create error', async () => {
+            mockCreate.mockRejectedValueOnce(new Error('db down'))
+            const service = new MusicSessionSnapshotService()
+            const queue = {
+                guild: { id: 'guild-err' },
+                currentTrack: {
+                    title: 't',
+                    author: 'a',
+                    url: 'u',
+                    duration: '1',
+                    source: 'youtube',
+                },
+                tracks: { toArray: () => [] },
+            } as unknown as GuildQueue
+
+            expect(await service.saveSnapshot(queue)).toBeNull()
         })
     })
 
-    it('returns null on save error and logs', async () => {
-        setexMock.mockRejectedValue(new Error('redis down'))
-        const service = new MusicSessionSnapshotService(300)
-        const queue = {
-            guild: { id: 'guild-err' },
-            currentTrack: {
-                title: 't',
-                author: 'a',
-                url: 'u',
-                duration: '1',
-                source: 'youtube',
-            },
-            tracks: { toArray: () => [] },
-        } as unknown as GuildQueue
-
-        const result = await service.saveSnapshot(queue)
-        expect(result).toBeNull()
-    })
-
-    it('returns null on getSnapshot redis read error', async () => {
-        getMock.mockRejectedValue(new Error('redis down'))
-        const service = new MusicSessionSnapshotService(300)
-        const result = await service.getSnapshot('g')
-        expect(result).toBeNull()
-    })
-
-    it('returns null on getSnapshot when key missing', async () => {
-        getMock.mockResolvedValue(null)
-        const service = new MusicSessionSnapshotService(300)
-        const result = await service.getSnapshot('g')
-        expect(result).toBeNull()
-    })
-
-    it('swallows deleteSnapshot redis errors', async () => {
-        delMock.mockRejectedValue(new Error('redis down'))
-        const service = new MusicSessionSnapshotService(300)
-        await expect(service.deleteSnapshot('g')).resolves.toBeUndefined()
-    })
-
-    it('clearSnapshotIfStale is no-op when queue has upcoming tracks', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const queue = {
-            guild: { id: 'g' },
-            currentTrack: { title: 't' },
-            tracks: { size: 3 },
-        } as unknown as GuildQueue
-        await service.clearSnapshotIfStale(queue)
-        expect(getMock).not.toHaveBeenCalled()
-    })
-
-    it('clearSnapshotIfStale is no-op when no current track', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const queue = {
-            guild: { id: 'g' },
-            currentTrack: null,
-            tracks: { size: 0 },
-        } as unknown as GuildQueue
-        await service.clearSnapshotIfStale(queue)
-        expect(getMock).not.toHaveBeenCalled()
-    })
-
-    it('clearSnapshotIfStale skips when snapshot has upcoming tracks', async () => {
-        getMock.mockResolvedValue(
-            JSON.stringify({
-                sessionSnapshotId: 's',
-                guildId: 'g',
-                savedAt: Date.now(),
+    describe('getSnapshot', () => {
+        it('maps a fresh row to a snapshot', async () => {
+            mockFindUnique.mockResolvedValueOnce(snapshotRow())
+            const service = new MusicSessionSnapshotService()
+            const snap = await service.getSnapshot('guild-1')
+            expect(snap).toMatchObject({
+                sessionSnapshotId: 'snap-1',
+                guildId: 'guild-1',
                 currentTrack: null,
-                upcomingTracks: [{ title: 'x', author: 'y', url: 'z', duration: '1', source: 's' }],
-            }),
-        )
-        const service = new MusicSessionSnapshotService(300)
-        const queue = {
-            guild: { id: 'g' },
-            currentTrack: { title: 't' },
-            tracks: { size: 0 },
-        } as unknown as GuildQueue
-        await service.clearSnapshotIfStale(queue)
-        expect(delMock).not.toHaveBeenCalled()
+            })
+            expect(snap?.upcomingTracks).toHaveLength(1)
+        })
+
+        it('returns null and prunes a row older than the storage TTL', async () => {
+            mockFindUnique.mockResolvedValueOnce(
+                snapshotRow({ savedAt: new Date(Date.now() - 60 * 60 * 1000) }),
+            )
+            const service = new MusicSessionSnapshotService(1) // 1s TTL
+            const snap = await service.getSnapshot('guild-1')
+            expect(snap).toBeNull()
+            expect(mockDeleteMany).toHaveBeenCalledWith({
+                where: { guildId: 'guild-1' },
+            })
+        })
+
+        it('returns null on read error', async () => {
+            mockFindUnique.mockRejectedValueOnce(new Error('db down'))
+            const service = new MusicSessionSnapshotService()
+            expect(await service.getSnapshot('g')).toBeNull()
+        })
+
+        it('returns null when no row exists', async () => {
+            mockFindUnique.mockResolvedValueOnce(null)
+            const service = new MusicSessionSnapshotService()
+            expect(await service.getSnapshot('g')).toBeNull()
+        })
     })
 
-    it('restoreSnapshot returns 0 when queue already has tracks', async () => {
-        const service = new MusicSessionSnapshotService(300)
-        const queue = {
-            guild: { id: 'g' },
-            currentTrack: { title: 't' },
-            tracks: { size: 5 },
-        } as unknown as GuildQueue
-        const result = await service.restoreSnapshot(queue)
-        expect(result.restoredCount).toBe(0)
-        expect(result.sessionSnapshotId).toBeNull()
-    })
+    describe('restoreSnapshot', () => {
+        it('restores upcoming tracks and clears the snapshot afterward', async () => {
+            mockFindUnique.mockResolvedValueOnce(snapshotRow())
+            const service = new MusicSessionSnapshotService()
+            const queue = restoringQueue('guild-2')
 
-    it('clears queue and returns restoredCount 0 when player.search throws mid-restore', async () => {
-        getMock.mockResolvedValue(
-            JSON.stringify({
-                sessionSnapshotId: 'snap-123',
-                guildId: 'g',
-                savedAt: Date.now(),
-                currentTrack: {
-                    title: 'Current Song',
-                    author: 'Artist 1',
-                    url: 'https://youtube.com/watch?v=abc',
-                    duration: '3:45',
-                    source: 'youtube',
-                },
-                upcomingTracks: [
-                    {
-                        title: 'Next Song',
-                        author: 'Artist 2',
-                        url: 'https://youtube.com/watch?v=def',
-                        duration: '4:20',
+            const result = await service.restoreSnapshot(queue)
+
+            expect(result.restoredCount).toBe(1)
+            expect(queue.addTrack).toHaveBeenCalledTimes(1)
+            expect(mockDeleteMany).toHaveBeenCalledWith({
+                where: { guildId: 'guild-2' },
+            })
+        })
+
+        it('prepends the current track to the restore list', async () => {
+            mockFindUnique.mockResolvedValueOnce(
+                snapshotRow({
+                    currentTrack: {
+                        title: 'Was Playing',
+                        author: 'Artist A',
+                        url: 'https://example.com/current',
+                        duration: '3:00',
                         source: 'youtube',
                     },
+                }),
+            )
+            const service = new MusicSessionSnapshotService()
+            const queue = restoringQueue('guild-ct', {
+                tracks: [
+                    {
+                        title: 'resolved',
+                        author: 'resolved',
+                        url: 'x',
+                        metadata: null,
+                        setMetadata: jest.fn(),
+                    },
                 ],
-            }),
-        )
+            })
 
-        const service = new MusicSessionSnapshotService(300)
-        const clearMock = jest.fn()
-        const searchMock = jest.fn()
-            .mockResolvedValueOnce({ tracks: [{ title: 'Current Song' }] })
-            .mockRejectedValueOnce(new Error('Search service unavailable'))
+            const result = await service.restoreSnapshot(queue)
+            expect(result.restoredCount).toBe(2)
+            expect(queue.addTrack).toHaveBeenCalledTimes(2)
+        })
 
-        const queue = {
-            guild: { id: 'g' },
-            currentTrack: null,
-            tracks: { size: 0 },
-            player: { search: searchMock },
-            clear: clearMock,
-            addTrack: jest.fn(),
-        } as unknown as GuildQueue
+        it('rejects a snapshot older than maxAgeMs WITHOUT deleting it', async () => {
+            mockFindUnique.mockResolvedValueOnce(
+                snapshotRow({ savedAt: new Date(Date.now() - 60 * 60 * 1000) }),
+            )
+            const service = new MusicSessionSnapshotService(7200) // within storage TTL
+            const queue = restoringQueue('guild-stale')
 
-        const result = await service.restoreSnapshot(queue)
+            const result = await service.restoreSnapshot(queue, undefined, {
+                maxAgeMs: 30 * 60 * 1000,
+            })
 
-        // Should have called clear to rollback the partial queue
-        expect(clearMock).toHaveBeenCalledTimes(1)
-        // Should return 0 restored and null sessionSnapshotId on error
-        expect(result.restoredCount).toBe(0)
-        expect(result.sessionSnapshotId).toBeNull()
+            expect(result.restoredCount).toBe(0)
+            expect(result.sessionSnapshotId).toBeNull()
+            expect(queue.addTrack).not.toHaveBeenCalled()
+            expect(mockDeleteMany).not.toHaveBeenCalled()
+        })
+
+        it('preserves autoplay metadata on restored tracks', async () => {
+            mockFindUnique.mockResolvedValueOnce(
+                snapshotRow({
+                    upcomingTracks: [
+                        {
+                            title: 'Recommended Song',
+                            author: 'Recommended Artist',
+                            url: 'https://example.com/recommended',
+                            duration: '3:00',
+                            source: 'youtube',
+                            recommendationReason: 'Because you listened',
+                            isAutoplay: true,
+                            requestedById: 'user-1',
+                        },
+                    ],
+                }),
+            )
+            const restoredTrack = {
+                title: 'Recommended Song',
+                author: 'Recommended Artist',
+                url: 'https://example.com/recommended',
+                metadata: null as unknown,
+                setMetadata(m: unknown) {
+                    this.metadata = m
+                },
+            }
+            const service = new MusicSessionSnapshotService()
+            const queue = restoringQueue('guild-autoplay', {
+                tracks: [restoredTrack],
+            })
+
+            await service.restoreSnapshot(queue)
+
+            expect(queue.addTrack).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    metadata: expect.objectContaining({
+                        isAutoplay: true,
+                        requestedById: 'user-1',
+                        recommendationReason: 'Because you listened',
+                    }),
+                }),
+            )
+        })
+
+        it('returns early when the queue already has tracks (no read)', async () => {
+            const service = new MusicSessionSnapshotService()
+            const queue = {
+                guild: { id: 'guild-busy' },
+                currentTrack: { title: 'Playing Now' },
+                tracks: { size: 2 },
+            } as unknown as GuildQueue
+
+            const result = await service.restoreSnapshot(queue)
+            expect(result.restoredCount).toBe(0)
+            expect(mockFindUnique).not.toHaveBeenCalled()
+        })
+
+        it('does not clear the snapshot when nothing is restored', async () => {
+            mockFindUnique.mockResolvedValueOnce(snapshotRow())
+            const service = new MusicSessionSnapshotService()
+            const queue = restoringQueue('guild-noresult', { tracks: [] })
+
+            const result = await service.restoreSnapshot(queue)
+            expect(result.restoredCount).toBe(0)
+            expect(mockDeleteMany).not.toHaveBeenCalled()
+        })
+
+        it('skips the current track when skipCurrentTrack is true', async () => {
+            mockFindUnique.mockResolvedValueOnce(
+                snapshotRow({
+                    currentTrack: {
+                        title: 'Same Song',
+                        author: 'Artist',
+                        url: 'https://example.com/same',
+                        duration: '3:00',
+                        source: 'youtube',
+                    },
+                }),
+            )
+            const service = new MusicSessionSnapshotService()
+            const queue = restoringQueue('guild-skip')
+
+            await service.restoreSnapshot(queue, undefined, {
+                skipCurrentTrack: true,
+            })
+            expect(queue.addTrack).toHaveBeenCalledTimes(1)
+        })
+
+        it('rolls back the queue when search throws mid-restore', async () => {
+            mockFindUnique.mockResolvedValueOnce(
+                snapshotRow({
+                    currentTrack: {
+                        title: 'Current Song',
+                        author: 'Artist 1',
+                        url: 'https://example.com/cur',
+                        duration: '3:45',
+                        source: 'youtube',
+                    },
+                }),
+            )
+            const clear = jest.fn()
+            const search = jest
+                .fn<any>()
+                .mockResolvedValueOnce({ tracks: [{ title: 'Current Song' }] })
+                .mockRejectedValueOnce(new Error('search unavailable'))
+            const queue = {
+                guild: { id: 'g' },
+                currentTrack: null,
+                tracks: { size: 0 },
+                player: { search },
+                clear,
+                addTrack: jest.fn(),
+            } as unknown as GuildQueue
+
+            const service = new MusicSessionSnapshotService()
+            const result = await service.restoreSnapshot(queue)
+
+            expect(clear).toHaveBeenCalledTimes(1)
+            expect(result.restoredCount).toBe(0)
+            expect(result.sessionSnapshotId).toBeNull()
+        })
+    })
+
+    describe('deleteSnapshot / clearSnapshotIfStale', () => {
+        it('swallows delete errors', async () => {
+            mockDeleteMany.mockRejectedValueOnce(new Error('db down'))
+            const service = new MusicSessionSnapshotService()
+            await expect(service.deleteSnapshot('g')).resolves.toBeUndefined()
+        })
+
+        it('clearSnapshotIfStale is a no-op when the queue has upcoming tracks', async () => {
+            const service = new MusicSessionSnapshotService()
+            const queue = {
+                guild: { id: 'g' },
+                currentTrack: { title: 't' },
+                tracks: { size: 3 },
+            } as unknown as GuildQueue
+            await service.clearSnapshotIfStale(queue)
+            expect(mockFindUnique).not.toHaveBeenCalled()
+        })
+
+        it('clearSnapshotIfStale skips when the snapshot has upcoming tracks', async () => {
+            mockFindUnique.mockResolvedValueOnce(snapshotRow())
+            const service = new MusicSessionSnapshotService()
+            const queue = {
+                guild: { id: 'guild-1' },
+                currentTrack: { title: 't' },
+                tracks: { size: 0 },
+            } as unknown as GuildQueue
+            await service.clearSnapshotIfStale(queue)
+            expect(mockDeleteMany).not.toHaveBeenCalled()
+        })
     })
 })

--- a/packages/bot/src/utils/music/sessionSnapshots.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.ts
@@ -2,7 +2,8 @@ import type { GuildQueue, Track } from 'discord-player'
 import { QueryType } from 'discord-player'
 import type { User } from 'discord.js'
 import { randomUUID } from 'crypto'
-import { redisClient } from '@lucky/shared/services'
+import { getPrismaClient } from '@lucky/shared/utils'
+import type { Prisma } from '@lucky/shared/utils'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 
@@ -39,6 +40,16 @@ const DEFAULT_MAX_SNAPSHOT_AGE_MS = 30 * 60 * 1_000
 type SearchOptions = {
     requestedBy?: User
     searchEngine: QueryType
+}
+
+/** Row shape this service reads from the `music_session_snapshots` table. */
+interface SnapshotRow {
+    sessionSnapshotId: string
+    guildId: string
+    savedAt: Date
+    currentTrack: unknown
+    upcomingTracks: unknown
+    voiceChannelId: string | null
 }
 
 function toDurationString(duration: unknown): string {
@@ -84,6 +95,13 @@ function applySnapshotMetadata(
     })
 }
 
+/**
+ * Persists the live queue state per guild (one snapshot each) in Postgres, so a
+ * session can be restored after a bot restart. A snapshot is overwritten on each
+ * save and deleted after a successful restore. Two independent staleness bounds
+ * apply: `ttlSeconds` (storage TTL, lazy-expired on read) and `maxSnapshotAgeMs`
+ * (the stricter restore guard — older snapshots are not auto-restored).
+ */
 export class MusicSessionSnapshotService {
     constructor(
         private readonly ttlSeconds = ENVIRONMENT_CONFIG.SESSIONS
@@ -91,8 +109,16 @@ export class MusicSessionSnapshotService {
         private readonly maxSnapshotAgeMs = DEFAULT_MAX_SNAPSHOT_AGE_MS,
     ) {}
 
-    private getKey(guildId: string): string {
-        return `music:session:${guildId}`
+    /** Maps a `music_session_snapshots` row to the public snapshot shape. */
+    private rowToSnapshot(row: SnapshotRow): QueueSessionSnapshot {
+        return {
+            sessionSnapshotId: row.sessionSnapshotId,
+            guildId: row.guildId,
+            savedAt: row.savedAt.getTime(),
+            currentTrack: (row.currentTrack ?? null) as SnapshotTrack | null,
+            upcomingTracks: (row.upcomingTracks ?? []) as SnapshotTrack[],
+            voiceChannelId: row.voiceChannelId ?? undefined,
+        }
     }
 
     async saveSnapshot(
@@ -110,24 +136,39 @@ export class MusicSessionSnapshotService {
                 return null
             }
 
-            const snapshot: QueueSessionSnapshot = {
-                sessionSnapshotId: randomUUID(),
+            const currentSnapshot = currentTrack
+                ? toSnapshotTrack(currentTrack as Track)
+                : null
+            const sessionSnapshotId = randomUUID()
+            const prisma = getPrismaClient()
+
+            // One snapshot per guild: overwrite by replacing the row. (delete +
+            // create avoids the Json-null footgun of clearing currentTrack on update.)
+            await prisma.musicSessionSnapshot.deleteMany({ where: { guildId } })
+            await prisma.musicSessionSnapshot.create({
+                data: {
+                    guildId,
+                    sessionSnapshotId,
+                    voiceChannelId: queue.channel?.id ?? null,
+                    upcomingTracks:
+                        upcomingTracks as unknown as Prisma.InputJsonValue,
+                    ...(currentSnapshot
+                        ? {
+                              currentTrack:
+                                  currentSnapshot as unknown as Prisma.InputJsonValue,
+                          }
+                        : {}),
+                },
+            })
+
+            return {
+                sessionSnapshotId,
                 guildId,
                 savedAt: Date.now(),
-                currentTrack: currentTrack
-                    ? toSnapshotTrack(currentTrack as Track)
-                    : null,
+                currentTrack: currentSnapshot,
                 upcomingTracks,
                 voiceChannelId: queue.channel?.id,
             }
-
-            await redisClient.setex(
-                this.getKey(guildId),
-                this.ttlSeconds,
-                JSON.stringify(snapshot),
-            )
-
-            return snapshot
         } catch (error) {
             errorLog({
                 message: 'Failed to save music session snapshot',
@@ -160,10 +201,19 @@ export class MusicSessionSnapshotService {
 
     async getSnapshot(guildId: string): Promise<QueueSessionSnapshot | null> {
         try {
-            const raw = await redisClient.get(this.getKey(guildId))
-            if (!raw) return null
-            const parsed = JSON.parse(raw) as QueueSessionSnapshot
-            return parsed
+            const prisma = getPrismaClient()
+            const row = await prisma.musicSessionSnapshot.findUnique({
+                where: { guildId },
+            })
+            if (!row) return null
+
+            // Lazy storage-TTL expiry: prune snapshots older than ttlSeconds.
+            if (row.savedAt.getTime() < Date.now() - this.ttlSeconds * 1000) {
+                await this.deleteSnapshot(guildId)
+                return null
+            }
+
+            return this.rowToSnapshot(row)
         } catch (error) {
             errorLog({
                 message: 'Failed to read music session snapshot',
@@ -174,13 +224,14 @@ export class MusicSessionSnapshotService {
     }
 
     /**
-     * Delete the snapshot for a guild from Redis.
+     * Delete the snapshot for a guild.
      * Called after a successful restore so the same snapshot is not re-applied
      * on subsequent connections.
      */
     async deleteSnapshot(guildId: string): Promise<void> {
         try {
-            await redisClient.del(this.getKey(guildId))
+            const prisma = getPrismaClient()
+            await prisma.musicSessionSnapshot.deleteMany({ where: { guildId } })
         } catch (error) {
             errorLog({
                 message: 'Failed to delete music session snapshot',
@@ -239,7 +290,10 @@ export class MusicSessionSnapshotService {
                 for (const entry of tracksToRestore) {
                     const query =
                         entry.url || `${entry.title} ${entry.author}`.trim()
-                    const result = await queue.player.search(query, searchOptions)
+                    const result = await queue.player.search(
+                        query,
+                        searchOptions,
+                    )
                     const track = result.tracks[0]
                     if (!track) continue
 
@@ -257,7 +311,8 @@ export class MusicSessionSnapshotService {
                 // Rollback: clear partial queue state on any search/add failure
                 queue.clear()
                 errorLog({
-                    message: 'Failed to restore track during restore loop; rolling back queue',
+                    message:
+                        'Failed to restore track during restore loop; rolling back queue',
                     error: loopError,
                 })
                 return { restoredCount: 0, sessionSnapshotId: null }

--- a/prisma/migrations/20260531000001_add_music_session_snapshot/migration.sql
+++ b/prisma/migrations/20260531000001_add_music_session_snapshot/migration.sql
@@ -1,0 +1,23 @@
+-- Music session snapshots (one per guild): auto-saved queue state for restore-after-restart.
+-- Part of the Redis scope-reduction (docs/decisions/2026-05-31-redis-scope-reduction.md):
+-- migrates MusicSessionSnapshotService off Redis onto Postgres. One row per guild,
+-- overwritten on each save (upsert) and deleted after a successful restore.
+
+CREATE TABLE "music_session_snapshots" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "sessionSnapshotId" TEXT NOT NULL,
+    "savedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "currentTrack" JSONB,
+    "upcomingTracks" JSONB NOT NULL,
+    "voiceChannelId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "music_session_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- One snapshot per guild (replaces the Redis per-guild key `music:session:<guildId>`).
+CREATE UNIQUE INDEX "music_session_snapshots_guildId_key" ON "music_session_snapshots" ("guildId");
+
+ALTER TABLE "music_session_snapshots" ADD CONSTRAINT "music_session_snapshots_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds" ("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ model Guild {
   twitchNotifications TwitchNotification[]
   featureToggles      GuildFeatureToggle[]
   namedQueues         NamedQueue[]
+  sessionSnapshot     MusicSessionSnapshot?
 
   @@map("guilds")
 }
@@ -288,6 +289,24 @@ model NamedQueue {
   @@unique([guildId, name])
   @@index([guildId])
   @@map("named_queues")
+}
+
+// Music session snapshot — one per guild; auto-saved queue state for restore-after-restart.
+model MusicSessionSnapshot {
+  id      String @id @default(cuid())
+  guildId String @unique
+  guild   Guild  @relation(fields: [guildId], references: [id], onDelete: Cascade)
+
+  sessionSnapshotId String
+  savedAt           DateTime @default(now())
+  currentTrack      Json? // SnapshotTrack | null
+  upcomingTracks    Json // SnapshotTrack[]
+  voiceChannelId    String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("music_session_snapshots")
 }
 
 // Track History & Analytics


### PR DESCRIPTION
**Phase-2 of the Redis scope-reduction** (ADR `docs/decisions/2026-05-31-redis-scope-reduction.md`; PRD #1111). Third store, after `TrackHistory` (#1112) and `NamedQueue` (#1113).

Migrates `MusicSessionSnapshotService` (per-guild queue snapshot for restore-after-restart) from Redis to Postgres.

**Schema:** new `MusicSessionSnapshot` model + migration `20260531000001_add_music_session_snapshot` (`guildId @unique` → one snapshot/guild, FK→`guilds` cascade, JSON columns for `currentTrack`/`upcomingTracks`). The PRD assumed reusing `GuildSession`, but that model didn't fit (no unique-guildId, missing fields, 7 unused playback-state columns, and orphaned) — operator chose a purpose-built model. **`GuildSession` remains orphaned scaffolding — flagged for a separate cleanup.**

**Behavior preserved** (public interface unchanged; 12 callers untouched):
- `saveSnapshot` → **delete + create** overwrite (avoids the Prisma Json-null footgun of clearing `currentTrack` on update)
- `getSnapshot` → `findUnique` + **lazy storage-TTL** (7200s) prune on read
- `restoreSnapshot` → unchanged logic, incl. the stricter 30-min restore staleness guard + mid-restore rollback
- `deleteSnapshot`/`clearSnapshotIfStale` → `deleteMany`

**Notes:**
- New FK requires the `Guild` row to exist; `saveSnapshot` fails gracefully (`null`) otherwise.
- Additive migration, no backfill; pre-cutover Redis snapshots simply aren't restored (within the 30-min guard window anyway).

**Verified locally:** shared + bot `tsc --noEmit` (strict) clean; **18 tests pass**; no residual Redis refs.
