### PR TITLE
refactor(shared): make postgres the source of truth for guild settings

### DIFF
--- a/docs/decisions/2026-05-31-guild-settings-postgres-source-of-truth.md
+++ b/docs/decisions/2026-05-31-guild-settings-postgres-source-of-truth.md
@@ -1,0 +1,84 @@
+---
+status: accepted
+date: 2026-05-31
+refines: 2026-05-31-redis-scope-reduction
+revisit_after: when a revisit trigger below fires
+---
+
+# Guild settings: Postgres is the source of truth, read directly (no cache)
+
+## Status
+
+Accepted. Refines [[2026-05-31-redis-scope-reduction]] for the `GuildSettings` store
+specifically. Decided via research + Opus `critic` (critic confirmed Option A, did not
+flip it; surfaced a pre-existing split-brain that sharpens the decision).
+
+## Context
+
+`GuildSettingsService` reads/writes guild settings (volume, prefix, autoplayMode,
+repeatMode, language, cooldowns, allow\* perms, djRole) to **Redis only**, key
+`guild_settings:{guildId}`, with a **7-day `setex` TTL**.
+
+But a Postgres model `GuildSettings` (table `guild_settings`, `guildId @unique`,
+`Guild.settings` relation) **already exists** with the same fields — and is **actively
+read/written by the birthday feature** (`birthdayScheduler.ts`, `birthday.ts` via
+`prisma.guildSettings`). So one logical entity has **two live, unsynced stores**:
+birthday columns in Postgres, music/perm settings in Redis. This is a split-brain, and
+the 7-day TTL means music settings silently reset (config loss) on expiry/restart.
+
+Settings are read on most bot command hot paths (~15 call sites: play/autoplay/cooldown
+checks), plus backend REST + frontend.
+
+## Decision
+
+**Postgres `guild_settings` is the single source of truth. `GuildSettingsService` reads
+and writes `prisma.guildSettings` directly, with no cache layer. Drop the Redis settings
+path.** This unifies the music/perm settings with the birthday columns already in that
+same row.
+
+No cache, deliberately: a cache is what creates cross-process staleness (backend web-UI
+write vs bot read) and, if Redis-backed, would re-add the dependency this refactor is
+removing. For a single-instance bot with a co-located Postgres, a direct read per command
+is cheap and always fresh — no invalidation mechanism needed. Postgres errors surface as
+errors (callers already handle a null/empty settings result by falling back to defaults).
+
+## Alternatives considered
+
+- **B — Postgres SoT + in-process (Map) read cache, short TTL.** Rejected for now: adds
+  cross-process staleness (bot serves stale settings for up to the TTL after a web-UI
+  change) for a latency win not yet shown to be needed. Add only if a revisit trigger fires.
+- **C — Postgres SoT + read-through Redis cache + write-invalidation** (mirrors
+  `AutoModService`). Rejected: keeps/extends Redis, directly against the parent ADR's
+  shrink-to-pub/sub-only goal. (AutoMod settings cache is itself a future revisit candidate.)
+- **D — status quo (Redis SoT, 7-day TTL).** Rejected: this _is_ the split-brain + the
+  silent-config-reset bug.
+
+## Consequences
+
+Positive: one source of truth; split-brain with birthday data resolved (same row); config
+survives restarts; one fewer Redis consumer; no cache ⇒ no invalidation/staleness logic.
+
+Negative / accept:
+
+- One Postgres read per settings access on bot command hot paths. Acceptable single-instance
+  with local Postgres; measure if it ever feels slow (revisit trigger).
+- **Cutover:** best-effort one-time backfill `redis.get(guild_settings:{guildId}) →
+prisma.guildSettings.upsert()` for known guilds before removing the Redis path. If a key
+  already expired (7-day TTL), that guild reverts to defaults — acceptable for a hobby bot,
+  and birthday columns are preserved by upsert. Backfill count must be logged + verified.
+- Birthday writes and settings writes now target the same Postgres row — confirm no field
+  collision (they touch disjoint columns today).
+
+## Revisit when
+
+- Per-command Postgres read latency becomes measurably noticeable on hot paths → add
+  Option B (in-process cache, short TTL). Only then.
+- Bot goes multi-instance → re-evaluate cache coherence (same trigger as the parent ADR).
+- A web-UI settings change must be reflected in the bot in <1s AND a cache has been added →
+  needs an invalidation signal (pub/sub), revisit then.
+
+## Implementation notes (for the spec, not part of the decision)
+
+Per critic: the PR must (1) unify the birthday path under the same Postgres model, (2) ship
+the one-time Redis→Postgres backfill + verification + a note that expired keys reset to
+defaults, (3) since there is no cache, explicitly confirm no invalidation is needed.

