### PR TITLE
docs(adr): record redis cache-drop + feedback-storage decisions

### DIFF
--- a/docs/decisions/2026-06-01-drop-redis-read-through-caches.md
+++ b/docs/decisions/2026-06-01-drop-redis-read-through-caches.md
@@ -1,0 +1,74 @@
+---
+status: accepted
+date: 2026-06-01
+refines: 2026-05-31-redis-scope-reduction
+revisit_after: when a revisit trigger below fires
+---
+
+# Drop the Redis read-through caches over Postgres (moderation, custom commands, role access)
+
+## Status
+
+Accepted. Refines [[2026-05-31-redis-scope-reduction]]; parallels
+[[2026-05-31-guild-settings-postgres-source-of-truth]]. Decided via research + Opus
+`critic` (critic did not flip the leader; it sharpened the rollout by call-frequency).
+
+## Context
+
+Three shared services — `moderationSettings`, `CustomCommandService`,
+`GuildRoleAccessService` — share one pattern: **Postgres is already the source of
+truth**; Redis is only a **read-through cache** (300s TTL) with write-invalidation
+(`redisClient.del` on update), all guarded by `redisClient.isHealthy()` so they already
+fall through to Postgres when Redis is down. So unlike GuildSettings (which was a real
+Redis-SoT split-brain), here Redis carries **no unique data** — pure optional cache.
+
+Cross-process: the backend (web UI) writes these; the bot reads them. Today a web-UI
+change is visible to the bot only on the next cache-miss (≤300s) — i.e. the cache _adds_
+staleness.
+
+Critic finding: the three are NOT one heat class. `CustomCommandService.listCommands()`
+runs **per message** (message-handler hot path) — but it already has **no cache** (direct
+table scan today). `getCommand()` is the cached one. `moderationSettings` +
+`GuildRoleAccessService` are **off-path** (guild-automation capture/apply only, not
+per-message).
+
+## Decision
+
+**Drop the Redis cache from all three; read Postgres directly.** Single-instance +
+co-located Postgres → a direct read per call is cheap and **always fresh**, and removing
+the cache _removes_ the cross-process staleness rather than adding it. Postgres errors
+fail fast (callers already have try/catch — confirmed at the custom-command handler).
+
+Roll out as two slices by risk:
+
+1. **Moderation + RBAC** (off-path, zero per-message heat) — drop cache, trivial.
+2. **Custom commands** (`getCommand` cached, `listCommands` already uncached + per-message)
+   — drop the `getCommand` cache; `listCommands` is unchanged. Acknowledge the per-message
+   Postgres read; revisit only if measured slow.
+
+## Alternatives considered
+
+- **A — keep the Redis caches.** Rejected: undercuts the pub/sub-only goal, and the cache
+  only _adds_ cross-process staleness here (Postgres is already SoT + co-located).
+- **C — in-memory (per-process) cache.** Rejected: bot wouldn't see backend web-UI writes
+  (per-process staleness, no shared invalidation) — strictly worse than direct read for the
+  backend-writes/bot-reads split. Reconsider only if a per-message read is measured hot.
+- **D — drop + Redis pub/sub invalidation.** Rejected: overkill; keeps Redis.
+
+## Consequences
+
+Positive: ~3 fewer Redis consumers (advances pub/sub-only); web-UI writes instantly fresh
+to the bot; fail-fast beats retry-on-flaky-Redis. No backfill (Redis held no unique data).
+Bonus: `CustomCommandService.incrementUsage()` had a latent cache-staleness bug (updated
+Postgres, not the cached copy) — dropping the cache fixes it.
+
+Negative / accept: a Postgres read per call, incl. `getCommand` on command use. Acceptable
+single-instance/co-located; measure if it ever feels slow. Keep `upsertCommand`'s
+`pg_advisory_xact_lock` — it's for transaction isolation, NOT cache coherence; survives the drop.
+
+## Revisit when
+
+- Custom-command per-message Postgres read latency becomes measurable (>~10ms) → add an
+  in-process LRU for `getCommand`/`listCommands` (process-local, no cross-process concern).
+- Bot goes multi-instance → in-memory caches break; re-evaluate shared cache / invalidation.
+- Postgres latency shows on guild-automation capture → cache or preload, decide then.

