### PR TITLE
fix(backend): wrap Spotify routes in asyncHandler (#1184)

### DIFF
--- a/packages/backend/src/routes/spotify.ts
+++ b/packages/backend/src/routes/spotify.ts
@@ -13,6 +13,7 @@ import {
     type AuthenticatedRequest,
 } from '../middleware/auth'
 import { apiLimiter } from '../middleware/rateLimit'
+import { asyncHandler } from '../middleware/asyncHandler'
 import { getPrimaryFrontendUrl } from '../utils/frontendOrigin'
 import { getOAuthRedirectUri } from '../utils/oauthRedirectUri'
 
@@ -59,7 +60,10 @@ function decodeAndVerifyState(state: string, secret: string): string | null {
         .digest('hex')
     const sigBuf = Buffer.from(sig, 'utf8')
     const expectedBuf = Buffer.from(expected, 'utf8')
-    if (sigBuf.length === expectedBuf.length && crypto.timingSafeEqual(sigBuf, expectedBuf)) {
+    if (
+        sigBuf.length === expectedBuf.length &&
+        crypto.timingSafeEqual(sigBuf, expectedBuf)
+    ) {
         return discordId
     }
     return null
@@ -90,52 +94,42 @@ export function setupSpotifyRoutes(app: Express): void {
     app.get(
         '/api/spotify/status',
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const discordId = req.user?.id
-                if (!discordId) {
-                    res.status(401).json({ error: 'Not authenticated' })
-                    return
-                }
-                const link = await spotifyLinkService.getByDiscordId(discordId)
-                const configured = isSpotifyAuthConfigured()
-                res.json({
-                    configured,
-                    linked: !!link,
-                    username: link?.spotifyUsername ?? null,
-                })
-            } catch (error) {
-                errorLog({ message: 'Spotify status error', error })
-                res.status(500).json({ error: 'Failed to check status' })
+        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+            const discordId = req.user?.id
+            if (!discordId) {
+                res.status(401).json({ error: 'Not authenticated' })
+                return
             }
-        },
+            const link = await spotifyLinkService.getByDiscordId(discordId)
+            const configured = isSpotifyAuthConfigured()
+            res.json({
+                configured,
+                linked: !!link,
+                username: link?.spotifyUsername ?? null,
+            })
+        }),
     )
 
     app.delete(
         '/api/spotify/unlink',
         requireAuth,
-        async (req: AuthenticatedRequest, res: Response) => {
-            try {
-                const discordId = req.user?.id
-                if (!discordId) {
-                    res.status(401).json({ error: 'Not authenticated' })
-                    return
-                }
-                const ok = await spotifyLinkService.unlink(discordId)
-                if (!ok) {
-                    res.status(404).json({ error: 'No Spotify link found' })
-                    return
-                }
-                debugLog({
-                    message: 'Spotify unlinked via API',
-                    data: { discordId },
-                })
-                res.json({ success: true })
-            } catch (error) {
-                errorLog({ message: 'Spotify unlink error', error })
-                res.status(500).json({ error: 'Failed to unlink' })
+        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+            const discordId = req.user?.id
+            if (!discordId) {
+                res.status(401).json({ error: 'Not authenticated' })
+                return
             }
-        },
+            const ok = await spotifyLinkService.unlink(discordId)
+            if (!ok) {
+                res.status(404).json({ error: 'No Spotify link found' })
+                return
+            }
+            debugLog({
+                message: 'Spotify unlinked via API',
+                data: { discordId },
+            })
+            res.json({ success: true })
+        }),
     )
 
     app.get(
@@ -182,7 +176,11 @@ export function setupSpotifyRoutes(app: Express): void {
                 }
                 const backendBaseUrl = resolveBackendBaseUrl(req)
                 const callbackUrl = `${backendBaseUrl}/api/spotify/callback?state=${encodeURIComponent(state)}`
-                const scopes = ['user-top-read', 'user-read-recently-played', 'user-library-read']
+                const scopes = [
+                    'user-top-read',
+                    'user-read-recently-played',
+                    'user-library-read',
+                ]
                 const authUrl = `https://accounts.spotify.com/authorize?client_id=${encodeURIComponent(clientId)}&response_type=code&redirect_uri=${encodeURIComponent(callbackUrl)}&scope=${encodeURIComponent(scopes.join(' '))}`
                 res.redirect(authUrl)
             } catch (error) {
@@ -193,9 +191,11 @@ export function setupSpotifyRoutes(app: Express): void {
         },
     )
 
-    app.get('/api/spotify/callback', apiLimiter, async (req: Request, res: Response) => {
-        const frontendUrl = getFrontendUrl()
-        try {
+    app.get(
+        '/api/spotify/callback',
+        apiLimiter,
+        asyncHandler(async (req: Request, res: Response) => {
+            const frontendUrl = getFrontendUrl()
             const cookies = req.cookies as Record<string, unknown> | undefined
             const stateFromCookie = cookies?.[SPOTIFY_STATE_COOKIE]
             const parsedQuery = spotifyCallbackQuery.safeParse(req.query)
@@ -249,9 +249,6 @@ export function setupSpotifyRoutes(app: Express): void {
                 data: { discordId, username: token.spotifyUsername },
             })
             res.redirect(`${frontendUrl}/?spotify_linked=true`)
-        } catch (error) {
-            errorLog({ message: 'Spotify callback error', error })
-            res.redirect(`${frontendUrl}/?error=spotify_callback_error`)
-        }
-    })
+        }),
+    )
 }

