### PR TITLE
fix(api): wrap automod + moderation settings responses as { settings }

### DIFF
--- a/packages/backend/src/routes/management.ts
+++ b/packages/backend/src/routes/management.ts
@@ -42,7 +42,7 @@ export function setupManagementRoutes(app: Express): void {
             const settings = await autoModService.getSettings(
                 p(req.params.guildId),
             )
-            res.json(settings)
+            res.json({ settings })
         }),
     )
 
@@ -68,7 +68,7 @@ export function setupManagementRoutes(app: Express): void {
                 },
                 userId,
             )
-            res.json(settings)
+            res.json({ settings })
         }),
     )
 

--- a/packages/backend/src/routes/moderation.ts
+++ b/packages/backend/src/routes/moderation.ts
@@ -141,7 +141,7 @@ export function setupModerationRoutes(app: Express): void {
             const settings = await moderationService.getSettings(
                 p(req.params.guildId),
             )
-            res.json(settings)
+            res.json({ settings })
         }),
     )
 
@@ -165,7 +165,7 @@ export function setupModerationRoutes(app: Express): void {
                 { setting: 'moderation', newValue: body },
                 userId,
             )
-            res.json(settings)
+            res.json({ settings })
         }),
     )
 

--- a/packages/backend/tests/integration/routes/management.test.ts
+++ b/packages/backend/tests/integration/routes/management.test.ts
@@ -118,7 +118,7 @@ describe('Management Routes Integration', () => {
                 .set('Cookie', ['sessionId=valid_session_id'])
                 .expect(200)
 
-            expect(response.body).toEqual(mockSettings)
+            expect(response.body).toEqual({ settings: mockSettings })
             expect(mockAutoModService.getSettings).toHaveBeenCalledWith(
                 '111111111111111111',
             )
@@ -148,7 +148,9 @@ describe('Management Routes Integration', () => {
             const mockGuildAccessServiceSvc = guildAccessService as jest.Mocked<
                 typeof guildAccessService
             >
-            mockGuildAccessServiceSvc.resolveGuildContext.mockResolvedValue(null)
+            mockGuildAccessServiceSvc.resolveGuildContext.mockResolvedValue(
+                null,
+            )
 
             const response = await request(app)
                 .get('/api/guilds/111111111111111111/automod/settings')
@@ -212,7 +214,7 @@ describe('Management Routes Integration', () => {
                 .send(updatedSettings)
                 .expect(200)
 
-            expect(response.body).toEqual(updatedSettings)
+            expect(response.body).toEqual({ settings: updatedSettings })
             expect(mockAutoModService.updateSettings).toHaveBeenCalledWith(
                 '111111111111111111',
                 updatedSettings,
@@ -359,10 +361,11 @@ describe('Management Routes Integration', () => {
                 { id: 'cmd-2', name: 'goodbye' },
             ]
 
-            const mockCustomCommandService = customCommandService as jest.Mocked<
-                typeof customCommandService
-            >
-            mockCustomCommandService.listCommands.mockResolvedValue(mockCommands)
+            const mockCustomCommandService =
+                customCommandService as jest.Mocked<typeof customCommandService>
+            mockCustomCommandService.listCommands.mockResolvedValue(
+                mockCommands,
+            )
 
             const response = await request(app)
                 .get('/api/guilds/111111111111111111/commands')
@@ -394,10 +397,11 @@ describe('Management Routes Integration', () => {
                 description: 'A greeting command',
             }
 
-            const mockCustomCommandService = customCommandService as jest.Mocked<
-                typeof customCommandService
-            >
-            mockCustomCommandService.createCommand.mockResolvedValue(responseBody)
+            const mockCustomCommandService =
+                customCommandService as jest.Mocked<typeof customCommandService>
+            mockCustomCommandService.createCommand.mockResolvedValue(
+                responseBody,
+            )
 
             const mockServerLogService = serverLogService as jest.Mocked<
                 typeof serverLogService
@@ -474,9 +478,8 @@ describe('Management Routes Integration', () => {
                 description: 'Updated description',
             }
 
-            const mockCustomCommandService = customCommandService as jest.Mocked<
-                typeof customCommandService
-            >
+            const mockCustomCommandService =
+                customCommandService as jest.Mocked<typeof customCommandService>
             mockCustomCommandService.updateCommand.mockResolvedValue(
                 responseBody,
             )
@@ -524,9 +527,8 @@ describe('Management Routes Integration', () => {
             >
             mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
 
-            const mockCustomCommandService = customCommandService as jest.Mocked<
-                typeof customCommandService
-            >
+            const mockCustomCommandService =
+                customCommandService as jest.Mocked<typeof customCommandService>
             mockCustomCommandService.deleteCommand.mockResolvedValue({
                 success: true,
             })
@@ -714,9 +716,7 @@ describe('Management Routes Integration', () => {
             mockSessionService.getSession.mockResolvedValue(null)
 
             const response = await request(app)
-                .get(
-                    '/api/guilds/111111111111111111/logs/users/user-123',
-                )
+                .get('/api/guilds/111111111111111111/logs/users/user-123')
                 .expect(401)
 
             expect(response.body).toEqual({

--- a/packages/backend/tests/integration/routes/moderation.test.ts
+++ b/packages/backend/tests/integration/routes/moderation.test.ts
@@ -65,7 +65,9 @@ describe('Moderation Routes Integration', () => {
         const sessionMock = sessionService as jest.Mocked<typeof sessionService>
         sessionMock.getSession.mockResolvedValue(MOCK_SESSION_DATA)
 
-        const accessMock = guildAccessService as jest.Mocked<typeof guildAccessService>
+        const accessMock = guildAccessService as jest.Mocked<
+            typeof guildAccessService
+        >
         accessMock.resolveGuildContext.mockResolvedValue({
             guildId: GUILD_ID,
             userId: MOCK_SESSION_DATA.userId,
@@ -583,7 +585,7 @@ describe('Moderation Routes Integration', () => {
                 .set('Cookie', ['sessionId=valid_session_id'])
                 .expect(200)
 
-            expect(response.body).toEqual(mockSettings)
+            expect(response.body).toEqual({ settings: mockSettings })
             expect(mockModerationService.getSettings).toHaveBeenCalledWith(
                 '111111111111111111',
             )
@@ -653,7 +655,7 @@ describe('Moderation Routes Integration', () => {
                 })
                 .expect(200)
 
-            expect(response.body).toEqual(mockSettings)
+            expect(response.body).toEqual({ settings: mockSettings })
             expect(mockModerationService.updateSettings).toHaveBeenCalledWith(
                 '111111111111111111',
                 {


### PR DESCRIPTION
Closes #1127.

## Problem
AutoMod + Moderation **settings** endpoints returned the settings object **bare** (`res.json(settings)`), but every other endpoint wraps its response (`{cases}`, `{templates}`, `{commands}`, `{success}`) and the frontend api layer is typed `get<{ settings }>` and reads `res.data.settings`. Result: `res.data.settings` was `undefined` → the AutoMod + Moderation settings UIs silently showed defaults instead of saved config (silent contract-drift).

## Fix
Wrap the 4 settings responses as `res.json({ settings })` to match the API convention + the existing frontend contract:
- `management.ts` — GET + PATCH `/automod/settings`
- `moderation.ts` — GET + PATCH `/moderation/settings`

Frontend needs **no change** — `automodApi`/`moderationApi` already type the envelope (`get<{ settings: AutoModSettings }>` / `{ settings: ModerationSettings }`).

## Tests
- Updated the 3 integration assertions to expect `{ settings }` (regression guard — the shape can't silently drift back).
- Full backend suite green: 65 suites / 854 tests; tsc clean.