### PR TITLE
fix(bot): stop all schedulers/timers on shutdown (#1197)

### DIFF
--- a/packages/bot/src/bot/start/initializer.spec.ts
+++ b/packages/bot/src/bot/start/initializer.spec.ts
@@ -15,8 +15,15 @@ const redisClientConnectMock = jest.fn()
 const redisClientDisconnectMock = jest.fn()
 const musicWatchdogStartMock = jest.fn()
 const musicWatchdogStopMock = jest.fn()
+const musicWatchdogStopPeriodicScanMock = jest.fn()
 const startMetricsServerMock = jest.fn()
 const stopMetricsServerMock = jest.fn().mockResolvedValue(undefined)
+const stopWebMusicHandlerMock = jest.fn()
+const birthdaySchedulerStopMock = jest.fn()
+const modDigestSchedulerStopMock = jest.fn()
+const aiDevToolkitStopMock = jest.fn()
+const dependencyCheckStopMock = jest.fn()
+const stopTwitchServiceMock = jest.fn()
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: (...args: unknown[]) => errorLogMock(...args),
@@ -56,7 +63,42 @@ jest.mock('../../utils/music/watchdog', () => ({
             musicWatchdogStartMock(...args),
         stopOrphanSessionMonitor: (...args: unknown[]) =>
             musicWatchdogStopMock(...args),
+        stopPeriodicScan: (...args: unknown[]) =>
+            musicWatchdogStopPeriodicScanMock(...args),
     },
+}))
+
+jest.mock('../../handlers/webMusic', () => ({
+    stopWebMusicHandler: (...args: unknown[]) =>
+        stopWebMusicHandlerMock(...args),
+}))
+
+jest.mock('../../utils/general/birthdayScheduler', () => ({
+    birthdayScheduler: {
+        stop: (...args: unknown[]) => birthdaySchedulerStopMock(...args),
+    },
+}))
+
+jest.mock('../../utils/moderation/modDigestScheduler', () => ({
+    modDigestSchedulerService: {
+        stop: (...args: unknown[]) => modDigestSchedulerStopMock(...args),
+    },
+}))
+
+jest.mock('../../services/AiDevToolkitService', () => ({
+    aiDevToolkitService: {
+        stop: (...args: unknown[]) => aiDevToolkitStopMock(...args),
+    },
+}))
+
+jest.mock('../../services/DependencyCheckService', () => ({
+    dependencyCheckService: {
+        stop: (...args: unknown[]) => dependencyCheckStopMock(...args),
+    },
+}))
+
+jest.mock('../../twitch', () => ({
+    stopTwitchService: (...args: unknown[]) => stopTwitchServiceMock(...args),
 }))
 
 jest.mock('@lucky/shared/services', () => ({
@@ -346,6 +388,74 @@ describe('BotInitializer', () => {
             await initializer.shutdown()
 
             expect(initializer.getClient()).toBeNull()
+        })
+    })
+
+    describe('shutdown — timer & scheduler cleanup', () => {
+        it('stops every long-lived timer and scheduler', async () => {
+            const initResult = await initializer.initializeBot()
+            expect(initResult.success).toBe(true)
+
+            await initializer.shutdown()
+
+            expect(stopWebMusicHandlerMock).toHaveBeenCalled()
+            expect(birthdaySchedulerStopMock).toHaveBeenCalled()
+            expect(modDigestSchedulerStopMock).toHaveBeenCalled()
+            expect(aiDevToolkitStopMock).toHaveBeenCalled()
+            expect(dependencyCheckStopMock).toHaveBeenCalled()
+            expect(stopTwitchServiceMock).toHaveBeenCalled()
+            expect(musicWatchdogStopMock).toHaveBeenCalled()
+            expect(musicWatchdogStopPeriodicScanMock).toHaveBeenCalled()
+            expect(stopMetricsServerMock).toHaveBeenCalled()
+        })
+
+        // Each stop is wrapped in its own try/catch so a single failure can't abort
+        // the rest of teardown. Drive each throw and assert: error is logged AND the
+        // client is still torn down (shutdown ran to completion).
+        const failingStops: Array<[string, jest.Mock]> = [
+            ['stopWebMusicHandler', stopWebMusicHandlerMock],
+            ['birthdayScheduler.stop', birthdaySchedulerStopMock],
+            ['modDigestSchedulerService.stop', modDigestSchedulerStopMock],
+            ['aiDevToolkitService.stop', aiDevToolkitStopMock],
+            ['dependencyCheckService.stop', dependencyCheckStopMock],
+            ['stopTwitchService', stopTwitchServiceMock],
+            ['stopOrphanSessionMonitor', musicWatchdogStopMock],
+            ['stopPeriodicScan', musicWatchdogStopPeriodicScanMock],
+        ]
+
+        it.each(failingStops)(
+            'continues shutdown when %s throws',
+            async (_label, mockFn) => {
+                const initResult = await initializer.initializeBot()
+                expect(initResult.success).toBe(true)
+
+                const client = initializer.getClient()
+                mockFn.mockImplementationOnce(() => {
+                    throw new Error('stop failed')
+                })
+
+                await initializer.shutdown()
+
+                // The failure was caught and logged...
+                expect(errorLogMock).toHaveBeenCalled()
+                // ...and teardown still completed.
+                expect(client?.destroy).toHaveBeenCalled()
+                expect(initializer.getClient()).toBeNull()
+                expect(initializer.isBotInitialized()).toBe(false)
+            },
+        )
+
+        it('still stops metrics server when a scheduler throws', async () => {
+            const initResult = await initializer.initializeBot()
+            expect(initResult.success).toBe(true)
+
+            birthdaySchedulerStopMock.mockImplementationOnce(() => {
+                throw new Error('boom')
+            })
+
+            await initializer.shutdown()
+
+            expect(stopMetricsServerMock).toHaveBeenCalled()
         })
     })
 

--- a/packages/bot/src/bot/start/initializer.ts
+++ b/packages/bot/src/bot/start/initializer.ts
@@ -12,11 +12,17 @@ import {
     startMetricsServer,
     stopMetricsServer,
 } from '../../utils/monitoring/metricsServer'
+import { stopWebMusicHandler } from '../../handlers/webMusic'
 import type { CustomClient } from '../../types'
 import { ConfigurationError } from '@lucky/shared/types'
 import { redisClient } from '@lucky/shared/services'
 import { initProviderHealth } from '../../utils/music/search/providerHealth'
 import { musicWatchdogService } from '../../utils/music/watchdog'
+import { birthdayScheduler } from '../../utils/general/birthdayScheduler'
+import { modDigestSchedulerService } from '../../utils/moderation/modDigestScheduler'
+import { aiDevToolkitService } from '../../services/AiDevToolkitService'
+import { dependencyCheckService } from '../../services/DependencyCheckService'
+import { stopTwitchService } from '../../twitch'
 import type {
     BotInitializationOptions,
     BotInitializationResult,
@@ -167,7 +173,73 @@ export class BotInitializer {
     }
 
     async shutdown(): Promise<void> {
-        stopPresenceRotation()
+        // Stop presence rotation first (following #1157 pattern)
+        try {
+            stopPresenceRotation()
+        } catch (error) {
+            errorLog({ message: 'Error stopping presence rotation:', error })
+        }
+
+        // Stop all long-lived timers/intervals
+        try {
+            stopWebMusicHandler()
+        } catch (error) {
+            errorLog({ message: 'Error stopping web music handler:', error })
+        }
+
+        try {
+            birthdayScheduler.stop()
+        } catch (error) {
+            errorLog({ message: 'Error stopping birthday scheduler:', error })
+        }
+
+        try {
+            modDigestSchedulerService.stop()
+        } catch (error) {
+            errorLog({ message: 'Error stopping mod digest scheduler:', error })
+        }
+
+        try {
+            aiDevToolkitService.stop()
+        } catch (error) {
+            errorLog({
+                message: 'Error stopping AI dev toolkit service:',
+                error,
+            })
+        }
+
+        try {
+            dependencyCheckService.stop()
+        } catch (error) {
+            errorLog({
+                message: 'Error stopping dependency check service:',
+                error,
+            })
+        }
+
+        try {
+            stopTwitchService()
+        } catch (error) {
+            errorLog({ message: 'Error stopping Twitch service:', error })
+        }
+
+        try {
+            musicWatchdogService.stopOrphanSessionMonitor()
+        } catch (error) {
+            errorLog({
+                message: 'Error stopping watchdog orphan-session monitor:',
+                error,
+            })
+        }
+
+        try {
+            musicWatchdogService.stopPeriodicScan()
+        } catch (error) {
+            errorLog({
+                message: 'Error stopping watchdog periodic scan:',
+                error,
+            })
+        }
 
         if (this.client) {
             try {

--- a/packages/bot/src/handlers/webMusic/index.ts
+++ b/packages/bot/src/handlers/webMusic/index.ts
@@ -60,6 +60,8 @@ async function handleCommand(
     }
 }
 
+let webMusicPublishInterval: ReturnType<typeof setInterval> | null = null
+
 export async function setupWebMusicHandler(
     client: CustomClient,
 ): Promise<void> {
@@ -110,8 +112,13 @@ export async function setupWebMusicHandler(
             },
         )
 
-        // Periodically publish state for all active queues to keep SSE clients in sync
-        setInterval(async () => {
+        // Periodically publish state for all active queues to keep SSE clients in sync.
+        // Clear any prior handle first — a second setup() call (e.g. reconnect) would
+        // otherwise orphan the previous interval and double-publish forever.
+        if (webMusicPublishInterval) {
+            clearInterval(webMusicPublishInterval)
+        }
+        webMusicPublishInterval = setInterval(async () => {
             try {
                 for (const queue of client.player.nodes.cache.values()) {
                     if (!queue) continue
@@ -137,5 +144,12 @@ export async function setupWebMusicHandler(
         infoLog({ message: 'Web music handler initialized' })
     } catch (error) {
         errorLog({ message: 'Failed to setup web music handler:', error })
+    }
+}
+
+export function stopWebMusicHandler(): void {
+    if (webMusicPublishInterval) {
+        clearInterval(webMusicPublishInterval)
+        webMusicPublishInterval = null
     }
 }


### PR DESCRIPTION
Closes #1197

7 long-lived intervals had working `stop()` methods never called in `BotInitializer.shutdown()` — wired them all in defensively (one failing stop can't block the others): birthdayScheduler, modDigestScheduler, aiDevToolkit, dependencyCheck, twitch, musicWatchdog (orphan-monitor + periodic-scan). Also stored the `webMusic` 30s interval handle + added a stop function.

## Merge ordering
Overlaps `shutdown()` with **#1171** (presence) and **#1166** (teardown). Resolution: keep #1171's `presenceControls = null` + all stop calls. Expect a trivial conflict depending on merge order.

- [ ] bot suite green (2490) + new shutdown-stops test
- [ ] tsc clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop all long-lived schedulers and intervals on bot shutdown to prevent timer leaks across restarts. Also clear any prior web music interval during setup to avoid double publishing after reconnects.

- **Bug Fixes**
  - Stop presence rotation via `stopPresenceRotation()`.
  - Web music: clear previous publish interval on setup; add `stopWebMusicHandler()` for shutdown.
  - Stop schedulers/services: `birthdayScheduler`, `modDigestSchedulerService`, `aiDevToolkitService`, `dependencyCheckService`, `stopTwitchService`, and music watchdog (orphan-session monitor + periodic scan).
  - Defensive teardown: each stop in try/catch; tests cover happy path, per-stop failures, and that the metrics server still stops.

<sup>Written for commit f154c11cc2df75ffd9eeafb644fe9c57e2be278b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

