### PR TITLE
refactor(bot): make provider-health purely in-memory, drop redis

### DIFF
--- a/packages/bot/src/utils/music/search/providerHealth.spec.ts
+++ b/packages/bot/src/utils/music/search/providerHealth.spec.ts
@@ -1,35 +1,12 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { beforeEach, describe, expect, it } from '@jest/globals'
 import {
     ProviderHealthService,
     providerFromQueryType,
     providerFromTrack,
     initProviderHealth,
-    providerHealthService,
 } from './providerHealth'
 
-const getMock = jest.fn<() => Promise<string | null>>()
-const setexMock = jest.fn<() => Promise<void>>()
-const isHealthyMock = jest.fn<() => boolean>()
-
-jest.mock('@lucky/shared/utils', () => ({
-    debugLog: jest.fn(),
-    errorLog: jest.fn(),
-}))
-
-jest.mock('@lucky/shared/services', () => ({
-    redisClient: {
-        isHealthy: (...args: unknown[]) => isHealthyMock(...args),
-        get: (...args: unknown[]) => getMock(...args),
-        setex: (...args: unknown[]) => setexMock(...args),
-    },
-}))
-
 describe('ProviderHealthService', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-        isHealthyMock.mockReturnValue(false)
-    })
-
     it('marks provider unavailable after consecutive failures', () => {
         const service = new ProviderHealthService({
             cooldownMs: 5_000,
@@ -123,11 +100,6 @@ describe('ProviderHealthService', () => {
 })
 
 describe('ProviderHealthService cooldown boundary conditions', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-        isHealthyMock.mockReturnValue(false)
-    })
-
     it('clears cooldownUntil in-place when expiry is reached on isAvailable call', () => {
         const service = new ProviderHealthService({
             cooldownMs: 1_000,
@@ -210,11 +182,6 @@ describe('ProviderHealthService cooldown boundary conditions', () => {
 })
 
 describe('provider mappers', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-        isHealthyMock.mockReturnValue(false)
-    })
-
     it('maps query types to providers', () => {
         expect(providerFromQueryType('youtubeSearch' as any)).toBe('youtube')
         expect(providerFromQueryType('spotifySearch' as any)).toBe('spotify')
@@ -248,116 +215,8 @@ describe('provider mappers', () => {
     })
 })
 
-describe('ProviderHealthService Redis persistence', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-        isHealthyMock.mockReturnValue(true)
-        setexMock.mockResolvedValue(undefined)
-    })
-
-    it('calls setex on recordFailure when Redis is healthy', () => {
-        const service = new ProviderHealthService({
-            cooldownMs: 10_000,
-            failureThreshold: 2,
-        })
-        service.recordFailure('youtube', 1_000, 'timeout')
-
-        expect(isHealthyMock).toHaveBeenCalled()
-        expect(setexMock).toHaveBeenCalledWith(
-            'music:provider_health:youtube',
-            expect.any(Number),
-            expect.stringContaining('youtube'),
-        )
-    })
-
-    it('calls setex on recordSuccess when Redis is healthy', () => {
-        const service = new ProviderHealthService({
-            cooldownMs: 10_000,
-            failureThreshold: 2,
-        })
-        service.recordSuccess('spotify', 2_000)
-
-        expect(setexMock).toHaveBeenCalledWith(
-            'music:provider_health:spotify',
-            expect.any(Number),
-            expect.stringContaining('spotify'),
-        )
-    })
-
-    it('skips setex when Redis is not healthy', () => {
-        isHealthyMock.mockReturnValue(false)
-        const service = new ProviderHealthService({
-            cooldownMs: 10_000,
-            failureThreshold: 2,
-        })
-        service.recordFailure('soundcloud', 1_000, 'fail')
-
-        expect(setexMock).not.toHaveBeenCalled()
-    })
-
-    it('uses TTL of cooldownMs * 2 / 1000 seconds', () => {
-        const service = new ProviderHealthService({
-            cooldownMs: 60_000,
-            failureThreshold: 1,
-        })
-        service.recordFailure('youtube', 1_000, 'fail')
-
-        const ttlArg = (setexMock.mock.calls[0] as unknown[])[1]
-        expect(ttlArg).toBe(120)
-    })
-})
-
-describe('initProviderHealth / loadFromRedis', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-        isHealthyMock.mockReturnValue(true)
-    })
-
-    it('restores provider status from Redis on init', async () => {
-        const restoredStatus = {
-            provider: 'youtube',
-            score: 0.4,
-            consecutiveFailures: 2,
-            cooldownUntil: Date.now() + 50_000,
-            lastFailureAt: Date.now() - 1_000,
-            lastSuccessAt: null,
-            lastError: 'rate limited',
-        }
-        getMock.mockImplementation(async (key: unknown) => {
-            if ((key as string).includes('youtube'))
-                return JSON.stringify(restoredStatus)
-            return null
-        })
-
-        await initProviderHealth()
-
-        const status = providerHealthService.getStatus('youtube')
-        expect(status.score).toBeCloseTo(0.4)
-        expect(status.consecutiveFailures).toBe(2)
-        expect(status.lastError).toBe('rate limited')
-    })
-
-    it('skips loading when Redis is not healthy', async () => {
-        isHealthyMock.mockReturnValue(false)
-
-        await initProviderHealth()
-
-        expect(getMock).not.toHaveBeenCalled()
-    })
-
-    it('leaves default state when Redis key is missing', async () => {
-        getMock.mockResolvedValue(null)
-
-        await initProviderHealth()
-
-        const status = providerHealthService.getStatus('soundcloud')
-        expect(status.score).toBe(1)
-        expect(status.consecutiveFailures).toBe(0)
-    })
-
-    it('ignores corrupt Redis data and keeps default state', async () => {
-        getMock.mockResolvedValue('not-valid-json{{')
-
-        await expect(initProviderHealth()).resolves.not.toThrow()
+describe('initProviderHealth', () => {
+    it('is a no-op that resolves without throwing (in-memory state)', async () => {
+        await expect(initProviderHealth()).resolves.toBeUndefined()
     })
 })

--- a/packages/bot/src/utils/music/search/providerHealth.spec.ts
+++ b/packages/bot/src/utils/music/search/providerHealth.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from '@jest/globals'
+import { describe, expect, it } from '@jest/globals'
 import {
     ProviderHealthService,
     providerFromQueryType,

--- a/packages/bot/src/utils/music/search/providerHealth.ts
+++ b/packages/bot/src/utils/music/search/providerHealth.ts
@@ -1,6 +1,4 @@
 import { QueryType } from 'discord-player'
-import { redisClient } from '@lucky/shared/services'
-import { debugLog, errorLog } from '@lucky/shared/utils'
 
 export type MusicProvider = 'youtube' | 'spotify' | 'soundcloud' | 'unknown'
 
@@ -34,12 +32,6 @@ const DEFAULT_OPTIONS = {
     failurePenalty: 0.2,
     successBoost: 0.05,
 } satisfies Required<ProviderHealthOptions>
-
-const REDIS_KEY_PREFIX = 'music:provider_health:'
-
-function redisKey(provider: MusicProvider): string {
-    return `${REDIS_KEY_PREFIX}${provider}`
-}
 
 function createInitialStatus(provider: MusicProvider): ProviderStatus {
     return {
@@ -76,36 +68,6 @@ export class ProviderHealthService {
         return status
     }
 
-    private persistToRedis(status: ProviderStatus): void {
-        if (!redisClient.isHealthy()) return
-        const ttlSeconds = Math.ceil((this.options.cooldownMs * 2) / 1000)
-        redisClient
-            .setex(redisKey(status.provider), ttlSeconds, JSON.stringify(status))
-            .catch((err) => {
-                errorLog({ message: 'Failed to persist provider health', error: err })
-            })
-    }
-
-    async loadFromRedis(): Promise<void> {
-        if (!redisClient.isHealthy()) return
-        for (const provider of DEFAULT_PROVIDERS) {
-            try {
-                const raw = await redisClient.get(redisKey(provider))
-                if (!raw) continue
-                const parsed: ProviderStatus = JSON.parse(raw) as ProviderStatus
-                if (parsed.provider === provider) {
-                    this.statuses.set(provider, parsed)
-                    debugLog({
-                        message: `Restored provider health from Redis: ${provider}`,
-                        data: { score: parsed.score, cooldownUntil: parsed.cooldownUntil },
-                    })
-                }
-            } catch {
-                // leave default in-memory state if Redis data is corrupt
-            }
-        }
-    }
-
     recordFailure(
         provider: MusicProvider,
         now = Date.now(),
@@ -121,8 +83,6 @@ export class ProviderHealthService {
         if (status.consecutiveFailures >= this.options.failureThreshold) {
             status.cooldownUntil = now + this.options.cooldownMs
         }
-
-        this.persistToRedis(status)
     }
 
     recordSuccess(provider: MusicProvider, now = Date.now()): void {
@@ -133,8 +93,6 @@ export class ProviderHealthService {
         status.cooldownUntil = null
         status.lastError = null
         status.score = Math.min(1, status.score + this.options.successBoost)
-
-        this.persistToRedis(status)
     }
 
     isAvailable(provider: MusicProvider, now = Date.now()): boolean {
@@ -180,8 +138,14 @@ export const providerHealthService = new ProviderHealthService({
     ),
 })
 
+/**
+ * Retained as a no-op for the startup sequence: provider health is now purely
+ * in-memory (it resets on restart by design — a short warm-up, not state worth
+ * persisting). Kept so `initializer.ts` needn't change and to give a seam if a
+ * persistence layer is ever wanted again.
+ */
 export async function initProviderHealth(): Promise<void> {
-    await providerHealthService.loadFromRedis()
+    // Intentionally empty — in-memory state starts fresh each process.
 }
 
 export function providerFromQueryType(queryType?: QueryType): MusicProvider {


### PR DESCRIPTION
**Phase-4 (partial) of the Redis scope-reduction** (ADR `docs/decisions/2026-05-31-redis-scope-reduction.md`; PRD #1111). Fifth store, after TrackHistory (#1112), NamedQueue (#1113), SessionSnapshot (#1114), GuildCounter (#1115).

Makes **provider health** purely in-memory. `ProviderHealthService` already kept all state in an in-memory `Map`; Redis was only an *optional* persistence layer (`persistToRedis`/`loadFromRedis`, gated on `isHealthy()`, bot-only). Provider health is a short failure/cooldown signal that's fine to rebuild on restart, so:

- Drop the Redis import + `persistToRedis`/`loadFromRedis`.
- `initProviderHealth()` kept as a **no-op** so `initializer.ts` (and other callers) are unchanged — also a seam if persistence is ever wanted again.
- Spec trimmed to in-memory behavior (Redis-persistence describe blocks removed); **12 tests pass**.

**Scope note:** the AutoMod spam-window (the other ephemeral candidate) is deliberately **NOT** in this PR. Migrating it breaks 6 Redis-coupled backend tests (`backend/tests/unit/services/AutoModService.test.ts` asserts `lpush`/`lrange`) and needs an in-memory test-reset seam — it gets its own focused PR. AutoMod *settings* cache stays on Redis (cross-process invalidation).

**Verified:** bot `tsc --noEmit` (strict) clean (pre-commit hook); 12 providerHealth tests pass; no residual Redis in the file.
