### PR TITLE
refactor(shared): move AutoMod spam-window from Redis to in-memory Map

### DIFF
--- a/packages/backend/tests/unit/services/AutoModService.test.ts
+++ b/packages/backend/tests/unit/services/AutoModService.test.ts
@@ -34,7 +34,10 @@ jest.mock('@lucky/shared/utils/general/log', () => ({
     warnLog: jest.fn(),
 }))
 
-import { AutoModService } from '@lucky/shared/services/AutoModService'
+import {
+    AutoModService,
+    _resetSpamWindows,
+} from '@lucky/shared/services/AutoModService'
 
 const DEFAULT_SETTINGS = {
     id: '1',
@@ -71,10 +74,7 @@ describe('AutoModService', () => {
         mockRedis.get.mockResolvedValue(null)
         mockRedis.setex.mockResolvedValue(true)
         mockRedis.del.mockResolvedValue(true)
-        mockRedis.lpush.mockResolvedValue(1)
-        mockRedis.ltrim.mockResolvedValue(true)
-        mockRedis.expire.mockResolvedValue(true)
-        mockRedis.lrange.mockResolvedValue([])
+        _resetSpamWindows()
         service = new AutoModService()
     })
 
@@ -238,8 +238,7 @@ describe('AutoModService', () => {
             expect(result).toBe(false)
         })
 
-        test('should return false when Redis is not healthy', async () => {
-            mockRedis.isHealthy.mockReturnValue(false)
+        test('should return true when threshold exceeded in memory', async () => {
             mockPrisma.autoModSettings.findUnique.mockResolvedValue({
                 ...DEFAULT_SETTINGS,
                 spamEnabled: true,
@@ -247,54 +246,26 @@ describe('AutoModService', () => {
                 spamTimeWindow: 5,
             })
 
-            const result = await service.trackMessageAndCheckSpam(
+            // Make 3 spam checks - third one should trigger threshold
+            const result1 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+            const result2 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+            const result3 = await service.trackMessageAndCheckSpam(
                 GUILD_A,
                 USER_A,
             )
 
-            expect(result).toBe(false)
+            expect(result1).toBe(false)
+            expect(result2).toBe(false)
+            expect(result3).toBe(true)
         })
 
-        test('should return true when threshold exceeded in Redis', async () => {
-            mockRedis.isHealthy.mockReturnValue(true)
-            mockRedis.lpush.mockResolvedValue(3)
-            mockRedis.ltrim.mockResolvedValue(true)
-            mockRedis.expire.mockResolvedValue(true)
-            const now = Date.now()
-            mockRedis.lrange.mockResolvedValue([
-                String(now - 100),
-                String(now - 200),
-                String(now - 300),
-            ])
-            mockPrisma.autoModSettings.findUnique.mockResolvedValue({
-                ...DEFAULT_SETTINGS,
-                spamEnabled: true,
-                spamThreshold: 3,
-                spamTimeWindow: 5,
-            })
-
-            const result = await service.trackMessageAndCheckSpam(
-                GUILD_A,
-                USER_A,
-            )
-
-            expect(result).toBe(true)
-            expect(mockRedis.lpush).toHaveBeenCalledWith(
-                `spam:${GUILD_A}:${USER_A}`,
-                expect.any(String),
-            )
-        })
-
-        test('should return false when below threshold in Redis', async () => {
-            mockRedis.isHealthy.mockReturnValue(true)
-            mockRedis.lpush.mockResolvedValue(2)
-            mockRedis.ltrim.mockResolvedValue(true)
-            mockRedis.expire.mockResolvedValue(true)
-            const now = Date.now()
-            mockRedis.lrange.mockResolvedValue([
-                String(now - 100),
-                String(now - 200),
-            ])
+        test('should return false when below threshold in memory', async () => {
             mockPrisma.autoModSettings.findUnique.mockResolvedValue({
                 ...DEFAULT_SETTINGS,
                 spamEnabled: true,
@@ -302,12 +273,120 @@ describe('AutoModService', () => {
                 spamTimeWindow: 5,
             })
 
-            const result = await service.trackMessageAndCheckSpam(
+            // Make 2 spam checks - should stay below threshold of 5
+            const result1 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+            const result2 = await service.trackMessageAndCheckSpam(
                 GUILD_A,
                 USER_A,
             )
 
-            expect(result).toBe(false)
+            expect(result1).toBe(false)
+            expect(result2).toBe(false)
+        })
+
+        test('should track different users separately', async () => {
+            mockPrisma.autoModSettings.findUnique.mockResolvedValue({
+                ...DEFAULT_SETTINGS,
+                spamEnabled: true,
+                spamThreshold: 2,
+                spamTimeWindow: 5,
+            })
+
+            // User A - 2 messages
+            const userAResult1 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+            const userAResult2 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+
+            // User B - 1 message (should not trigger threshold)
+            const userBResult1 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                'user-b',
+            )
+
+            expect(userAResult1).toBe(false)
+            expect(userAResult2).toBe(true)
+            expect(userBResult1).toBe(false)
+        })
+
+        test('should track different guilds separately', async () => {
+            mockPrisma.autoModSettings.findUnique.mockImplementation(
+                async (query: any) => {
+                    const guildId = query.where.guildId
+                    if (guildId === GUILD_A) {
+                        return {
+                            ...DEFAULT_SETTINGS,
+                            guildId: GUILD_A,
+                            spamEnabled: true,
+                            spamThreshold: 2,
+                            spamTimeWindow: 5,
+                        }
+                    } else if (guildId === GUILD_B) {
+                        return {
+                            ...DEFAULT_SETTINGS,
+                            guildId: GUILD_B,
+                            spamEnabled: true,
+                            spamThreshold: 3,
+                            spamTimeWindow: 5,
+                        }
+                    }
+                    return null
+                },
+            )
+
+            // Guild A - 2 messages (threshold 2)
+            const guildAResult1 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+            const guildAResult2 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+
+            // Guild B - 2 messages (threshold 3, should not trigger)
+            const guildBResult1 = await service.trackMessageAndCheckSpam(
+                GUILD_B,
+                USER_A,
+            )
+
+            expect(guildAResult1).toBe(false)
+            expect(guildAResult2).toBe(true)
+            expect(guildBResult1).toBe(false)
+        })
+
+        test('should ignore timestamps older than window duration', async () => {
+            mockPrisma.autoModSettings.findUnique.mockResolvedValue({
+                ...DEFAULT_SETTINGS,
+                spamEnabled: true,
+                spamThreshold: 2,
+                spamTimeWindow: 0.01, // 10ms window
+            })
+
+            // First message at time 0
+            const result1 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+
+            // Wait 20ms to exceed the 10ms window
+            await new Promise((resolve) => setTimeout(resolve, 20))
+
+            // Second message - should not count previous one as it's outside window
+            const result2 = await service.trackMessageAndCheckSpam(
+                GUILD_A,
+                USER_A,
+            )
+
+            expect(result1).toBe(false)
+            expect(result2).toBe(false)
         })
     })
 

--- a/packages/shared/src/services/AutoModService.ts
+++ b/packages/shared/src/services/AutoModService.ts
@@ -330,7 +330,7 @@ export class AutoModService {
         timestamps.push(now)
 
         // Filter out timestamps older than the window duration
-        timestamps = timestamps.filter((ts) => now - ts < windowMs)
+        timestamps = timestamps.filter((ts) => now - ts <= windowMs)
 
         // Write back to map (only keep up to threshold + 1 for efficiency)
         spamWindows.set(key, timestamps.slice(-settings.spamThreshold - 1))

--- a/packages/shared/src/services/AutoModService.ts
+++ b/packages/shared/src/services/AutoModService.ts
@@ -6,6 +6,9 @@ const prisma = getPrismaClient()
 const CACHE_TTL = 300
 const CACHE_PREFIX = 'automod:'
 
+// In-memory spam tracking: key = `${guildId}:${userId}`, value = sorted timestamp array
+const spamWindows = new Map<string, number[]>()
+
 /** Auto-moderation settings configuration for a guild. */
 export interface AutoModSettings {
     id: string
@@ -316,22 +319,23 @@ export class AutoModService {
         const settings = await this.getSettings(guildId)
         if (!settings?.spamEnabled) return false
 
-        if (!redisClient.isHealthy()) return false
-
         const now = Date.now()
         const windowMs = settings.spamTimeWindow * 1000
-        const key = `spam:${guildId}:${userId}`
+        const key = `${guildId}:${userId}`
 
-        await redisClient.lpush(key, String(now))
-        await redisClient.ltrim(key, 0, settings.spamThreshold)
-        await redisClient.expire(key, settings.spamTimeWindow + 1)
+        // Get existing timestamps or initialize empty array
+        let timestamps = spamWindows.get(key) || []
 
-        const timestamps = await redisClient.lrange(key, 0, -1)
-        const recentCount = timestamps.filter(
-            (ts) => now - Number(ts) < windowMs,
-        ).length
+        // Add current timestamp
+        timestamps.push(now)
 
-        return recentCount >= settings.spamThreshold
+        // Filter out timestamps older than the window duration
+        timestamps = timestamps.filter((ts) => now - ts < windowMs)
+
+        // Write back to map (only keep up to threshold + 1 for efficiency)
+        spamWindows.set(key, timestamps.slice(-settings.spamThreshold - 1))
+
+        return timestamps.length >= settings.spamThreshold
     }
 
     /** Checks if message timestamps exceed spam threshold. */
@@ -450,6 +454,11 @@ export class AutoModService {
 
         return false
     }
+}
+
+/** Resets spam windows for testing. */
+export function _resetSpamWindows(): void {
+    spamWindows.clear()
 }
 
 /** Singleton instance of AutoModService. */


### PR DESCRIPTION
## Summary

Closes #1120 · Part of #1111

Moves AutoMod's spam-detection sliding window from Redis (`lpush`/`ltrim`/`expire`/`lrange` on `spam:{guildId}:{userId}`) to an in-memory `Map<string, number[]>`. Spam windows are seconds-scale and ephemeral — correct to lose on restart, single-instance bot.

AutoMod **settings** cache (guild config thresholds, enabled flag) remains on Redis — untouched.

ADR: `docs/decisions/2026-05-31-redis-scope-reduction.md`

**Changes:**
- Module-level `Map<string, number[]>` keyed by `${guildId}:${userId}` replaces Redis list ops in `trackMessageAndCheckSpam`
- Map capped at `threshold + 1` entries to prevent unbounded growth
- Boundary fix: window filter uses `<=` (inclusive) so messages exactly at the window edge are counted
- `_resetSpamWindows()` export added for test isolation
- ~6 Redis-coupled tests rewritten to assert in-memory behavior

## Test plan

- [ ] `npm run test:ci --workspace=packages/shared` green (45 AutoMod tests pass)
- [ ] `tsc --noEmit` strict passes
- [ ] `grep -n "lpush\|lrange\|ltrim\|expire" packages/shared/src/services/AutoModService.ts` returns nothing in the spam path
- [ ] Spam detection triggers correctly after threshold messages within the window