### PR TITLE
fix(web): surface Levels RBAC fetch failure instead of swallowing it

### DIFF
--- a/packages/frontend/src/pages/Levels.test.tsx
+++ b/packages/frontend/src/pages/Levels.test.tsx
@@ -174,6 +174,19 @@ describe('Levels', () => {
         expect(rewards[1].textContent).toContain('Lv.10')
     })
 
+    test('surfaces a visible error when the RBAC fetch fails (not silent)', async () => {
+        mockGuildStore()
+        vi.mocked(api.guilds.getRbac).mockRejectedValue(
+            new Error('rbac fetch failed'),
+        )
+        render(<Levels />)
+
+        // The failure is surfaced inline rather than masked as empty roles.
+        expect(
+            await screen.findByText(/load this server.s roles/i),
+        ).toBeInTheDocument()
+    })
+
     test('handles config save successfully', async () => {
         mockGuildStore()
         vi.mocked(api.levels.updateConfig).mockResolvedValue(undefined as never)

--- a/packages/frontend/src/pages/Levels.tsx
+++ b/packages/frontend/src/pages/Levels.tsx
@@ -19,6 +19,7 @@ function Levels() {
     const [leaderboard, setLeaderboard] = useState<MemberXP[]>([])
     const [rewards, setRewards] = useState<LevelReward[]>([])
     const [roles, setRoles] = useState<GuildRoleOption[]>([])
+    const [rolesError, setRolesError] = useState(false)
     const [saving, setSaving] = useState(false)
     const [adding, setAdding] = useState(false)
     const [newLevel, setNewLevel] = useState('')
@@ -40,15 +41,21 @@ function Levels() {
 
         const loadData = async () => {
             setLoading(true)
+            setRolesError(false)
             try {
                 const [configData, leaderboardData, rewardsData, rbacData] =
                     await Promise.all([
                         api.levels.getConfig(selectedGuild.id),
                         api.levels.getLeaderboard(selectedGuild.id, 20),
                         api.levels.getRewards(selectedGuild.id),
-                        api.guilds
-                            .getRbac(selectedGuild.id)
-                            .catch(() => ({ data: { roles: [] } })),
+                        // RBAC failure is isolated so it can't blank the whole
+                        // page, but it must be surfaced (not silently swallowed):
+                        // an empty role list then means "failed to load", which
+                        // rolesError distinguishes from "no roles configured".
+                        api.guilds.getRbac(selectedGuild.id).catch(() => {
+                            if (mounted) setRolesError(true)
+                            return { data: { roles: [] } }
+                        }),
                     ])
 
                 if (!mounted) return
@@ -301,6 +308,13 @@ function Levels() {
                     <h3 className='text-lg font-semibold text-lucky-text-primary mb-4'>
                         Level Rewards
                     </h3>
+
+                    {rolesError && (
+                        <p className='text-sm text-lucky-error mb-4'>
+                            Couldn&apos;t load this server&apos;s roles — reward
+                            role names may show as raw IDs. Refresh to retry.
+                        </p>
+                    )}
 
                     <div className='space-y-3 mb-4'>
                         {rewards.length === 0 ? (


### PR DESCRIPTION
Closes #1128.

## Problem
On the Levels page, the role-access (RBAC) fetch was wrapped in `.catch(() => ({ data: { roles: [] } }))` inside a `Promise.all`. A network/500/auth failure silently yielded an empty role list — reward role names then degraded to raw IDs (`getRoleName` falls back to the id) with **no feedback**, so the user couldn't tell "no roles configured" from "roles failed to load."

## Fix
- Add a `rolesError` state; the isolated RBAC `.catch` now sets it (so a failure can't blank the whole page, but is no longer silent).
- Inline error in the Level Rewards card when `rolesError`: "Couldn't load this server's roles — reward role names may show as raw IDs. Refresh to retry." Distinct from the empty/no-roles state.

## Tests
- New case: RBAC fetch rejects → the error is visible (not silent).
- Frontend suite green: 69 files / 713 tests; tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error messaging when server roles fail to load. The page continues loading other data while displaying an error message, prompting users to refresh if role names appear as raw IDs instead of proper names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->