--- a/packages/backend/tests/integration/routes/spotify.test.ts
+++ b/packages/backend/tests/integration/routes/spotify.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import request from 'supertest'
-import type { Express } from 'express'
+import type { Express, Request, Response, NextFunction } from 'express'
 import express from 'express'
 
 const mockSpotifyLinkService = {
@@ -18,7 +18,10 @@ jest.mock('@lucky/shared/services', () => ({
     spotifyLinkService: mockSpotifyLinkService,
 }))
 
-jest.mock('../../../src/services/SpotifyAuthService', () => mockSpotifyAuthService)
+jest.mock(
+    '../../../src/services/SpotifyAuthService',
+    () => mockSpotifyAuthService,
+)
 
 import { setupSpotifyRoutes } from '../../../src/routes/spotify'
 
@@ -38,13 +41,24 @@ jest.mock('../../../src/utils/frontendOrigin', () => ({
 }))
 
 jest.mock('../../../src/utils/oauthRedirectUri', () => ({
-    getOAuthRedirectUri: () => 'https://api.lucassantana.tech/api/spotify/callback',
+    getOAuthRedirectUri: () =>
+        'https://api.lucassantana.tech/api/spotify/callback',
 }))
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
     debugLog: jest.fn(),
 }))
+
+// Global error handler for tests
+function errorHandler(
+    err: Error,
+    _req: Request,
+    res: Response,
+    _next: NextFunction,
+): void {
+    res.status(500).json({ error: 'Internal server error' })
+}
 
 describe('Spotify Routes', () => {
     let app: Express
@@ -54,10 +68,12 @@ describe('Spotify Routes', () => {
         app = express()
         app.use(express.json())
         setupSpotifyRoutes(app)
+        app.use(errorHandler)
 
         process.env.SPOTIFY_CLIENT_ID = 'test-client-id'
         process.env.SPOTIFY_CLIENT_SECRET = 'test-client-secret'
-        process.env.SPOTIFY_REDIRECT_URI = 'https://api.lucassantana.tech/api/spotify/callback'
+        process.env.SPOTIFY_REDIRECT_URI =
+            'https://api.lucassantana.tech/api/spotify/callback'
         process.env.WEBAPP_SESSION_SECRET = 'test-secret'
     })
 
@@ -101,7 +117,9 @@ describe('Spotify Routes', () => {
 
             expect(res.status).toBe(200)
             expect(res.body.success).toBe(true)
-            expect(mockSpotifyLinkService.unlink).toHaveBeenCalledWith('test-discord-id')
+            expect(mockSpotifyLinkService.unlink).toHaveBeenCalledWith(
+                'test-discord-id',
+            )
         })
 
         it('returns 404 when no link found', async () => {
@@ -120,17 +138,23 @@ describe('Spotify Routes', () => {
             const res = await request(app).get('/api/spotify/connect')
 
             expect(res.status).toBe(302)
-            expect(res.header.location).toContain('https://accounts.spotify.com/authorize')
+            expect(res.header.location).toContain(
+                'https://accounts.spotify.com/authorize',
+            )
             expect(res.header.location).toContain('client_id=test-client-id')
         })
 
         it('redirects to frontend with error when not configured', async () => {
-            mockSpotifyAuthService.isSpotifyAuthConfigured.mockReturnValue(false)
+            mockSpotifyAuthService.isSpotifyAuthConfigured.mockReturnValue(
+                false,
+            )
 
             const res = await request(app).get('/api/spotify/connect')
 
             expect(res.status).toBe(302)
-            expect(res.header.location).toContain('error=spotify_not_configured')
+            expect(res.header.location).toContain(
+                'error=spotify_not_configured',
+            )
         })
     })
 
@@ -154,7 +178,9 @@ describe('Spotify Routes', () => {
             const encodedState = `${state}.${sig}`
 
             const res = await request(app)
-                .get(`/api/spotify/callback?code=auth-code&state=${encodedState}`)
+                .get(
+                    `/api/spotify/callback?code=auth-code&state=${encodedState}`,
+                )
                 .set('Cookie', [`spotify_state=${encodedState}`])
 
             expect(res.status).toBe(302)
@@ -173,11 +199,15 @@ describe('Spotify Routes', () => {
             const encodedState = `${state}.${sig}`
 
             const res = await request(app)
-                .get(`/api/spotify/callback?code=bad-code&state=${encodedState}`)
+                .get(
+                    `/api/spotify/callback?code=bad-code&state=${encodedState}`,
+                )
                 .set('Cookie', [`spotify_state=${encodedState}`])
 
             expect(res.status).toBe(302)
-            expect(res.header.location).toContain('error=spotify_exchange_failed')
+            expect(res.header.location).toContain(
+                'error=spotify_exchange_failed',
+            )
         })
 
         it('redirects with error when code is missing', async () => {
@@ -188,16 +218,20 @@ describe('Spotify Routes', () => {
 
         it('redirects with error when state is invalid hmac', async () => {
             const badState = `${Buffer.from('user-x').toString('base64url')}.badhmacsignature`
-            const res = await request(app)
-                .get(`/api/spotify/callback?code=code&state=${badState}`)
+            const res = await request(app).get(
+                `/api/spotify/callback?code=code&state=${badState}`,
+            )
             expect(res.status).toBe(302)
             expect(res.header.location).toContain('error=spotify_invalid_state')
         })
 
         it('redirects with error when set fails', async () => {
             mockSpotifyAuthService.exchangeCodeForToken.mockResolvedValue({
-                accessToken: 'at', refreshToken: 'rt', expiresIn: 3600,
-                spotifyId: 'sid', spotifyUsername: 'user',
+                accessToken: 'at',
+                refreshToken: 'rt',
+                expiresIn: 3600,
+                spotifyId: 'sid',
+                spotifyUsername: 'user',
             })
             mockSpotifyLinkService.set.mockResolvedValue(null)
 
@@ -208,8 +242,9 @@ describe('Spotify Routes', () => {
                 .digest('hex')
             const encodedState = `${state}.${sig}`
 
-            const res = await request(app)
-                .get(`/api/spotify/callback?code=code&state=${encodedState}`)
+            const res = await request(app).get(
+                `/api/spotify/callback?code=code&state=${encodedState}`,
+            )
             expect(res.status).toBe(302)
             expect(res.header.location).toContain('error=spotify_save_failed')
         })
@@ -226,7 +261,9 @@ describe('Spotify Routes', () => {
             }))
             setupSpotifyRoutes(app2)
 
-            const res = await request(app2).get('/api/spotify/connect?state=invalid.state')
+            const res = await request(app2).get(
+                '/api/spotify/connect?state=invalid.state',
+            )
             expect(res.status).toBe(302)
         })
 
@@ -240,15 +277,39 @@ describe('Spotify Routes', () => {
 
     describe('error catch paths', () => {
         it('status returns 500 on unexpected error', async () => {
-            mockSpotifyLinkService.getByDiscordId.mockRejectedValue(new Error('db error'))
+            mockSpotifyLinkService.getByDiscordId.mockRejectedValue(
+                new Error('db error'),
+            )
             const res = await request(app).get('/api/spotify/status')
             expect(res.status).toBe(500)
         })
 
         it('unlink returns 500 on unexpected error', async () => {
-            mockSpotifyLinkService.unlink.mockRejectedValue(new Error('db error'))
+            mockSpotifyLinkService.unlink.mockRejectedValue(
+                new Error('db error'),
+            )
             const res = await request(app).delete('/api/spotify/unlink')
             expect(res.status).toBe(500)
+        })
+
+        it('callback returns 500 on unexpected error during exchange', async () => {
+            mockSpotifyAuthService.exchangeCodeForToken.mockRejectedValue(
+                new Error('token exchange error'),
+            )
+
+            const state = Buffer.from('test-discord-id').toString('base64url')
+            const sig = require('crypto')
+                .createHmac('sha256', 'test-secret')
+                .update('test-discord-id')
+                .digest('hex')
+            const encodedState = `${state}.${sig}`
+
+            const res = await request(app).get(
+                `/api/spotify/callback?code=auth-code&state=${encodedState}`,
+            )
+
+            expect(res.status).toBe(500)
+            expect(res.body.error).toBe('Internal server error')
         })
     })
 })


### PR DESCRIPTION
## Summary

Wraps async Spotify routes (/status, /unlink, /callback) with asyncHandler middleware to ensure thrown/rejected errors are caught and routed through the global error handler instead of bypassing it.

Routes wrapped:
- GET /api/spotify/status
- DELETE /api/spotify/unlink
- GET /api/spotify/callback

All async route errors now pass through the global errorHandler middleware which logs and returns proper 500 status responses.

## Tests

- All 16 Spotify route tests pass
- Added test case verifying error handling for callback route
- Type checking passes
- Linter passes

Closes #1184

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped async Spotify routes with `asyncHandler` so thrown/rejected errors go to the global error handler and return consistent 500 JSON responses. Applies to `/status`, `/unlink`, and `/callback`; expected callback failures still redirect with error params.

- **Bug Fixes**
  - Wrapped GET `/api/spotify/status`, DELETE `/api/spotify/unlink`, and GET `/api/spotify/callback` with `asyncHandler`; removed inline try/catch.
  - Extended tests to cover unexpected error paths (including callback token exchange) and assert 500 JSON via the global error handler; all Spotify route tests pass.

<sup>Written for commit b1fa4fd8ca6f9784c37ed26363630123b639282f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling for Spotify integration endpoints (status, unlink, callback) to consistently return JSON error responses with proper HTTP status codes.

* **Tests**
  * Enhanced integration test coverage for Spotify endpoint error scenarios, including token exchange failures and error response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->