### PR TITLE
fix(bot): watchdog discovers orphan sessions via postgres, not redis

### DIFF
--- a/packages/bot/src/utils/music/sessionSnapshots.spec.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.spec.ts
@@ -21,6 +21,7 @@ jest.mock('discord-player', () => ({
 
 const mockGetPrismaClient = jest.mocked(getPrismaClient)
 const mockFindUnique = jest.fn<any>()
+const mockFindMany = jest.fn<any>()
 const mockDeleteMany = jest.fn<any>()
 const mockCreate = jest.fn<any>()
 
@@ -88,11 +89,13 @@ describe('MusicSessionSnapshotService', () => {
         mockGetPrismaClient.mockReturnValue({
             musicSessionSnapshot: {
                 findUnique: mockFindUnique,
+                findMany: mockFindMany,
                 deleteMany: mockDeleteMany,
                 create: mockCreate,
             },
         } as any)
         mockFindUnique.mockResolvedValue(null)
+        mockFindMany.mockResolvedValue([])
         mockDeleteMany.mockResolvedValue({ count: 1 })
         mockCreate.mockResolvedValue(snapshotRow())
     })
@@ -207,6 +210,29 @@ describe('MusicSessionSnapshotService', () => {
             mockFindUnique.mockResolvedValueOnce(null)
             const service = new MusicSessionSnapshotService()
             expect(await service.getSnapshot('g')).toBeNull()
+        })
+    })
+
+    describe('listGuildIds', () => {
+        it('returns guild ids for non-expired snapshots (TTL-filtered query)', async () => {
+            mockFindMany.mockResolvedValueOnce([
+                { guildId: 'g1' },
+                { guildId: 'g2' },
+            ])
+            const service = new MusicSessionSnapshotService()
+            expect(await service.listGuildIds()).toEqual(['g1', 'g2'])
+            expect(mockFindMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { savedAt: { gte: expect.any(Date) } },
+                    select: { guildId: true },
+                }),
+            )
+        })
+
+        it('returns an empty array on query error', async () => {
+            mockFindMany.mockRejectedValueOnce(new Error('db down'))
+            const service = new MusicSessionSnapshotService()
+            expect(await service.listGuildIds()).toEqual([])
         })
     })
 

