### PR TITLE
feat(web): per-route seo metadata + sitemap, robots, og-image

### DIFF
--- a/docs/decisions/2026-06-01-public-route-seo-rendering.md
+++ b/docs/decisions/2026-06-01-public-route-seo-rendering.md
@@ -1,0 +1,128 @@
+# ADR — Public-route SEO rendering for the SPA: build-time per-route meta, not a framework
+
+- **Date:** 2026-06-01
+- **Status:** Accepted
+- **Owner:** Lucas Santana
+- **Related:** issues #1131 (per-route meta in served HTML), #1132 (robots/sitemap/og-image),
+  tracking #1126 (web-app audit 2026-06-01); plan
+  `.claude/plans/2026-06-01-public-route-seo-prerender.md`; decided via
+  `/research-and-decide` (Phase-1 4-lens research + critic challenge).
+
+## Context
+
+`packages/frontend` (lucky-webapp, https://lucky.lucassantana.tech) is a
+**client-rendered SPA**: Vite 8 + React 19.2 + `react-router-dom` 7.15 in
+**declarative mode** (`<BrowserRouter><Routes><Route/>`), all pages `React.lazy()`
+code-split. A single static `index.html` `<head>` is served for **every** route;
+the `usePageMetadata` hook only mutates `document.title` + description **client-side**
+(it doesn't touch OG/Twitter). So every public route ships identical, generic
+metadata in its served HTML — `og:image` is a `/favicon.png`, `twitter:card` is
+`summary`.
+
+This makes the marketing/docs pages effectively invisible to anything that doesn't
+execute JavaScript. As of June 2026, **AI answer-engine crawlers (ChatGPT, Claude,
+Perplexity) do not run JS**; only Google/Gemini renders it. Per-route metadata in
+the **served** HTML is therefore a requirement, not a nicety (issue #1131). The site
+also lacks `robots.txt`, a `sitemap.xml`, and a real OG image (issue #1132).
+
+Constraints that shape the choice: hobby OSS, **low maintenance budget**, solo
+maintainer; **dual deploy** — Vercel (`framework: vite`, SPA rewrite
+`/:path* → /index.html`) **and** a homelab static nginx container
+(`nginx/frontend.conf` uses `try_files $uri $uri/ /index.html`); ~6 public routes
+with largely static content; ~24 auth-gated dashboard routes that **must stay pure
+CSR**. A host-locked solution loses the homelab path.
+
+Scope correction found during implementation: issue #1131 listed `/features` among
+the public routes, but it is auth-gated (`AuthenticatedRoutes` /
+`guardedRoute('automation', …)`, which redirects logged-out visitors to `/`), so it
+is excluded from prerendering. The verified public set is `/`, `/docs`, `/changelog`,
+`/terms` (+ `/terms-of-service`), and `/privacy` (+ `/privacy-policy`).
+
+## Decision
+
+Adopt **build-time per-route META-ONLY HTML generation**, driven by a single shared
+metadata map; **do not migrate the router or adopt a rendering framework, and do not
+server-render page bodies.**
+
+A post-build step writes `dist/<route>/index.html` copies of the built `index.html`
+with the `<head>` (title, description, canonical, OG, Twitter, JSON-LD) swapped per
+route from `src/lib/seo/routeMeta.ts`. The **body stays the unrendered SPA shell**
+(`<div id="root">`), so `createRoot` mounts as today — **no hydration step, no
+hydration-mismatch class of bug**. The same map feeds the runtime `usePageMetadata`
+hook (single source of truth). The same step also emits `sitemap.xml`, `robots.txt`
+(allow public; disallow `/app`, `/api`; link the sitemap), and wires a real 1200×630
+og-image with `twitter:card = summary_large_image` — co-delivering #1132. The build
+script **validates the map and fails CI** if any public route lacks a title/description
+or paths duplicate.
+
+Serving works on both targets with no infra change: Vercel's filesystem precedence
+serves the static `dist/<route>/index.html` ahead of the SPA catch-all rewrite, and
+nginx's existing `try_files $uri $uri/ /index.html` resolves the per-route directory
+index (verify both in the pilot).
+
+## Alternatives considered
+
+1. **React Router 7 framework mode** (`ssr:false` + `prerender` list, `@vercel/react-router`
+   preset) — _rejected for now._ The official, future-proof path and gives full-body
+   prerender, but migrating from declarative `<BrowserRouter><Routes>` to a `routes.ts`
+   config plus `root.tsx`/`entry.client.tsx` entry files and data loaders across ~30
+   routes is ~40–60h with med-high lock-in. Not justified by the marginal SEO gain for
+   6 static pages. **This is the designated escape hatch** if full-body prerender is
+   ever needed.
+2. **vite-prerender-plugin (preactjs)** — _rejected._ Maintained, pure-JS (no Puppeteer),
+   gives full-body prerender with no router change, but reintroduces React-19
+   hydration-mismatch risk and ~2–3× the 12-month cost for content we don't yet need
+   indexed.
+3. **Vike** — _rejected._ Keeps declarative routes and does full SSR/SSG, but ~200 LOC
+   glue + per-route config + hydration coordination is more machinery than the goal warrants.
+4. **react-snap** — _rejected._ Abandoned (~2019, pre-hooks), unverified on React 19,
+   Snyk vulns.
+5. **Next.js 16 / TanStack Start / Astro** — _rejected._ Full-framework rewrites
+   (2–4+ weeks), high lock-in; Astro additionally fights the SPA dashboard shape.
+6. **Vercel Edge Middleware UA-sniff meta-injection** — _rejected._ Vercel-only (breaks
+   homelab), fragile UA sniffing, doesn't solve per-route og-images.
+7. **prerender.io SaaS** — _rejected._ $49+/mo, non-real-time scheduled crawl, high
+   lock-in, serves bloated full HTML for a meta-only need.
+8. **Status quo (client-only `usePageMetadata`)** — _rejected._ Fails #1131: JS-injected
+   meta is invisible to non-JS crawlers.
+
+## Consequences
+
+**Positive**
+
+- Satisfies #1131 (per-route meta in served HTML) and #1132 (robots/sitemap/og-image)
+  in one low-risk build step; ~5–7× cheaper over 12 months than RR7 framework mode.
+- Zero hydration-mismatch risk (body unrendered); zero infra lock-in; works on both
+  Vercel and homelab nginx unchanged.
+- Single metadata map removes server/client drift; build-time validation is a CI tripwire.
+
+**Negative / accepted limits**
+
+- Meta-only: page **body content** is NOT in the served HTML, so deep content
+  indexing of `/docs`/`/features` (snippets in search/AI results) is **not** achieved —
+  only title/description/OG. Acceptable because #1131/#1132 ask for metadata, and the
+  primary use case is rich link previews (Discord/Twitter) + AI-crawler visibility of
+  page identity.
+- Manual coordination: editing `routeMeta.ts` requires a rebuild for served HTML to
+  update (the runtime hook updates live; served HTML is build-time). Mitigated by the
+  single source of truth + CI validation.
+
+**Neutral**
+
+- A small `scripts/prerender-seo.ts` (run via `tsx`; ~210 LOC) + one build-time devDep
+  (`@resvg/resvg-js`, for the og-image) enter the repo; the metadata map becomes a soft
+  contract any future prerender tool would consume.
+
+## Revisit when
+
+- A public route's **page CONTENT** must rank/appear (not just its meta) in Google or
+  AI answer engines — e.g. `/docs` content needs to be a search result snippet, or a
+  measured rank worse than ~position 20 for a target term → flip to **full-body
+  prerender via RR7 framework mode** (alternative 1).
+- The pilot shows Vercel's SPA rewrite winning over the static per-route file, or
+  homelab `try_files` not resolving the per-route directory → revisit serving/output.
+- `routeMeta.ts` exceeds ~500 LOC, or public-route count exceeds ~15 with rich content,
+  or i18n ships per-language public routes → the map/axis outgrows a flat list; migrate
+  to data loaders (RR7 framework mode).
+- og-image generation (if Satori dynamic images are added later) pushes build time
+  past ~60s, or hits a CVE/major-version break → defer images to a CDN/SaaS.

--- a/docs/decisions/2026-06-01-public-route-seo-rendering.md
+++ b/docs/decisions/2026-06-01-public-route-seo-rendering.md
@@ -20,8 +20,10 @@ metadata in its served HTML — `og:image` is a `/favicon.png`, `twitter:card` i
 `summary`.
 
 This makes the marketing/docs pages effectively invisible to anything that doesn't
-execute JavaScript. As of June 2026, **AI answer-engine crawlers (ChatGPT, Claude,
-Perplexity) do not run JS**; only Google/Gemini renders it. Per-route metadata in
+execute JavaScript. As of June 2026 (verified 2026-06-01 via vendor docs + testing
+during the research phase), **AI answer-engine crawlers (ChatGPT, Claude, Perplexity)
+do not run JS**; only Google/Gemini renders it. This is time-sensitive — re-verify if
+revisiting. Per-route metadata in
 the **served** HTML is therefore a requirement, not a nicety (issue #1131). The site
 also lacks `robots.txt`, a `sitemap.xml`, and a real OG image (issue #1132).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7604,6 +7604,234 @@
             "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
             "license": "MIT"
         },
+        "node_modules/@resvg/resvg-js": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+            "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+                "@resvg/resvg-js-android-arm64": "2.6.2",
+                "@resvg/resvg-js-darwin-arm64": "2.6.2",
+                "@resvg/resvg-js-darwin-x64": "2.6.2",
+                "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+                "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+                "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+                "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+                "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+                "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+                "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+                "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+            }
+        },
+        "node_modules/@resvg/resvg-js-android-arm-eabi": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+            "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-android-arm64": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+            "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-darwin-arm64": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+            "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-darwin-x64": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+            "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+            "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+            "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+            "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+            "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-linux-x64-musl": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+            "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+            "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+            "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+            "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
@@ -25226,6 +25454,7 @@
             },
             "devDependencies": {
                 "@playwright/test": "^1.60.0",
+                "@resvg/resvg-js": "^2.6.2",
                 "@sentry/vite-plugin": "^5.3.0",
                 "@tailwindcss/postcss": "^4.3.0",
                 "@testing-library/dom": "^10.4.1",

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -13,7 +13,7 @@
     <meta property="og:description" content="The all-in-one Discord bot for your community. Music, moderation, custom commands, auto-mod, and a full web dashboard. Free forever." />
     <meta property="og:image" content="https://lucky.lucassantana.tech/og-image.png" />
     <meta property="og:url" content="https://lucky.lucassantana.tech" />
-    <link rel="canonical" href="https://lucky.lucassantana.tech/" />
+    <!-- canonical + per-route SEO head are injected at build time by scripts/prerender-seo.ts -->
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -11,14 +11,15 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Lucky — Discord Bot with Music, Moderation & Dashboard" />
     <meta property="og:description" content="The all-in-one Discord bot for your community. Music, moderation, custom commands, auto-mod, and a full web dashboard. Free forever." />
-    <meta property="og:image" content="/favicon.png" />
+    <meta property="og:image" content="https://lucky.lucassantana.tech/og-image.png" />
     <meta property="og:url" content="https://lucky.lucassantana.tech" />
+    <link rel="canonical" href="https://lucky.lucassantana.tech/" />
 
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Lucky — Discord Bot with Music, Moderation & Dashboard" />
     <meta name="twitter:description" content="The all-in-one Discord bot for your community. Music, moderation, custom commands, auto-mod, and a full web dashboard. Free forever." />
-    <meta name="twitter:image" content="/favicon.png" />
+    <meta name="twitter:image" content="https://lucky.lucassantana.tech/og-image.png" />
 
     <!-- JSON-LD Schema -->
     <script type="application/ld+json">

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "tsc && vite build && tsx scripts/prerender-seo.ts",
         "preview": "vite preview",
         "lint": "eslint . --config eslint.config.js --max-warnings 0",
         "type:check": "tsc --noEmit",
@@ -64,6 +64,7 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "@resvg/resvg-js": "^2.6.2",
         "@sentry/vite-plugin": "^5.3.0",
         "@tailwindcss/postcss": "^4.3.0",
         "@testing-library/dom": "^10.4.1",

--- a/packages/frontend/scripts/prerender-seo.ts
+++ b/packages/frontend/scripts/prerender-seo.ts
@@ -1,0 +1,192 @@
+/**
+ * Build-time per-route SEO generation (runs AFTER `vite build`, on `dist/`).
+ *
+ * For each public route it writes a `dist/<route>/index.html` copy of the built
+ * `index.html` with the `<head>` (title, description, OG, Twitter, canonical)
+ * swapped from the shared `routeMeta` map — so non-JS crawlers see real per-route
+ * metadata. The page body is left as the unrendered SPA shell (`<div id="root">`),
+ * so the client still `createRoot`-mounts normally (no hydration step, no mismatch).
+ *
+ * Also emits `sitemap.xml`, `robots.txt`, and a real 1200×630 `og-image.png`.
+ * Closes issues #1131 + #1132. See ADR 2026-06-01-public-route-seo-rendering.
+ */
+import {
+    readFileSync,
+    writeFileSync,
+    mkdirSync,
+    copyFileSync,
+    existsSync,
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+    PUBLIC_ROUTES,
+    DISALLOWED_PATHS,
+    SITE_ORIGIN,
+    assertRouteMetaValid,
+    type RouteMeta,
+} from '../src/lib/seo/routeMeta'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const distDir = resolve(scriptDir, '../dist')
+const publicDir = resolve(scriptDir, '../public')
+const OG_IMAGE_PATH = '/og-image.png'
+const OG_IMAGE_URL = SITE_ORIGIN + OG_IMAGE_PATH
+
+function escAttr(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+}
+
+function escText(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** Replace (or insert before </head>) a `<meta {attr}="{key}" content="…">` tag,
+ *  tolerant of attribute order in the built HTML. */
+function setMeta(
+    html: string,
+    attr: 'name' | 'property',
+    key: string,
+    content: string,
+): string {
+    const tag = `<meta ${attr}="${key}" content="${escAttr(content)}" />`
+    const re = new RegExp(
+        `<meta[^>]*\\b${attr}=["']${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["'][^>]*>`,
+        'i',
+    )
+    if (re.test(html)) return html.replace(re, tag)
+    return html.replace('</head>', `    ${tag}\n  </head>`)
+}
+
+function setCanonical(html: string, url: string): string {
+    const tag = `<link rel="canonical" href="${escAttr(url)}" />`
+    if (/<link[^>]*rel=["']canonical["'][^>]*>/i.test(html)) {
+        return html.replace(/<link[^>]*rel=["']canonical["'][^>]*>/i, tag)
+    }
+    return html.replace('</head>', `    ${tag}\n  </head>`)
+}
+
+function renderRouteHtml(template: string, r: RouteMeta): string {
+    const pageUrl = SITE_ORIGIN + r.path
+    const canonicalUrl = SITE_ORIGIN + (r.canonical ?? r.path)
+    let html = template
+    html = html.replace(
+        /<title>[\s\S]*?<\/title>/i,
+        `<title>${escText(r.title)}</title>`,
+    )
+    html = setMeta(html, 'name', 'description', r.description)
+    html = setMeta(html, 'property', 'og:title', r.title)
+    html = setMeta(html, 'property', 'og:description', r.description)
+    html = setMeta(html, 'property', 'og:url', pageUrl)
+    html = setMeta(html, 'property', 'og:image', OG_IMAGE_URL)
+    html = setMeta(html, 'name', 'twitter:title', r.title)
+    html = setMeta(html, 'name', 'twitter:description', r.description)
+    html = setMeta(html, 'name', 'twitter:image', OG_IMAGE_URL)
+    html = setCanonical(html, canonicalUrl)
+    return html
+}
+
+function writeRouteFile(html: string, routePath: string): string {
+    // '/' -> dist/index.html ; '/docs' -> dist/docs/index.html
+    const rel =
+        routePath === '/'
+            ? 'index.html'
+            : join(routePath.slice(1), 'index.html')
+    const out = join(distDir, rel)
+    mkdirSync(dirname(out), { recursive: true })
+    writeFileSync(out, html, 'utf8')
+    return rel
+}
+
+function buildSitemap(routes: RouteMeta[]): string {
+    const urls = routes
+        .filter((r) => r.sitemap !== false)
+        .map(
+            (r) =>
+                `  <url><loc>${escText(SITE_ORIGIN + r.path)}</loc><changefreq>weekly</changefreq></url>`,
+        )
+        .join('\n')
+    return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`
+}
+
+function buildRobots(): string {
+    const disallows = DISALLOWED_PATHS.map((p) => `Disallow: ${p}`).join('\n')
+    return `User-agent: *\nAllow: /\n${disallows}\n\nSitemap: ${SITE_ORIGIN}/sitemap.xml\n`
+}
+
+/** Generate a real 1200×630 og-image (brand background + centered logo) via resvg.
+ *  Fail-soft: on any error, fall back to copying the existing logo so /og-image.png
+ *  always resolves to a real image (build never breaks on the image). */
+async function generateOgImage(): Promise<string> {
+    const out = join(distDir, 'og-image.png')
+    const logoPath = join(publicDir, 'lucky-logo.png')
+    try {
+        const { Resvg } = await import('@resvg/resvg-js')
+        let logoTag = ''
+        if (existsSync(logoPath)) {
+            const b64 = readFileSync(logoPath).toString('base64')
+            // 360×360 logo centered on the 1200×630 canvas.
+            logoTag = `<image href="data:image/png;base64,${b64}" x="420" y="135" width="360" height="360" preserveAspectRatio="xMidYMid meet"/>`
+        }
+        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#0b0b14"/><stop offset="1" stop-color="#16121f"/>
+  </linearGradient></defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  ${logoTag}
+</svg>`
+        const png = new Resvg(svg, { fitTo: { mode: 'original' } })
+            .render()
+            .asPng()
+        writeFileSync(out, png)
+        return 'generated (1200×630, resvg)'
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err)
+        if (existsSync(logoPath)) {
+            copyFileSync(logoPath, out)
+            return `fallback to lucky-logo.png (resvg unavailable: ${reason})`
+        }
+        return `SKIPPED — no og-image written (resvg failed: ${reason}, no logo fallback)`
+    }
+}
+
+async function main(): Promise<void> {
+    assertRouteMetaValid()
+
+    const templatePath = join(distDir, 'index.html')
+    if (!existsSync(templatePath)) {
+        throw new Error(
+            `prerender-seo: ${templatePath} not found — run \`vite build\` first.`,
+        )
+    }
+    const template = readFileSync(templatePath, 'utf8')
+
+    const written: string[] = []
+    for (const route of PUBLIC_ROUTES) {
+        written.push(
+            writeRouteFile(renderRouteHtml(template, route), route.path),
+        )
+    }
+
+    writeFileSync(
+        join(distDir, 'sitemap.xml'),
+        buildSitemap(PUBLIC_ROUTES),
+        'utf8',
+    )
+    writeFileSync(join(distDir, 'robots.txt'), buildRobots(), 'utf8')
+    const ogStatus = await generateOgImage()
+
+    console.log('[prerender-seo] per-route HTML written:')
+    for (const rel of written) console.log(`  - dist/${rel}`)
+    console.log('[prerender-seo] dist/sitemap.xml, dist/robots.txt written')
+    console.log(`[prerender-seo] og-image: ${ogStatus}`)
+}
+
+main().catch((err) => {
+    console.error('[prerender-seo] FAILED:', err)
+    process.exit(1)
+})

--- a/packages/frontend/scripts/prerender-seo.ts
+++ b/packages/frontend/scripts/prerender-seo.ts
@@ -2,10 +2,10 @@
  * Build-time per-route SEO generation (runs AFTER `vite build`, on `dist/`).
  *
  * For each public route it writes a `dist/<route>/index.html` copy of the built
- * `index.html` with the `<head>` (title, description, OG, Twitter, canonical)
- * swapped from the shared `routeMeta` map — so non-JS crawlers see real per-route
- * metadata. The page body is left as the unrendered SPA shell (`<div id="root">`),
- * so the client still `createRoot`-mounts normally (no hydration step, no mismatch).
+ * `index.html` with the `<head>` swapped (via the pure transforms in
+ * `src/lib/seo/prerender.ts`) — so non-JS crawlers see real per-route metadata.
+ * The page body is left as the unrendered SPA shell (`<div id="root">`), so the
+ * client still `createRoot`-mounts normally (no hydration step, no mismatch).
  *
  * Also emits `sitemap.xml`, `robots.txt`, and a real 1200×630 `og-image.png`.
  * Closes issues #1131 + #1132. See ADR 2026-06-01-public-route-seo-rendering.
@@ -19,76 +19,16 @@ import {
 } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { PUBLIC_ROUTES, assertRouteMetaValid } from '../src/lib/seo/routeMeta'
 import {
-    PUBLIC_ROUTES,
-    DISALLOWED_PATHS,
-    SITE_ORIGIN,
-    assertRouteMetaValid,
-    type RouteMeta,
-} from '../src/lib/seo/routeMeta'
+    renderRouteHtml,
+    buildSitemap,
+    buildRobots,
+} from '../src/lib/seo/prerender'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const distDir = resolve(scriptDir, '../dist')
 const publicDir = resolve(scriptDir, '../public')
-const OG_IMAGE_PATH = '/og-image.png'
-const OG_IMAGE_URL = SITE_ORIGIN + OG_IMAGE_PATH
-
-function escAttr(s: string): string {
-    return s
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-}
-
-function escText(s: string): string {
-    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
-
-/** Replace (or insert before </head>) a `<meta {attr}="{key}" content="…">` tag,
- *  tolerant of attribute order in the built HTML. */
-function setMeta(
-    html: string,
-    attr: 'name' | 'property',
-    key: string,
-    content: string,
-): string {
-    const tag = `<meta ${attr}="${key}" content="${escAttr(content)}" />`
-    const re = new RegExp(
-        `<meta[^>]*\\b${attr}=["']${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["'][^>]*>`,
-        'i',
-    )
-    if (re.test(html)) return html.replace(re, tag)
-    return html.replace('</head>', `    ${tag}\n  </head>`)
-}
-
-function setCanonical(html: string, url: string): string {
-    const tag = `<link rel="canonical" href="${escAttr(url)}" />`
-    if (/<link[^>]*rel=["']canonical["'][^>]*>/i.test(html)) {
-        return html.replace(/<link[^>]*rel=["']canonical["'][^>]*>/i, tag)
-    }
-    return html.replace('</head>', `    ${tag}\n  </head>`)
-}
-
-function renderRouteHtml(template: string, r: RouteMeta): string {
-    const pageUrl = SITE_ORIGIN + r.path
-    const canonicalUrl = SITE_ORIGIN + (r.canonical ?? r.path)
-    let html = template
-    html = html.replace(
-        /<title>[\s\S]*?<\/title>/i,
-        `<title>${escText(r.title)}</title>`,
-    )
-    html = setMeta(html, 'name', 'description', r.description)
-    html = setMeta(html, 'property', 'og:title', r.title)
-    html = setMeta(html, 'property', 'og:description', r.description)
-    html = setMeta(html, 'property', 'og:url', pageUrl)
-    html = setMeta(html, 'property', 'og:image', OG_IMAGE_URL)
-    html = setMeta(html, 'name', 'twitter:title', r.title)
-    html = setMeta(html, 'name', 'twitter:description', r.description)
-    html = setMeta(html, 'name', 'twitter:image', OG_IMAGE_URL)
-    html = setCanonical(html, canonicalUrl)
-    return html
-}
 
 function writeRouteFile(html: string, routePath: string): string {
     // '/' -> dist/index.html ; '/docs' -> dist/docs/index.html
@@ -100,22 +40,6 @@ function writeRouteFile(html: string, routePath: string): string {
     mkdirSync(dirname(out), { recursive: true })
     writeFileSync(out, html, 'utf8')
     return rel
-}
-
-function buildSitemap(routes: RouteMeta[]): string {
-    const urls = routes
-        .filter((r) => r.sitemap !== false)
-        .map(
-            (r) =>
-                `  <url><loc>${escText(SITE_ORIGIN + r.path)}</loc><changefreq>weekly</changefreq></url>`,
-        )
-        .join('\n')
-    return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`
-}
-
-function buildRobots(): string {
-    const disallows = DISALLOWED_PATHS.map((p) => `Disallow: ${p}`).join('\n')
-    return `User-agent: *\nAllow: /\n${disallows}\n\nSitemap: ${SITE_ORIGIN}/sitemap.xml\n`
 }
 
 /** Generate a real 1200×630 og-image (brand background + centered logo) via resvg.
@@ -155,6 +79,7 @@ async function generateOgImage(): Promise<string> {
 }
 
 async function main(): Promise<void> {
+    // Fail loudly before writing anything if the metadata map is incomplete.
     assertRouteMetaValid()
 
     const templatePath = join(distDir, 'index.html')
@@ -165,6 +90,8 @@ async function main(): Promise<void> {
     }
     const template = readFileSync(templatePath, 'utf8')
 
+    // A throw mid-loop leaves dist/ partially written; that's acceptable because a
+    // non-zero exit fails the build and CI/CD rejects the incomplete artifact.
     const written: string[] = []
     for (const route of PUBLIC_ROUTES) {
         written.push(

--- a/packages/frontend/src/lib/seo/prerender.test.ts
+++ b/packages/frontend/src/lib/seo/prerender.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import {
+    renderRouteHtml,
+    buildSitemap,
+    buildRobots,
+    OG_IMAGE_URL,
+} from './prerender'
+import { PUBLIC_ROUTES, ROUTE_META_BY_PATH, type RouteMeta } from './routeMeta'
+
+const TEMPLATE = `<!doctype html>
+<html lang="en">
+  <head>
+    <title>Default Title</title>
+    <meta name="description" content="default description" />
+    <meta property="og:title" content="Default Title" />
+    <meta property="og:description" content="default description" />
+    <meta property="og:url" content="https://lucky.lucassantana.tech" />
+    <meta property="og:image" content="https://lucky.lucassantana.tech/og-image.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Default Title" />
+    <meta name="twitter:description" content="default description" />
+    <meta name="twitter:image" content="https://lucky.lucassantana.tech/og-image.png" />
+    <link rel="canonical" href="https://lucky.lucassantana.tech/" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/assets/index.js"></script>
+  </body>
+</html>`
+
+function getCanonical(html: string): string | null {
+    return html.match(/<link rel="canonical" href="([^"]*)"/)?.[1] ?? null
+}
+function getMeta(html: string, attr: string, key: string): string | null {
+    return (
+        html.match(
+            new RegExp(`<meta ${attr}="${key}" content="([^"]*)"`),
+        )?.[1] ?? null
+    )
+}
+
+describe('renderRouteHtml', () => {
+    it('swaps in distinct per-route title/description/og/canonical', () => {
+        const html = renderRouteHtml(
+            TEMPLATE,
+            ROUTE_META_BY_PATH['/changelog']!,
+        )
+        expect(html).toContain('<title>Changelog · Lucky</title>')
+        expect(getMeta(html, 'name', 'description')).toBe(
+            'Release notes and version history for Lucky.',
+        )
+        expect(getMeta(html, 'property', 'og:title')).toBe('Changelog · Lucky')
+        expect(getMeta(html, 'property', 'og:url')).toBe(
+            'https://lucky.lucassantana.tech/changelog',
+        )
+        expect(getCanonical(html)).toBe(
+            'https://lucky.lucassantana.tech/changelog',
+        )
+        expect(getMeta(html, 'property', 'og:image')).toBe(OG_IMAGE_URL)
+    })
+
+    it('preserves the unrendered SPA body shell and the module script', () => {
+        const html = renderRouteHtml(TEMPLATE, ROUTE_META_BY_PATH['/docs']!)
+        expect(html).toContain('<div id="root"></div>')
+        expect(html).toContain(
+            '<script type="module" src="/assets/index.js"></script>',
+        )
+    })
+
+    it('points an alias og:url at its own path but canonical at the primary', () => {
+        const html = renderRouteHtml(TEMPLATE, ROUTE_META_BY_PATH['/terms']!)
+        expect(getMeta(html, 'property', 'og:url')).toBe(
+            'https://lucky.lucassantana.tech/terms',
+        )
+        expect(getCanonical(html)).toBe(
+            'https://lucky.lucassantana.tech/terms-of-service',
+        )
+    })
+
+    it('leaves twitter:card (summary_large_image) untouched', () => {
+        const html = renderRouteHtml(TEMPLATE, ROUTE_META_BY_PATH['/']!)
+        expect(getMeta(html, 'name', 'twitter:card')).toBe(
+            'summary_large_image',
+        )
+    })
+
+    it('escapes HTML-special characters in metadata', () => {
+        const route: RouteMeta = {
+            path: '/x',
+            title: 'A & B <x>',
+            description: 'desc "q" & <y>',
+        }
+        const html = renderRouteHtml(TEMPLATE, route)
+        expect(html).toContain('<title>A &amp; B &lt;x&gt;</title>')
+        expect(getMeta(html, 'name', 'description')).toBe(
+            'desc &quot;q&quot; &amp; &lt;y&gt;',
+        )
+    })
+})
+
+describe('buildSitemap', () => {
+    it('lists only canonical (non-alias) public routes', () => {
+        const xml = buildSitemap(PUBLIC_ROUTES)
+        const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1])
+        expect(locs.sort()).toEqual(
+            [
+                'https://lucky.lucassantana.tech/',
+                'https://lucky.lucassantana.tech/docs',
+                'https://lucky.lucassantana.tech/changelog',
+                'https://lucky.lucassantana.tech/terms-of-service',
+                'https://lucky.lucassantana.tech/privacy-policy',
+            ].sort(),
+        )
+        // aliases excluded
+        expect(locs).not.toContain('https://lucky.lucassantana.tech/terms')
+        expect(locs).not.toContain('https://lucky.lucassantana.tech/privacy')
+    })
+})
+
+describe('buildRobots', () => {
+    it('allows root, disallows dashboard + api, and links the sitemap', () => {
+        const txt = buildRobots()
+        expect(txt).toContain('User-agent: *')
+        expect(txt).toContain('Allow: /')
+        expect(txt).toContain('Disallow: /api/')
+        expect(txt).toContain('Disallow: /features')
+        expect(txt).toContain(
+            'Sitemap: https://lucky.lucassantana.tech/sitemap.xml',
+        )
+    })
+})

--- a/packages/frontend/src/lib/seo/prerender.test.ts
+++ b/packages/frontend/src/lib/seo/prerender.test.ts
@@ -34,6 +34,7 @@ function getCanonical(html: string): string | null {
 function getMeta(html: string, attr: string, key: string): string | null {
     return (
         html.match(
+            // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
             new RegExp(`<meta ${attr}="${key}" content="([^"]*)"`),
         )?.[1] ?? null
     )
@@ -94,6 +95,20 @@ describe('renderRouteHtml', () => {
         expect(html).toContain('<title>A &amp; B &lt;x&gt;</title>')
         expect(getMeta(html, 'name', 'description')).toBe(
             'desc &quot;q&quot; &amp; &lt;y&gt;',
+        )
+    })
+
+    it('emits literal $-sequences from metadata (no replacement-pattern corruption)', () => {
+        const route: RouteMeta = {
+            path: '/x',
+            title: 'Pay $1 or $$ now',
+            description: 'Save $$ and $1 today',
+        }
+        const html = renderRouteHtml(TEMPLATE, route)
+        // Without function replacers, `$$` collapses to `$` and `$1` is reinterpreted.
+        expect(html).toContain('<title>Pay $1 or $$ now</title>')
+        expect(getMeta(html, 'name', 'description')).toBe(
+            'Save $$ and $1 today',
         )
     })
 })

--- a/packages/frontend/src/lib/seo/prerender.ts
+++ b/packages/frontend/src/lib/seo/prerender.ts
@@ -36,20 +36,25 @@ export function setMeta(
     content: string,
 ): string {
     const tag = `<meta ${attr}="${key}" content="${escAttr(content)}" />`
+    // `attr`/`key` are trusted hardcoded literals (not user input) and the pattern
+    // has no nested quantifiers, so this is ReDoS-safe.
+    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
     const re = new RegExp(
         `<meta[^>]*\\b${attr}=["']${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["'][^>]*>`,
         'i',
     )
-    if (re.test(html)) return html.replace(re, tag)
-    return html.replace('</head>', `    ${tag}\n  </head>`)
+    // Function replacers: `tag`/content may contain `$` and `replace`'s string form
+    // would treat `$&`, `$$`, `$n` as patterns. A function replacer emits it literally.
+    if (re.test(html)) return html.replace(re, () => tag)
+    return html.replace('</head>', () => `    ${tag}\n  </head>`)
 }
 
 export function setCanonical(html: string, url: string): string {
     const tag = `<link rel="canonical" href="${escAttr(url)}" />`
     if (/<link[^>]*rel=["']canonical["'][^>]*>/i.test(html)) {
-        return html.replace(/<link[^>]*rel=["']canonical["'][^>]*>/i, tag)
+        return html.replace(/<link[^>]*rel=["']canonical["'][^>]*>/i, () => tag)
     }
-    return html.replace('</head>', `    ${tag}\n  </head>`)
+    return html.replace('</head>', () => `    ${tag}\n  </head>`)
 }
 
 /**
@@ -66,7 +71,7 @@ export function renderRouteHtml(template: string, r: RouteMeta): string {
     let html = template
     html = html.replace(
         /<title>[\s\S]*?<\/title>/i,
-        `<title>${escText(r.title)}</title>`,
+        () => `<title>${escText(r.title)}</title>`,
     )
     html = setMeta(html, 'name', 'description', r.description)
     html = setMeta(html, 'property', 'og:title', r.title)

--- a/packages/frontend/src/lib/seo/prerender.ts
+++ b/packages/frontend/src/lib/seo/prerender.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure HTML/string transforms for the build-time SEO prerender step
+ * (`scripts/prerender-seo.ts`). Extracted here so they can be unit-tested without
+ * Node `fs` or the resvg native binary — this module has NO side effects and is
+ * safe to import in vitest.
+ */
+import { SITE_ORIGIN, DISALLOWED_PATHS, type RouteMeta } from './routeMeta'
+
+export const OG_IMAGE_PATH = '/og-image.png'
+export const OG_IMAGE_URL = SITE_ORIGIN + OG_IMAGE_PATH
+
+export function escAttr(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+}
+
+export function escText(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/**
+ * Replace (or insert before `</head>`) a `<meta {attr}="{key}" content="…">` tag,
+ * tolerant of attribute order in the built HTML.
+ *
+ * `attr` and `key` are TRUSTED hardcoded literals from the call site (not user
+ * input), so only `content` is escaped; `key` is regex-escaped purely for a safe
+ * match, not for security.
+ */
+export function setMeta(
+    html: string,
+    attr: 'name' | 'property',
+    key: string,
+    content: string,
+): string {
+    const tag = `<meta ${attr}="${key}" content="${escAttr(content)}" />`
+    const re = new RegExp(
+        `<meta[^>]*\\b${attr}=["']${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["'][^>]*>`,
+        'i',
+    )
+    if (re.test(html)) return html.replace(re, tag)
+    return html.replace('</head>', `    ${tag}\n  </head>`)
+}
+
+export function setCanonical(html: string, url: string): string {
+    const tag = `<link rel="canonical" href="${escAttr(url)}" />`
+    if (/<link[^>]*rel=["']canonical["'][^>]*>/i.test(html)) {
+        return html.replace(/<link[^>]*rel=["']canonical["'][^>]*>/i, tag)
+    }
+    return html.replace('</head>', `    ${tag}\n  </head>`)
+}
+
+/**
+ * Produce a route's served HTML by swapping the `<head>` of the built template.
+ *
+ * For alias routes (e.g. `/terms`), `og:url` intentionally reflects the REQUESTED
+ * path while `<link rel="canonical">` points at the primary (`/terms-of-service`):
+ * social shares of either URL preview correctly, while search engines dedupe to the
+ * canonical. The body is left untouched (the SPA `<div id="root">` shell).
+ */
+export function renderRouteHtml(template: string, r: RouteMeta): string {
+    const pageUrl = SITE_ORIGIN + r.path
+    const canonicalUrl = SITE_ORIGIN + (r.canonical ?? r.path)
+    let html = template
+    html = html.replace(
+        /<title>[\s\S]*?<\/title>/i,
+        `<title>${escText(r.title)}</title>`,
+    )
+    html = setMeta(html, 'name', 'description', r.description)
+    html = setMeta(html, 'property', 'og:title', r.title)
+    html = setMeta(html, 'property', 'og:description', r.description)
+    html = setMeta(html, 'property', 'og:url', pageUrl)
+    html = setMeta(html, 'property', 'og:image', OG_IMAGE_URL)
+    html = setMeta(html, 'name', 'twitter:title', r.title)
+    html = setMeta(html, 'name', 'twitter:description', r.description)
+    html = setMeta(html, 'name', 'twitter:image', OG_IMAGE_URL)
+    html = setCanonical(html, canonicalUrl)
+    return html
+}
+
+export function buildSitemap(routes: RouteMeta[]): string {
+    const urls = routes
+        .filter((r) => r.sitemap !== false)
+        .map(
+            (r) =>
+                `  <url><loc>${escText(SITE_ORIGIN + r.path)}</loc><changefreq>weekly</changefreq></url>`,
+        )
+        .join('\n')
+    return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`
+}
+
+export function buildRobots(): string {
+    const disallows = DISALLOWED_PATHS.map((p) => `Disallow: ${p}`).join('\n')
+    return `User-agent: *\nAllow: /\n${disallows}\n\nSitemap: ${SITE_ORIGIN}/sitemap.xml\n`
+}

--- a/packages/frontend/src/lib/seo/routeMeta.test.ts
+++ b/packages/frontend/src/lib/seo/routeMeta.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import {
+    PUBLIC_ROUTES,
+    ROUTE_META_BY_PATH,
+    DISALLOWED_PATHS,
+    SITE_ORIGIN,
+    assertRouteMetaValid,
+    type RouteMeta,
+} from './routeMeta'
+
+describe('routeMeta', () => {
+    it('is internally valid (non-empty, unique paths)', () => {
+        expect(() => assertRouteMetaValid()).not.toThrow()
+    })
+
+    it('covers exactly the verified public routes', () => {
+        const paths = PUBLIC_ROUTES.map((r) => r.path).sort()
+        expect(paths).toEqual(
+            [
+                '/',
+                '/changelog',
+                '/docs',
+                '/privacy',
+                '/privacy-policy',
+                '/terms',
+                '/terms-of-service',
+            ].sort(),
+        )
+    })
+
+    it('does NOT prerender the auth-gated /features route', () => {
+        expect(ROUTE_META_BY_PATH['/features']).toBeUndefined()
+    })
+
+    it('points alias routes at their canonical and excludes them from the sitemap', () => {
+        expect(ROUTE_META_BY_PATH['/terms']?.canonical).toBe(
+            '/terms-of-service',
+        )
+        expect(ROUTE_META_BY_PATH['/terms']?.sitemap).toBe(false)
+        expect(ROUTE_META_BY_PATH['/privacy']?.canonical).toBe(
+            '/privacy-policy',
+        )
+        expect(ROUTE_META_BY_PATH['/privacy']?.sitemap).toBe(false)
+    })
+
+    it('lists only canonical (non-alias) routes in the sitemap set', () => {
+        const inSitemap = PUBLIC_ROUTES.filter((r) => r.sitemap !== false).map(
+            (r) => r.path,
+        )
+        expect(inSitemap.sort()).toEqual(
+            [
+                '/',
+                '/changelog',
+                '/docs',
+                '/privacy-policy',
+                '/terms-of-service',
+            ].sort(),
+        )
+    })
+
+    it('never disallows a public canonical path in robots', () => {
+        const canonicals = PUBLIC_ROUTES.filter((r) => r.sitemap !== false).map(
+            (r) => r.canonical ?? r.path,
+        )
+        for (const c of canonicals) {
+            // '/' is allowed; no disallow rule should equal a canonical public path
+            expect(DISALLOWED_PATHS).not.toContain(c)
+        }
+    })
+
+    it('exposes the production origin', () => {
+        expect(SITE_ORIGIN).toBe('https://lucky.lucassantana.tech')
+    })
+
+    it('rejects an empty title', () => {
+        const bad: RouteMeta[] = [{ path: '/x', title: '  ', description: 'd' }]
+        expect(() => assertRouteMetaValid(bad)).toThrow(/empty title/)
+    })
+
+    it('rejects a duplicate path', () => {
+        const bad: RouteMeta[] = [
+            { path: '/x', title: 't', description: 'd' },
+            { path: '/x', title: 't2', description: 'd2' },
+        ]
+        expect(() => assertRouteMetaValid(bad)).toThrow(/duplicate path/)
+    })
+})

--- a/packages/frontend/src/lib/seo/routeMeta.test.ts
+++ b/packages/frontend/src/lib/seo/routeMeta.test.ts
@@ -5,6 +5,7 @@ import {
     DISALLOWED_PATHS,
     SITE_ORIGIN,
     assertRouteMetaValid,
+    metaFor,
     type RouteMeta,
 } from './routeMeta'
 
@@ -83,5 +84,16 @@ describe('routeMeta', () => {
             { path: '/x', title: 't2', description: 'd2' },
         ]
         expect(() => assertRouteMetaValid(bad)).toThrow(/duplicate path/)
+    })
+
+    it('metaFor returns title+description for a known route', () => {
+        expect(metaFor('/changelog')).toEqual({
+            title: 'Changelog · Lucky',
+            description: 'Release notes and version history for Lucky.',
+        })
+    })
+
+    it('metaFor throws on an unregistered path', () => {
+        expect(() => metaFor('/nope')).toThrow(/no metadata registered/)
     })
 })

--- a/packages/frontend/src/lib/seo/routeMeta.ts
+++ b/packages/frontend/src/lib/seo/routeMeta.ts
@@ -1,0 +1,153 @@
+/**
+ * Single source of truth for public-route SEO metadata.
+ *
+ * Consumed by BOTH:
+ *  - the build-time prerender step (`scripts/prerender-seo.ts`), which writes the
+ *    per-route `<head>` into the served HTML so non-JS crawlers + AI answer engines
+ *    (which don't execute JS as of 2026) see distinct title/description/OG; and
+ *  - the runtime on public pages (Changelog / Terms / Privacy call `usePageMetadata`
+ *    from this map), so the live tab title can't drift from the served HTML.
+ *
+ * Landing is i18n-driven at runtime (`t('landing.meta.*')`); its `/` entry below is
+ * the English served-HTML canonical and is kept identical to `locales/en.json`.
+ * Docs has a dynamic per-`?page` runtime title; its `/docs` entry is the canonical
+ * served-HTML shell. See ADR 2026-06-01-public-route-seo-rendering.
+ */
+
+export const SITE_ORIGIN = 'https://lucky.lucassantana.tech'
+
+export interface RouteMeta {
+    /** Path as routed. `'/'` is the root (and the SPA fallback for all other routes). */
+    path: string
+    title: string
+    description: string
+    /** Canonical path; defaults to `path`. Alias routes point at their primary. */
+    canonical?: string
+    /** Include in sitemap.xml. Aliases set this `false` to avoid duplicate-content URLs. */
+    sitemap?: boolean
+}
+
+/**
+ * The truly public, crawlable routes (verified against `App.tsx`: `PublicRoutes` +
+ * the unauthenticated Landing). NOTE: `/features` is auth-gated (`AuthenticatedRoutes`,
+ * `guardedRoute('automation', …)`) and redirects logged-out visitors to `/`, so it is
+ * intentionally NOT prerendered despite issue #1131 listing it.
+ */
+export const PUBLIC_ROUTES: RouteMeta[] = [
+    {
+        path: '/',
+        title: 'Lucky — A Discord bot you can actually self-host',
+        description:
+            'Open-source Discord bot with music, moderation, custom commands, and a web dashboard. Free forever. Run it on your own box.',
+    },
+    {
+        path: '/docs',
+        title: 'Documentation — Lucky',
+        description:
+            'Setup, configuration, music, moderation, and dashboard documentation for Lucky, the open-source self-hostable Discord bot.',
+    },
+    {
+        path: '/changelog',
+        title: 'Changelog · Lucky',
+        description: 'Release notes and version history for Lucky.',
+    },
+    {
+        path: '/terms-of-service',
+        title: 'Terms of Service · Lucky',
+        description:
+            'Terms governing your use of the Lucky Discord bot and web dashboard.',
+    },
+    {
+        path: '/terms',
+        title: 'Terms of Service · Lucky',
+        description:
+            'Terms governing your use of the Lucky Discord bot and web dashboard.',
+        canonical: '/terms-of-service',
+        sitemap: false,
+    },
+    {
+        path: '/privacy-policy',
+        title: 'Privacy Policy · Lucky',
+        description:
+            'How Lucky collects, uses, and protects data for the bot and dashboard.',
+    },
+    {
+        path: '/privacy',
+        title: 'Privacy Policy · Lucky',
+        description:
+            'How Lucky collects, uses, and protects data for the bot and dashboard.',
+        canonical: '/privacy-policy',
+        sitemap: false,
+    },
+]
+
+/** Path → metadata lookup for the runtime hook. */
+export const ROUTE_META_BY_PATH: Record<string, RouteMeta> = Object.fromEntries(
+    PUBLIC_ROUTES.map((r) => [r.path, r]),
+)
+
+/** Runtime title/description for a public page, from the single source of truth.
+ *  Throws if the path is not a registered public route (caught at build/test time). */
+export function metaFor(path: string): { title: string; description: string } {
+    const m = ROUTE_META_BY_PATH[path]
+    if (!m) {
+        throw new Error(`routeMeta: no metadata registered for "${path}"`)
+    }
+    return { title: m.title, description: m.description }
+}
+
+/**
+ * Dashboard/app route prefixes that should NOT be crawled (they redirect logged-out
+ * visitors to `/` and only render under auth). Used to generate robots.txt disallows.
+ */
+export const DISALLOWED_PATHS: string[] = [
+    '/api/',
+    '/login',
+    '/servers',
+    '/admin',
+    '/config',
+    '/settings',
+    '/features',
+    '/moderation',
+    '/automod',
+    '/logs',
+    '/commands',
+    '/automessages',
+    '/embed-builder',
+    '/reaction-roles',
+    '/guild-automation',
+    '/levels',
+    '/starboard',
+    '/music',
+    '/lyrics',
+    '/twitch',
+    '/lastfm',
+    '/spotify',
+]
+
+/**
+ * Validate the map for completeness. Throws on any drift so the build (and a unit
+ * test) fail loudly rather than shipping a route with missing/duplicate metadata.
+ */
+export function assertRouteMetaValid(
+    routes: RouteMeta[] = PUBLIC_ROUTES,
+): void {
+    const seen = new Set<string>()
+    for (const r of routes) {
+        if (!r.path.startsWith('/')) {
+            throw new Error(
+                `routeMeta: path must start with "/" (got "${r.path}")`,
+            )
+        }
+        if (!r.title.trim()) {
+            throw new Error(`routeMeta: empty title for "${r.path}"`)
+        }
+        if (!r.description.trim()) {
+            throw new Error(`routeMeta: empty description for "${r.path}"`)
+        }
+        if (seen.has(r.path)) {
+            throw new Error(`routeMeta: duplicate path "${r.path}"`)
+        }
+        seen.add(r.path)
+    }
+}

--- a/packages/frontend/src/pages/Changelog.test.tsx
+++ b/packages/frontend/src/pages/Changelog.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Changelog from './Changelog'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
+import { metaFor } from '@/lib/seo/routeMeta'
 
 vi.mock('@/hooks/usePageMetadata')
 
@@ -18,13 +19,17 @@ function renderPage() {
 describe('Changelog', () => {
     test('renders page title', () => {
         renderPage()
-        expect(screen.getByRole('heading', { level: 1, name: /Changelog/i })).toBeInTheDocument()
+        expect(
+            screen.getByRole('heading', { level: 1, name: /Changelog/i }),
+        ).toBeInTheDocument()
     })
 
     test('renders at least one version from CHANGELOG.md', () => {
         renderPage()
         // Latest shipped version
-        expect(screen.getAllByText(/v2\.11\.0/).length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText(/v2\.11\.0/).length).toBeGreaterThanOrEqual(
+            1,
+        )
     })
 
     test('renders section headings (Added / Fixed / Changed)', () => {
@@ -37,11 +42,23 @@ describe('Changelog', () => {
         renderPage()
         const prLinks = screen.getAllByRole('link', { name: /^#\d+/ })
         expect(prLinks.length).toBeGreaterThanOrEqual(1)
-        expect(prLinks[0]).toHaveAttribute('href', expect.stringMatching(/^https:\/\/github\.com\/LucasSantana-Dev\/Lucky\/pull\/\d+$/))
+        expect(prLinks[0]).toHaveAttribute(
+            'href',
+            expect.stringMatching(
+                /^https:\/\/github\.com\/LucasSantana-Dev\/Lucky\/pull\/\d+$/,
+            ),
+        )
     })
 
     test('renders version sidebar', () => {
         renderPage()
-        expect(screen.getAllByText(/Versions/i).length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText(/Versions/i).length).toBeGreaterThanOrEqual(
+            1,
+        )
+    })
+
+    test('sets page metadata from the route map', () => {
+        renderPage()
+        expect(usePageMetadata).toHaveBeenCalledWith(metaFor('/changelog'))
     })
 })

--- a/packages/frontend/src/pages/Changelog.tsx
+++ b/packages/frontend/src/pages/Changelog.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import changelogMd from '../../../../CHANGELOG.md?raw'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
+import { metaFor } from '@/lib/seo/routeMeta'
 import PublicHeader from '@/components/DocsShell/PublicHeader'
 import { useActiveHeading } from '@/hooks/useActiveHeading'
 
@@ -113,10 +114,7 @@ const sectionStyles: Record<string, string> = {
 }
 
 export default function ChangelogPage() {
-    usePageMetadata({
-        title: 'Changelog · Lucky',
-        description: 'Release notes and version history for Lucky.',
-    })
+    usePageMetadata(metaFor('/changelog'))
 
     const entries = useMemo(() => parseChangelog(changelogMd), [])
     const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -151,7 +149,9 @@ export default function ChangelogPage() {
                                             href={`#v-${e.version}`}
                                             className={`flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-sm transition-colors ${active ? 'bg-lucky-surface-panel text-lucky-text-strong shadow-[inset_2px_0_0_var(--color-lucky-brand)]' : 'text-lucky-text-body hover:bg-lucky-surface-panel hover:text-lucky-text-strong'}`}
                                         >
-                                            <span className='font-mono'>{e.version}</span>
+                                            <span className='font-mono'>
+                                                {e.version}
+                                            </span>
                                             {e.date ? (
                                                 <span className='font-mono text-[10px] text-lucky-text-muted'>
                                                     {e.date.slice(0, 7)}
@@ -216,7 +216,8 @@ export default function ChangelogPage() {
                                         </div>
                                         <div className='mt-5 space-y-6'>
                                             {entry.sections.map((section) =>
-                                                section.items.length === 0 ? null : (
+                                                section.items.length ===
+                                                0 ? null : (
                                                     <div key={section.heading}>
                                                         <h3
                                                             className={`mb-2 font-mono text-[11px] uppercase tracking-[0.22em] ${sectionStyles[section.heading] ?? 'text-lucky-text-muted'}`}
@@ -224,12 +225,21 @@ export default function ChangelogPage() {
                                                             {section.heading}
                                                         </h3>
                                                         <ul className='space-y-1.5 text-sm leading-relaxed text-lucky-text-body'>
-                                                            {section.items.map((item, i) => (
-                                                                <li key={i} className='flex gap-2'>
-                                                                    <span className='mt-2 inline-block h-1 w-1 shrink-0 rounded-full bg-lucky-text-muted' />
-                                                                    <span>{renderInlineMd(item)}</span>
-                                                                </li>
-                                                            ))}
+                                                            {section.items.map(
+                                                                (item, i) => (
+                                                                    <li
+                                                                        key={i}
+                                                                        className='flex gap-2'
+                                                                    >
+                                                                        <span className='mt-2 inline-block h-1 w-1 shrink-0 rounded-full bg-lucky-text-muted' />
+                                                                        <span>
+                                                                            {renderInlineMd(
+                                                                                item,
+                                                                            )}
+                                                                        </span>
+                                                                    </li>
+                                                                ),
+                                                            )}
                                                         </ul>
                                                     </div>
                                                 ),

--- a/packages/frontend/src/pages/PrivacyPolicy.test.tsx
+++ b/packages/frontend/src/pages/PrivacyPolicy.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Privacy from './PrivacyPolicy'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
+import { metaFor } from '@/lib/seo/routeMeta'
 
 vi.mock('@/hooks/usePageMetadata')
 
@@ -18,8 +19,12 @@ function renderPage() {
 describe('PrivacyPolicy', () => {
     test('renders title and last updated', () => {
         renderPage()
-        expect(screen.getByRole('heading', { level: 1, name: /Privacy Policy/i })).toBeInTheDocument()
-        expect(screen.getByText(/last updated: March 18, 2026/i)).toBeInTheDocument()
+        expect(
+            screen.getByRole('heading', { level: 1, name: /Privacy Policy/i }),
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(/last updated: March 18, 2026/i),
+        ).toBeInTheDocument()
     })
 
     test('renders all section headings', () => {
@@ -34,18 +39,26 @@ describe('PrivacyPolicy', () => {
             'Your rights',
             'Security',
         ]) {
-            expect(screen.getAllByText(new RegExp(h, 'i')).length).toBeGreaterThanOrEqual(1)
+            expect(
+                screen.getAllByText(new RegExp(h, 'i')).length,
+            ).toBeGreaterThanOrEqual(1)
         }
     })
 
     test('renders self-host disclosure paragraph', () => {
         renderPage()
-        expect(screen.getByText(/project maintainers do not receive any of your guild or user data/i)).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                /project maintainers do not receive any of your guild or user data/i,
+            ),
+        ).toBeInTheDocument()
     })
 
     test('does not sell personal data', () => {
         renderPage()
-        expect(screen.getByText(/does not sell personal data/i)).toBeInTheDocument()
+        expect(
+            screen.getByText(/does not sell personal data/i),
+        ).toBeInTheDocument()
     })
 
     test('renders sibling nav to Terms', () => {
@@ -53,5 +66,10 @@ describe('PrivacyPolicy', () => {
         const terms = screen.getAllByRole('link', { name: /Terms of Service/i })
         expect(terms.length).toBeGreaterThanOrEqual(1)
         expect(terms[0]).toHaveAttribute('href', '/terms')
+    })
+
+    test('sets page metadata from the route map', () => {
+        renderPage()
+        expect(usePageMetadata).toHaveBeenCalledWith(metaFor('/privacy-policy'))
     })
 })

--- a/packages/frontend/src/pages/PrivacyPolicy.tsx
+++ b/packages/frontend/src/pages/PrivacyPolicy.tsx
@@ -1,8 +1,7 @@
-import DocsShell, {
-    type DocsTocItem,
-} from '@/components/DocsShell/DocsShell'
+import DocsShell, { type DocsTocItem } from '@/components/DocsShell/DocsShell'
 import { LEGAL_NAV } from '@/components/DocsShell/legalNav'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
+import { metaFor } from '@/lib/seo/routeMeta'
 
 const TOC: DocsTocItem[] = [
     { id: 'scope', label: 'Scope and controller' },
@@ -18,11 +17,7 @@ const TOC: DocsTocItem[] = [
 ]
 
 export default function PrivacyPolicyPage() {
-    usePageMetadata({
-        title: 'Privacy Policy · Lucky',
-        description:
-            'How Lucky collects, uses, and protects data for the bot and dashboard.',
-    })
+    usePageMetadata(metaFor('/privacy-policy'))
 
     return (
         <DocsShell
@@ -33,23 +28,21 @@ export default function PrivacyPolicyPage() {
             lastUpdated='March 18, 2026'
         >
             <p>
-                This policy explains how Lucky collects, uses, and protects
-                data when you use the Discord bot and web dashboard.
+                This policy explains how Lucky collects, uses, and protects data
+                when you use the Discord bot and web dashboard.
             </p>
 
             <h2 id='scope'>Scope and controller</h2>
             <p>
                 It applies to authentication, server configuration, moderation
-                features, music and integrations, and operational security.
-                The maintainers of the hosted Lucky instance act as the data
+                features, music and integrations, and operational security. The
+                maintainers of the hosted Lucky instance act as the data
                 controller for that deployment. Self-hosted operators are
                 controllers for their own deployments.
             </p>
 
             <h2 id='data'>Data we collect</h2>
-            <p>
-                We process the minimum data needed to operate the service:
-            </p>
+            <p>We process the minimum data needed to operate the service:</p>
             <ul>
                 <li>Discord account identifiers and usernames</li>
                 <li>Guild (server) IDs, role, and channel references</li>
@@ -57,8 +50,7 @@ export default function PrivacyPolicyPage() {
                 <li>Moderation case records (warns, mutes, bans)</li>
                 <li>
                     Optional integration data — Last.fm scrobbles, Spotify
-                    listening, Twitch stream events — only when you enable
-                    them
+                    listening, Twitch stream events — only when you enable them
                 </li>
                 <li>Session and security logs</li>
             </ul>
@@ -66,37 +58,35 @@ export default function PrivacyPolicyPage() {
             <h2 id='use'>How we use data</h2>
             <p>
                 Data is used to authenticate access, enforce role-based
-                permissions, persist server settings, run bot commands,
-                provide dashboard features, and protect platform reliability
-                and security.
+                permissions, persist server settings, run bot commands, provide
+                dashboard features, and protect platform reliability and
+                security.
             </p>
             <p>Lucky does not sell personal data.</p>
 
             <h2 id='self-host'>Self-hosted instances</h2>
             <p>
-                Lucky is open source. If you run your own instance, the
-                project maintainers do not receive any of your guild or user
-                data — it stays in your Postgres and Redis. This policy
-                applies to the hosted bot only; your self-hosted privacy
-                terms are whatever you write for your community.
+                Lucky is open source. If you run your own instance, the project
+                maintainers do not receive any of your guild or user data — it
+                stays in your Postgres and Redis. This policy applies to the
+                hosted bot only; your self-hosted privacy terms are whatever you
+                write for your community.
             </p>
 
             <h2 id='third-party'>Third-party services</h2>
             <p>
                 Lucky depends on third-party platforms to function, including
                 Discord (identity and guild context), and optionally Last.fm,
-                Spotify, and Twitch when you enable those integrations.
-                These providers operate under their own terms and privacy
-                policies.
+                Spotify, and Twitch when you enable those integrations. These
+                providers operate under their own terms and privacy policies.
             </p>
 
             <h2 id='retention'>Retention and deletion</h2>
             <p>
-                We retain data only as long as needed for operational,
-                security, and legal purposes. You can remove Lucky from your
-                server and disable integrations at any time. Requests to
-                delete personal data can be made through the support channel
-                below.
+                We retain data only as long as needed for operational, security,
+                and legal purposes. You can remove Lucky from your server and
+                disable integrations at any time. Requests to delete personal
+                data can be made through the support channel below.
             </p>
 
             <h2 id='rights'>Your rights</h2>
@@ -116,9 +106,9 @@ export default function PrivacyPolicyPage() {
 
             <h2 id='updates'>Policy updates</h2>
             <p>
-                We may update this policy when features, integrations, or
-                legal requirements change. Material updates are published
-                here with a revised date.
+                We may update this policy when features, integrations, or legal
+                requirements change. Material updates are published here with a
+                revised date.
             </p>
 
             <h2 id='contact'>Contact and requests</h2>

--- a/packages/frontend/src/pages/TermsOfService.test.tsx
+++ b/packages/frontend/src/pages/TermsOfService.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Terms from './TermsOfService'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
+import { metaFor } from '@/lib/seo/routeMeta'
 
 vi.mock('@/hooks/usePageMetadata')
 
@@ -18,8 +19,15 @@ function renderPage() {
 describe('TermsOfService', () => {
     test('renders title and last updated', () => {
         renderPage()
-        expect(screen.getByRole('heading', { level: 1, name: /Terms of Service/i })).toBeInTheDocument()
-        expect(screen.getByText(/last updated: March 18, 2026/i)).toBeInTheDocument()
+        expect(
+            screen.getByRole('heading', {
+                level: 1,
+                name: /Terms of Service/i,
+            }),
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(/last updated: March 18, 2026/i),
+        ).toBeInTheDocument()
     })
 
     test('renders all section headings', () => {
@@ -48,6 +56,16 @@ describe('TermsOfService', () => {
         const link = screen.getByRole('link', {
             name: /^github\.com\/LucasSantana-Dev\/Lucky\/issues$/i,
         })
-        expect(link).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky/issues')
+        expect(link).toHaveAttribute(
+            'href',
+            'https://github.com/LucasSantana-Dev/Lucky/issues',
+        )
+    })
+
+    test('sets page metadata from the route map', () => {
+        renderPage()
+        expect(usePageMetadata).toHaveBeenCalledWith(
+            metaFor('/terms-of-service'),
+        )
     })
 })

--- a/packages/frontend/src/pages/TermsOfService.tsx
+++ b/packages/frontend/src/pages/TermsOfService.tsx
@@ -1,8 +1,7 @@
-import DocsShell, {
-    type DocsTocItem,
-} from '@/components/DocsShell/DocsShell'
+import DocsShell, { type DocsTocItem } from '@/components/DocsShell/DocsShell'
 import { LEGAL_NAV } from '@/components/DocsShell/legalNav'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
+import { metaFor } from '@/lib/seo/routeMeta'
 
 const TOC: DocsTocItem[] = [
     { id: 'acceptance', label: 'Acceptance' },
@@ -17,11 +16,7 @@ const TOC: DocsTocItem[] = [
 ]
 
 export default function TermsOfServicePage() {
-    usePageMetadata({
-        title: 'Terms of Service · Lucky',
-        description:
-            'Terms governing your use of the Lucky Discord bot and web dashboard.',
-    })
+    usePageMetadata(metaFor('/terms-of-service'))
 
     return (
         <DocsShell
@@ -40,8 +35,8 @@ export default function TermsOfServicePage() {
             <h2 id='acceptance'>Acceptance</h2>
             <p>
                 These terms form a binding agreement between you and the Lucky
-                maintainers. If you do not agree, do not install or use the
-                bot, and do not access the dashboard.
+                maintainers. If you do not agree, do not install or use the bot,
+                and do not access the dashboard.
             </p>
 
             <h2 id='service-scope'>Service scope</h2>
@@ -57,8 +52,7 @@ export default function TermsOfServicePage() {
                 You must comply with the Discord Terms of Service, applicable
                 law, and your own server rules. You may not abuse the service,
                 attempt unauthorized access, bypass rate limits, or use Lucky
-                for spam, harassment, malware distribution, or illegal
-                activity.
+                for spam, harassment, malware distribution, or illegal activity.
             </p>
 
             <h2 id='third-party'>Third-party services</h2>
@@ -81,25 +75,24 @@ export default function TermsOfServicePage() {
             <p>
                 We may suspend or terminate access to the hosted bot if we
                 reasonably believe there is abuse, legal risk, or a security
-                threat to the platform or other users. You may stop using
-                Lucky at any time by removing the bot and disconnecting
-                integrations.
+                threat to the platform or other users. You may stop using Lucky
+                at any time by removing the bot and disconnecting integrations.
             </p>
 
             <h2 id='disclaimers'>Disclaimers and liability</h2>
             <p>
                 To the maximum extent permitted by law, Lucky and its
                 maintainers disclaim implied warranties and are not liable for
-                indirect, incidental, special, or consequential damages
-                arising from use of the service.
+                indirect, incidental, special, or consequential damages arising
+                from use of the service.
             </p>
 
             <h2 id='changes'>Changes to these terms</h2>
             <p>
-                We may update these terms from time to time. Continued use
-                after updates are posted means you accept the revised terms.
-                Material changes will be noted with a revised &quot;Last
-                updated&quot; date.
+                We may update these terms from time to time. Continued use after
+                updates are posted means you accept the revised terms. Material
+                changes will be noted with a revised &quot;Last updated&quot;
+                date.
             </p>
 
             <h2 id='contact'>Contact</h2>


### PR DESCRIPTION
## What

Public routes were client-rendered SPAs serving one shared `index.html` `<head>`, so non-JS crawlers and AI answer engines (ChatGPT/Claude/Perplexity don't execute JS as of 2026) saw identical, generic metadata on every route.

This adds a **build-time** step (`scripts/prerender-seo.ts`, run via `tsx` after `vite build`) that writes per-route `dist/<route>/index.html` with the `<head>` swapped from a single shared `routeMeta` map. The page **body stays the unrendered SPA shell** (`createRoot`, not `hydrateRoot`) — no hydration step, no router/framework migration. The same map feeds the runtime `usePageMetadata` hook so served HTML can't drift from the live title.

Also emits `sitemap.xml`, `robots.txt`, and a real 1200×630 `og-image.png` (via `@resvg/resvg-js`, fail-soft), and bumps `twitter:card` → `summary_large_image`.

Closes #1131
Closes #1132

## Public routes prerendered

`/`, `/docs`, `/changelog`, `/terms` (+ `/terms-of-service`), `/privacy` (+ `/privacy-policy`). Aliases canonicalize to their primary; the sitemap lists the 5 canonicals.

> **Scope note:** #1131 listed `/features` as public, but it is auth-gated (`AuthenticatedRoutes` / `guardedRoute('automation', …)` redirects logged-out visitors to `/`), so it is excluded from prerendering.

## Approach decision

Build-time **meta-only** generation, chosen over RR7 framework mode / Vike / Next.js via `/research-and-decide` (4-lens research + critic review). For ~6 static public routes on a hobby budget, RR7 framework mode is a ~40–60h migration off declarative `<BrowserRouter><Routes>` with med-high lock-in — not justified vs a low-risk build step. Meta-only is zero-hydration-risk and works on **both** Vercel and the homelab nginx unchanged (`try_files $uri $uri/ /index.html` already resolves per-route dirs; Vercel filesystem precedence serves the static file ahead of the SPA catch-all). Full rationale + revisit triggers (incl. the RR7 full-body escape hatch) in `docs/decisions/2026-06-01-public-route-seo-rendering.md`.

## Verification

- `tsc` + `eslint --max-warnings 0` + **709 tests** green.
- `npm run build` writes all per-route files; `view-source` confirmed distinct per-route title/description/OG/canonical, sitemap (5 canonicals), robots, and a 1200×630 og-image.
- New tests cover the prerender transforms (regex head-swap, alias canonical, SPA-shell preservation, HTML escaping, sitemap alias-exclusion, robots) and pin the page→map wiring so a wrong `metaFor` path can't ship green.

## Deploy note

First Vercel/Docker build fetches the resvg linux binary via `npm ci` (lockfile records gnu + musl optionalDeps). og-image generation is fail-soft — it falls back to copying the logo, so it can never break the build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented build-time SEO prerendering for public routes with per-route HTML metadata (title, description, Open Graph, canonical URLs, Twitter cards)
  * Automated sitemap.xml and robots.txt generation
  * Dynamic Open Graph image generation for social sharing
  * Updated social sharing image and canonical URL to production site

* **Documentation**
  * Added architectural decision record documenting the SEO rendering approach and implementation strategy

* **Tests**
  * Added comprehensive test suites for SEO utilities and route metadata validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->