### PR TITLE
fix(bot): startup session restore scans postgres, not redis

### DIFF
--- a/packages/bot/src/utils/music/sessionStartupRestore.spec.ts
+++ b/packages/bot/src/utils/music/sessionStartupRestore.spec.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import type { CustomClient } from '../../types'
+
+jest.mock('@lucky/shared/config', () => ({
+    ENVIRONMENT_CONFIG: { MUSIC: { SESSION_RESTORE_ENABLED: true } },
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+    infoLog: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
+const listGuildIdsMock = jest.fn<any>()
+const getSnapshotMock = jest.fn<any>()
+const deleteSnapshotMock = jest.fn<any>()
+const restoreSnapshotMock = jest.fn<any>()
+
+jest.mock('./sessionSnapshots', () => ({
+    musicSessionSnapshotService: {
+        listGuildIds: (...a: unknown[]) => listGuildIdsMock(...a),
+        getSnapshot: (...a: unknown[]) => getSnapshotMock(...a),
+        deleteSnapshot: (...a: unknown[]) => deleteSnapshotMock(...a),
+        restoreSnapshot: (...a: unknown[]) => restoreSnapshotMock(...a),
+    },
+}))
+
+import { restoreSessionsOnStartup } from './sessionStartupRestore'
+
+function clientWith(guildId: string, channelVoice = true): CustomClient {
+    const channel = { isVoiceBased: () => channelVoice }
+    const guild = { channels: { cache: { get: () => channel } } }
+    const queue = { connection: null, connect: jest.fn(async () => undefined) }
+    return {
+        guilds: {
+            cache: {
+                get: (id: string) => (id === guildId ? guild : undefined),
+            },
+        },
+        player: { nodes: { create: jest.fn(() => queue) } },
+    } as unknown as CustomClient
+}
+
+describe('restoreSessionsOnStartup', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        listGuildIdsMock.mockResolvedValue([])
+        getSnapshotMock.mockResolvedValue(null)
+        restoreSnapshotMock.mockResolvedValue({
+            restoredCount: 0,
+            sessionSnapshotId: null,
+        })
+    })
+
+    it('discovers guilds via Postgres listGuildIds, not Redis', async () => {
+        await restoreSessionsOnStartup(clientWith('g1'))
+        expect(listGuildIdsMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('no-ops when there are no snapshots', async () => {
+        listGuildIdsMock.mockResolvedValue([])
+        await restoreSessionsOnStartup(clientWith('g1'))
+        expect(getSnapshotMock).not.toHaveBeenCalled()
+    })
+
+    it('restores a fresh snapshot for a cached guild', async () => {
+        listGuildIdsMock.mockResolvedValue(['g1'])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now() - 60_000,
+            voiceChannelId: 'vc-1',
+        })
+        restoreSnapshotMock.mockResolvedValue({
+            restoredCount: 2,
+            sessionSnapshotId: 's1',
+        })
+
+        await restoreSessionsOnStartup(clientWith('g1'))
+        expect(restoreSnapshotMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('deletes a stale snapshot instead of restoring', async () => {
+        listGuildIdsMock.mockResolvedValue(['g1'])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now() - 60 * 60 * 1000, // 1h > 30m
+            voiceChannelId: 'vc-1',
+        })
+
+        await restoreSessionsOnStartup(clientWith('g1'))
+        expect(deleteSnapshotMock).toHaveBeenCalledWith('g1')
+        expect(restoreSnapshotMock).not.toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/utils/music/sessionStartupRestore.ts
+++ b/packages/bot/src/utils/music/sessionStartupRestore.ts
@@ -1,53 +1,50 @@
 import type { CustomClient } from '../../types'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
-import { redisClient } from '@lucky/shared/services'
 import { errorLog, infoLog, warnLog } from '@lucky/shared/utils'
 import { musicSessionSnapshotService } from './sessionSnapshots'
 
-const SESSION_KEY_PREFIX = 'music:session:'
 const STARTUP_MAX_AGE_MS = 30 * 60 * 1_000 // 30 minutes
 
 /**
- * Scans Redis for guild session snapshots and attempts to restore each one
- * by rejoining the stored voice channel and re-queuing tracks.
+ * Restores guild session snapshots (now stored in Postgres) on startup by
+ * rejoining the stored voice channel and re-queuing tracks.
  *
  * Called once from clientReady. Per-guild errors are isolated so one failure
  * does not abort the entire sweep.
  */
-export async function restoreSessionsOnStartup(client: CustomClient): Promise<void> {
+export async function restoreSessionsOnStartup(
+    client: CustomClient,
+): Promise<void> {
     if (!ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED) return
 
-    let keys: string[]
-    try {
-        keys = await redisClient.keys(`${SESSION_KEY_PREFIX}*`)
-    } catch (error) {
-        errorLog({ message: 'Startup session sweep: failed to scan Redis keys', error })
-        return
-    }
+    const guildIds = await musicSessionSnapshotService.listGuildIds()
 
-    if (keys.length === 0) return
+    if (guildIds.length === 0) return
 
-    infoLog({ message: `Startup session sweep: found ${keys.length} snapshot(s)` })
+    infoLog({
+        message: `Startup session sweep: found ${guildIds.length} snapshot(s)`,
+    })
 
-    for (const key of keys) {
-        const guildId = key.slice(SESSION_KEY_PREFIX.length)
-
+    for (const guildId of guildIds) {
         try {
             const guild = client.guilds.cache.get(guildId)
             if (!guild) {
                 warnLog({
-                    message: 'Startup session sweep: guild not in cache, skipping',
+                    message:
+                        'Startup session sweep: guild not in cache, skipping',
                     data: { guildId },
                 })
                 continue
             }
 
-            const snapshot = await musicSessionSnapshotService.getSnapshot(guildId)
+            const snapshot =
+                await musicSessionSnapshotService.getSnapshot(guildId)
             if (!snapshot) continue
 
             if (!snapshot.voiceChannelId) {
                 warnLog({
-                    message: 'Startup session sweep: snapshot missing voiceChannelId, skipping',
+                    message:
+                        'Startup session sweep: snapshot missing voiceChannelId, skipping',
                     data: { guildId },
                 })
                 continue
@@ -66,7 +63,8 @@ export async function restoreSessionsOnStartup(client: CustomClient): Promise<vo
             const channel = guild.channels.cache.get(snapshot.voiceChannelId)
             if (!channel?.isVoiceBased()) {
                 warnLog({
-                    message: 'Startup session sweep: voice channel not found or not voice-based',
+                    message:
+                        'Startup session sweep: voice channel not found or not voice-based',
                     data: { guildId, voiceChannelId: snapshot.voiceChannelId },
                 })
                 continue
@@ -80,9 +78,13 @@ export async function restoreSessionsOnStartup(client: CustomClient): Promise<vo
                 await queue.connect(channel)
             }
 
-            const result = await musicSessionSnapshotService.restoreSnapshot(queue, undefined, {
-                maxAgeMs: STARTUP_MAX_AGE_MS,
-            })
+            const result = await musicSessionSnapshotService.restoreSnapshot(
+                queue,
+                undefined,
+                {
+                    maxAgeMs: STARTUP_MAX_AGE_MS,
+                },
+            )
 
             if (result.restoredCount > 0) {
                 infoLog({
@@ -96,7 +98,8 @@ export async function restoreSessionsOnStartup(client: CustomClient): Promise<vo
             }
         } catch (error) {
             errorLog({
-                message: 'Startup session sweep: failed to restore snapshot for guild',
+                message:
+                    'Startup session sweep: failed to restore snapshot for guild',
                 error,
                 data: { guildId },
             })


### PR DESCRIPTION
**Bug fix** (PRD #1111). **Twin of #1118**, same root cause.

`restoreSessionsOnStartup` (called from `clientReady`) discovered guilds to restore via `redisClient.keys('music:session:*')`. Snapshots moved to Postgres in #1114, so that scan returns **empty** → the function early-returns → **startup session restore has silently done nothing since #1114**. I fixed the watchdog twin in #1118 but missed this one.

**Fix:**
- Swap the Redis `.keys()` scan for `musicSessionSnapshotService.listGuildIds()` (the Postgres TTL-filtered method added in #1118).
- Drop the dead `redisClient` import + `SESSION_KEY_PREFIX` const (file no longer touches Redis).
- Add the spec this file never had: discovers-via-Postgres, no-op-when-empty, restores-fresh, deletes-stale (4 tests).

Caller (`clientReady.ts`) unchanged — signature identical.

**Verified:** bot `tsc --noEmit` (strict) clean; 4 new tests pass; no residual Redis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for music session restoration on startup, verifying snapshot discovery, restoration, and cleanup of stale sessions.

* **Refactor**
  * Updated session snapshot retrieval to use database storage for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->