--- a/packages/bot/src/utils/music/sessionSnapshots.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.ts
@@ -224,6 +224,29 @@ export class MusicSessionSnapshotService {
     }
 
     /**
+     * Lists guild IDs that currently have a non-expired snapshot. Replaces the
+     * watchdog's old Redis `keys('music:session:*')` scan now that snapshots live
+     * in Postgres. Filters by the storage TTL so callers don't act on stale rows.
+     */
+    async listGuildIds(): Promise<string[]> {
+        try {
+            const prisma = getPrismaClient()
+            const cutoff = new Date(Date.now() - this.ttlSeconds * 1000)
+            const rows = await prisma.musicSessionSnapshot.findMany({
+                where: { savedAt: { gte: cutoff } },
+                select: { guildId: true },
+            })
+            return rows.map((r) => r.guildId)
+        } catch (error) {
+            errorLog({
+                message: 'Failed to list music session snapshot guilds',
+                error,
+            })
+            return []
+        }
+    }
+
+    /**
      * Delete the snapshot for a guild.
      * Called after a successful restore so the same snapshot is not re-applied
      * on subsequent connections.

--- a/packages/bot/src/utils/music/watchdog.spec.ts
+++ b/packages/bot/src/utils/music/watchdog.spec.ts
@@ -5,20 +5,12 @@ import { MusicWatchdogService } from './watchdog'
 
 // --- mocks ---
 
-const keysMock = jest.fn()
-const isHealthyMock = jest.fn()
+const listGuildIdsMock = jest.fn()
 
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
     errorLog: jest.fn(),
     infoLog: jest.fn(),
-}))
-
-jest.mock('@lucky/shared/services', () => ({
-    redisClient: {
-        isHealthy: (...args: unknown[]) => isHealthyMock(...args),
-        keys: (...args: unknown[]) => keysMock(...args),
-    },
 }))
 
 const getSnapshotMock = jest.fn()
@@ -27,6 +19,7 @@ const deleteSnapshotMock = jest.fn()
 
 jest.mock('./sessionSnapshots', () => ({
     musicSessionSnapshotService: {
+        listGuildIds: (...args: unknown[]) => listGuildIdsMock(...args),
         getSnapshot: (...args: unknown[]) => getSnapshotMock(...args),
         restoreSnapshot: (...args: unknown[]) => restoreSnapshotMock(...args),
         deleteSnapshot: (...args: unknown[]) => deleteSnapshotMock(...args),
@@ -36,7 +29,6 @@ jest.mock('./sessionSnapshots', () => ({
 describe('MusicWatchdogService', () => {
     beforeEach(() => {
         jest.useFakeTimers()
-        isHealthyMock.mockReturnValue(false)
     })
 
     it('attempts recovery when queue is stalled', async () => {
@@ -97,8 +89,7 @@ describe('MusicWatchdogService', () => {
 describe('MusicWatchdogService — orphan session monitor', () => {
     beforeEach(() => {
         jest.useFakeTimers()
-        isHealthyMock.mockReturnValue(true)
-        keysMock.mockResolvedValue([])
+        listGuildIdsMock.mockResolvedValue([])
         getSnapshotMock.mockResolvedValue(null)
         restoreSnapshotMock.mockResolvedValue({
             restoredCount: 1,
@@ -125,9 +116,8 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         service.stopOrphanSessionMonitor()
     })
 
-
     it('scanOrphanSessions skips guild when snapshot is missing', async () => {
-        keysMock.mockResolvedValue(['music:session:guild-99'])
+        listGuildIdsMock.mockResolvedValue(['guild-99'])
         getSnapshotMock.mockResolvedValue(null)
 
         const nodes = { get: jest.fn().mockReturnValue(null) }
@@ -140,7 +130,7 @@ describe('MusicWatchdogService — orphan session monitor', () => {
     })
 
     it('scanOrphanSessions skips guild when snapshot is stale (>30 min)', async () => {
-        keysMock.mockResolvedValue(['music:session:guild-stale'])
+        listGuildIdsMock.mockResolvedValue(['guild-stale'])
         getSnapshotMock.mockResolvedValue({
             savedAt: Date.now() - 31 * 60 * 1_000,
             voiceChannelId: 'vc-1',
@@ -157,7 +147,7 @@ describe('MusicWatchdogService — orphan session monitor', () => {
     })
 
     it('scanOrphanSessions skips guild when queue is already playing', async () => {
-        keysMock.mockResolvedValue(['music:session:guild-playing'])
+        listGuildIdsMock.mockResolvedValue(['guild-playing'])
         getSnapshotMock.mockResolvedValue({
             savedAt: Date.now() - 60_000,
             voiceChannelId: 'vc-1',
@@ -175,7 +165,7 @@ describe('MusicWatchdogService — orphan session monitor', () => {
     })
 
     it('scanOrphanSessions skips guild when voice channel has no non-bot members', async () => {
-        keysMock.mockResolvedValue(['music:session:guild-empty'])
+        listGuildIdsMock.mockResolvedValue(['guild-empty'])
         getSnapshotMock.mockResolvedValue({
             savedAt: Date.now() - 60_000,
             voiceChannelId: 'vc-empty',
@@ -204,7 +194,7 @@ describe('MusicWatchdogService — orphan session monitor', () => {
     })
 
     it('scanOrphanSessions recovers orphan session when all conditions met', async () => {
-        keysMock.mockResolvedValue(['music:session:guild-recover'])
+        listGuildIdsMock.mockResolvedValue(['guild-recover'])
         getSnapshotMock.mockResolvedValue({
             savedAt: Date.now() - 60_000,
             voiceChannelId: 'vc-active',
@@ -242,14 +232,16 @@ describe('MusicWatchdogService — orphan session monitor', () => {
 
         expect(nodes.create).toHaveBeenCalledWith(guild)
         expect(queue.connect).toHaveBeenCalledWith(voiceChannel)
-        expect(restoreSnapshotMock).toHaveBeenCalledWith(queue, undefined, { skipCurrentTrack: true })
+        expect(restoreSnapshotMock).toHaveBeenCalledWith(queue, undefined, {
+            skipCurrentTrack: true,
+        })
         expect(service.getGuildState('guild-recover')).toEqual(
             expect.objectContaining({ lastRecoveryAction: 'rejoin' }),
         )
     })
 
     it('reuses existing queue during orphan recovery and avoids creating a new queue', async () => {
-        keysMock.mockResolvedValue(['music:session:guild-existing'])
+        listGuildIdsMock.mockResolvedValue(['guild-existing'])
         getSnapshotMock.mockResolvedValue({
             savedAt: Date.now() - 60_000,
             voiceChannelId: 'vc-existing',
@@ -285,11 +277,15 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         await service.scanOrphanSessions(player)
 
         expect(nodes.create).not.toHaveBeenCalled()
-        expect(restoreSnapshotMock).toHaveBeenCalledWith(existingQueue, undefined, { skipCurrentTrack: true })
+        expect(restoreSnapshotMock).toHaveBeenCalledWith(
+            existingQueue,
+            undefined,
+            { skipCurrentTrack: true },
+        )
     })
 
     it('clears snapshot and marks failed when restore yields no tracks', async () => {
-        keysMock.mockResolvedValue(['music:session:guild-empty-restore'])
+        listGuildIdsMock.mockResolvedValue(['guild-empty-restore'])
         getSnapshotMock.mockResolvedValue({
             savedAt: Date.now() - 60_000,
             voiceChannelId: 'vc-active',
@@ -335,10 +331,7 @@ describe('MusicWatchdogService — orphan session monitor', () => {
     })
 
     it('scanOrphanSessions isolates errors per guild', async () => {
-        keysMock.mockResolvedValue([
-            'music:session:guild-err',
-            'music:session:guild-ok',
-        ])
+        listGuildIdsMock.mockResolvedValue(['guild-err', 'guild-ok'])
         getSnapshotMock
             .mockRejectedValueOnce(new Error('Redis read error'))
             .mockResolvedValueOnce(null)
@@ -354,7 +347,7 @@ describe('MusicWatchdogService — orphan session monitor', () => {
     })
 
     it('scanOrphanSessions skips guild when channel type is not GuildVoice', async () => {
-        keysMock.mockResolvedValue(['music:session:guild-stage'])
+        listGuildIdsMock.mockResolvedValue(['guild-stage'])
         getSnapshotMock.mockResolvedValue({
             savedAt: Date.now() - 60_000,
             voiceChannelId: 'stage-vc',
@@ -425,7 +418,6 @@ describe('MusicWatchdogService — constructor env var parsing', () => {
 describe('MusicWatchdogService — checkAndRecover edge cases', () => {
     beforeEach(() => {
         jest.useFakeTimers()
-        isHealthyMock.mockReturnValue(false)
     })
 
     it('returns failed when connection is not ready after second rejoin', async () => {
@@ -504,14 +496,11 @@ describe('MusicWatchdogService — checkAndRecover edge cases', () => {
 describe('MusicWatchdogService — startPeriodicScan', () => {
     beforeEach(() => {
         jest.useFakeTimers()
-        isHealthyMock.mockReturnValue(false)
-        keysMock.mockResolvedValue([])
+        listGuildIdsMock.mockResolvedValue([])
     })
 
-
     it('scanOrphanedSessions arms orphaned queues that are not playing', async () => {
-        isHealthyMock.mockReturnValue(true)
-        keysMock.mockResolvedValue(['music:session:guild-orphan'])
+        listGuildIdsMock.mockResolvedValue(['guild-orphan'])
 
         const queue = {
             guild: { id: 'guild-orphan' },

--- a/packages/bot/src/utils/music/watchdog.ts
+++ b/packages/bot/src/utils/music/watchdog.ts
@@ -2,7 +2,6 @@ import type { GuildQueue, Player } from 'discord-player'
 import type { VoiceChannel } from 'discord.js'
 import { ChannelType } from 'discord.js'
 import { debugLog, errorLog, infoLog } from '@lucky/shared/utils'
-import { redisClient } from '@lucky/shared/services'
 import { musicSessionSnapshotService } from './sessionSnapshots'
 
 export type RecoveryAction =
@@ -21,8 +20,6 @@ export type WatchdogGuildState = {
     lastRecoveryDetail: string | null
 }
 
-const SNAPSHOT_KEY_PREFIX = 'music:session:'
-const SESSION_KEY_PREFIX = 'music:session:'
 const SNAPSHOT_MAX_AGE_MS = 30 * 60 * 1_000
 
 type MusicWatchdogOptions = {
@@ -241,18 +238,9 @@ export class MusicWatchdogService {
     }
 
     async scanOrphanSessions(player: Player): Promise<void> {
-        if (!redisClient.isHealthy()) return
+        const guildIds = await musicSessionSnapshotService.listGuildIds()
 
-        let sessionKeys: string[]
-        try {
-            sessionKeys = await redisClient.keys(`${SESSION_KEY_PREFIX}*`)
-        } catch (error) {
-            errorLog({ message: 'Watchdog failed to scan session keys', error })
-            return
-        }
-
-        for (const key of sessionKeys) {
-            const guildId = key.slice(SESSION_KEY_PREFIX.length)
+        for (const guildId of guildIds) {
             try {
                 await this.recoverOrphanSession(player, guildId)
             } catch (error) {
@@ -302,8 +290,11 @@ export class MusicWatchdogService {
             await queue.connect(voiceChannel)
         }
 
-        const restoreResult =
-            await musicSessionSnapshotService.restoreSnapshot(queue, undefined, { skipCurrentTrack: true })
+        const restoreResult = await musicSessionSnapshotService.restoreSnapshot(
+            queue,
+            undefined,
+            { skipCurrentTrack: true },
+        )
         if (!restoreResult || restoreResult.restoredCount <= 0) {
             await musicSessionSnapshotService.deleteSnapshot(guildId)
 
@@ -343,9 +334,8 @@ export class MusicWatchdogService {
     ): Promise<string[]> {
         const recovered: string[] = []
         try {
-            const keys = await redisClient.keys(`${SNAPSHOT_KEY_PREFIX}*`)
-            for (const key of keys) {
-                const guildId = key.slice(SNAPSHOT_KEY_PREFIX.length)
+            const guildIds = await musicSessionSnapshotService.listGuildIds()
+            for (const guildId of guildIds) {
                 const queue = getQueue(guildId)
                 if (!queue) continue
                 if (queue.node.isPlaying()) continue


### PR DESCRIPTION
**Bug fix + Redis scope-reduction** (PRD #1111). Regression introduced by #1114.

When `MusicSessionSnapshot` moved to Postgres (#1114), the watchdog kept discovering orphan-session guilds via `redisClient.keys('music:session:*')` (two scans: `scanOrphanSessions`, `scanOrphanedSessions`). Snapshots no longer live in Redis → those scans return **empty** → orphan-session recovery has silently done nothing since #1114.

**Fix:**
- Add `MusicSessionSnapshotService.listGuildIds()` — TTL-filtered `findMany({ where:{ savedAt:{ gte: cutoff } }, select:{ guildId:true } })`. Indexed-friendly; replaces the Redis `.keys()` scan (also the ADR-named "watchdog `.keys()`→indexed query" item).
- Both watchdog scans now call `listGuildIds()`.
- Drop the dead `redisClient` import + `SESSION_KEY_PREFIX`/`SNAPSHOT_KEY_PREFIX` consts from the watchdog (it no longer touches Redis at all).

**Verified:** bot `tsc --noEmit` (strict) clean; **39 tests pass** (watchdog + sessionSnapshots, incl. 2 new `listGuildIds` cases); no residual Redis in watchdog.
