### PR TITLE
ci: run madge + portability on merge_group (merge-queue prereq)

### DIFF
--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -5,6 +5,8 @@ on:
         branches: ['release/**', main]
     pull_request:
         branches: ['release/**', main]
+    merge_group:
+        branches: ['release/**', main]
 
 # Hard gate. Blocks merges if cycle count exceeds baseline.
 # Baseline: COUNT > 1 (permits 1 known residual type-only cycle).

--- a/.github/workflows/path-portability.yml
+++ b/.github/workflows/path-portability.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [main, 'release/**']
+  merge_group:
+    branches: [main, 'release/**']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

Enabling a GitHub **merge queue** (adopted in ADR 2026-05-27, never configured) requires that **every required status check** runs and reports on the `merge_group` event. Otherwise queued PRs hang forever waiting for a check that never fires.

Audit of required checks (legacy branch protection ∪ ruleset):

| Check | Source | merge_group? |
|---|---|---|
| Quality Gates | ci.yml | ✅ already |
| Security | ci.yml | ✅ already |
| SonarCloud Scan | ci.yml job | ✅ already (PR/push-gated steps skip on merge_group → passes) |
| Build — Docker images | ci.yml | ✅ already |
| **madge / packages/bot** | madge.yml | ❌ **fixed here** |
| **portability** | path-portability.yml | ❌ **fixed here** |
| GitGuardian Security Checks | external app | verified at queue-enable time |

This PR adds the `merge_group` trigger to the two workflow gaps. Enabling the queue rule itself is a follow-up settings change once this is on `main`.

No behavioral change to PR/push runs.

@cubic-dev-ai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `madge` and path portability checks on GitHub `merge_group` events so merge-queue entries get all required checks and don’t hang. No change to PR/push behavior.

- **Bug Fixes**
  - Added `merge_group` triggers to `.github/workflows/madge.yml` and `.github/workflows/path-portability.yml` for `main` and `release/**`, matching `ci.yml`.

<sup>Written for commit e8f4d8205b01f69654af6de5db1cd8d4c2378413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

