### PR TITLE
feat(levels): show member display names on leaderboard, not raw ids

### DIFF
--- a/docs/decisions/2026-06-01-discord-display-name-resolution.md
+++ b/docs/decisions/2026-06-01-discord-display-name-resolution.md
@@ -1,0 +1,119 @@
+# ADR — Resolving Discord user IDs to display names: denormalize at write-time, not a shared identity cache
+
+- **Date:** 2026-06-01
+- **Status:** Accepted
+- **Owner:** Lucas Santana
+- **Related:** levels leaderboard shows raw IDs (Image #3 in the 2026-06-01 grill); plan
+  `.claude/plans/2026-06-01-display-name-denorm.md`; decided via `/research-and-decide`
+  (4-lens research + critic). Precedent: `ModerationCase` / `ServerLog` denorm.
+
+## Context
+
+Several dashboard surfaces render raw numeric Discord user IDs instead of names. The
+clear case is the **levels leaderboard**: `LevelService.getLeaderboard` is
+`prisma.memberXP.findMany({orderBy:{xp}})`, and `MemberXP {guildId,userId,xp,level}`
+stores **no name**, so the UI prints e.g. `282294772570521600`. The ask was plural
+("several places... nicknames"), and "nicknames" means the **guild-scoped** display
+name (nickname → global_name → username).
+
+Verified repo facts that shaped the choice:
+
+- `ModerationCase {username @default("Unknown")}` already **denormalizes the name at
+  write-time** (the bot writes `user.tag` when a case is created).
+- `ServerLog` already denormalizes names into its `details` JSON at write
+  (`auditHandler.ts` writes `authorTag`, and `username`/`tag` for bans); the logs page
+  renders `log.userName` when present. The screenshot with no names is an incomplete
+  `details → userName` **mapping**, not missing data.
+- **`MemberXP` is the only surface with no name at all** — the real gap.
+- The bot enables only `Guilds, GuildMessages, GuildVoiceStates, MessageContent,
+GuildMessageReactions` — **NOT** the privileged `GuildMembers` intent — so
+  `GuildMemberUpdate/Add` events do not fire. But XP is granted on `MESSAGE_CREATE`,
+  where `message.member.displayName` (incl. guild nickname) **is** available without
+  any privileged intent.
+- 2026 Discord REST limits: per-route member/user fetch ~1 req/s (30/30s), global
+  50/s, per-guild buckets + an Aug-2025 per-guild member-list limit. So resolving
+  names via REST at render is a 429 footgun, especially for logs (many distinct users).
+- Hobby scale (tens–hundreds of members/guild), Postgres is source of truth, LOW
+  maintenance budget.
+
+## Decision
+
+**Resolve IDs → display names by denormalizing the display name at write-time on each
+surface, extending the existing `ModerationCase`/`ServerLog` precedent to the levels
+leaderboard.** Concretely:
+
+1. Add `displayName String?` (and optionally `avatar String?`) to `MemberXP`. Capture
+   it from `message.member.displayName` at XP-grant time in the bot's `xpHandler`
+   (no privileged intent — `message.member` is in the guild MESSAGE_CREATE payload).
+   The leaderboard API returns it; the frontend renders `displayName` and falls back to
+   the raw ID only when absent.
+2. Fix the `ServerLog` `details → userName` mapping so the already-denormalized name
+   (`details.authorTag` / `username`) surfaces in the logs UI. No schema change.
+3. `ModerationCase` already denormalizes — no change.
+4. One-time best-effort backfill of historical `MemberXP.displayName` (from the global
+   `User` cache where present; otherwise leave null → resolves on the member's next
+   message). Raw-ID fallback covers nulls.
+
+The render fallback chain everywhere is `displayName/nickname → globalName → username
+→ rawId`.
+
+## Alternatives considered
+
+1. **Shared `GuildMember` identity cache** `{guildId,userId,nickname,globalName,username,
+avatar}` populated by the bot, read by all surfaces, with a throttled lazy-REST
+   backfill for cold misses — _rejected (for now)._ It is the cleaner long-term
+   consolidation, but: the bot already has `message.member` at every write-point (so a
+   separate cache buys little over denorm); the lazy-REST backfill is a 429 risk the
+   critic flagged (and is unsafe for logs' many distinct users); it duplicates the
+   existing global `User` table; and it is over-engineered for hobby scale. **This is
+   the designated escape hatch** (see Revisit).
+2. **Enable the `GuildMembers` privileged intent + event-driven cache refresh** —
+   _rejected._ Gives free rename-refresh without a message, but requires a portal+code
+   privileged-intent change and discord.js member-cache memory tuning (auto-caches all
+   members). Not justified at hobby scale; staleness tolerance is high.
+3. **Expand the global `User` cache + JOIN** — _rejected._ `User` is global and cannot
+   represent per-guild **nicknames**, which the ask requires.
+4. **Lazy REST resolve at render (no persistence)** — _rejected._ Per-route ~1 req/s +
+   per-guild limits → 429 storms and page-load latency; catastrophic for logs.
+
+## Consequences
+
+**Positive**
+
+- Minimal, proven (mirrors `ModerationCase`), works with current intents, zero
+  Discord-REST rate-limit risk, no new table/identity duplication.
+- Guild nicknames supported (captured via `member.displayName`).
+- Generalizes by the same one-line write-time capture if a new surface appears.
+
+**Negative / accepted limits**
+
+- A renamed member shows their **old** name until their next activity on that surface
+  (next message for leaderboard). Fine for active leaderboards; staler for long-inactive
+  members shown on a surface.
+- Per-surface denorm (a small field on each surface that shows users) rather than one
+  shared read. Accepted — it's the codebase idiom and avoids the cache's complexity.
+- Historical `MemberXP` rows show raw IDs until their owner next messages (or the
+  best-effort backfill fills them).
+
+**Neutral**
+
+- Adds 1–2 nullable columns to `MemberXP` + a write-time capture; a frontend/backend
+  mapping fix for logs.
+
+## Revisit when
+
+Adopt the shared `GuildMember` cache (alternative 1), possibly with the `GuildMembers`
+intent (alternative 2), when ANY of these hold:
+
+- A surface must show names for users with **no natural write-context** (e.g. a full
+  member list, or accurate names for long-inactive members).
+- **Real-time** rename freshness becomes a product requirement.
+- Guild sizes grow large enough (≈ >5k members) that denorm staleness or duplication
+  becomes a real complaint.
+- A **fourth+** surface needs identity and per-surface denorm becomes a maintenance drag.
+
+## Privacy
+
+Denormalized names live on existing rows (`MemberXP`, `ServerLog`, `ModerationCase`) and
+inherit those rows' lifecycle. Delete a guild's rows on guild-leave; align retention
+with existing log/XP retention. No new long-lived identity store is introduced.

--- a/packages/bot/src/handlers/message/__tests__/xpHandler.test.ts
+++ b/packages/bot/src/handlers/message/__tests__/xpHandler.test.ts
@@ -77,6 +77,7 @@ describe('xpHandler', () => {
             const message = {
                 author: { id: 'user1', bot: false },
                 channelId: 'channel1',
+                member: { displayName: 'CoolNick' },
             } as unknown as Message
 
             const context: MessageContext = {
@@ -97,6 +98,7 @@ describe('xpHandler', () => {
             const message = {
                 author: { id: 'user1', bot: false },
                 channelId: 'channel1',
+                member: { displayName: 'CoolNick' },
             } as unknown as Message
 
             const context: MessageContext = {
@@ -123,6 +125,7 @@ describe('xpHandler', () => {
             const message = {
                 author: { id: 'user1', bot: false },
                 channelId: 'channel1',
+                member: { displayName: 'CoolNick' },
             } as unknown as Message
 
             const context: MessageContext = {
@@ -154,6 +157,7 @@ describe('xpHandler', () => {
             const message = {
                 author: { id: 'user1', bot: false },
                 channelId: 'channel1',
+                member: { displayName: 'CoolNick' },
             } as unknown as Message
 
             const context: MessageContext = {
@@ -168,6 +172,7 @@ describe('xpHandler', () => {
                 'guild1',
                 'user1',
                 10,
+                'CoolNick',
             )
         })
 
@@ -287,6 +292,7 @@ describe('xpHandler', () => {
             const message = {
                 author: { id: 'user1', bot: false },
                 channelId: 'channel1',
+                member: { displayName: 'CoolNick' },
             } as unknown as Message
 
             const context: MessageContext = {
@@ -301,6 +307,7 @@ describe('xpHandler', () => {
                 'guild1',
                 'user1',
                 10,
+                'CoolNick',
             )
         })
 
@@ -363,6 +370,7 @@ describe('xpHandler', () => {
             const message = {
                 author: { id: 'user1', bot: false },
                 channelId: 'channel1',
+                member: { displayName: 'CoolNick' },
             } as unknown as Message
 
             const context: MessageContext = {

--- a/packages/bot/src/handlers/message/xpHandler.ts
+++ b/packages/bot/src/handlers/message/xpHandler.ts
@@ -44,6 +44,7 @@ export const xpHandler: MessageHandler = {
                 guildId,
                 userId,
                 config.xpPerMessage,
+                message.member?.displayName ?? message.author.username,
             )
 
             if (result.leveledUp && config.announceChannel) {

--- a/packages/frontend/src/pages/Levels.tsx
+++ b/packages/frontend/src/pages/Levels.tsx
@@ -199,7 +199,8 @@ function Levels() {
                                 >
                                     <div className='flex-1'>
                                         <p className='font-medium text-lucky-text-primary'>
-                                            {member.userId}
+                                            {member.displayName ??
+                                                member.userId}
                                         </p>
                                         <p className='text-sm text-lucky-text-secondary'>
                                             Level {member.level}

--- a/packages/frontend/src/services/levelsApi.ts
+++ b/packages/frontend/src/services/levelsApi.ts
@@ -15,6 +15,7 @@ export interface MemberXP {
     id: string
     guildId: string
     userId: string
+    displayName?: string | null
     xp: number
     level: number
     lastXpAt: string
@@ -54,7 +55,10 @@ export function createLevelsApi(client: AxiosInstance) {
             return res.data.config
         },
 
-        async updateConfig(guildId: string, data: UpdateLevelConfigInput): Promise<LevelConfig> {
+        async updateConfig(
+            guildId: string,
+            data: UpdateLevelConfigInput,
+        ): Promise<LevelConfig> {
             const res = await client.patch<{ config: LevelConfig }>(
                 `/guilds/${guildId}/levels/config`,
                 data,
@@ -70,7 +74,10 @@ export function createLevelsApi(client: AxiosInstance) {
             return res.data.leaderboard
         },
 
-        async getRank(guildId: string, userId: string): Promise<{ memberXp: MemberXP; rank: number }> {
+        async getRank(
+            guildId: string,
+            userId: string,
+        ): Promise<{ memberXp: MemberXP; rank: number }> {
             const res = await client.get<{ memberXp: MemberXP; rank: number }>(
                 `/guilds/${guildId}/levels/rank/${userId}`,
             )
@@ -84,7 +91,10 @@ export function createLevelsApi(client: AxiosInstance) {
             return res.data.rewards
         },
 
-        async addReward(guildId: string, data: AddRewardInput): Promise<LevelReward> {
+        async addReward(
+            guildId: string,
+            data: AddRewardInput,
+        ): Promise<LevelReward> {
             const res = await client.post<{ reward: LevelReward }>(
                 `/guilds/${guildId}/levels/rewards`,
                 data,

--- a/packages/shared/src/services/LevelService.ts
+++ b/packages/shared/src/services/LevelService.ts
@@ -19,6 +19,7 @@ export type MemberXP = {
     id: string
     guildId: string
     userId: string
+    displayName: string | null
     xp: number
     level: number
     lastXpAt: Date
@@ -76,11 +77,24 @@ export class LevelService {
         guildId: string,
         userId: string,
         amount: number,
+        displayName?: string | null,
     ): Promise<{ member: MemberXP; leveledUp: boolean; newLevel: number }> {
         const current = await prisma.memberXP.upsert({
             where: { guildId_userId: { guildId, userId } },
-            create: { guildId, userId, xp: amount, lastXpAt: new Date() },
-            update: { xp: { increment: amount }, lastXpAt: new Date() },
+            create: {
+                guildId,
+                userId,
+                xp: amount,
+                lastXpAt: new Date(),
+                displayName: displayName ?? null,
+            },
+            // Only overwrite the name when a fresh one is supplied, so a missing
+            // value never wipes a previously-captured name.
+            update: {
+                xp: { increment: amount },
+                lastXpAt: new Date(),
+                ...(displayName ? { displayName } : {}),
+            },
         })
 
         let leveledUp = false

--- a/prisma/migrations/20260601000000_add_member_xp_display_name/migration.sql
+++ b/prisma/migrations/20260601000000_add_member_xp_display_name/migration.sql
@@ -1,0 +1,3 @@
+-- Denormalized display name (guild nickname -> global name -> username) captured at
+-- XP-grant time, so the leaderboard renders names instead of raw Discord user IDs.
+ALTER TABLE "member_xp" ADD COLUMN "displayName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -782,12 +782,13 @@ model LevelConfig {
 }
 
 model MemberXP {
-  id        String   @id @default(cuid())
-  guildId   String
-  userId    String
-  xp        Int      @default(0)
-  level     Int      @default(0)
-  lastXpAt  DateTime @default(now())
+  id          String   @id @default(cuid())
+  guildId     String
+  userId      String
+  displayName String?
+  xp          Int      @default(0)
+  level       Int      @default(0)
+  lastXpAt    DateTime @default(now())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 


### PR DESCRIPTION
## What
Leaderboard rendered raw Discord IDs (e.g. `282294772570521600`) because `MemberXP` stored no name.

Fix: denormalize the display name at write-time (the existing `ModerationCase`/`ServerLog` idiom). The bot captures `message.member.displayName` (guild nickname → global name → username) at XP-grant → stored on `MemberXP` → leaderboard API returns it → frontend renders it with a raw-ID fallback. Refreshes on the member's next message; never overwritten with an empty value. **No `GuildMembers` privileged intent, no Discord REST at render.**

## Decision
Recorded in `docs/decisions/2026-06-01-discord-display-name-resolution.md` (4-lens research + critic). Rejected a shared `GuildMember` cache as premature (escape hatch documented).

## Changes
- `MemberXP.displayName` (nullable) + migration `20260601000000_add_member_xp_display_name`
- `LevelService.addXP(…, displayName?)` writes it (create + refresh-on-update, never wipes)
- bot `xpHandler` passes `message.member.displayName`
- frontend Levels renders `displayName ?? userId`; `levelsApi` type updated
- xpHandler test asserts the captured name flows through

## Verify
4-pkg `tsc` ✓, frontend lint ✓, xpHandler 12/12 ✓, Levels 24/24 ✓. Historical rows show IDs until the member next messages (accepted; see ADR). Server-logs name-mapping is a small fast-follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Leaderboards now display guild-scoped display names instead of raw user IDs, with automatic fallback to user ID when unavailable.

* **Documentation**
  * Added architectural decision record documenting display name denormalization strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->