### PR TITLE
fix: guard unsafe external API response handling (#1207)

### DIFF
--- a/packages/bot/src/lastfm/lastFmApi.spec.ts
+++ b/packages/bot/src/lastfm/lastFmApi.spec.ts
@@ -364,6 +364,15 @@ describe('lastFmApi', () => {
                     fetchMock.mockRejectedValueOnce(new Error('network error'))
                     tracks = await getRecentTracks('username')
                     expect(tracks).toEqual([])
+                    // Test res.ok guard: non-ok response should return empty array
+                    fetchMock.mockResolvedValueOnce({ ok: false })
+                    tracks = await getRecentTracks('username')
+                    expect(tracks).toEqual([])
+                    expect(debugLogMock).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            message: 'lastFmApi: getRecentTracks HTTP error',
+                        }),
+                    )
                 },
             ],
         ])('returns empty array when %s', async (_label, test) => {
@@ -424,6 +433,15 @@ describe('lastFmApi', () => {
                     fetchMock.mockRejectedValueOnce(new Error('network error'))
                     tracks = await getSimilarTracks('Artist', 'Track')
                     expect(tracks).toEqual([])
+                    // Test res.ok guard: non-ok response should return empty array
+                    fetchMock.mockResolvedValueOnce({ ok: false })
+                    tracks = await getSimilarTracks('Artist', 'Track')
+                    expect(tracks).toEqual([])
+                    expect(debugLogMock).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            message: 'lastFmApi: getSimilarTracks HTTP error',
+                        }),
+                    )
                 },
             ],
         ])('returns empty array when %s', async (_label, test) => {
@@ -535,6 +553,11 @@ describe('lastFmApi', () => {
                     fetchMock.mockResolvedValueOnce({ ok: false })
                     tracks = await getTagTopTracks('jazz')
                     expect(tracks).toEqual([])
+                    expect(debugLogMock).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            message: 'lastFmApi: getTagTopTracks HTTP error',
+                        }),
+                    )
                     fetchMock.mockResolvedValueOnce({
                         ok: true,
                         json: async () => ({}),
@@ -685,6 +708,11 @@ describe('lastFmApi', () => {
                     fetchMock.mockResolvedValueOnce({ ok: false })
                     let result = await getLovedTracks('user', 10)
                     expect(result).toEqual([])
+                    expect(debugLogMock).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            message: 'lastFmApi: getLovedTracks HTTP error',
+                        }),
+                    )
                     fetchMock.mockResolvedValueOnce({
                         ok: true,
                         json: async () => ({}),

--- a/packages/bot/src/lastfm/lastFmApi.ts
+++ b/packages/bot/src/lastfm/lastFmApi.ts
@@ -185,7 +185,13 @@ export async function getTrackMetadata(
                 `${API_BASE}?method=track.getInfo&artist=${encodeURIComponent(lookupArtist)}&track=${encodeURIComponent(trimmedTitle)}&autocorrect=1&format=json&api_key=${config.apiKey}`, // NOSONAR
             )
             if (!response.ok) {
-                debugLog({ message: 'lastFmApi: getTrackMetadata HTTP error', data: { status: response.status, statusText: response.statusText } })
+                debugLog({
+                    message: 'lastFmApi: getTrackMetadata HTTP error',
+                    data: {
+                        status: response.status,
+                        statusText: response.statusText,
+                    },
+                })
                 return null
             }
             const data = (await response.json()) as {
@@ -203,9 +209,7 @@ export async function getTrackMetadata(
             const album = t.album?.title || ''
             const albumArtist = t.album?.artist || ''
             const mbid = t.mbid || ''
-            const durationNum = t.duration
-                ? parseInt(t.duration, 10) || 0
-                : 0
+            const durationNum = t.duration ? parseInt(t.duration, 10) || 0 : 0
             const meta: LastFmTrackMetadata = {
                 artist: t.artist.name,
                 title: t.name,
@@ -218,7 +222,10 @@ export async function getTrackMetadata(
                 const oldest = TRACK_METADATA_CACHE.keys().next().value
                 if (oldest) TRACK_METADATA_CACHE.delete(oldest)
             }
-            TRACK_METADATA_CACHE.set(key, { meta, expiresAt: now + TRACK_METADATA_TTL_MS })
+            TRACK_METADATA_CACHE.set(key, {
+                meta,
+                expiresAt: now + TRACK_METADATA_TTL_MS,
+            })
             return meta
         } catch (err) {
             logAndSwallow(err, 'lastfm.getTrackMetadata', {
@@ -367,6 +374,16 @@ export async function getRecentTracks(
         const response = await fetch(
             `${API_BASE}?method=user.getrecenttracks&user=${encodeURIComponent(lastFmUsername)}&limit=${limit}&format=json&api_key=${config.apiKey}`,
         )
+        if (!response.ok) {
+            debugLog({
+                message: 'lastFmApi: getRecentTracks HTTP error',
+                data: {
+                    status: response.status,
+                    statusText: response.statusText,
+                },
+            })
+            return []
+        }
         const data = (await response.json()) as {
             recenttracks?: {
                 track?: Array<{
@@ -477,6 +494,16 @@ export async function getSimilarTracks(
         const response = await fetch(
             `${API_BASE}?method=track.getSimilar&artist=${encodeURIComponent(artist)}&track=${encodeURIComponent(title)}&limit=${limit}&autocorrect=1&format=json&api_key=${config.apiKey}`,
         )
+        if (!response.ok) {
+            debugLog({
+                message: 'lastFmApi: getSimilarTracks HTTP error',
+                data: {
+                    status: response.status,
+                    statusText: response.statusText,
+                },
+            })
+            return []
+        }
         const data = (await response.json()) as {
             similartracks?: {
                 track?: Array<{
@@ -507,6 +534,16 @@ export async function getTagTopTracks(
         const response = await fetch(
             `${API_BASE}?method=tag.getTopTracks&tag=${encodeURIComponent(tag)}&limit=${limit}&format=json&api_key=${config.apiKey}`,
         )
+        if (!response.ok) {
+            debugLog({
+                message: 'lastFmApi: getTagTopTracks HTTP error',
+                data: {
+                    status: response.status,
+                    statusText: response.statusText,
+                },
+            })
+            return []
+        }
         const data = (await response.json()) as {
             toptracks?: {
                 track?: Array<{
@@ -535,6 +572,16 @@ export async function getLovedTracks(
         const response = await fetch(
             `${API_BASE}?method=user.getlovedtracks&user=${encodeURIComponent(username)}&limit=${limit}&format=json&api_key=${config.apiKey}`,
         )
+        if (!response.ok) {
+            debugLog({
+                message: 'lastFmApi: getLovedTracks HTTP error',
+                data: {
+                    status: response.status,
+                    statusText: response.statusText,
+                },
+            })
+            return []
+        }
         const data = (await response.json()) as {
             lovedtracks?: {
                 track?: Array<{


### PR DESCRIPTION
## Summary

Closes #1207. Adds `res.ok` guards to Last.fm API endpoints that were blindly parsing responses without checking HTTP status, which could cause crashes on error/rate-limit bodies.

## Changes

**lastFmApi.ts:** Added `res.ok` check + graceful fallback in:
- `getRecentTracks()` — returns `[]` on non-ok
- `getSimilarTracks()` — returns `[]` on non-ok  
- `getTagTopTracks()` — returns `[]` on non-ok
- `getLovedTracks()` — returns `[]` on non-ok

**Verification:**
- `getTrackMetadata()` and `getTopTracks()` — already guarded ✓
- `packages/bot/src/twitch/token.ts` — already guarded ✓
- `packages/bot/src/twitch/twitchApi.ts` — already guarded ✓
- `packages/backend/src/routes/twitch.ts` — already guarded ✓

## Tests

- All 41 lastFmApi tests pass
- Added assertions for `res.ok` guards in getRecentTracks, getSimilarTracks, getTagTopTracks, getLovedTracks
- Type-check passes on bot, backend, shared, frontend

## Behavior

External API failures now degrade gracefully (log + empty fallback) rather than crash on malformed responses. No changes to normal operation; purely defensive guards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `res.ok` checks to Last.fm API calls to prevent crashes on non-2xx responses. Errors now log and return empty arrays, keeping the bot stable under API failures.

- **Bug Fixes**
  - Guarded `getRecentTracks`, `getSimilarTracks`, `getTagTopTracks`, and `getLovedTracks` with `res.ok` before calling `json()`.
  - On non-OK responses, return `[]` and emit a debug log message.
  - Added tests for these guards; all Last.fm tests pass.
  - No change to normal behavior on successful responses.

<sup>Written for commit a7b131bd53c281bac21360e7140a6279b52e9908. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

