### PR TITLE
fix(web): relabel landing RepoCard stats to real servers/users

### DIFF
--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -1,342 +1,341 @@
 {
-  "common": {
-    "loading": "Loading…",
-    "retry": "Retry",
-    "cancel": "Cancel",
-    "save": "Save",
-    "delete": "Delete",
-    "edit": "Edit",
-    "close": "Close",
-    "closeSidebar": "Close sidebar",
-    "open": "Open",
-    "activeServerAriaLabel": "Active server: {{name}}. Click to switch.",
-    "viewAll": "View all",
-    "selectServer": "Select a server",
-    "accessDenied": "Access denied",
-    "accessDeniedDescription": "You do not have permission to view the {{module}} module for this server.",
-    "logout": "Log out",
-    "language": "Language"
-  },
-  "languages": {
-    "en": "English",
-    "pt-BR": "Português (Brasil)"
-  },
-  "modules": {
-    "overview": "overview",
-    "settings": "settings",
-    "moderation": "moderation",
-    "automation": "automation",
-    "music": "music",
-    "integrations": "integrations"
-  },
-  "sidebar": {
-    "activeGuild": "Active guild",
-    "switchServer": "Switch server",
-    "commandCenter": "Command center",
-    "status": {
-      "selectServer": "Select a server",
-      "needsSetup": "Needs setup",
-      "ready": "Ready"
+    "common": {
+        "loading": "Loading…",
+        "retry": "Retry",
+        "cancel": "Cancel",
+        "save": "Save",
+        "delete": "Delete",
+        "edit": "Edit",
+        "close": "Close",
+        "closeSidebar": "Close sidebar",
+        "open": "Open",
+        "activeServerAriaLabel": "Active server: {{name}}. Click to switch.",
+        "viewAll": "View all",
+        "selectServer": "Select a server",
+        "accessDenied": "Access denied",
+        "accessDeniedDescription": "You do not have permission to view the {{module}} module for this server.",
+        "logout": "Log out",
+        "language": "Language"
     },
-    "subtitle": {
-      "selectServer": "Choose a community to unlock guild tools.",
-      "needsSetup": "Lucky is not installed in this server yet.",
-      "ready": "Guild command center is ready for operations."
+    "languages": {
+        "en": "English",
+        "pt-BR": "Português (Brasil)"
     },
-    "sections": {
-      "overview": "Overview",
-      "moderation": "Moderation",
-      "automation": "Automation",
-      "community": "Community",
-      "media": "Media",
-      "integrations": "Integrations"
+    "modules": {
+        "overview": "overview",
+        "settings": "settings",
+        "moderation": "moderation",
+        "automation": "automation",
+        "music": "music",
+        "integrations": "integrations"
     },
-    "nav": {
-      "dashboard": "Dashboard",
-      "serverSettings": "Server Settings",
-      "modCases": "Mod Cases",
-      "autoModeration": "Auto-Moderation",
-      "serverLogs": "Server Logs",
-      "customCommands": "Custom Commands",
-      "autoMessages": "Auto Messages",
-      "embedBuilder": "Embed Builder",
-      "reactionRoles": "Reaction Roles",
-      "guildAutomation": "Guild Automation",
-      "levelSystem": "Level System",
-      "starboard": "Starboard",
-      "musicPlayer": "Music Player",
-      "trackHistory": "Track History",
-      "lyrics": "Lyrics",
-      "musicalTaste": "Musical Taste",
-      "lastFm": "Last.fm",
-      "twitch": "Twitch",
-      "features": "Features"
+    "sidebar": {
+        "activeGuild": "Active guild",
+        "switchServer": "Switch server",
+        "commandCenter": "Command center",
+        "status": {
+            "selectServer": "Select a server",
+            "needsSetup": "Needs setup",
+            "ready": "Ready"
+        },
+        "subtitle": {
+            "selectServer": "Choose a community to unlock guild tools.",
+            "needsSetup": "Lucky is not installed in this server yet.",
+            "ready": "Guild command center is ready for operations."
+        },
+        "sections": {
+            "overview": "Overview",
+            "moderation": "Moderation",
+            "automation": "Automation",
+            "community": "Community",
+            "media": "Media",
+            "integrations": "Integrations"
+        },
+        "nav": {
+            "dashboard": "Dashboard",
+            "serverSettings": "Server Settings",
+            "modCases": "Mod Cases",
+            "autoModeration": "Auto-Moderation",
+            "serverLogs": "Server Logs",
+            "customCommands": "Custom Commands",
+            "autoMessages": "Auto Messages",
+            "embedBuilder": "Embed Builder",
+            "reactionRoles": "Reaction Roles",
+            "guildAutomation": "Guild Automation",
+            "levelSystem": "Level System",
+            "starboard": "Starboard",
+            "musicPlayer": "Music Player",
+            "trackHistory": "Track History",
+            "lyrics": "Lyrics",
+            "musicalTaste": "Musical Taste",
+            "lastFm": "Last.fm",
+            "twitch": "Twitch",
+            "features": "Features"
+        }
+    },
+    "layout": {
+        "routes": {
+            "dashboard": {
+                "title": "Dashboard",
+                "subtitle": "Operational overview and key status signals for your server."
+            },
+            "servers": {
+                "title": "Servers",
+                "subtitle": "Review installation status and manage your eligible communities."
+            },
+            "serverSettings": {
+                "title": "Server Settings",
+                "subtitle": "Configure bot behaviour, channels, roles, and preferences."
+            },
+            "moderation": {
+                "title": "Mod Cases",
+                "subtitle": "Review and manage moderation actions for this server."
+            },
+            "autoMod": {
+                "title": "Auto-Moderation",
+                "subtitle": "Configure automated rule enforcement and filters."
+            },
+            "serverLogs": {
+                "title": "Server Logs",
+                "subtitle": "Inspect audit events and bot activity records."
+            },
+            "customCommands": {
+                "title": "Custom Commands",
+                "subtitle": "Create and manage custom slash commands for this server."
+            },
+            "autoMessages": {
+                "title": "Auto Messages",
+                "subtitle": "Schedule recurring messages to any channel."
+            },
+            "embedBuilder": {
+                "title": "Embed Builder",
+                "subtitle": "Design and send rich Discord embeds."
+            },
+            "reactionRoles": {
+                "title": "Reaction Roles",
+                "subtitle": "Assign roles based on member emoji reactions."
+            },
+            "guildAutomation": {
+                "title": "Guild Automation",
+                "subtitle": "Configure automated guild management workflows."
+            },
+            "levels": {
+                "title": "Level System",
+                "subtitle": "Configure XP, level roles, and leaderboards."
+            },
+            "starboard": {
+                "title": "Starboard",
+                "subtitle": "Surface popular messages to a dedicated channel."
+            },
+            "lyrics": {
+                "title": "Lyrics",
+                "subtitle": "Fetch and display song lyrics in your server."
+            },
+            "lastFm": {
+                "title": "Last.fm",
+                "subtitle": "Control account linking and scrobble attribution behavior."
+            },
+            "twitch": {
+                "title": "Twitch Notifications",
+                "subtitle": "Post live alerts when tracked streamers go online."
+            },
+            "features": {
+                "title": "Features",
+                "subtitle": "Toggle bot feature modules for your server."
+            },
+            "trackHistory": {
+                "title": "Track History",
+                "subtitle": "Inspect recent playback and requester activity."
+            },
+            "music": {
+                "title": "Music Player",
+                "subtitle": "Manage queue, autoplay, and real-time playback controls."
+            },
+            "preferredArtists": {
+                "title": "Musical Taste",
+                "subtitle": "Tune autoplay taste preferences and artist priorities."
+            },
+            "spotify": {
+                "title": "Spotify",
+                "subtitle": "Link or unlink Spotify to power autoplay matching."
+            },
+            "fallback": {
+                "title": "Lucky Dashboard",
+                "subtitle": "Configure modules, moderation, and engagement workflows."
+            }
+        }
+    },
+    "landing": {
+        "meta": {
+            "title": "Lucky — A Discord bot you can actually self-host",
+            "description": "Open-source Discord bot with music, moderation, custom commands, and a web dashboard. Free forever. Run it on your own box."
+        },
+        "hero": {
+            "eyebrow": "Open source · Apache 2.0",
+            "headlineLine1": "A Discord bot built right.",
+            "headlineLine2": "And yours to run.",
+            "subtitle": "Music, moderation, custom commands, and a full web dashboard. Use the hosted version in two clicks, or run it on your own box if you'd rather.",
+            "ctaPrimary": "Add to Discord",
+            "ctaSecondary": "Self-host on GitHub"
+        },
+        "repoCard": {
+            "name": "LucasSantana-Dev / Lucky",
+            "description": "Self-hosted Discord music bot — Spotify + YouTube + SoundCloud, autoplay recommendations, React dashboard, moderation suite.",
+            "license": "Apache-2.0",
+            "lang": "TypeScript",
+            "serversLabel": "servers",
+            "usersLabel": "users",
+            "viewOnGithub": "View on GitHub",
+            "copyClone": "Copy clone URL"
+        },
+        "whySelfHost": {
+            "heading": "Why self-host",
+            "items": {
+                "data": {
+                    "title": "Your guild data stays yours",
+                    "description": "Postgres, Redis, your hardware. No third-party ToS over your community. Export and migrate any time."
+                },
+                "fork": {
+                    "title": "Fork the source",
+                    "description": "TypeScript monorepo. Add commands, change behavior, swap providers without waiting on a roadmap or paying for an API tier."
+                },
+                "free": {
+                    "title": "Free, with no premium tier",
+                    "description": "No feature paywall, no Patreon, no rate-limited tier. Apache 2.0. The hosted version exists for people who don't want to run a box."
+                }
+            }
+        },
+        "commands": {
+            "heading": "100+ commands, scoped to what you actually run",
+            "rows": {
+                "play": {
+                    "name": "/play",
+                    "description": "Queue a track from Spotify, YouTube, or SoundCloud",
+                    "kbd": "music"
+                },
+                "autoplay": {
+                    "name": "/autoplay",
+                    "description": "Genre-aware recommendations, won't drift languages",
+                    "kbd": "music"
+                },
+                "queue": {
+                    "name": "/queue",
+                    "description": "Inspect or reorder the current queue",
+                    "kbd": "music"
+                },
+                "ban": {
+                    "name": "/mod ban",
+                    "description": "Tempban with reason, auto-DM, audit-log entry",
+                    "kbd": "mod"
+                },
+                "automod": {
+                    "name": "/automod",
+                    "description": "Spam, caps, links, invites — per-guild rules",
+                    "kbd": "mod"
+                },
+                "custom": {
+                    "name": "/cc create",
+                    "description": "Custom commands with variable interpolation",
+                    "kbd": "custom"
+                }
+            },
+            "more": "+ 100 more in the dashboard"
+        },
+        "stack": {
+            "heading": "For developers — what you're running",
+            "subheading": "Standard Node + Postgres stack. Nothing exotic. `docker compose up` and you're online. Skip this if you're using the hosted version.",
+            "items": {
+                "bot": {
+                    "name": "lucky-bot",
+                    "description": "discord.js client, Lavalink-free audio via yt-dlp + Opus"
+                },
+                "backend": {
+                    "name": "lucky-backend",
+                    "description": "Express API, OAuth, Prisma to Postgres"
+                },
+                "frontend": {
+                    "name": "lucky-frontend",
+                    "description": "React 19 + Vite + Tailwind, Discord OAuth dashboard"
+                },
+                "postgres": {
+                    "name": "postgres",
+                    "description": "Guild config, custom commands, moderation log"
+                },
+                "redis": {
+                    "name": "redis",
+                    "description": "Session cache, rate-limit buckets, autoplay state"
+                },
+                "nginx": {
+                    "name": "nginx",
+                    "description": "Reverse proxy, /webhook → /hooks rewrite for deploy"
+                }
+            }
+        },
+        "footerRepo": {
+            "heading": "Open source under Apache 2.0",
+            "subheading": "Fork it, contribute, run it, deploy your own. The code is the spec."
+        },
+        "footer": {
+            "tagline": "Open-source Discord bot. Run it yourself or use the hosted version.",
+            "links": "Product",
+            "support": "Community",
+            "supportCopy": "Issues and PRs welcome on GitHub. Or hop in the Discord support server.",
+            "terms": "Terms",
+            "privacy": "Privacy",
+            "github": "GitHub",
+            "docs": "Docs",
+            "changelog": "Changelog",
+            "discord": "Support server",
+            "copyright": "© 2026 Lucky. Apache 2.0."
+        },
+        "features": {
+            "heading": "What Lucky does",
+            "subheading": "Everything most servers need, in one bot. No premium tier paywalling the good parts.",
+            "items": {
+                "music": {
+                    "title": "Music with smart autoplay",
+                    "description": "Queue from Spotify, YouTube, or SoundCloud. Autoplay matches the mood and won't drift into the wrong language."
+                },
+                "moderation": {
+                    "title": "Moderation that doesn't sleep",
+                    "description": "Auto-mod for spam, caps, links, and invites. Tempbans with reasons, audit log entries, and per-server rules."
+                },
+                "customCommands": {
+                    "title": "Custom commands",
+                    "description": "Build replies, role-toggles, embeds, and shortcuts without writing code. Variable interpolation included."
+                },
+                "dashboard": {
+                    "title": "A real web dashboard",
+                    "description": "Configure everything from your browser. Discord OAuth login, no JSON files, no SSH."
+                },
+                "embeds": {
+                    "title": "Embed builder",
+                    "description": "Compose rich Discord embeds with a live preview. Save templates, send on schedule, edit in place."
+                }
+            }
+        }
+    },
+    "login": {
+        "meta": {
+            "title": "Login - Lucky",
+            "description": "Login to Lucky Dashboard to manage your Discord servers"
+        },
+        "brand": "Discord Bot Dashboard",
+        "headline": "Manage your Discord servers",
+        "description": "Configure moderation, custom commands, music, and more — all in one place.",
+        "modules": "Modules",
+        "commands": "Commands",
+        "uptime": "Uptime",
+        "authentication": "Authentication",
+        "signInWithDiscord": "Sign in with Discord",
+        "permissionsNote": "Your guild permissions and bot controls are tied to your Discord account.",
+        "connecting": "Connecting...",
+        "loginButton": "Login with Discord",
+        "badges": {
+            "oauthSecured": "OAuth secured",
+            "fastSetup": "Fast setup",
+            "liveControls": "Live controls"
+        },
+        "copyright": "© 2026 Lucky. All rights reserved."
     }
-  },
-  "layout": {
-    "routes": {
-      "dashboard": {
-        "title": "Dashboard",
-        "subtitle": "Operational overview and key status signals for your server."
-      },
-      "servers": {
-        "title": "Servers",
-        "subtitle": "Review installation status and manage your eligible communities."
-      },
-      "serverSettings": {
-        "title": "Server Settings",
-        "subtitle": "Configure bot behaviour, channels, roles, and preferences."
-      },
-      "moderation": {
-        "title": "Mod Cases",
-        "subtitle": "Review and manage moderation actions for this server."
-      },
-      "autoMod": {
-        "title": "Auto-Moderation",
-        "subtitle": "Configure automated rule enforcement and filters."
-      },
-      "serverLogs": {
-        "title": "Server Logs",
-        "subtitle": "Inspect audit events and bot activity records."
-      },
-      "customCommands": {
-        "title": "Custom Commands",
-        "subtitle": "Create and manage custom slash commands for this server."
-      },
-      "autoMessages": {
-        "title": "Auto Messages",
-        "subtitle": "Schedule recurring messages to any channel."
-      },
-      "embedBuilder": {
-        "title": "Embed Builder",
-        "subtitle": "Design and send rich Discord embeds."
-      },
-      "reactionRoles": {
-        "title": "Reaction Roles",
-        "subtitle": "Assign roles based on member emoji reactions."
-      },
-      "guildAutomation": {
-        "title": "Guild Automation",
-        "subtitle": "Configure automated guild management workflows."
-      },
-      "levels": {
-        "title": "Level System",
-        "subtitle": "Configure XP, level roles, and leaderboards."
-      },
-      "starboard": {
-        "title": "Starboard",
-        "subtitle": "Surface popular messages to a dedicated channel."
-      },
-      "lyrics": {
-        "title": "Lyrics",
-        "subtitle": "Fetch and display song lyrics in your server."
-      },
-      "lastFm": {
-        "title": "Last.fm",
-        "subtitle": "Control account linking and scrobble attribution behavior."
-      },
-      "twitch": {
-        "title": "Twitch Notifications",
-        "subtitle": "Post live alerts when tracked streamers go online."
-      },
-      "features": {
-        "title": "Features",
-        "subtitle": "Toggle bot feature modules for your server."
-      },
-      "trackHistory": {
-        "title": "Track History",
-        "subtitle": "Inspect recent playback and requester activity."
-      },
-      "music": {
-        "title": "Music Player",
-        "subtitle": "Manage queue, autoplay, and real-time playback controls."
-      },
-      "preferredArtists": {
-        "title": "Musical Taste",
-        "subtitle": "Tune autoplay taste preferences and artist priorities."
-      },
-      "spotify": {
-        "title": "Spotify",
-        "subtitle": "Link or unlink Spotify to power autoplay matching."
-      },
-      "fallback": {
-        "title": "Lucky Dashboard",
-        "subtitle": "Configure modules, moderation, and engagement workflows."
-      }
-    }
-  },
-  "landing": {
-    "meta": {
-      "title": "Lucky — A Discord bot you can actually self-host",
-      "description": "Open-source Discord bot with music, moderation, custom commands, and a web dashboard. Free forever. Run it on your own box."
-    },
-    "hero": {
-      "eyebrow": "Open source · Apache 2.0",
-      "headlineLine1": "A Discord bot built right.",
-      "headlineLine2": "And yours to run.",
-      "subtitle": "Music, moderation, custom commands, and a full web dashboard. Use the hosted version in two clicks, or run it on your own box if you'd rather.",
-      "ctaPrimary": "Add to Discord",
-      "ctaSecondary": "Self-host on GitHub"
-    },
-    "repoCard": {
-      "name": "LucasSantana-Dev / Lucky",
-      "description": "Self-hosted Discord music bot — Spotify + YouTube + SoundCloud, autoplay recommendations, React dashboard, moderation suite.",
-      "license": "Apache-2.0",
-      "lang": "TypeScript",
-      "starsLabel": "stars",
-      "forksLabel": "forks",
-      "issuesLabel": "open issues",
-      "viewOnGithub": "View on GitHub",
-      "copyClone": "Copy clone URL"
-    },
-    "whySelfHost": {
-      "heading": "Why self-host",
-      "items": {
-        "data": {
-          "title": "Your guild data stays yours",
-          "description": "Postgres, Redis, your hardware. No third-party ToS over your community. Export and migrate any time."
-        },
-        "fork": {
-          "title": "Fork the source",
-          "description": "TypeScript monorepo. Add commands, change behavior, swap providers without waiting on a roadmap or paying for an API tier."
-        },
-        "free": {
-          "title": "Free, with no premium tier",
-          "description": "No feature paywall, no Patreon, no rate-limited tier. Apache 2.0. The hosted version exists for people who don't want to run a box."
-        }
-      }
-    },
-    "commands": {
-      "heading": "100+ commands, scoped to what you actually run",
-      "rows": {
-        "play": {
-          "name": "/play",
-          "description": "Queue a track from Spotify, YouTube, or SoundCloud",
-          "kbd": "music"
-        },
-        "autoplay": {
-          "name": "/autoplay",
-          "description": "Genre-aware recommendations, won't drift languages",
-          "kbd": "music"
-        },
-        "queue": {
-          "name": "/queue",
-          "description": "Inspect or reorder the current queue",
-          "kbd": "music"
-        },
-        "ban": {
-          "name": "/mod ban",
-          "description": "Tempban with reason, auto-DM, audit-log entry",
-          "kbd": "mod"
-        },
-        "automod": {
-          "name": "/automod",
-          "description": "Spam, caps, links, invites — per-guild rules",
-          "kbd": "mod"
-        },
-        "custom": {
-          "name": "/cc create",
-          "description": "Custom commands with variable interpolation",
-          "kbd": "custom"
-        }
-      },
-      "more": "+ 100 more in the dashboard"
-    },
-    "stack": {
-      "heading": "For developers — what you're running",
-      "subheading": "Standard Node + Postgres stack. Nothing exotic. `docker compose up` and you're online. Skip this if you're using the hosted version.",
-      "items": {
-        "bot": {
-          "name": "lucky-bot",
-          "description": "discord.js client, Lavalink-free audio via yt-dlp + Opus"
-        },
-        "backend": {
-          "name": "lucky-backend",
-          "description": "Express API, OAuth, Prisma to Postgres"
-        },
-        "frontend": {
-          "name": "lucky-frontend",
-          "description": "React 19 + Vite + Tailwind, Discord OAuth dashboard"
-        },
-        "postgres": {
-          "name": "postgres",
-          "description": "Guild config, custom commands, moderation log"
-        },
-        "redis": {
-          "name": "redis",
-          "description": "Session cache, rate-limit buckets, autoplay state"
-        },
-        "nginx": {
-          "name": "nginx",
-          "description": "Reverse proxy, /webhook → /hooks rewrite for deploy"
-        }
-      }
-    },
-    "footerRepo": {
-      "heading": "Open source under Apache 2.0",
-      "subheading": "Fork it, contribute, run it, deploy your own. The code is the spec."
-    },
-    "footer": {
-      "tagline": "Open-source Discord bot. Run it yourself or use the hosted version.",
-      "links": "Product",
-      "support": "Community",
-      "supportCopy": "Issues and PRs welcome on GitHub. Or hop in the Discord support server.",
-      "terms": "Terms",
-      "privacy": "Privacy",
-      "github": "GitHub",
-      "docs": "Docs",
-      "changelog": "Changelog",
-      "discord": "Support server",
-      "copyright": "© 2026 Lucky. Apache 2.0."
-    },
-    "features": {
-      "heading": "What Lucky does",
-      "subheading": "Everything most servers need, in one bot. No premium tier paywalling the good parts.",
-      "items": {
-        "music": {
-          "title": "Music with smart autoplay",
-          "description": "Queue from Spotify, YouTube, or SoundCloud. Autoplay matches the mood and won't drift into the wrong language."
-        },
-        "moderation": {
-          "title": "Moderation that doesn't sleep",
-          "description": "Auto-mod for spam, caps, links, and invites. Tempbans with reasons, audit log entries, and per-server rules."
-        },
-        "customCommands": {
-          "title": "Custom commands",
-          "description": "Build replies, role-toggles, embeds, and shortcuts without writing code. Variable interpolation included."
-        },
-        "dashboard": {
-          "title": "A real web dashboard",
-          "description": "Configure everything from your browser. Discord OAuth login, no JSON files, no SSH."
-        },
-        "embeds": {
-          "title": "Embed builder",
-          "description": "Compose rich Discord embeds with a live preview. Save templates, send on schedule, edit in place."
-        }
-      }
-    }
-  },
-  "login": {
-    "meta": {
-      "title": "Login - Lucky",
-      "description": "Login to Lucky Dashboard to manage your Discord servers"
-    },
-    "brand": "Discord Bot Dashboard",
-    "headline": "Manage your Discord servers",
-    "description": "Configure moderation, custom commands, music, and more — all in one place.",
-    "modules": "Modules",
-    "commands": "Commands",
-    "uptime": "Uptime",
-    "authentication": "Authentication",
-    "signInWithDiscord": "Sign in with Discord",
-    "permissionsNote": "Your guild permissions and bot controls are tied to your Discord account.",
-    "connecting": "Connecting...",
-    "loginButton": "Login with Discord",
-    "badges": {
-      "oauthSecured": "OAuth secured",
-      "fastSetup": "Fast setup",
-      "liveControls": "Live controls"
-    },
-    "copyright": "© 2026 Lucky. All rights reserved."
-  }
 }

--- a/packages/frontend/src/locales/pt-BR.json
+++ b/packages/frontend/src/locales/pt-BR.json
@@ -1,342 +1,341 @@
 {
-  "common": {
-    "loading": "Carregando…",
-    "retry": "Tentar novamente",
-    "cancel": "Cancelar",
-    "save": "Salvar",
-    "delete": "Excluir",
-    "edit": "Editar",
-    "close": "Fechar",
-    "closeSidebar": "Fechar barra lateral",
-    "open": "Abrir",
-    "activeServerAriaLabel": "Servidor ativo: {{name}}. Clique para trocar.",
-    "viewAll": "Ver tudo",
-    "selectServer": "Selecione um servidor",
-    "accessDenied": "Acesso negado",
-    "accessDeniedDescription": "Você não tem permissão para visualizar o módulo {{module}} deste servidor.",
-    "logout": "Sair",
-    "language": "Idioma"
-  },
-  "languages": {
-    "en": "English",
-    "pt-BR": "Português (Brasil)"
-  },
-  "modules": {
-    "overview": "visão geral",
-    "settings": "configurações",
-    "moderation": "moderação",
-    "automation": "automação",
-    "music": "música",
-    "integrations": "integrações"
-  },
-  "sidebar": {
-    "activeGuild": "Servidor ativo",
-    "switchServer": "Trocar servidor",
-    "commandCenter": "Central de comando",
-    "status": {
-      "selectServer": "Selecione um servidor",
-      "needsSetup": "Precisa configurar",
-      "ready": "Pronto"
+    "common": {
+        "loading": "Carregando…",
+        "retry": "Tentar novamente",
+        "cancel": "Cancelar",
+        "save": "Salvar",
+        "delete": "Excluir",
+        "edit": "Editar",
+        "close": "Fechar",
+        "closeSidebar": "Fechar barra lateral",
+        "open": "Abrir",
+        "activeServerAriaLabel": "Servidor ativo: {{name}}. Clique para trocar.",
+        "viewAll": "Ver tudo",
+        "selectServer": "Selecione um servidor",
+        "accessDenied": "Acesso negado",
+        "accessDeniedDescription": "Você não tem permissão para visualizar o módulo {{module}} deste servidor.",
+        "logout": "Sair",
+        "language": "Idioma"
     },
-    "subtitle": {
-      "selectServer": "Escolha uma comunidade para desbloquear as ferramentas do servidor.",
-      "needsSetup": "O Lucky ainda não está instalado neste servidor.",
-      "ready": "A central de comando do servidor está pronta para operar."
+    "languages": {
+        "en": "English",
+        "pt-BR": "Português (Brasil)"
     },
-    "sections": {
-      "overview": "Visão geral",
-      "moderation": "Moderação",
-      "automation": "Automação",
-      "community": "Comunidade",
-      "media": "Mídia",
-      "integrations": "Integrações"
+    "modules": {
+        "overview": "visão geral",
+        "settings": "configurações",
+        "moderation": "moderação",
+        "automation": "automação",
+        "music": "música",
+        "integrations": "integrações"
     },
-    "nav": {
-      "dashboard": "Painel",
-      "serverSettings": "Configurações do servidor",
-      "modCases": "Casos de moderação",
-      "autoModeration": "Auto-moderação",
-      "serverLogs": "Logs do servidor",
-      "customCommands": "Comandos personalizados",
-      "autoMessages": "Mensagens automáticas",
-      "embedBuilder": "Construtor de embeds",
-      "reactionRoles": "Cargos por reação",
-      "guildAutomation": "Automação do servidor",
-      "levelSystem": "Sistema de níveis",
-      "starboard": "Starboard",
-      "musicPlayer": "Player de música",
-      "trackHistory": "Histórico de faixas",
-      "lyrics": "Letras",
-      "musicalTaste": "Gosto musical",
-      "lastFm": "Last.fm",
-      "twitch": "Twitch",
-      "features": "Recursos"
+    "sidebar": {
+        "activeGuild": "Servidor ativo",
+        "switchServer": "Trocar servidor",
+        "commandCenter": "Central de comando",
+        "status": {
+            "selectServer": "Selecione um servidor",
+            "needsSetup": "Precisa configurar",
+            "ready": "Pronto"
+        },
+        "subtitle": {
+            "selectServer": "Escolha uma comunidade para desbloquear as ferramentas do servidor.",
+            "needsSetup": "O Lucky ainda não está instalado neste servidor.",
+            "ready": "A central de comando do servidor está pronta para operar."
+        },
+        "sections": {
+            "overview": "Visão geral",
+            "moderation": "Moderação",
+            "automation": "Automação",
+            "community": "Comunidade",
+            "media": "Mídia",
+            "integrations": "Integrações"
+        },
+        "nav": {
+            "dashboard": "Painel",
+            "serverSettings": "Configurações do servidor",
+            "modCases": "Casos de moderação",
+            "autoModeration": "Auto-moderação",
+            "serverLogs": "Logs do servidor",
+            "customCommands": "Comandos personalizados",
+            "autoMessages": "Mensagens automáticas",
+            "embedBuilder": "Construtor de embeds",
+            "reactionRoles": "Cargos por reação",
+            "guildAutomation": "Automação do servidor",
+            "levelSystem": "Sistema de níveis",
+            "starboard": "Starboard",
+            "musicPlayer": "Player de música",
+            "trackHistory": "Histórico de faixas",
+            "lyrics": "Letras",
+            "musicalTaste": "Gosto musical",
+            "lastFm": "Last.fm",
+            "twitch": "Twitch",
+            "features": "Recursos"
+        }
+    },
+    "layout": {
+        "routes": {
+            "dashboard": {
+                "title": "Painel",
+                "subtitle": "Visão operacional e principais indicadores do seu servidor."
+            },
+            "servers": {
+                "title": "Servidores",
+                "subtitle": "Confira o status de instalação e gerencie suas comunidades elegíveis."
+            },
+            "serverSettings": {
+                "title": "Configurações do servidor",
+                "subtitle": "Configure o comportamento do bot, canais, cargos e preferências."
+            },
+            "moderation": {
+                "title": "Casos de moderação",
+                "subtitle": "Revise e gerencie ações de moderação deste servidor."
+            },
+            "autoMod": {
+                "title": "Auto-moderação",
+                "subtitle": "Configure regras automáticas e filtros de aplicação."
+            },
+            "serverLogs": {
+                "title": "Logs do servidor",
+                "subtitle": "Inspecione eventos de auditoria e atividades do bot."
+            },
+            "customCommands": {
+                "title": "Comandos personalizados",
+                "subtitle": "Crie e gerencie comandos de barra personalizados deste servidor."
+            },
+            "autoMessages": {
+                "title": "Mensagens automáticas",
+                "subtitle": "Agende mensagens recorrentes em qualquer canal."
+            },
+            "embedBuilder": {
+                "title": "Construtor de embeds",
+                "subtitle": "Crie e envie embeds avançados do Discord."
+            },
+            "reactionRoles": {
+                "title": "Cargos por reação",
+                "subtitle": "Atribua cargos com base nas reações de emoji dos membros."
+            },
+            "guildAutomation": {
+                "title": "Automação do servidor",
+                "subtitle": "Configure fluxos automatizados de gerenciamento do servidor."
+            },
+            "levels": {
+                "title": "Sistema de níveis",
+                "subtitle": "Configure XP, cargos por nível e rankings."
+            },
+            "starboard": {
+                "title": "Starboard",
+                "subtitle": "Destaque mensagens populares em um canal dedicado."
+            },
+            "lyrics": {
+                "title": "Letras",
+                "subtitle": "Busque e exiba letras de músicas no seu servidor."
+            },
+            "lastFm": {
+                "title": "Last.fm",
+                "subtitle": "Controle a vinculação de contas e a atribuição de scrobbles."
+            },
+            "twitch": {
+                "title": "Notificações da Twitch",
+                "subtitle": "Envie alertas ao vivo quando streamers monitorados ficam online."
+            },
+            "features": {
+                "title": "Recursos",
+                "subtitle": "Ative ou desative módulos de recursos para o seu servidor."
+            },
+            "trackHistory": {
+                "title": "Histórico de faixas",
+                "subtitle": "Inspecione a reprodução recente e a atividade dos solicitantes."
+            },
+            "music": {
+                "title": "Player de música",
+                "subtitle": "Gerencie fila, autoplay e controles de reprodução em tempo real."
+            },
+            "preferredArtists": {
+                "title": "Gosto musical",
+                "subtitle": "Ajuste preferências de autoplay e prioridade de artistas."
+            },
+            "spotify": {
+                "title": "Spotify",
+                "subtitle": "Vincule ou desvincule o Spotify para alimentar o autoplay."
+            },
+            "fallback": {
+                "title": "Painel Lucky",
+                "subtitle": "Configure módulos, moderação e fluxos de engajamento."
+            }
+        }
+    },
+    "landing": {
+        "meta": {
+            "title": "Lucky — Um bot do Discord que você pode hospedar",
+            "description": "Bot do Discord open source com música, moderação, comandos personalizados e painel web. Grátis para sempre. Rode na sua própria máquina."
+        },
+        "hero": {
+            "eyebrow": "Open source · Apache 2.0",
+            "headlineLine1": "Um bot do Discord bem feito.",
+            "headlineLine2": "E você que manda.",
+            "subtitle": "Música, moderação, comandos personalizados e um painel web completo. Use a versão hospedada em dois cliques, ou rode no seu próprio box se preferir.",
+            "ctaPrimary": "Adicionar ao Discord",
+            "ctaSecondary": "Auto-hospedar no GitHub"
+        },
+        "repoCard": {
+            "name": "LucasSantana-Dev / Lucky",
+            "description": "Bot de música do Discord auto-hospedável — Spotify + YouTube + SoundCloud, autoplay com recomendações, painel React, suíte de moderação.",
+            "license": "Apache-2.0",
+            "lang": "TypeScript",
+            "serversLabel": "servidores",
+            "usersLabel": "usuários",
+            "viewOnGithub": "Ver no GitHub",
+            "copyClone": "Copiar URL de clone"
+        },
+        "whySelfHost": {
+            "heading": "Por que auto-hospedar",
+            "items": {
+                "data": {
+                    "title": "Os dados do seu servidor são seus",
+                    "description": "Postgres, Redis, seu hardware. Nada de termos de uso de terceiros sobre a sua comunidade. Exporte e migre quando quiser."
+                },
+                "fork": {
+                    "title": "Fork no código",
+                    "description": "Monorepo TypeScript. Adicione comandos, mude comportamento, troque providers sem esperar por uma roadmap ou pagar por tier de API."
+                },
+                "free": {
+                    "title": "Grátis, sem tier premium",
+                    "description": "Sem paywall, sem Patreon, sem limite de uso por tier. Apache 2.0. A versão hospedada existe pra quem não quer rodar uma máquina."
+                }
+            }
+        },
+        "commands": {
+            "heading": "100+ comandos, com escopo no que você roda",
+            "rows": {
+                "play": {
+                    "name": "/play",
+                    "description": "Adicione um track do Spotify, YouTube ou SoundCloud à fila",
+                    "kbd": "música"
+                },
+                "autoplay": {
+                    "name": "/autoplay",
+                    "description": "Recomendações por gênero, sem trocar de idioma",
+                    "kbd": "música"
+                },
+                "queue": {
+                    "name": "/queue",
+                    "description": "Veja ou reordene a fila atual",
+                    "kbd": "música"
+                },
+                "ban": {
+                    "name": "/mod ban",
+                    "description": "Tempban com motivo, DM automática, audit log",
+                    "kbd": "moderação"
+                },
+                "automod": {
+                    "name": "/automod",
+                    "description": "Spam, caps, links, convites — regras por servidor",
+                    "kbd": "moderação"
+                },
+                "custom": {
+                    "name": "/cc create",
+                    "description": "Comandos customizados com interpolação de variáveis",
+                    "kbd": "custom"
+                }
+            },
+            "more": "+ 100 outros no painel"
+        },
+        "stack": {
+            "heading": "Para desenvolvedores — o que você está rodando",
+            "subheading": "Stack padrão Node + Postgres. Nada exótico. `docker compose up` e você está online. Pule esta seção se está usando a versão hospedada.",
+            "items": {
+                "bot": {
+                    "name": "lucky-bot",
+                    "description": "Cliente discord.js, áudio sem Lavalink via yt-dlp + Opus"
+                },
+                "backend": {
+                    "name": "lucky-backend",
+                    "description": "API Express, OAuth, Prisma com Postgres"
+                },
+                "frontend": {
+                    "name": "lucky-frontend",
+                    "description": "React 19 + Vite + Tailwind, painel com OAuth do Discord"
+                },
+                "postgres": {
+                    "name": "postgres",
+                    "description": "Config de servidor, comandos customizados, log de moderação"
+                },
+                "redis": {
+                    "name": "redis",
+                    "description": "Cache de sessão, rate-limit, estado de autoplay"
+                },
+                "nginx": {
+                    "name": "nginx",
+                    "description": "Reverse proxy, rewrite /webhook → /hooks para deploy"
+                }
+            }
+        },
+        "footerRepo": {
+            "heading": "Open source sob Apache 2.0",
+            "subheading": "Fork, contribua, rode, faça o deploy. O código é a especificação."
+        },
+        "footer": {
+            "tagline": "Bot do Discord open source. Rode você mesmo ou use a versão hospedada.",
+            "links": "Produto",
+            "support": "Comunidade",
+            "supportCopy": "Issues e PRs são bem-vindos no GitHub. Ou entre no servidor de suporte do Discord.",
+            "terms": "Termos",
+            "privacy": "Privacidade",
+            "github": "GitHub",
+            "docs": "Docs",
+            "changelog": "Changelog",
+            "discord": "Servidor de suporte",
+            "copyright": "© 2026 Lucky. Apache 2.0."
+        },
+        "features": {
+            "heading": "O que o Lucky faz",
+            "subheading": "Tudo que a maioria dos servidores precisa, em um bot só. Sem tier premium escondendo o que importa.",
+            "items": {
+                "music": {
+                    "title": "Música com autoplay inteligente",
+                    "description": "Adicione tracks do Spotify, YouTube ou SoundCloud. O autoplay acompanha o mood e não troca de idioma."
+                },
+                "moderation": {
+                    "title": "Moderação que não dorme",
+                    "description": "Auto-mod para spam, caps, links e convites. Tempbans com motivo, registro no audit log e regras por servidor."
+                },
+                "customCommands": {
+                    "title": "Comandos personalizados",
+                    "description": "Crie respostas, toggles de role, embeds e atalhos sem escrever código. Com interpolação de variáveis."
+                },
+                "dashboard": {
+                    "title": "Um painel web de verdade",
+                    "description": "Configure tudo direto do navegador. Login com OAuth do Discord, sem arquivos JSON, sem SSH."
+                },
+                "embeds": {
+                    "title": "Construtor de embeds",
+                    "description": "Monte embeds ricos com prévia ao vivo. Salve templates, envie agendado, edite no lugar."
+                }
+            }
+        }
+    },
+    "login": {
+        "meta": {
+            "title": "Entrar - Lucky",
+            "description": "Entre no painel do Lucky para gerenciar seus servidores do Discord"
+        },
+        "brand": "Painel do Bot do Discord",
+        "headline": "Gerencie seus servidores do Discord",
+        "description": "Configure moderação, comandos personalizados, música e muito mais — tudo em um só lugar.",
+        "modules": "Módulos",
+        "commands": "Comandos",
+        "uptime": "Tempo online",
+        "authentication": "Autenticação",
+        "signInWithDiscord": "Entrar com Discord",
+        "permissionsNote": "Suas permissões de servidor e controles do bot estão vinculados à sua conta do Discord.",
+        "connecting": "Conectando...",
+        "loginButton": "Entrar com Discord",
+        "badges": {
+            "oauthSecured": "Protegido por OAuth",
+            "fastSetup": "Configuração rápida",
+            "liveControls": "Controles em tempo real"
+        },
+        "copyright": "© 2026 Lucky. Todos os direitos reservados."
     }
-  },
-  "layout": {
-    "routes": {
-      "dashboard": {
-        "title": "Painel",
-        "subtitle": "Visão operacional e principais indicadores do seu servidor."
-      },
-      "servers": {
-        "title": "Servidores",
-        "subtitle": "Confira o status de instalação e gerencie suas comunidades elegíveis."
-      },
-      "serverSettings": {
-        "title": "Configurações do servidor",
-        "subtitle": "Configure o comportamento do bot, canais, cargos e preferências."
-      },
-      "moderation": {
-        "title": "Casos de moderação",
-        "subtitle": "Revise e gerencie ações de moderação deste servidor."
-      },
-      "autoMod": {
-        "title": "Auto-moderação",
-        "subtitle": "Configure regras automáticas e filtros de aplicação."
-      },
-      "serverLogs": {
-        "title": "Logs do servidor",
-        "subtitle": "Inspecione eventos de auditoria e atividades do bot."
-      },
-      "customCommands": {
-        "title": "Comandos personalizados",
-        "subtitle": "Crie e gerencie comandos de barra personalizados deste servidor."
-      },
-      "autoMessages": {
-        "title": "Mensagens automáticas",
-        "subtitle": "Agende mensagens recorrentes em qualquer canal."
-      },
-      "embedBuilder": {
-        "title": "Construtor de embeds",
-        "subtitle": "Crie e envie embeds avançados do Discord."
-      },
-      "reactionRoles": {
-        "title": "Cargos por reação",
-        "subtitle": "Atribua cargos com base nas reações de emoji dos membros."
-      },
-      "guildAutomation": {
-        "title": "Automação do servidor",
-        "subtitle": "Configure fluxos automatizados de gerenciamento do servidor."
-      },
-      "levels": {
-        "title": "Sistema de níveis",
-        "subtitle": "Configure XP, cargos por nível e rankings."
-      },
-      "starboard": {
-        "title": "Starboard",
-        "subtitle": "Destaque mensagens populares em um canal dedicado."
-      },
-      "lyrics": {
-        "title": "Letras",
-        "subtitle": "Busque e exiba letras de músicas no seu servidor."
-      },
-      "lastFm": {
-        "title": "Last.fm",
-        "subtitle": "Controle a vinculação de contas e a atribuição de scrobbles."
-      },
-      "twitch": {
-        "title": "Notificações da Twitch",
-        "subtitle": "Envie alertas ao vivo quando streamers monitorados ficam online."
-      },
-      "features": {
-        "title": "Recursos",
-        "subtitle": "Ative ou desative módulos de recursos para o seu servidor."
-      },
-      "trackHistory": {
-        "title": "Histórico de faixas",
-        "subtitle": "Inspecione a reprodução recente e a atividade dos solicitantes."
-      },
-      "music": {
-        "title": "Player de música",
-        "subtitle": "Gerencie fila, autoplay e controles de reprodução em tempo real."
-      },
-      "preferredArtists": {
-        "title": "Gosto musical",
-        "subtitle": "Ajuste preferências de autoplay e prioridade de artistas."
-      },
-      "spotify": {
-        "title": "Spotify",
-        "subtitle": "Vincule ou desvincule o Spotify para alimentar o autoplay."
-      },
-      "fallback": {
-        "title": "Painel Lucky",
-        "subtitle": "Configure módulos, moderação e fluxos de engajamento."
-      }
-    }
-  },
-  "landing": {
-    "meta": {
-      "title": "Lucky — Um bot do Discord que você pode hospedar",
-      "description": "Bot do Discord open source com música, moderação, comandos personalizados e painel web. Grátis para sempre. Rode na sua própria máquina."
-    },
-    "hero": {
-      "eyebrow": "Open source · Apache 2.0",
-      "headlineLine1": "Um bot do Discord bem feito.",
-      "headlineLine2": "E você que manda.",
-      "subtitle": "Música, moderação, comandos personalizados e um painel web completo. Use a versão hospedada em dois cliques, ou rode no seu próprio box se preferir.",
-      "ctaPrimary": "Adicionar ao Discord",
-      "ctaSecondary": "Auto-hospedar no GitHub"
-    },
-    "repoCard": {
-      "name": "LucasSantana-Dev / Lucky",
-      "description": "Bot de música do Discord auto-hospedável — Spotify + YouTube + SoundCloud, autoplay com recomendações, painel React, suíte de moderação.",
-      "license": "Apache-2.0",
-      "lang": "TypeScript",
-      "starsLabel": "estrelas",
-      "forksLabel": "forks",
-      "issuesLabel": "issues abertas",
-      "viewOnGithub": "Ver no GitHub",
-      "copyClone": "Copiar URL de clone"
-    },
-    "whySelfHost": {
-      "heading": "Por que auto-hospedar",
-      "items": {
-        "data": {
-          "title": "Os dados do seu servidor são seus",
-          "description": "Postgres, Redis, seu hardware. Nada de termos de uso de terceiros sobre a sua comunidade. Exporte e migre quando quiser."
-        },
-        "fork": {
-          "title": "Fork no código",
-          "description": "Monorepo TypeScript. Adicione comandos, mude comportamento, troque providers sem esperar por uma roadmap ou pagar por tier de API."
-        },
-        "free": {
-          "title": "Grátis, sem tier premium",
-          "description": "Sem paywall, sem Patreon, sem limite de uso por tier. Apache 2.0. A versão hospedada existe pra quem não quer rodar uma máquina."
-        }
-      }
-    },
-    "commands": {
-      "heading": "100+ comandos, com escopo no que você roda",
-      "rows": {
-        "play": {
-          "name": "/play",
-          "description": "Adicione um track do Spotify, YouTube ou SoundCloud à fila",
-          "kbd": "música"
-        },
-        "autoplay": {
-          "name": "/autoplay",
-          "description": "Recomendações por gênero, sem trocar de idioma",
-          "kbd": "música"
-        },
-        "queue": {
-          "name": "/queue",
-          "description": "Veja ou reordene a fila atual",
-          "kbd": "música"
-        },
-        "ban": {
-          "name": "/mod ban",
-          "description": "Tempban com motivo, DM automática, audit log",
-          "kbd": "moderação"
-        },
-        "automod": {
-          "name": "/automod",
-          "description": "Spam, caps, links, convites — regras por servidor",
-          "kbd": "moderação"
-        },
-        "custom": {
-          "name": "/cc create",
-          "description": "Comandos customizados com interpolação de variáveis",
-          "kbd": "custom"
-        }
-      },
-      "more": "+ 100 outros no painel"
-    },
-    "stack": {
-      "heading": "Para desenvolvedores — o que você está rodando",
-      "subheading": "Stack padrão Node + Postgres. Nada exótico. `docker compose up` e você está online. Pule esta seção se está usando a versão hospedada.",
-      "items": {
-        "bot": {
-          "name": "lucky-bot",
-          "description": "Cliente discord.js, áudio sem Lavalink via yt-dlp + Opus"
-        },
-        "backend": {
-          "name": "lucky-backend",
-          "description": "API Express, OAuth, Prisma com Postgres"
-        },
-        "frontend": {
-          "name": "lucky-frontend",
-          "description": "React 19 + Vite + Tailwind, painel com OAuth do Discord"
-        },
-        "postgres": {
-          "name": "postgres",
-          "description": "Config de servidor, comandos customizados, log de moderação"
-        },
-        "redis": {
-          "name": "redis",
-          "description": "Cache de sessão, rate-limit, estado de autoplay"
-        },
-        "nginx": {
-          "name": "nginx",
-          "description": "Reverse proxy, rewrite /webhook → /hooks para deploy"
-        }
-      }
-    },
-    "footerRepo": {
-      "heading": "Open source sob Apache 2.0",
-      "subheading": "Fork, contribua, rode, faça o deploy. O código é a especificação."
-    },
-    "footer": {
-      "tagline": "Bot do Discord open source. Rode você mesmo ou use a versão hospedada.",
-      "links": "Produto",
-      "support": "Comunidade",
-      "supportCopy": "Issues e PRs são bem-vindos no GitHub. Ou entre no servidor de suporte do Discord.",
-      "terms": "Termos",
-      "privacy": "Privacidade",
-      "github": "GitHub",
-      "docs": "Docs",
-      "changelog": "Changelog",
-      "discord": "Servidor de suporte",
-      "copyright": "© 2026 Lucky. Apache 2.0."
-    },
-    "features": {
-      "heading": "O que o Lucky faz",
-      "subheading": "Tudo que a maioria dos servidores precisa, em um bot só. Sem tier premium escondendo o que importa.",
-      "items": {
-        "music": {
-          "title": "Música com autoplay inteligente",
-          "description": "Adicione tracks do Spotify, YouTube ou SoundCloud. O autoplay acompanha o mood e não troca de idioma."
-        },
-        "moderation": {
-          "title": "Moderação que não dorme",
-          "description": "Auto-mod para spam, caps, links e convites. Tempbans com motivo, registro no audit log e regras por servidor."
-        },
-        "customCommands": {
-          "title": "Comandos personalizados",
-          "description": "Crie respostas, toggles de role, embeds e atalhos sem escrever código. Com interpolação de variáveis."
-        },
-        "dashboard": {
-          "title": "Um painel web de verdade",
-          "description": "Configure tudo direto do navegador. Login com OAuth do Discord, sem arquivos JSON, sem SSH."
-        },
-        "embeds": {
-          "title": "Construtor de embeds",
-          "description": "Monte embeds ricos com prévia ao vivo. Salve templates, envie agendado, edite no lugar."
-        }
-      }
-    }
-  },
-  "login": {
-    "meta": {
-      "title": "Entrar - Lucky",
-      "description": "Entre no painel do Lucky para gerenciar seus servidores do Discord"
-    },
-    "brand": "Painel do Bot do Discord",
-    "headline": "Gerencie seus servidores do Discord",
-    "description": "Configure moderação, comandos personalizados, música e muito mais — tudo em um só lugar.",
-    "modules": "Módulos",
-    "commands": "Comandos",
-    "uptime": "Tempo online",
-    "authentication": "Autenticação",
-    "signInWithDiscord": "Entrar com Discord",
-    "permissionsNote": "Suas permissões de servidor e controles do bot estão vinculados à sua conta do Discord.",
-    "connecting": "Conectando...",
-    "loginButton": "Entrar com Discord",
-    "badges": {
-      "oauthSecured": "Protegido por OAuth",
-      "fastSetup": "Configuração rápida",
-      "liveControls": "Controles em tempo real"
-    },
-    "copyright": "© 2026 Lucky. Todos os direitos reservados."
-  }
 }

--- a/packages/frontend/src/pages/Landing.test.tsx
+++ b/packages/frontend/src/pages/Landing.test.tsx
@@ -15,10 +15,7 @@ vi.mock('framer-motion', async () => {
             React.createElement(tag, { ...props, ref }, children),
         )
     return {
-        motion: new Proxy(
-            {},
-            { get: (_t, prop: string) => passthrough(prop) },
-        ),
+        motion: new Proxy({}, { get: (_t, prop: string) => passthrough(prop) }),
         AnimatePresence: ({ children }: any) => children,
         useReducedMotion: vi.fn(() => false),
     }
@@ -27,7 +24,12 @@ vi.mock('@/services/api')
 
 const mockLogin = vi.fn()
 
-type StatsFixture = { totalGuilds: number; totalUsers: number; uptimeSeconds: number; serversOnline: number }
+type StatsFixture = {
+    totalGuilds: number
+    totalUsers: number
+    uptimeSeconds: number
+    serversOnline: number
+}
 
 function setupMocks(overrides?: {
     prefersReducedMotion?: boolean
@@ -36,16 +38,21 @@ function setupMocks(overrides?: {
 }) {
     const {
         prefersReducedMotion = false,
-        statsData = { totalGuilds: 240, totalUsers: 18_400, uptimeSeconds: 86_400, serversOnline: 1 },
+        statsData = {
+            totalGuilds: 240,
+            totalUsers: 18_400,
+            uptimeSeconds: 86_400,
+            serversOnline: 1,
+        },
         statsError,
     } = overrides || {}
 
-    vi.mocked(useAuthStore).mockImplementation(
-        ((selector?: (value: unknown) => unknown) => {
-            const state = { login: mockLogin }
-            return selector ? selector(state) : state
-        }) as typeof useAuthStore
-    )
+    vi.mocked(useAuthStore).mockImplementation(((
+        selector?: (value: unknown) => unknown,
+    ) => {
+        const state = { login: mockLogin }
+        return selector ? selector(state) : state
+    }) as typeof useAuthStore)
 
     vi.mocked(usePageMetadata).mockImplementation(() => undefined)
     vi.mocked(useReducedMotion).mockReturnValue(prefersReducedMotion)
@@ -53,7 +60,7 @@ function setupMocks(overrides?: {
     vi.mocked(api).stats = {
         getPublic: statsError
             ? vi.fn().mockRejectedValue(statsError)
-            : vi.fn().mockResolvedValue({ data: statsData })
+            : vi.fn().mockResolvedValue({ data: statsData }),
     } as any
 }
 
@@ -77,7 +84,10 @@ describe('Landing', () => {
         expect(wordmarks.length).toBeGreaterThanOrEqual(1)
         const githubLinks = screen.getAllByRole('link', { name: /github/i })
         expect(githubLinks.length).toBeGreaterThanOrEqual(1)
-        expect(githubLinks[0]).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky')
+        expect(githubLinks[0]).toHaveAttribute(
+            'href',
+            'https://github.com/LucasSantana-Dev/Lucky',
+        )
     })
 
     test('renders hero with cat logo, eyebrow and headline', () => {
@@ -86,16 +96,23 @@ describe('Landing', () => {
         expect(logos.length).toBeGreaterThanOrEqual(2)
         const eyebrows = screen.getAllByText(/Open source/i)
         expect(eyebrows.length).toBeGreaterThanOrEqual(1)
-        expect(screen.getByText(/A Discord bot built right\./i)).toBeInTheDocument()
+        expect(
+            screen.getByText(/A Discord bot built right\./i),
+        ).toBeInTheDocument()
         expect(screen.getByText(/And yours to run\./i)).toBeInTheDocument()
     })
 
     test('renders Add to Discord primary CTA in hero and nav', () => {
         render(<Landing />)
-        const inviteLinks = screen.getAllByRole('link', { name: /Add to Discord/i })
+        const inviteLinks = screen.getAllByRole('link', {
+            name: /Add to Discord/i,
+        })
         expect(inviteLinks.length).toBeGreaterThanOrEqual(2)
         inviteLinks.forEach((link) => {
-            expect(link).toHaveAttribute('href', expect.stringContaining('discord.com/oauth2/authorize'))
+            expect(link).toHaveAttribute(
+                'href',
+                expect.stringContaining('discord.com/oauth2/authorize'),
+            )
             expect(link).toHaveAttribute('target', '_blank')
             expect(link).toHaveAttribute('rel', 'noopener noreferrer')
         })
@@ -103,8 +120,13 @@ describe('Landing', () => {
 
     test('renders Self-host on GitHub secondary CTA in hero', () => {
         render(<Landing />)
-        const selfHost = screen.getByRole('link', { name: /Self-host on GitHub/i })
-        expect(selfHost).toHaveAttribute('href', 'https://github.com/LucasSantana-Dev/Lucky')
+        const selfHost = screen.getByRole('link', {
+            name: /Self-host on GitHub/i,
+        })
+        expect(selfHost).toHaveAttribute(
+            'href',
+            'https://github.com/LucasSantana-Dev/Lucky',
+        )
         expect(selfHost).toHaveAttribute('target', '_blank')
     })
 
@@ -120,9 +142,8 @@ describe('Landing', () => {
         expect(screen.getByText('Apache-2.0')).toBeInTheDocument()
         expect(screen.getByText('TypeScript')).toBeInTheDocument()
         await waitFor(() => {
-            expect(screen.getByText('stars')).toBeInTheDocument()
-            expect(screen.getByText('forks')).toBeInTheDocument()
-            expect(screen.getByText('open issues')).toBeInTheDocument()
+            expect(screen.getByText('servers')).toBeInTheDocument()
+            expect(screen.getByText('users')).toBeInTheDocument()
         })
     })
 
@@ -139,14 +160,20 @@ describe('Landing', () => {
         } as any
         render(<Landing />)
         const ellipses = screen.getAllByText('…')
-        expect(ellipses.length).toBeGreaterThanOrEqual(3)
+        expect(ellipses.length).toBeGreaterThanOrEqual(2)
     })
 
     test('renders features section with five user-facing items', () => {
         render(<Landing />)
-        expect(screen.getByText(/Music with smart autoplay/i)).toBeInTheDocument()
-        expect(screen.getByText(/Moderation that doesn't sleep/i)).toBeInTheDocument()
-        expect(screen.getAllByText(/Custom commands/i).length).toBeGreaterThanOrEqual(1)
+        expect(
+            screen.getByText(/Music with smart autoplay/i),
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(/Moderation that doesn't sleep/i),
+        ).toBeInTheDocument()
+        expect(
+            screen.getAllByText(/Custom commands/i).length,
+        ).toBeGreaterThanOrEqual(1)
         expect(screen.getByText(/A real web dashboard/i)).toBeInTheDocument()
         expect(screen.getByText(/Embed builder/i)).toBeInTheDocument()
     })
@@ -165,13 +192,15 @@ describe('Landing', () => {
 
         await waitFor(() =>
             expect(writeText).toHaveBeenCalledWith(
-                'git clone https://github.com/LucasSantana-Dev/Lucky.git'
-            )
+                'git clone https://github.com/LucasSantana-Dev/Lucky.git',
+            ),
         )
     })
 
     test('repo card handles clipboard failure gracefully', async () => {
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined)
         const writeText = vi.fn().mockRejectedValue(new Error('denied'))
         Object.defineProperty(navigator, 'clipboard', {
             value: { writeText },
@@ -181,7 +210,9 @@ describe('Landing', () => {
 
         try {
             render(<Landing />)
-            const copyBtn = screen.getByRole('button', { name: /Copy clone URL/i })
+            const copyBtn = screen.getByRole('button', {
+                name: /Copy clone URL/i,
+            })
             fireEvent.click(copyBtn)
             await waitFor(() => expect(errorSpy).toHaveBeenCalled())
         } finally {
@@ -191,9 +222,13 @@ describe('Landing', () => {
 
     test('renders why-self-host section with three reason cards', () => {
         render(<Landing />)
-        expect(screen.getByText('Your guild data stays yours')).toBeInTheDocument()
+        expect(
+            screen.getByText('Your guild data stays yours'),
+        ).toBeInTheDocument()
         expect(screen.getByText('Fork the source')).toBeInTheDocument()
-        expect(screen.getByText('Free, with no premium tier')).toBeInTheDocument()
+        expect(
+            screen.getByText('Free, with no premium tier'),
+        ).toBeInTheDocument()
     })
 
     test('renders command list with all six commands and category tags', () => {
@@ -206,7 +241,9 @@ describe('Landing', () => {
         expect(screen.getByText('/cc create')).toBeInTheDocument()
         expect(screen.getAllByText(/music/i).length).toBeGreaterThanOrEqual(2)
         expect(screen.getAllByText(/mod$/i).length).toBeGreaterThanOrEqual(1)
-        expect(screen.getByText('+ 100 more in the dashboard')).toBeInTheDocument()
+        expect(
+            screen.getByText('+ 100 more in the dashboard'),
+        ).toBeInTheDocument()
     })
 
     test('renders stack list with all six services', () => {
@@ -221,21 +258,35 @@ describe('Landing', () => {
 
     test('renders repo footer banner and footer copyright', () => {
         render(<Landing />)
-        expect(screen.getByText(/Open source under Apache 2.0/i)).toBeInTheDocument()
-        expect(screen.getByText(/© 2026 Lucky\. Apache 2\.0\./)).toBeInTheDocument()
+        expect(
+            screen.getByText(/Open source under Apache 2.0/i),
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(/© 2026 Lucky\. Apache 2\.0\./),
+        ).toBeInTheDocument()
     })
 
     test('renders footer with Terms, Privacy and Discord support links', () => {
         render(<Landing />)
-        expect(screen.getByRole('link', { name: /Terms/i })).toHaveAttribute('href', '/terms')
-        expect(screen.getByRole('link', { name: /Privacy/i })).toHaveAttribute('href', '/privacy')
-        const supportLink = screen.getByRole('link', { name: /Support server/i })
+        expect(screen.getByRole('link', { name: /Terms/i })).toHaveAttribute(
+            'href',
+            '/terms',
+        )
+        expect(screen.getByRole('link', { name: /Privacy/i })).toHaveAttribute(
+            'href',
+            '/privacy',
+        )
+        const supportLink = screen.getByRole('link', {
+            name: /Support server/i,
+        })
         expect(supportLink).toHaveAttribute('target', '_blank')
         expect(supportLink).toHaveAttribute('rel', 'noreferrer')
     })
 
     test('logs and recovers when stats fetch rejects', async () => {
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined)
         try {
             setupMocks({ statsError: new Error('boom') })
             render(<Landing />)
@@ -248,16 +299,34 @@ describe('Landing', () => {
     test('respects prefers-reduced-motion', () => {
         setupMocks({ prefersReducedMotion: true })
         render(<Landing />)
-        expect(screen.getByText(/A Discord bot built right\./i)).toBeInTheDocument()
+        expect(
+            screen.getByText(/A Discord bot built right\./i),
+        ).toBeInTheDocument()
     })
 
     test('shows zero stats correctly when api returns zeros', async () => {
-        setupMocks({ statsData: { totalGuilds: 0, totalUsers: 0, uptimeSeconds: 0, serversOnline: 0 } })
+        setupMocks({
+            statsData: {
+                totalGuilds: 0,
+                totalUsers: 0,
+                uptimeSeconds: 0,
+                serversOnline: 0,
+            },
+        })
         render(<Landing />)
         await waitFor(() => expect(api.stats.getPublic).toHaveBeenCalled())
         const zeros = await screen.findAllByText('0')
-        // Three stats columns (stars/forks/issues): forks/issues are floored from Math.max(1, …)
-        // so when totalGuilds=0 stars=0; forks=max(1, 0)=1; issues=max(1, 0)=1 → only stars is 0
-        expect(zeros.length).toBeGreaterThanOrEqual(1)
+        // Two honest stat columns (servers/users): both come straight from the
+        // API, so totalGuilds=0 + totalUsers=0 → both render '0'.
+        expect(zeros.length).toBeGreaterThanOrEqual(2)
+    })
+
+    test('repo card shows an em-dash fallback when the stats fetch fails', async () => {
+        setupMocks({ statsError: new Error('stats unavailable') })
+        render(<Landing />)
+        await waitFor(() => expect(api.stats.getPublic).toHaveBeenCalled())
+        // No stale 0 / placeholder — unavailable stats render as '—'.
+        const dashes = await screen.findAllByText('—')
+        expect(dashes.length).toBeGreaterThanOrEqual(2)
     })
 })

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -6,13 +6,12 @@ import { motion, useReducedMotion } from 'framer-motion'
 import { api } from '@/services/api'
 import {
     Star,
-    GitFork,
-    CircleDot,
     Scale,
     ArrowUpRight,
     Copy,
     Check,
     Server,
+    Users,
     Database,
     Layers,
     Music2,
@@ -23,7 +22,13 @@ import {
     Sparkles,
 } from 'lucide-react'
 
-function GithubMark({ size = 16, className }: { size?: number; className?: string }) {
+function GithubMark({
+    size = 16,
+    className,
+}: {
+    size?: number
+    className?: string
+}) {
     return (
         <svg
             xmlns='http://www.w3.org/2000/svg'
@@ -44,13 +49,23 @@ const BOT_INVITE_URL = `https://discord.com/oauth2/authorize?client_id=${CLIENT_
 const REPO_URL = 'https://github.com/LucasSantana-Dev/Lucky'
 const CLONE_URL = 'https://github.com/LucasSantana-Dev/Lucky.git'
 
-type RepoStats = { stars: number; forks: number; openIssues: number; loading: boolean }
+type RepoStats = {
+    servers: number
+    users: number
+    error: boolean
+    loading: boolean
+}
 
 export default function Landing() {
     const login = useAuthStore((s) => s.login)
     const prefersReducedMotion = useReducedMotion()
     const { t } = useTranslation()
-    const [repoStats, setRepoStats] = useState<RepoStats>({ stars: 0, forks: 0, openIssues: 0, loading: true })
+    const [repoStats, setRepoStats] = useState<RepoStats>({
+        servers: 0,
+        users: 0,
+        error: false,
+        loading: true,
+    })
 
     useEffect(() => {
         let active = true
@@ -59,15 +74,15 @@ export default function Landing() {
                 const res = await api.stats.getPublic()
                 if (!active) return
                 setRepoStats({
-                    stars: res.data.totalGuilds,
-                    forks: Math.max(1, Math.floor(res.data.totalGuilds / 12)),
-                    openIssues: Math.max(1, Math.floor(res.data.totalUsers / 1000)),
+                    servers: res.data.totalGuilds,
+                    users: res.data.totalUsers,
+                    error: false,
                     loading: false,
                 })
             } catch (error) {
                 if (!active) return
-                console.error('Failed to fetch repo stats:', error)
-                setRepoStats((s) => ({ ...s, loading: false }))
+                console.error('Failed to fetch bot stats:', error)
+                setRepoStats((s) => ({ ...s, error: true, loading: false }))
             }
         }
         fetchStats()
@@ -84,7 +99,10 @@ export default function Landing() {
     return (
         <div className='lucky-shell min-h-screen dark text-white bg-lucky-surface-canvas'>
             <TopNav onOpenDashboard={login} />
-            <Hero stats={repoStats} prefersReducedMotion={prefersReducedMotion ?? false} />
+            <Hero
+                stats={repoStats}
+                prefersReducedMotion={prefersReducedMotion ?? false}
+            />
             <FeatureGrid />
             <CommandList />
             <WhySelfHost />
@@ -103,7 +121,14 @@ function TopNav({ onOpenDashboard }: { onOpenDashboard: () => void }) {
                     href='/'
                     className='inline-flex items-center gap-2 text-lucky-text-strong hover:text-lucky-brand transition-colors'
                 >
-                    <img src='/lucky-logo.png' alt='Lucky' width='28' height='28' className='h-7 w-7 rounded-full' loading='eager' />
+                    <img
+                        src='/lucky-logo.png'
+                        alt='Lucky'
+                        width='28'
+                        height='28'
+                        className='h-7 w-7 rounded-full'
+                        loading='eager'
+                    />
                     <span className='font-mono text-sm font-semibold tracking-tight'>
                         lucky<span className='text-lucky-brand'>.</span>
                     </span>
@@ -164,7 +189,11 @@ function Hero({ stats, prefersReducedMotion }: HeroProps) {
         ? {}
         : {
               animate: { y: [0, -6, 0] },
-              transition: { duration: 4, repeat: Infinity, ease: 'easeInOut' as const },
+              transition: {
+                  duration: 4,
+                  repeat: Infinity,
+                  ease: 'easeInOut' as const,
+              },
           }
 
     return (
@@ -185,12 +214,19 @@ function Hero({ stats, prefersReducedMotion }: HeroProps) {
                         />
                     </motion.div>
                     <p className='mb-5 inline-flex items-center gap-2 rounded-full border border-lucky-border-soft bg-lucky-surface-panel px-3 py-1 font-mono text-[11px] uppercase tracking-[0.18em] text-lucky-text-muted'>
-                        <span className='h-1.5 w-1.5 rounded-full bg-lucky-success' aria-hidden />
+                        <span
+                            className='h-1.5 w-1.5 rounded-full bg-lucky-success'
+                            aria-hidden
+                        />
                         {t('landing.hero.eyebrow')}
                     </p>
                     <h1 className='mb-6 max-w-[16ch] text-[clamp(2.6rem,5.5vw,4.4rem)] font-black leading-[1.02] tracking-[-0.035em] text-lucky-text-strong'>
-                        <span className='block'>{t('landing.hero.headlineLine1')}</span>
-                        <span className='block text-lucky-brand'>{t('landing.hero.headlineLine2')}</span>
+                        <span className='block'>
+                            {t('landing.hero.headlineLine1')}
+                        </span>
+                        <span className='block text-lucky-brand'>
+                            {t('landing.hero.headlineLine2')}
+                        </span>
                     </h1>
                     <p className='mb-8 max-w-[52ch] text-base text-lucky-text-body leading-relaxed md:text-lg'>
                         {t('landing.hero.subtitle')}
@@ -203,7 +239,11 @@ function Hero({ stats, prefersReducedMotion }: HeroProps) {
                             className='group inline-flex h-11 items-center justify-center gap-2 rounded-md bg-lucky-brand px-5 font-semibold text-white shadow-[0_6px_24px_-8px_rgba(236,72,153,0.55)] hover:bg-lucky-brand-strong transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
                         >
                             {t('landing.hero.ctaPrimary')}
-                            <ArrowUpRight size={15} className='transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5' aria-hidden />
+                            <ArrowUpRight
+                                size={15}
+                                className='transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5'
+                                aria-hidden
+                            />
                         </a>
                         <a
                             href={REPO_URL}
@@ -211,7 +251,8 @@ function Hero({ stats, prefersReducedMotion }: HeroProps) {
                             rel='noreferrer'
                             className='inline-flex h-11 items-center justify-center gap-2 rounded-md border border-lucky-border-strong bg-transparent px-5 font-semibold text-lucky-text-body hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
                         >
-                            <GithubMark size={14} /> {t('landing.hero.ctaSecondary')}
+                            <GithubMark size={14} />{' '}
+                            {t('landing.hero.ctaSecondary')}
                         </a>
                     </div>
                 </motion.div>
@@ -222,7 +263,11 @@ function Hero({ stats, prefersReducedMotion }: HeroProps) {
                         : {
                               initial: { opacity: 0, y: 24 },
                               animate: { opacity: 1, y: 0 },
-                              transition: { duration: 0.6, delay: 0.12, ease: [0.16, 1, 0.3, 1] as const },
+                              transition: {
+                                  duration: 0.6,
+                                  delay: 0.12,
+                                  ease: [0.16, 1, 0.3, 1] as const,
+                              },
                           })}
                 >
                     <RepoCard stats={stats} locale={locale} />
@@ -237,7 +282,11 @@ function FeatureGrid() {
     const features = [
         { key: 'music', icon: Music2, span: 'md:col-span-2' },
         { key: 'moderation', icon: Shield, span: 'md:col-span-1' },
-        { key: 'customCommands', icon: SlidersHorizontal, span: 'md:col-span-1' },
+        {
+            key: 'customCommands',
+            icon: SlidersHorizontal,
+            span: 'md:col-span-1',
+        },
         { key: 'dashboard', icon: LayoutDashboard, span: 'md:col-span-2' },
         { key: 'embeds', icon: Sparkles, span: 'md:col-span-3' },
     ] as const
@@ -249,7 +298,9 @@ function FeatureGrid() {
                     <h2 className='mb-3 text-3xl font-semibold tracking-tight text-lucky-text-strong md:text-4xl'>
                         {t('landing.features.heading')}
                     </h2>
-                    <p className='text-base text-lucky-text-body leading-relaxed'>{t('landing.features.subheading')}</p>
+                    <p className='text-base text-lucky-text-body leading-relaxed'>
+                        {t('landing.features.subheading')}
+                    </p>
                 </div>
                 <ul className='grid gap-3 md:grid-cols-3'>
                     {features.map(({ key, icon: Icon, span }) => {
@@ -261,11 +312,17 @@ function FeatureGrid() {
                                         <Icon size={18} aria-hidden />
                                     </span>
                                     <div>
-                                        <h3 className={`mb-2 font-semibold text-lucky-text-strong tracking-tight ${isWide ? 'text-lg md:text-xl' : 'text-base'}`}>
-                                            {t(`landing.features.items.${key}.title`)}
+                                        <h3
+                                            className={`mb-2 font-semibold text-lucky-text-strong tracking-tight ${isWide ? 'text-lg md:text-xl' : 'text-base'}`}
+                                        >
+                                            {t(
+                                                `landing.features.items.${key}.title`,
+                                            )}
                                         </h3>
                                         <p className='text-sm text-lucky-text-body leading-relaxed'>
-                                            {t(`landing.features.items.${key}.description`)}
+                                            {t(
+                                                `landing.features.items.${key}.description`,
+                                            )}
                                         </p>
                                     </div>
                                 </article>
@@ -285,14 +342,18 @@ function BlueprintGrid() {
                 aria-hidden
                 className='pointer-events-none absolute inset-0 opacity-[0.05]'
                 style={{
-                    backgroundImage: 'radial-gradient(circle, #adbac7 1px, transparent 1px)',
+                    backgroundImage:
+                        'radial-gradient(circle, #adbac7 1px, transparent 1px)',
                     backgroundSize: '24px 24px',
                 }}
             />
             <div
                 aria-hidden
                 className='pointer-events-none absolute inset-0'
-                style={{ background: 'radial-gradient(ellipse 80% 65% at 50% 30%, transparent 50%, #0f1117 100%)' }}
+                style={{
+                    background:
+                        'radial-gradient(ellipse 80% 65% at 50% 30%, transparent 50%, #0f1117 100%)',
+                }}
             />
         </>
     )
@@ -323,10 +384,13 @@ function RepoCard({ stats, locale }: { stats: RepoStats; locale: string }) {
             <header className='flex items-center justify-between gap-3 border-b border-lucky-border-soft bg-lucky-surface-elevated px-4 py-3'>
                 <div className='flex items-center gap-2 text-lucky-text-strong'>
                     <GithubMark size={15} />
-                    <span className='font-semibold tracking-tight'>{t('landing.repoCard.name')}</span>
+                    <span className='font-semibold tracking-tight'>
+                        {t('landing.repoCard.name')}
+                    </span>
                 </div>
                 <span className='inline-flex items-center gap-1 rounded-full border border-lucky-border-soft px-2 py-0.5 text-[11px] text-lucky-text-muted'>
-                    <Scale size={11} aria-hidden /> {t('landing.repoCard.license')}
+                    <Scale size={11} aria-hidden />{' '}
+                    {t('landing.repoCard.license')}
                 </span>
             </header>
 
@@ -335,31 +399,62 @@ function RepoCard({ stats, locale }: { stats: RepoStats; locale: string }) {
                     {t('landing.repoCard.description')}
                 </p>
 
-                <dl className='grid grid-cols-3 gap-3 text-[12px]'>
-                    <RepoStat icon={Star} value={loading ? '…' : fmt(stats.stars)} label={t('landing.repoCard.starsLabel')} />
-                    <RepoStat icon={GitFork} value={loading ? '…' : fmt(stats.forks)} label={t('landing.repoCard.forksLabel')} />
-                    <RepoStat icon={CircleDot} value={loading ? '…' : fmt(stats.openIssues)} label={t('landing.repoCard.issuesLabel')} />
+                <dl className='grid grid-cols-2 gap-3 text-[12px]'>
+                    <RepoStat
+                        icon={Server}
+                        value={
+                            loading
+                                ? '…'
+                                : stats.error
+                                  ? '—'
+                                  : fmt(stats.servers)
+                        }
+                        label={t('landing.repoCard.serversLabel')}
+                    />
+                    <RepoStat
+                        icon={Users}
+                        value={
+                            loading ? '…' : stats.error ? '—' : fmt(stats.users)
+                        }
+                        label={t('landing.repoCard.usersLabel')}
+                    />
                 </dl>
 
                 <div className='flex items-center gap-2 text-[11px] text-lucky-text-muted'>
-                    <span className='h-2 w-2 rounded-full bg-[#2b7489]' aria-hidden />
+                    <span
+                        className='h-2 w-2 rounded-full bg-[#2b7489]'
+                        aria-hidden
+                    />
                     {t('landing.repoCard.lang')}
                     <span className='ml-auto inline-flex h-1 flex-1 max-w-[120px] overflow-hidden rounded-full bg-lucky-border-soft'>
-                        <span className='h-full bg-[#2b7489]' style={{ width: '96%' }} />
-                        <span className='h-full bg-lucky-brand' style={{ width: '4%' }} />
+                        <span
+                            className='h-full bg-[#2b7489]'
+                            style={{ width: '96%' }}
+                        />
+                        <span
+                            className='h-full bg-lucky-brand'
+                            style={{ width: '4%' }}
+                        />
                     </span>
                 </div>
 
                 <div className='rounded-md border border-lucky-border-soft bg-lucky-surface-canvas px-3 py-2.5 text-[12px] flex items-center justify-between gap-2 group'>
                     <code className='truncate text-lucky-text-body'>
-                        <span className='text-lucky-text-muted select-none'>$ </span>git clone {CLONE_URL}
+                        <span className='text-lucky-text-muted select-none'>
+                            ${' '}
+                        </span>
+                        git clone {CLONE_URL}
                     </code>
                     <button
                         onClick={handleCopy}
                         aria-label={t('landing.repoCard.copyClone')}
                         className='shrink-0 inline-flex h-7 w-7 items-center justify-center rounded text-lucky-text-muted hover:bg-lucky-surface-panel hover:text-lucky-text-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand'
                     >
-                        {copied ? <Check size={13} className='text-lucky-success' /> : <Copy size={13} />}
+                        {copied ? (
+                            <Check size={13} className='text-lucky-success' />
+                        ) : (
+                            <Copy size={13} />
+                        )}
                     </button>
                 </div>
 
@@ -377,11 +472,25 @@ function RepoCard({ stats, locale }: { stats: RepoStats; locale: string }) {
     )
 }
 
-function RepoStat({ icon: Icon, value, label }: { icon: typeof Star; value: string; label: string }) {
+function RepoStat({
+    icon: Icon,
+    value,
+    label,
+}: {
+    icon: typeof Star
+    value: string
+    label: string
+}) {
     return (
         <div className='flex items-baseline gap-1.5'>
-            <Icon size={12} className='translate-y-[1px] text-lucky-text-muted' aria-hidden />
-            <span className='font-semibold tabular-nums text-lucky-text-strong'>{value}</span>
+            <Icon
+                size={12}
+                className='translate-y-[1px] text-lucky-text-muted'
+                aria-hidden
+            />
+            <span className='font-semibold tabular-nums text-lucky-text-strong'>
+                {value}
+            </span>
             <span className='text-lucky-text-muted'>{label}</span>
         </div>
     )
@@ -404,7 +513,9 @@ function WhySelfHost() {
                                 {t(`landing.whySelfHost.items.${key}.title`)}
                             </h3>
                             <p className='text-sm text-lucky-text-body leading-relaxed'>
-                                {t(`landing.whySelfHost.items.${key}.description`)}
+                                {t(
+                                    `landing.whySelfHost.items.${key}.description`,
+                                )}
                             </p>
                         </li>
                     ))}
@@ -416,14 +527,22 @@ function WhySelfHost() {
 
 function CommandList() {
     const { t } = useTranslation()
-    const rows = ['play', 'autoplay', 'queue', 'ban', 'automod', 'custom'] as const
+    const rows = [
+        'play',
+        'autoplay',
+        'queue',
+        'ban',
+        'automod',
+        'custom',
+    ] as const
 
     const kindColor: Record<string, string> = {
         music: 'text-lucky-brand bg-lucky-brand/10 border-lucky-brand/30',
         mod: 'text-lucky-warning bg-lucky-warning/10 border-lucky-warning/30',
         custom: 'text-lucky-success bg-lucky-success/10 border-lucky-success/30',
         música: 'text-lucky-brand bg-lucky-brand/10 border-lucky-brand/30',
-        moderação: 'text-lucky-warning bg-lucky-warning/10 border-lucky-warning/30',
+        moderação:
+            'text-lucky-warning bg-lucky-warning/10 border-lucky-warning/30',
     }
 
     return (
@@ -435,22 +554,29 @@ function CommandList() {
                 <ul className='overflow-hidden rounded-xl border border-lucky-border-soft bg-lucky-surface-canvas'>
                     {rows.map((key, idx) => {
                         const name = t(`landing.commands.rows.${key}.name`)
-                        const desc = t(`landing.commands.rows.${key}.description`)
+                        const desc = t(
+                            `landing.commands.rows.${key}.description`,
+                        )
                         const kbd = t(`landing.commands.rows.${key}.kbd`)
                         return (
                             <li
                                 key={key}
                                 className={`group flex items-center gap-4 px-4 py-3.5 transition-colors hover:bg-lucky-surface-panel md:px-5 ${
-                                    idx > 0 ? 'border-t border-lucky-border-soft' : ''
+                                    idx > 0
+                                        ? 'border-t border-lucky-border-soft'
+                                        : ''
                                 }`}
                             >
                                 <code className='shrink-0 font-mono text-sm font-semibold text-lucky-text-strong w-[120px] md:w-[140px]'>
                                     {name}
                                 </code>
-                                <p className='flex-1 truncate text-sm text-lucky-text-body'>{desc}</p>
+                                <p className='flex-1 truncate text-sm text-lucky-text-body'>
+                                    {desc}
+                                </p>
                                 <span
                                     className={`shrink-0 rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider ${
-                                        kindColor[kbd] ?? 'text-lucky-text-muted bg-lucky-surface-elevated border-lucky-border-soft'
+                                        kindColor[kbd] ??
+                                        'text-lucky-text-muted bg-lucky-surface-elevated border-lucky-border-soft'
                                     }`}
                                 >
                                     {kbd}
@@ -459,7 +585,9 @@ function CommandList() {
                         )
                     })}
                 </ul>
-                <p className='mt-4 font-mono text-xs text-lucky-text-muted'>{t('landing.commands.more')}</p>
+                <p className='mt-4 font-mono text-xs text-lucky-text-muted'>
+                    {t('landing.commands.more')}
+                </p>
             </div>
         </section>
     )
@@ -492,7 +620,10 @@ function StackList() {
                 </div>
                 <ul className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
                     {stack.map(({ key, icon: Icon }) => (
-                        <li key={key} className='surface-panel flex items-start gap-3 rounded-lg p-4'>
+                        <li
+                            key={key}
+                            className='surface-panel flex items-start gap-3 rounded-lg p-4'
+                        >
                             <span className='mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-lucky-surface-elevated text-lucky-brand'>
                                 <Icon size={15} aria-hidden />
                             </span>
@@ -501,7 +632,9 @@ function StackList() {
                                     {t(`landing.stack.items.${key}.name`)}
                                 </p>
                                 <p className='mt-1 text-xs text-lucky-text-body leading-relaxed'>
-                                    {t(`landing.stack.items.${key}.description`)}
+                                    {t(
+                                        `landing.stack.items.${key}.description`,
+                                    )}
                                 </p>
                             </div>
                         </li>
@@ -530,7 +663,8 @@ function RepoFooterBanner() {
                     rel='noreferrer'
                     className='inline-flex h-11 items-center gap-2 rounded-md border border-lucky-border-strong bg-lucky-surface-panel px-5 font-mono text-sm font-semibold text-lucky-text-strong hover:bg-lucky-surface-elevated transition-colors'
                 >
-                    <GithubMark size={15} /> github.com/LucasSantana-Dev/Lucky <ArrowUpRight size={13} aria-hidden />
+                    <GithubMark size={15} /> github.com/LucasSantana-Dev/Lucky{' '}
+                    <ArrowUpRight size={13} aria-hidden />
                 </a>
             </div>
         </section>
@@ -547,28 +681,51 @@ function FooterSection() {
                         <div className='inline-flex items-baseline gap-1.5 font-mono text-sm font-semibold text-lucky-text-strong'>
                             lucky<span className='text-lucky-brand'>.</span>
                         </div>
-                        <p className='max-w-xs text-sm text-lucky-text-muted'>{t('landing.footer.tagline')}</p>
+                        <p className='max-w-xs text-sm text-lucky-text-muted'>
+                            {t('landing.footer.tagline')}
+                        </p>
                     </div>
                     <FooterColumn
                         heading={t('landing.footer.links')}
                         links={[
-                            { href: REPO_URL, label: t('landing.footer.github'), external: true },
+                            {
+                                href: REPO_URL,
+                                label: t('landing.footer.github'),
+                                external: true,
+                            },
                             { href: '/docs', label: t('landing.footer.docs') },
-                            { href: '/changelog', label: t('landing.footer.changelog') },
+                            {
+                                href: '/changelog',
+                                label: t('landing.footer.changelog'),
+                            },
                         ]}
                     />
                     <FooterColumn
                         heading={t('landing.footer.support')}
                         links={[
-                            { href: 'https://discord.gg/lucky', label: t('landing.footer.discord'), external: true },
-                            { href: '/terms', label: t('landing.footer.terms') },
-                            { href: '/privacy', label: t('landing.footer.privacy') },
+                            {
+                                href: 'https://discord.gg/lucky',
+                                label: t('landing.footer.discord'),
+                                external: true,
+                            },
+                            {
+                                href: '/terms',
+                                label: t('landing.footer.terms'),
+                            },
+                            {
+                                href: '/privacy',
+                                label: t('landing.footer.privacy'),
+                            },
                         ]}
                     />
                 </div>
                 <div className='mt-10 flex flex-col items-start justify-between gap-3 border-t border-lucky-border-soft pt-6 md:flex-row md:items-center'>
-                    <p className='font-mono text-xs text-lucky-text-muted'>{t('landing.footer.copyright')}</p>
-                    <p className='text-xs text-lucky-text-muted'>{t('landing.footer.supportCopy')}</p>
+                    <p className='font-mono text-xs text-lucky-text-muted'>
+                        {t('landing.footer.copyright')}
+                    </p>
+                    <p className='text-xs text-lucky-text-muted'>
+                        {t('landing.footer.supportCopy')}
+                    </p>
                 </div>
             </div>
         </footer>
@@ -584,17 +741,23 @@ function FooterColumn({
 }) {
     return (
         <div>
-            <h4 className='mb-4 font-mono text-[11px] uppercase tracking-[0.2em] text-lucky-text-muted'>{heading}</h4>
+            <h4 className='mb-4 font-mono text-[11px] uppercase tracking-[0.2em] text-lucky-text-muted'>
+                {heading}
+            </h4>
             <ul className='space-y-2.5'>
                 {links.map(({ href, label, external }) => (
                     <li key={href}>
                         <a
                             href={href}
-                            {...(external ? { target: '_blank', rel: 'noreferrer' } : {})}
+                            {...(external
+                                ? { target: '_blank', rel: 'noreferrer' }
+                                : {})}
                             className='inline-flex items-center gap-1 text-sm text-lucky-text-muted hover:text-lucky-brand transition-colors'
                         >
                             {label}
-                            {external ? <ArrowUpRight size={11} aria-hidden /> : null}
+                            {external ? (
+                                <ArrowUpRight size={11} aria-hidden />
+                            ) : null}
                         </a>
                     </li>
                 ))}


### PR DESCRIPTION
Closes #1134.

## Problem
The landing hero RepoCard mapped bot stats to GitHub-repo-shaped labels: `stars = totalGuilds`, `forks = Math.floor(totalGuilds/12)`, `openIssues = Math.floor(totalUsers/1000)`. Users saw "forks" and "open issues" showing **fabricated** derived numbers.

## Fix (relabel — the stopgap; real GitHub stats would be #1135)
- Show the two real stats the public endpoint actually returns: **Servers** (`totalGuilds`, `Server` icon) and **Users** (`totalUsers`, `Users` icon). Dropped the fabricated forks/issues; `grid-cols-3` → `grid-cols-2`.
- Graceful fallback: on fetch error, stats render `—` (not a stale `0`); `…` while loading.
- i18n: replaced `starsLabel`/`forksLabel`/`issuesLabel` with `serversLabel`/`usersLabel` in en + pt-BR.

## Tests
- Updated label assertions (servers/users), loading-ellipsis count (2), zero-stats; new error-fallback test (`—` on reject).
- Frontend suite green: 69 files / 715 tests; tsc clean.

Note: #1130 and #1133 from the same audit batch were verified **not bugs** and closed.