--- a/docs/decisions/2026-06-01-recommendation-feedback-storage.md
+++ b/docs/decisions/2026-06-01-recommendation-feedback-storage.md
@@ -1,0 +1,78 @@
+---
+status: accepted
+date: 2026-06-01
+refines: 2026-05-31-redis-scope-reduction
+revisit_after: when a revisit trigger below fires
+---
+
+# Recommendation feedback: explicit→Postgres, artist→unify on userArtistPreference, implicit→in-memory
+
+## Status
+
+Accepted. Refines [[2026-05-31-redis-scope-reduction]]. Decided via research + Opus
+`critic` (ACCEPT, no flip).
+
+## Context
+
+`RecommendationFeedbackService` (`packages/bot/src/services/musicRecommendation/feedbackService.ts`)
+stores autoplay feedback in THREE Redis maps (per-user JSON blobs, `setex`):
+
+1. **explicit** `music:feedback:{userId}` — per-track 👍/👎, 30d TTL, time-decayed weight
+   (`decayWeight`). Redis-only SoT. Written by Discord commands; read by the autoplay replenisher.
+2. **artist** `music:artist_feedback:{userId}` — per-artist prefer/block, 30d TTL.
+   **SPLIT-BRAIN:** the bot writes Redis-only (`setArtistFeedback`), but reads MERGE Redis +
+   the Postgres `userArtistPreference` table — and the **backend** (`artistSuggestion.ts`,
+   web-UI "Preferred Artists") writes prefer/block to that SAME table. Set an artist via
+   Discord vs the web UI → the two stores diverge. Same bug class as GuildSettings.
+3. **implicit** `music:implicit_feedback:{userId}` — behavioral implicit_like/dislike, 14d TTL,
+   hard-capped at the 200 most-recent. Redis-only. Written by player trackHandlers (skip/replay).
+
+Feedback biases autoplay quality only — losing it degrades recommendations, breaks nothing
+(no correctness stake beyond the split-brain). Single instance, co-located Postgres.
+
+## Decision
+
+Three maps, three answers (by data class, not one bucket):
+
+1. **explicit → Postgres** — new `UserTrackFeedback` table (guildId, discordUserId, trackKey,
+   feedback, updatedAt, expiresAt). Lazy-TTL-prune on read (same pattern as the other
+   migrations this session). Decay weight stays a read-time computation.
+2. **artist → unify on the existing `userArtistPreference` table** — kills the split-brain.
+   The Discord write path (`setArtistFeedback`/`removeArtistFeedback`) writes
+   `prisma.userArtistPreference` directly (upsert/delete), exactly like the backend already
+   does. The read path drops the Redis merge and reads Postgres only. Service methods stay as
+   thin wrappers so the ~5 call sites are unchanged.
+3. **implicit → in-memory** (`Map` + 14d TTL + 200 cap). Most ephemeral, behavioral; loss on
+   restart = a temporary autoplay-personalization dip for ~14d, acceptable single-instance.
+
+## Alternatives considered
+
+- **A — all three → Postgres.** Rejected: implicit is behavioral/ephemeral/capped; a table +
+  prune job for signal that's fine to lose on restart is overkill for a hobby bot.
+- **C — keep Redis.** Rejected: leaves the live artist split-brain + undercuts pub/sub-only.
+- **D — defer entirely.** Rejected: the artist split-brain is a live divergence bug; the
+  explicit/implicit moves are cheap riders once we're in the file.
+
+## Consequences
+
+Positive: kills the artist split-brain (one write path: Postgres); explicit feedback survives
+restarts; 3 fewer Redis consumers; implicit simplifies to an in-memory Map. Per-store cutover
+is atomic (read+write switch in the same PR) so no cross-PR split-brain window.
+
+Negative / accept: a new `UserTrackFeedback` table + migration. Postgres reads on the autoplay
+replenisher path (off the per-message hot path — runs on queue-empty). No backfill of current
+Redis feedback — it ages out under its own 30d/14d TTL; users rebuild quickly (acceptable,
+quality-only). Implicit lost on restart (single-instance only).
+
+## Revisit when
+
+- Bot goes multi-instance → in-memory implicit map breaks; move it to Postgres then.
+- Replenisher Postgres read latency becomes measurable → add an in-process cache.
+- Explicit-feedback table grows unbounded despite TTL → add a periodic sweep alongside lazy prune.
+
+## Implementation notes (for the PR, not the decision)
+
+Per critic: per-store atomic cutover (read + write in one PR). `setArtistFeedback` becomes a
+thin Postgres wrapper, not deleted (call sites unchanged). Add a `// REVISIT multi-instance`
+note at the in-memory implicit map. The existing `Recommendation` telemetry model is separate —
+do NOT fold feedback into it.


### PR DESCRIPTION
Commits the two ADRs from this session's research-and-decide passes (referenced by issues #1121–1124, parent #1111). Doc-only.

- `2026-06-01-drop-redis-read-through-caches` — moderationSettings / CustomCommandService / GuildRoleAccessService drop their Redis read-through cache, read Postgres directly (PG already SoT; cache only added cross-process staleness).
- `2026-06-01-recommendation-feedback-storage` — feedbackService: explicit→Postgres (new UserTrackFeedback), artist→unify on existing userArtistPreference (kills split-brain), implicit→in-memory.

Closes the SoT gap: issues reference these ADRs by path, so they must be on main before an agent grabs the work.