--- a/docs/specs/2026-05-31-redis-scope-reduction/spec.md
+++ b/docs/specs/2026-05-31-redis-scope-reduction/spec.md
@@ -1,0 +1,51 @@
+---
+status: active
+created: 2026-05-31
+owner: lucassantana
+pr: https://github.com/LucasSantana-Dev/Lucky/issues/1111
+tags: redis,postgres,refactor,infra
+---
+
+# redis-scope-reduction
+
+## Goal
+
+Reduce Redis to a single responsibility. Today ~20 modules use Redis for KV/cache; only one — the `MusicControlService` bot↔backend pub/sub (`music:command|result|state`) — genuinely needs it. Move everything else to Postgres (persistent) or in-memory (ephemeral) so Redis becomes a small, pub/sub-only dependency.
+
+## Approach
+
+Per ADR `docs/decisions/2026-05-31-redis-scope-reduction.md` (decided via research + critic; critic flipped the original "drop Redis entirely" — the music pub/sub is load-bearing IPC for the web music surface). Decouple Redis's two roles:
+
+- **Persistent stores → Postgres/Prisma** (durable across restart).
+- **Ephemeral caches → in-memory** (`Map` + TTL; reset-on-restart acceptable).
+- **Retain a minimal Redis only for the music pub/sub.**
+
+Incremental, one store per PR, each: new/reused Prisma model + migration + preserve service interface + mock-prisma spec + verify tsc/tests. No big-bang.
+
+## Status
+
+Shipped (merged to main):
+
+- TrackHistory → Postgres (#1112)
+- NamedQueue → Postgres (#1113)
+- MusicSessionSnapshot → Postgres (#1114)
+- GuildCounter → Postgres + dead-duplicate deletion + rate-limit→in-memory (#1115)
+- ProviderHealth → in-memory (#1116)
+
+Remaining:
+
+- AutoMod spam-window → in-memory (breaks ~6 Redis-coupled backend tests; needs a test-reset seam)
+- GuildSettings settings → Postgres (latent bug: guild config on a 7-day Redis TTL silently resets)
+- Watchdog `.keys('music:session:*')` → indexed Postgres query
+- Bot startup hard-throw on Redis-unavailable → pub/sub-only
+- Drop the orphaned `GuildSession` model (superseded by `MusicSessionSnapshot`)
+
+## Out of scope
+
+- Removing Redis entirely / re-architecting the music pub/sub (Postgres `LISTEN/NOTIFY` or WebSocket) — ADR Option B, deferred as its own gated decision.
+- Backend HTTP session store (`connect-redis`) — already has a file/memory fallback.
+
+## Revisit when
+
+- Bot goes multi-instance → in-memory caches break; a shared store is needed again.
+- Postgres write latency on former-Redis hot paths becomes measurable.

--- a/packages/shared/src/__tests__/services/GuildSettingsService.test.ts
+++ b/packages/shared/src/__tests__/services/GuildSettingsService.test.ts
@@ -1,84 +1,120 @@
 import { describe, test, expect, beforeEach, jest } from '@jest/globals'
-import { GuildSettingsService } from '../../services/GuildSettingsService'
-import { redisClient } from '../../services/redis'
 
-jest.mock('../../services/redis', () => ({
-    redisClient: {
-        get: jest.fn(),
-        setex: jest.fn(),
-        del: jest.fn(),
+// Service captures getPrismaClient() lazily per call; mock returns a stable client.
+const mockUpsert = jest.fn<any>()
+const mockFindUnique = jest.fn<any>()
+const mockDeleteMany = jest.fn<any>()
+const mockPrisma = {
+    guildSettings: {
+        upsert: mockUpsert,
+        findUnique: mockFindUnique,
+        deleteMany: mockDeleteMany,
     },
-}))
+}
 
-// Counters now use Prisma; settings tests don't exercise them, but the import
-// must be mocked so the real prismaClient (import.meta) isn't compiled here.
 jest.mock('../../utils/database/prismaClient', () => ({
-    getPrismaClient: jest.fn(),
+    getPrismaClient: () => mockPrisma,
     disconnectPrisma: jest.fn(),
 }))
 
-const mockGet = redisClient.get as jest.MockedFunction<typeof redisClient.get>
-const mockSetex = redisClient.setex as unknown as jest.MockedFunction<
-    (key: string, ttl: number, value: string) => Promise<string>
->
+import { GuildSettingsService } from '../../services/GuildSettingsService'
 
-describe('GuildSettingsService.updateGuildSettings (upsert)', () => {
+describe('GuildSettingsService settings (Postgres source of truth)', () => {
     let service: GuildSettingsService
 
     beforeEach(() => {
         jest.clearAllMocks()
-        service = new GuildSettingsService(60)
+        service = new GuildSettingsService()
     })
 
-    test('seeds defaults and persists when no existing settings', async () => {
-        mockGet.mockResolvedValue(null)
-        mockSetex.mockResolvedValue('OK')
+    test('updateGuildSettings upserts only the provided fields', async () => {
+        mockUpsert.mockResolvedValue({})
 
         const result = await service.updateGuildSettings('guild-1', {
             autoplayGenres: ['rock', 'jazz'],
         })
 
         expect(result).toBe(true)
-        expect(mockSetex).toHaveBeenCalledTimes(1)
-        const call = mockSetex.mock.calls[0]
-        expect(call[0]).toBe('guild_settings:guild-1')
-        expect(call[1]).toBe(60)
-        const persisted = JSON.parse(call[2] as string)
-        expect(persisted.guildId).toBe('guild-1')
-        expect(persisted.autoplayGenres).toEqual(['rock', 'jazz'])
-        expect(persisted.defaultVolume).toBe(50) // from defaults
+        expect(mockUpsert).toHaveBeenCalledTimes(1)
+        const arg = mockUpsert.mock.calls[0][0] as any
+        expect(arg.where).toEqual({ guildId: 'guild-1' })
+        // Only the provided field is in the data — no birthday columns clobbered.
+        expect(arg.update).toEqual({ autoplayGenres: ['rock', 'jazz'] })
+        expect(arg.create).toEqual({
+            guildId: 'guild-1',
+            autoplayGenres: ['rock', 'jazz'],
+        })
     })
 
-    test('merges updates with existing settings', async () => {
-        mockGet.mockResolvedValue(
-            JSON.stringify({
-                guildId: 'guild-1',
-                defaultVolume: 80,
-                autoplayGenres: ['old'],
-                autoPlayEnabled: true,
-            }),
-        )
-        mockSetex.mockResolvedValue('OK')
+    test('setGuildSettings writes the new DJ/idle/voteskip columns', async () => {
+        mockUpsert.mockResolvedValue({})
 
+        await service.setGuildSettings('guild-1', {
+            djRoleId: 'role-9',
+            idleTimeoutMinutes: 15,
+            voteSkipThreshold: 60,
+        })
+
+        const arg = mockUpsert.mock.calls[0][0] as any
+        expect(arg.update).toEqual({
+            djRoleId: 'role-9',
+            idleTimeoutMinutes: 15,
+            voteSkipThreshold: 60,
+        })
+    })
+
+    test('getGuildSettings maps a row, coalescing nullable columns', async () => {
+        mockFindUnique.mockResolvedValue({
+            guildId: 'guild-1',
+            defaultVolume: 80,
+            maxQueueSize: 100,
+            autoPlayEnabled: true,
+            autoplayMode: 'discover',
+            autoplayGenres: ['rock'],
+            repeatMode: 0,
+            shuffleEnabled: false,
+            prefix: null, // -> default '/'
+            embedColor: null, // -> default
+            language: 'en',
+            allowDownloads: true,
+            allowPlaylists: true,
+            allowSpotify: true,
+            commandCooldown: 3,
+            downloadCooldown: 10,
+            djRoleId: null, // -> undefined
+            idleTimeoutMinutes: null, // -> 0
+            voteSkipThreshold: null, // -> 50
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        })
+
+        const s = await service.getGuildSettings('guild-1')
+        expect(s).not.toBeNull()
+        expect(s!.defaultVolume).toBe(80)
+        expect(s!.prefix).toBe('/')
+        expect(s!.djRoleId).toBeUndefined()
+        expect(s!.idleTimeoutMinutes).toBe(0)
+        expect(s!.voteSkipThreshold).toBe(50)
+    })
+
+    test('getGuildSettings returns null when no row exists', async () => {
+        mockFindUnique.mockResolvedValue(null)
+        expect(await service.getGuildSettings('nope')).toBeNull()
+    })
+
+    test('returns false when the DB write throws', async () => {
+        mockUpsert.mockRejectedValue(new Error('db down'))
         const result = await service.updateGuildSettings('guild-1', {
             autoplayGenres: ['rock'],
         })
-
-        expect(result).toBe(true)
-        const persisted = JSON.parse(mockSetex.mock.calls[0][2] as string)
-        expect(persisted.defaultVolume).toBe(80) // preserved from existing
-        expect(persisted.autoplayGenres).toEqual(['rock']) // overwritten
-        expect(persisted.guildId).toBe('guild-1')
-    })
-
-    test('returns false when redis throws', async () => {
-        mockGet.mockResolvedValue(null)
-        mockSetex.mockRejectedValue(new Error('redis down'))
-
-        const result = await service.updateGuildSettings('guild-1', {
-            autoplayGenres: ['rock'],
-        })
-
         expect(result).toBe(false)
+    })
+
+    test('deleteGuildSettings removes the row', async () => {
+        mockDeleteMany.mockResolvedValue({ count: 1 })
+        expect(await service.deleteGuildSettings('guild-1')).toBe(true)
+        expect(mockDeleteMany).toHaveBeenCalledWith({
+            where: { guildId: 'guild-1' },
+        })
     })
 })

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -1,4 +1,3 @@
-import { redisClient } from './redis'
 import { getPrismaClient } from '../utils/database/prismaClient'
 import { infoLog, errorLog } from '../utils/general/log'
 
@@ -35,26 +34,16 @@ export interface AutoplayCounter {
 }
 
 /**
- * Manages guild settings (Redis) and per-guild music counters (Postgres).
+ * Manages guild settings + per-guild music counters, all in Postgres.
  *
- * Settings remain in Redis. The autoplay/repeat counters are persisted in the
- * `guild_counters` table so they survive restarts. Rate-limit cooldowns are
- * ephemeral and held in-process.
+ * Settings are the `guild_settings` table (Postgres is the source of truth, read
+ * directly per call — no cache; single-instance + local DB makes that cheap and
+ * always fresh). Autoplay/repeat counters live in `guild_counters`. Rate-limit
+ * cooldowns are ephemeral and held in-process.
  */
 export class GuildSettingsService {
-    private readonly ttl: number
     /** Ephemeral per-`guild:command` last-use epoch ms for rate limiting. */
     private readonly rateLimits = new Map<string, number>()
-
-    constructor(ttl = 7 * 24 * 60 * 60) {
-        this.ttl = ttl
-    }
-
-    private getRedisKey(guildId: string, type?: string): string {
-        return type
-            ? `guild_settings:${guildId}:${type}`
-            : `guild_settings:${guildId}`
-    }
 
     private getDefaultSettings(): GuildSettings {
         return {
@@ -82,44 +71,116 @@ export class GuildSettingsService {
         }
     }
 
-    /** Retrieves guild settings from Redis cache. */
+    /** Maps a `guild_settings` row to the public GuildSettings shape. */
+    private rowToSettings(row: {
+        guildId: string
+        defaultVolume: number
+        maxQueueSize: number
+        autoPlayEnabled: boolean
+        autoplayMode: string
+        autoplayGenres: string[]
+        repeatMode: number
+        shuffleEnabled: boolean
+        prefix: string | null
+        embedColor: string | null
+        language: string
+        allowDownloads: boolean
+        allowPlaylists: boolean
+        allowSpotify: boolean
+        commandCooldown: number
+        downloadCooldown: number
+        djRoleId: string | null
+        idleTimeoutMinutes: number | null
+        voteSkipThreshold: number | null
+        createdAt: Date
+        updatedAt: Date
+    }): GuildSettings {
+        const defaults = this.getDefaultSettings()
+        return {
+            guildId: row.guildId,
+            defaultVolume: row.defaultVolume,
+            maxQueueSize: row.maxQueueSize,
+            autoPlayEnabled: row.autoPlayEnabled,
+            autoplayMode: row.autoplayMode as GuildSettings['autoplayMode'],
+            autoplayGenres: row.autoplayGenres,
+            repeatMode: row.repeatMode,
+            shuffleEnabled: row.shuffleEnabled,
+            prefix: row.prefix ?? defaults.prefix,
+            embedColor: row.embedColor ?? defaults.embedColor,
+            language: row.language,
+            allowDownloads: row.allowDownloads,
+            allowPlaylists: row.allowPlaylists,
+            allowSpotify: row.allowSpotify,
+            commandCooldown: row.commandCooldown,
+            downloadCooldown: row.downloadCooldown,
+            djRoleId: row.djRoleId ?? undefined,
+            idleTimeoutMinutes: row.idleTimeoutMinutes ?? 0,
+            voteSkipThreshold: row.voteSkipThreshold ?? 50,
+            createdAt: row.createdAt,
+            updatedAt: row.updatedAt,
+        }
+    }
+
+    /**
+     * Translates the public settings shape into Prisma column data, omitting
+     * undefined keys (so a partial update only touches the fields provided, and
+     * never clobbers birthday columns this service doesn't own).
+     */
+    private toPrismaData(
+        settings: Partial<GuildSettings>,
+    ): Record<string, unknown> {
+        const data: Record<string, unknown> = {}
+        const copy = <K extends keyof GuildSettings>(k: K) => {
+            if (settings[k] !== undefined) data[k as string] = settings[k]
+        }
+        copy('defaultVolume')
+        copy('maxQueueSize')
+        copy('autoPlayEnabled')
+        copy('autoplayMode')
+        copy('autoplayGenres')
+        copy('repeatMode')
+        copy('shuffleEnabled')
+        copy('prefix')
+        copy('embedColor')
+        copy('language')
+        copy('allowDownloads')
+        copy('allowPlaylists')
+        copy('allowSpotify')
+        copy('commandCooldown')
+        copy('downloadCooldown')
+        copy('djRoleId')
+        copy('idleTimeoutMinutes')
+        copy('voteSkipThreshold')
+        return data
+    }
+
+    /** Retrieves guild settings from Postgres (source of truth). */
     async getGuildSettings(guildId: string): Promise<GuildSettings | null> {
         try {
-            const settingsData = await redisClient.get(
-                this.getRedisKey(guildId),
-            )
-            if (!settingsData) {
-                return null
-            }
-            return JSON.parse(settingsData) as GuildSettings
+            const prisma = getPrismaClient()
+            const row = await prisma.guildSettings.findUnique({
+                where: { guildId },
+            })
+            return row ? this.rowToSettings(row) : null
         } catch (error) {
             errorLog({ message: 'Failed to get guild settings', error })
             return null
         }
     }
 
-    /** Sets guild settings, fully replacing existing values. */
+    /** Upserts guild settings (create with defaults+patch, or update in place). */
     async setGuildSettings(
         guildId: string,
         settings: Partial<GuildSettings>,
     ): Promise<boolean> {
         try {
-            const existingSettings =
-                (await this.getGuildSettings(guildId)) ||
-                this.getDefaultSettings()
-            const updatedSettings: GuildSettings = {
-                ...existingSettings,
-                ...settings,
-                guildId,
-                updatedAt: new Date(),
-            }
-
-            await redisClient.setex(
-                this.getRedisKey(guildId),
-                this.ttl,
-                JSON.stringify(updatedSettings),
-            )
-
+            const prisma = getPrismaClient()
+            const data = this.toPrismaData(settings)
+            await prisma.guildSettings.upsert({
+                where: { guildId },
+                create: { guildId, ...data },
+                update: data,
+            })
             infoLog({ message: `Updated guild settings for ${guildId}` })
             return true
         } catch (error) {
@@ -128,42 +189,23 @@ export class GuildSettingsService {
         }
     }
 
-    /** Updates guild settings, merging with existing values. */
+    /**
+     * Updates guild settings, merging with existing values. Identical to
+     * setGuildSettings now that Postgres upsert handles the merge per-column;
+     * kept as a distinct method for the existing call sites.
+     */
     async updateGuildSettings(
         guildId: string,
         updates: Partial<GuildSettings>,
     ): Promise<boolean> {
-        try {
-            const currentSettings = (await this.getGuildSettings(guildId)) ?? {
-                ...this.getDefaultSettings(),
-                guildId,
-            }
-
-            const updatedSettings = {
-                ...currentSettings,
-                ...updates,
-                guildId,
-                updatedAt: new Date(),
-            }
-
-            await redisClient.setex(
-                this.getRedisKey(guildId),
-                this.ttl,
-                JSON.stringify(updatedSettings),
-            )
-
-            infoLog({ message: `Updated guild settings for ${guildId}` })
-            return true
-        } catch (error) {
-            errorLog({ message: 'Failed to update guild settings', error })
-            return false
-        }
+        return this.setGuildSettings(guildId, updates)
     }
 
-    /** Deletes all guild settings from cache. */
+    /** Deletes a guild's settings row. */
     async deleteGuildSettings(guildId: string): Promise<boolean> {
         try {
-            await redisClient.del(this.getRedisKey(guildId))
+            const prisma = getPrismaClient()
+            await prisma.guildSettings.deleteMany({ where: { guildId } })
             infoLog({ message: `Deleted guild settings for ${guildId}` })
             return true
         } catch (error) {

--- a/prisma/migrations/20260531000003_add_guild_settings_dj_idle_voteskip/migration.sql
+++ b/prisma/migrations/20260531000003_add_guild_settings_dj_idle_voteskip/migration.sql
@@ -1,0 +1,10 @@
+-- Add the three guild-settings fields that lived only in the Redis blob
+-- (djRoleId, idleTimeoutMinutes, voteSkipThreshold) to the Postgres
+-- guild_settings table. Part of the Redis scope-reduction
+-- (docs/decisions/2026-05-31-guild-settings-postgres-source-of-truth.md):
+-- GuildSettingsService becomes Postgres source-of-truth, so every settings
+-- field needs a column. Additive + nullable; existing rows keep defaults.
+
+ALTER TABLE "guild_settings" ADD COLUMN "djRoleId" TEXT;
+ALTER TABLE "guild_settings" ADD COLUMN "idleTimeoutMinutes" INTEGER DEFAULT 0;
+ALTER TABLE "guild_settings" ADD COLUMN "voteSkipThreshold" INTEGER DEFAULT 50;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,6 +163,11 @@ model GuildSettings {
   commandCooldown  Int @default(3) // seconds
   downloadCooldown Int @default(10) // seconds
 
+  // DJ / moderation
+  djRoleId          String?
+  idleTimeoutMinutes Int?   @default(0) // 0 = no idle disconnect
+  voteSkipThreshold  Int?   @default(50) // percent of listeners required
+
   // Birthday announcement channel — if null, the scheduler skips the guild.
   birthdayChannelId String?
   // Optional role granted for the day. Scheduler reconciles membership each

--- a/scripts/backfill-guild-settings.mjs
+++ b/scripts/backfill-guild-settings.mjs
@@ -1,0 +1,127 @@
+/**
+ * One-time backfill: Redis guild settings -> Postgres `guild_settings`.
+ *
+ * Context: GuildSettingsService moved from Redis (key `guild_settings:{guildId}`,
+ * 7-day TTL) to Postgres source-of-truth
+ * (docs/decisions/2026-05-31-guild-settings-postgres-source-of-truth.md).
+ * Run this ONCE, BEFORE deploying the new code, so live settings aren't lost.
+ * Idempotent: re-running upserts the same rows. Guilds whose Redis key already
+ * expired simply aren't present -> they fall back to model defaults (acceptable).
+ *
+ * Birthday columns are NOT touched (upsert only sets the settings fields), so
+ * the existing Postgres birthday data is preserved.
+ *
+ * Usage:
+ *   REDIS_HOST=... REDIS_PORT=... DATABASE_URL=... node scripts/backfill-guild-settings.mjs
+ *   (add --dry-run to preview without writing)
+ */
+import Redis from 'ioredis'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { PrismaClient } = require(
+    '../packages/shared/src/generated/prisma/client.js',
+)
+
+const DRY_RUN = process.argv.includes('--dry-run')
+
+// Only these fields belong to settings; everything else (birthday*) is left alone.
+const SETTINGS_FIELDS = [
+    'defaultVolume',
+    'maxQueueSize',
+    'autoPlayEnabled',
+    'autoplayMode',
+    'autoplayGenres',
+    'repeatMode',
+    'shuffleEnabled',
+    'prefix',
+    'embedColor',
+    'language',
+    'allowDownloads',
+    'allowPlaylists',
+    'allowSpotify',
+    'commandCooldown',
+    'downloadCooldown',
+    'djRoleId',
+    'idleTimeoutMinutes',
+    'voteSkipThreshold',
+]
+
+function pickSettings(blob) {
+    const out = {}
+    for (const k of SETTINGS_FIELDS) {
+        if (blob[k] !== undefined && blob[k] !== null) out[k] = blob[k]
+    }
+    return out
+}
+
+async function main() {
+    const databaseUrl = process.env.DATABASE_URL
+    if (!databaseUrl) throw new Error('DATABASE_URL is required')
+
+    const redis = new Redis({
+        host: process.env.REDIS_HOST ?? 'localhost',
+        port: Number.parseInt(process.env.REDIS_PORT ?? '6379', 10),
+        password: process.env.REDIS_PASSWORD,
+        db: Number.parseInt(process.env.REDIS_DB ?? '0', 10),
+        lazyConnect: true,
+    })
+    await redis.connect()
+    const prisma = new PrismaClient({
+        adapter: new PrismaPg({ connectionString: databaseUrl }),
+    })
+
+    let scanned = 0
+    let written = 0
+    let skipped = 0
+    try {
+        // Settings keys are exactly `guild_settings:{guildId}` — exclude the
+        // `:autoplay_counter` / `:repeat_count` / `:rate_limit:*` sub-keys.
+        const stream = redis.scanStream({ match: 'guild_settings:*', count: 200 })
+        for await (const keys of stream) {
+            for (const key of keys) {
+                const rest = key.slice('guild_settings:'.length)
+                if (rest.includes(':')) continue // sub-key, not a settings blob
+                scanned += 1
+                const guildId = rest
+                const raw = await redis.get(key)
+                if (!raw) {
+                    skipped += 1
+                    continue
+                }
+                let blob
+                try {
+                    blob = JSON.parse(raw)
+                } catch {
+                    console.warn(`[skip] ${key}: unparseable JSON`)
+                    skipped += 1
+                    continue
+                }
+                const data = pickSettings(blob)
+                if (DRY_RUN) {
+                    console.log(`[dry] ${guildId}: would upsert`, Object.keys(data))
+                    continue
+                }
+                await prisma.guildSettings.upsert({
+                    where: { guildId },
+                    create: { guildId, ...data },
+                    update: data,
+                })
+                written += 1
+            }
+        }
+    } finally {
+        await redis.quit()
+        await prisma.$disconnect()
+    }
+
+    console.log(
+        `Backfill ${DRY_RUN ? '(dry-run) ' : ''}done: scanned=${scanned} written=${written} skipped=${skipped}`,
+    )
+}
+
+main().catch((err) => {
+    console.error('Backfill failed:', err)
+    process.exit(1)
+})


### PR DESCRIPTION
**Redis scope-reduction** (ADR `docs/decisions/2026-05-31-guild-settings-postgres-source-of-truth.md`, refines redis-scope-reduction; PRD #1111). Sixth store.

Makes **Postgres the source of truth for guild settings**. `GuildSettingsService` now reads/writes `prisma.guildSettings` directly — **no cache** (single-instance + local DB → per-command read is cheap + always fresh; a cache would re-add staleness + Redis, against the goal).

**Resolves a split-brain:** the Postgres `guild_settings` table already existed and was written by the birthday feature, while music/perm settings lived in Redis (7-day TTL → silent config reset on expiry). Now one row, one source.

**Changes:**
- 4 settings methods (`get`/`set`/`update`/`delete`) rewired Redis→Postgres. `update` = upsert with only the provided fields (never clobbers the birthday columns this service doesn't own).
- Migration `20260531000003`: adds the 3 settings-only columns that lived only in the Redis blob — `djRoleId`, `idleTimeoutMinutes`, `voteSkipThreshold` (additive, nullable, defaults). The other ~15 columns already existed.
- `scripts/backfill-guild-settings.mjs` — one-time, operator-run BEFORE deploy: scans Redis `guild_settings:*` blobs → `prisma.guildSettings.upsert` (birthday columns preserved; expired keys → defaults; `--dry-run`).
- Redis fully dropped from this service (counters already Postgres, rate-limit already in-memory).

**Decision + spec docs included** (from the research-and-decide pass).

**Verified:** shared + bot + backend `tsc --noEmit` (strict) clean; **18 shared tests + 11 bot counter tests pass**; no residual Redis in the service.

**Operator note:** run the backfill once before deploying, else guilds revert to default settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DJ role configuration to restrict music commands to specific roles
  * Added idle timeout settings for automatic bot disconnection after inactivity
  * Added customizable vote skip threshold for track skipping requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->