### PR TITLE
feat(shared): support report foundation (#1223)

### DIFF
--- a/packages/shared/src/config/config.ts
+++ b/packages/shared/src/config/config.ts
@@ -232,3 +232,14 @@ export const ENVIRONMENT_CONFIG = {
 } as const
 
 export type EnvironmentConfig = typeof ENVIRONMENT_CONFIG
+
+/**
+ * Get the Support URL from environment variables (optional).
+ * Returns the SUPPORT_URL if set, or undefined if not configured.
+ * This allows graceful degradation when support infrastructure is optional.
+ *
+ * @returns SUPPORT_URL string or undefined
+ */
+export function getSupportUrl(): string | undefined {
+    return process.env.SUPPORT_URL
+}

--- a/packages/shared/src/config/config.ts
+++ b/packages/shared/src/config/config.ts
@@ -241,5 +241,6 @@ export type EnvironmentConfig = typeof ENVIRONMENT_CONFIG
  * @returns SUPPORT_URL string or undefined
  */
 export function getSupportUrl(): string | undefined {
-    return process.env.SUPPORT_URL
+    const url = process.env.SUPPORT_URL?.trim()
+    return url ? url : undefined
 }

--- a/packages/shared/src/services/SupportReportService.spec.ts
+++ b/packages/shared/src/services/SupportReportService.spec.ts
@@ -136,6 +136,17 @@ describe('SupportReportService', () => {
                 }),
             )
         })
+
+        it('rejects an image with a disallowed mime type', async () => {
+            await expect(
+                service.create({
+                    context: 'bad image',
+                    surface: 'web',
+                    image: Buffer.from('data'),
+                    imageMimeType: 'image/gif',
+                }),
+            ).rejects.toThrow('Invalid support image')
+        })
     })
 
     describe('get', () => {
@@ -294,6 +305,32 @@ describe('SupportReportService', () => {
 
             expect(findMany).toHaveBeenCalledWith(
                 expect.objectContaining({ take: 20 }),
+            )
+        })
+
+        it('clamps non-finite or non-positive take to a valid bound', async () => {
+            const findMany =
+                jest
+                    .fn<(args: unknown) => Promise<Array<{ id: string }>>>()
+                    .mockResolvedValue([])
+            // @ts-ignore - partial prisma client mock
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: { findMany },
+            })
+
+            await service.list({ take: Number.NaN })
+            expect(findMany).toHaveBeenLastCalledWith(
+                expect.objectContaining({ take: 20 }),
+            )
+
+            await service.list({ take: 0 })
+            expect(findMany).toHaveBeenLastCalledWith(
+                expect.objectContaining({ take: 1 }),
+            )
+
+            await service.list({ take: -5 })
+            expect(findMany).toHaveBeenLastCalledWith(
+                expect.objectContaining({ take: 1 }),
             )
         })
     })

--- a/packages/shared/src/services/SupportReportService.spec.ts
+++ b/packages/shared/src/services/SupportReportService.spec.ts
@@ -224,6 +224,26 @@ describe('SupportReportService', () => {
             )
         })
 
+        it('omits image bytes and orders with a stable id tiebreaker', async () => {
+            const findMany =
+                jest
+                    .fn<(args: unknown) => Promise<Array<{ id: string }>>>()
+                    .mockResolvedValue([])
+            // @ts-ignore - partial prisma client mock
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: { findMany },
+            })
+
+            await service.list()
+
+            expect(findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    omit: { image: true },
+                    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+                }),
+            )
+        })
+
         it('bounds take to maximum of 100', async () => {
             const findMany =
                 jest.fn<(args: unknown) => Promise<Array<{ id: string }>>>().mockResolvedValue(

--- a/packages/shared/src/services/SupportReportService.spec.ts
+++ b/packages/shared/src/services/SupportReportService.spec.ts
@@ -1,0 +1,296 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @ts-nocheck
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
+
+const mockGetPrismaClient = jest.fn()
+
+jest.mock('../utils/database/prismaClient', () => ({
+    getPrismaClient: mockGetPrismaClient,
+    disconnectPrisma: jest.fn(),
+}))
+
+import { SupportReportService } from './SupportReportService'
+
+describe('SupportReportService', () => {
+    let service: SupportReportService
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        service = new SupportReportService()
+    })
+
+    describe('create', () => {
+        it('persists a report and returns the id', async () => {
+            const newReport: any = {
+                id: 'report-1',
+                createdAt: new Date(),
+                context: 'Playback error on /play command',
+                image: null,
+                imageMimeType: null,
+                correlationId: 'abc123xy',
+                guildId: 'guild-456',
+                surface: 'bot',
+                errorCategory: 'playback-error',
+                status: 'new',
+                rateLimitKey: 'hash-abc123',
+            }
+
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    create: jest.fn().mockResolvedValue(newReport),
+                },
+            } as any)
+
+            const result = await service.create({
+                context: 'Playback error on /play command',
+                surface: 'bot',
+                guildId: 'guild-456',
+                correlationId: 'abc123xy',
+                errorCategory: 'playback-error',
+                rateLimitKey: 'hash-abc123',
+            })
+
+            expect(result.id).toBe('report-1')
+            expect(mockGetPrismaClient).toHaveBeenCalled()
+        })
+
+        it('persists report with image bytes and mimetype', async () => {
+            const imageBuffer = Buffer.from('fake-image-bytes')
+            const newReport: any = {
+                id: 'report-2',
+                createdAt: new Date(),
+                context: 'Screenshot attached',
+                image: imageBuffer,
+                imageMimeType: 'image/png',
+                correlationId: 'xyz789ab',
+                guildId: 'guild-789',
+                surface: 'web',
+                errorCategory: 'ui-error',
+                status: 'new',
+                rateLimitKey: 'hash-xyz789',
+            }
+
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    create: jest.fn().mockResolvedValue(newReport),
+                },
+            } as any)
+
+            const result = await service.create({
+                context: 'Screenshot attached',
+                surface: 'web',
+                guildId: 'guild-789',
+                image: imageBuffer,
+                imageMimeType: 'image/png',
+                correlationId: 'xyz789ab',
+                errorCategory: 'ui-error',
+            })
+
+            expect(result.id).toBe('report-2')
+        })
+
+        it('defaults nullable fields to null', async () => {
+            const newReport: any = {
+                id: 'report-3',
+                createdAt: new Date(),
+                context: 'Error occurred',
+                image: null,
+                imageMimeType: null,
+                correlationId: null,
+                guildId: null,
+                surface: 'bot',
+                errorCategory: null,
+                status: 'new',
+                rateLimitKey: null,
+            }
+
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    create: jest.fn().mockResolvedValue(newReport),
+                },
+            } as any)
+
+            const result = await service.create({
+                context: 'Error occurred',
+                surface: 'bot',
+            })
+
+            expect(result.id).toBe('report-3')
+        })
+    })
+
+    describe('get', () => {
+        it('returns a report when it exists', async () => {
+            const report: any = {
+                id: 'report-1',
+                createdAt: new Date(),
+                context: 'Test context',
+                image: null,
+                imageMimeType: null,
+                correlationId: 'abc123xy',
+                guildId: 'guild-456',
+                surface: 'bot',
+                errorCategory: 'test-error',
+                status: 'new',
+                rateLimitKey: null,
+            }
+
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    findUnique: jest.fn().mockResolvedValue(report),
+                },
+            } as any)
+
+            const result = await service.get('report-1')
+
+            expect(result).toEqual(report)
+            expect(result?.id).toBe('report-1')
+        })
+
+        it('returns null when report does not exist', async () => {
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    findUnique: jest.fn().mockResolvedValue(null),
+                },
+            } as any)
+
+            const result = await service.get('nonexistent')
+
+            expect(result).toBeNull()
+        })
+    })
+
+    describe('list', () => {
+        it('returns reports in descending createdAt order', async () => {
+            const reports: any[] = [
+                {
+                    id: 'report-3',
+                    createdAt: new Date('2026-06-04T12:00:00Z'),
+                    context: 'Latest',
+                    image: null,
+                    imageMimeType: null,
+                    correlationId: null,
+                    guildId: null,
+                    surface: 'bot',
+                    errorCategory: null,
+                    status: 'new',
+                    rateLimitKey: null,
+                },
+                {
+                    id: 'report-2',
+                    createdAt: new Date('2026-06-04T11:00:00Z'),
+                    context: 'Middle',
+                    image: null,
+                    imageMimeType: null,
+                    correlationId: null,
+                    guildId: null,
+                    surface: 'bot',
+                    errorCategory: null,
+                    status: 'new',
+                    rateLimitKey: null,
+                },
+                {
+                    id: 'report-1',
+                    createdAt: new Date('2026-06-04T10:00:00Z'),
+                    context: 'Oldest',
+                    image: null,
+                    imageMimeType: null,
+                    correlationId: null,
+                    guildId: null,
+                    surface: 'bot',
+                    errorCategory: null,
+                    status: 'new',
+                    rateLimitKey: null,
+                },
+            ]
+
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    findMany: jest.fn().mockResolvedValue(reports),
+                },
+            } as any)
+
+            const result = await service.list({ take: 20 })
+
+            expect(result).toHaveLength(3)
+            expect(result[0].id).toBe('report-3')
+            expect(result[1].id).toBe('report-2')
+            expect(result[2].id).toBe('report-1')
+        })
+
+        it('respects the take parameter', async () => {
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    findMany: jest.fn().mockResolvedValue([]),
+                },
+            } as any)
+
+            await service.list({ take: 50 })
+
+            // @ts-expect-error - jest mock type
+            const mockClient = mockGetPrismaClient()
+            expect(mockClient.supportReport.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({ take: 50 }),
+            )
+        })
+
+        it('bounds take to maximum of 100', async () => {
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    findMany: jest.fn().mockResolvedValue([]),
+                },
+            } as any)
+
+            await service.list({ take: 200 })
+
+            // @ts-expect-error - jest mock type
+            const mockClient = mockGetPrismaClient()
+            expect(mockClient.supportReport.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({ take: 100 }),
+            )
+        })
+
+        it('filters by status when provided', async () => {
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    findMany: jest.fn().mockResolvedValue([]),
+                },
+            } as any)
+
+            await service.list({ status: 'triaged' })
+
+            // @ts-expect-error - jest mock type
+            const mockClient = mockGetPrismaClient()
+            expect(mockClient.supportReport.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { status: 'triaged' },
+                }),
+            )
+        })
+
+        it('applies default take of 20 when not specified', async () => {
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    // @ts-expect-error - jest mock type mismatch
+                    findMany: jest.fn().mockResolvedValue([]),
+                },
+            } as any)
+
+            await service.list()
+
+            // @ts-expect-error - jest mock type
+            const mockClient = mockGetPrismaClient()
+            expect(mockClient.supportReport.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({ take: 20 }),
+            )
+        })
+    })
+})

--- a/packages/shared/src/services/SupportReportService.spec.ts
+++ b/packages/shared/src/services/SupportReportService.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-// @ts-nocheck
 import { describe, expect, it, jest, beforeEach } from '@jest/globals'
 
 const mockGetPrismaClient = jest.fn()
@@ -21,7 +19,7 @@ describe('SupportReportService', () => {
 
     describe('create', () => {
         it('persists a report and returns the id', async () => {
-            const newReport: any = {
+            const newReport = {
                 id: 'report-1',
                 createdAt: new Date(),
                 context: 'Playback error on /play command',
@@ -35,12 +33,13 @@ describe('SupportReportService', () => {
                 rateLimitKey: 'hash-abc123',
             }
 
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
                 supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
+                    // @ts-ignore - jest mock resolved value type
                     create: jest.fn().mockResolvedValue(newReport),
                 },
-            } as any)
+            })
 
             const result = await service.create({
                 context: 'Playback error on /play command',
@@ -57,7 +56,7 @@ describe('SupportReportService', () => {
 
         it('persists report with image bytes and mimetype', async () => {
             const imageBuffer = Buffer.from('fake-image-bytes')
-            const newReport: any = {
+            const newReport = {
                 id: 'report-2',
                 createdAt: new Date(),
                 context: 'Screenshot attached',
@@ -71,12 +70,13 @@ describe('SupportReportService', () => {
                 rateLimitKey: 'hash-xyz789',
             }
 
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
                 supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
+                    // @ts-ignore - jest mock resolved value type
                     create: jest.fn().mockResolvedValue(newReport),
                 },
-            } as any)
+            })
 
             const result = await service.create({
                 context: 'Screenshot attached',
@@ -92,7 +92,7 @@ describe('SupportReportService', () => {
         })
 
         it('defaults nullable fields to null', async () => {
-            const newReport: any = {
+            const newReport = {
                 id: 'report-3',
                 createdAt: new Date(),
                 context: 'Error occurred',
@@ -106,12 +106,14 @@ describe('SupportReportService', () => {
                 rateLimitKey: null,
             }
 
+            const createMock =
+                jest.fn<(args: unknown) => Promise<{ id: string }>>().mockResolvedValue(
+                    newReport,
+                )
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
-                supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
-                    create: jest.fn().mockResolvedValue(newReport),
-                },
-            } as any)
+                supportReport: { create: createMock },
+            })
 
             const result = await service.create({
                 context: 'Error occurred',
@@ -119,12 +121,26 @@ describe('SupportReportService', () => {
             })
 
             expect(result.id).toBe('report-3')
+            // Optional fields absent from input must be persisted as null.
+            expect(createMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        image: null,
+                        imageMimeType: null,
+                        correlationId: null,
+                        guildId: null,
+                        errorCategory: null,
+                        rateLimitKey: null,
+                        status: 'new',
+                    }),
+                }),
+            )
         })
     })
 
     describe('get', () => {
         it('returns a report when it exists', async () => {
-            const report: any = {
+            const report = {
                 id: 'report-1',
                 createdAt: new Date(),
                 context: 'Test context',
@@ -138,12 +154,13 @@ describe('SupportReportService', () => {
                 rateLimitKey: null,
             }
 
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
                 supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
+                    // @ts-ignore - jest mock resolved value type
                     findUnique: jest.fn().mockResolvedValue(report),
                 },
-            } as any)
+            })
 
             const result = await service.get('report-1')
 
@@ -152,11 +169,13 @@ describe('SupportReportService', () => {
         })
 
         it('returns null when report does not exist', async () => {
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
                 supportReport: {
+                    // @ts-ignore - jest mock resolved value type
                     findUnique: jest.fn().mockResolvedValue(null),
                 },
-            } as any)
+            })
 
             const result = await service.get('nonexistent')
 
@@ -166,54 +185,19 @@ describe('SupportReportService', () => {
 
     describe('list', () => {
         it('returns reports in descending createdAt order', async () => {
-            const reports: any[] = [
-                {
-                    id: 'report-3',
-                    createdAt: new Date('2026-06-04T12:00:00Z'),
-                    context: 'Latest',
-                    image: null,
-                    imageMimeType: null,
-                    correlationId: null,
-                    guildId: null,
-                    surface: 'bot',
-                    errorCategory: null,
-                    status: 'new',
-                    rateLimitKey: null,
-                },
-                {
-                    id: 'report-2',
-                    createdAt: new Date('2026-06-04T11:00:00Z'),
-                    context: 'Middle',
-                    image: null,
-                    imageMimeType: null,
-                    correlationId: null,
-                    guildId: null,
-                    surface: 'bot',
-                    errorCategory: null,
-                    status: 'new',
-                    rateLimitKey: null,
-                },
-                {
-                    id: 'report-1',
-                    createdAt: new Date('2026-06-04T10:00:00Z'),
-                    context: 'Oldest',
-                    image: null,
-                    imageMimeType: null,
-                    correlationId: null,
-                    guildId: null,
-                    surface: 'bot',
-                    errorCategory: null,
-                    status: 'new',
-                    rateLimitKey: null,
-                },
+            const reports = [
+                { id: 'report-3', createdAt: new Date('2026-06-04T12:00:00Z') },
+                { id: 'report-2', createdAt: new Date('2026-06-04T11:00:00Z') },
+                { id: 'report-1', createdAt: new Date('2026-06-04T10:00:00Z') },
             ]
 
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
                 supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
+                    // @ts-ignore - jest mock resolved value type
                     findMany: jest.fn().mockResolvedValue(reports),
                 },
-            } as any)
+            })
 
             const result = await service.list({ take: 20 })
 
@@ -224,52 +208,52 @@ describe('SupportReportService', () => {
         })
 
         it('respects the take parameter', async () => {
+            const findMany =
+                jest.fn<(args: unknown) => Promise<Array<{ id: string }>>>().mockResolvedValue(
+                    [],
+                )
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
-                supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
-                    findMany: jest.fn().mockResolvedValue([]),
-                },
-            } as any)
+                supportReport: { findMany },
+            })
 
             await service.list({ take: 50 })
 
-            // @ts-expect-error - jest mock type
-            const mockClient = mockGetPrismaClient()
-            expect(mockClient.supportReport.findMany).toHaveBeenCalledWith(
+            expect(findMany).toHaveBeenCalledWith(
                 expect.objectContaining({ take: 50 }),
             )
         })
 
         it('bounds take to maximum of 100', async () => {
+            const findMany =
+                jest.fn<(args: unknown) => Promise<Array<{ id: string }>>>().mockResolvedValue(
+                    [],
+                )
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
-                supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
-                    findMany: jest.fn().mockResolvedValue([]),
-                },
-            } as any)
+                supportReport: { findMany },
+            })
 
             await service.list({ take: 200 })
 
-            // @ts-expect-error - jest mock type
-            const mockClient = mockGetPrismaClient()
-            expect(mockClient.supportReport.findMany).toHaveBeenCalledWith(
+            expect(findMany).toHaveBeenCalledWith(
                 expect.objectContaining({ take: 100 }),
             )
         })
 
         it('filters by status when provided', async () => {
+            const findMany =
+                jest.fn<(args: unknown) => Promise<Array<{ id: string }>>>().mockResolvedValue(
+                    [],
+                )
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
-                supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
-                    findMany: jest.fn().mockResolvedValue([]),
-                },
-            } as any)
+                supportReport: { findMany },
+            })
 
             await service.list({ status: 'triaged' })
 
-            // @ts-expect-error - jest mock type
-            const mockClient = mockGetPrismaClient()
-            expect(mockClient.supportReport.findMany).toHaveBeenCalledWith(
+            expect(findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     where: { status: 'triaged' },
                 }),
@@ -277,18 +261,18 @@ describe('SupportReportService', () => {
         })
 
         it('applies default take of 20 when not specified', async () => {
+            const findMany =
+                jest.fn<(args: unknown) => Promise<Array<{ id: string }>>>().mockResolvedValue(
+                    [],
+                )
+            // @ts-ignore - partial prisma client mock
             mockGetPrismaClient.mockReturnValue({
-                supportReport: {
-                    // @ts-expect-error - jest mock type mismatch
-                    findMany: jest.fn().mockResolvedValue([]),
-                },
-            } as any)
+                supportReport: { findMany },
+            })
 
             await service.list()
 
-            // @ts-expect-error - jest mock type
-            const mockClient = mockGetPrismaClient()
-            expect(mockClient.supportReport.findMany).toHaveBeenCalledWith(
+            expect(findMany).toHaveBeenCalledWith(
                 expect.objectContaining({ take: 20 }),
             )
         })

--- a/packages/shared/src/services/SupportReportService.ts
+++ b/packages/shared/src/services/SupportReportService.ts
@@ -18,6 +18,11 @@ export type SupportReport = {
 }
 
 /**
+ * A support report summary as returned by list queries — image bytes omitted.
+ */
+export type SupportReportListItem = Omit<SupportReport, 'image'>
+
+/**
  * Input payload for creating a new support report.
  */
 export interface CreateReportInput {
@@ -90,11 +95,13 @@ export class SupportReportService {
 
     /**
      * Lists support reports with optional filtering and pagination.
+     * The image bytes are omitted from list rows (fetch them via {@link get});
+     * imageMimeType is kept so callers can show an attachment indicator.
      *
      * @param filter List options: take (bounded to 100), cursor, status
-     * @returns Promise with array of SupportReport
+     * @returns Promise with array of SupportReport summaries (no image bytes)
      */
-    async list(filter: ListReportsFilter = {}): Promise<SupportReport[]> {
+    async list(filter: ListReportsFilter = {}): Promise<SupportReportListItem[]> {
         const prisma = getPrismaClient()
 
         // Bound take to maximum of 100
@@ -105,7 +112,9 @@ export class SupportReportService {
             take,
             skip: filter.cursor ? 1 : 0,
             cursor: filter.cursor ? { id: filter.cursor } : undefined,
-            orderBy: { createdAt: 'desc' },
+            // createdAt is non-unique; the id tiebreaker keeps cursor pages stable.
+            orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+            omit: { image: true },
         })
 
         return reports

--- a/packages/shared/src/services/SupportReportService.ts
+++ b/packages/shared/src/services/SupportReportService.ts
@@ -1,4 +1,5 @@
 import { getPrismaClient } from '../utils/database/prismaClient.js'
+import { validateSupportImage } from '../utils/support/supportImageValidation.js'
 
 /**
  * Represents a support report record.
@@ -58,6 +59,18 @@ export class SupportReportService {
      * @returns Promise with { id }
      */
     async create(input: CreateReportInput): Promise<{ id: string }> {
+        // Defense-in-depth: reject malformed image payloads before persisting,
+        // even though the public route is the primary validation point.
+        if (input.image) {
+            const validation = validateSupportImage({
+                size: input.image.byteLength,
+                mimetype: input.imageMimeType,
+            })
+            if (!validation.valid) {
+                throw new Error(`Invalid support image: ${validation.error}`)
+            }
+        }
+
         const prisma = getPrismaClient()
 
         const report = await prisma.supportReport.create({
@@ -104,8 +117,11 @@ export class SupportReportService {
     async list(filter: ListReportsFilter = {}): Promise<SupportReportListItem[]> {
         const prisma = getPrismaClient()
 
-        // Bound take to maximum of 100
-        const take = Math.min(filter.take ?? 20, 100)
+        // Clamp take to a positive integer in [1, 100]; guard NaN/Infinity/<=0.
+        const requested = Number.isFinite(filter.take)
+            ? Math.floor(filter.take as number)
+            : 20
+        const take = Math.min(Math.max(requested, 1), 100)
 
         const reports = await prisma.supportReport.findMany({
             where: filter.status ? { status: filter.status } : undefined,

--- a/packages/shared/src/services/SupportReportService.ts
+++ b/packages/shared/src/services/SupportReportService.ts
@@ -1,0 +1,113 @@
+import { getPrismaClient } from '../utils/database/prismaClient.js'
+
+/**
+ * Represents a support report record.
+ */
+export type SupportReport = {
+    id: string
+    createdAt: Date
+    context: string
+    image: unknown // Prisma Bytes field; can be Uint8Array or Buffer
+    imageMimeType: string | null
+    correlationId: string | null
+    guildId: string | null
+    surface: string
+    errorCategory: string | null
+    status: string
+    rateLimitKey: string | null
+}
+
+/**
+ * Input payload for creating a new support report.
+ */
+export interface CreateReportInput {
+    context: string // required: user-provided context
+    image?: Uint8Array | Buffer | null // optional: image bytes
+    imageMimeType?: string // optional: MIME type if image present
+    correlationId?: string // optional: correlation ID from error
+    guildId?: string // optional: guild that submitted
+    surface: 'bot' | 'web' // required: where the error occurred
+    errorCategory?: string // optional: light categorization hint
+    rateLimitKey?: string // optional: opaque rate-limit key (no raw PII)
+}
+
+/**
+ * List filter options for support reports.
+ */
+export interface ListReportsFilter {
+    take?: number // max records to return (bounded to 100)
+    cursor?: string // pagination cursor (report id)
+    status?: string // optional: filter by status
+}
+
+/**
+ * Service for managing support reports.
+ * Owns the SupportReport Prisma model; handles creation, retrieval, listing.
+ */
+export class SupportReportService {
+    /**
+     * Creates a new support report and persists it.
+     * Returns the created report's id.
+     *
+     * @param input Create input with context, optional image, correlationId, etc.
+     * @returns Promise with { id }
+     */
+    async create(input: CreateReportInput): Promise<{ id: string }> {
+        const prisma = getPrismaClient()
+
+        const report = await prisma.supportReport.create({
+            data: {
+                context: input.context,
+                image: (input.image ?? null) as any,
+                imageMimeType: input.imageMimeType || null,
+                correlationId: input.correlationId || null,
+                guildId: input.guildId || null,
+                surface: input.surface,
+                errorCategory: input.errorCategory || null,
+                status: 'new',
+                rateLimitKey: input.rateLimitKey || null,
+            },
+        })
+
+        return { id: report.id }
+    }
+
+    /**
+     * Retrieves a single support report by id.
+     *
+     * @param id Report id (cuid)
+     * @returns Promise with full SupportReport or null if not found
+     */
+    async get(id: string): Promise<SupportReport | null> {
+        const prisma = getPrismaClient()
+
+        const report = await prisma.supportReport.findUnique({
+            where: { id },
+        })
+
+        return report || null
+    }
+
+    /**
+     * Lists support reports with optional filtering and pagination.
+     *
+     * @param filter List options: take (bounded to 100), cursor, status
+     * @returns Promise with array of SupportReport
+     */
+    async list(filter: ListReportsFilter = {}): Promise<SupportReport[]> {
+        const prisma = getPrismaClient()
+
+        // Bound take to maximum of 100
+        const take = Math.min(filter.take ?? 20, 100)
+
+        const reports = await prisma.supportReport.findMany({
+            where: filter.status ? { status: filter.status } : undefined,
+            take,
+            skip: filter.cursor ? 1 : 0,
+            cursor: filter.cursor ? { id: filter.cursor } : undefined,
+            orderBy: { createdAt: 'desc' },
+        })
+
+        return reports
+    }
+}

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -105,3 +105,9 @@ export {
     type PerSourceRow,
     type Summary,
 } from './recommendationTelemetryReadService'
+export {
+    SupportReportService,
+    type SupportReport,
+    type CreateReportInput,
+    type ListReportsFilter,
+} from './SupportReportService.js'

--- a/packages/shared/src/utils/support/correlationId.spec.ts
+++ b/packages/shared/src/utils/support/correlationId.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
+
+const mockIsSentryEnabled = jest.fn<() => boolean>()
+const mockSetTag = jest.fn()
+
+jest.mock('../monitoring/sentry', () => ({
+    isSentryEnabled: mockIsSentryEnabled,
+}))
+
+jest.mock('@sentry/node', () => ({
+    setTag: mockSetTag,
+}))
+
+import { mintCorrelationId, tagCorrelationIdToSentry } from './correlationId'
+
+describe('mintCorrelationId', () => {
+    it('mints a non-empty id', () => {
+        expect(mintCorrelationId().length).toBeGreaterThan(0)
+    })
+
+    it('mints an 8-character id', () => {
+        expect(mintCorrelationId()).toHaveLength(8)
+    })
+
+    it('mints only URL-safe characters', () => {
+        // URL-safe alphabet: A-Z a-z 0-9 - _ (no padding, no slashes).
+        for (let i = 0; i < 50; i++) {
+            expect(mintCorrelationId()).toMatch(/^[A-Za-z0-9_-]{8}$/)
+        }
+    })
+
+    it('mints distinct ids across calls (sufficiently unique)', () => {
+        const ids = new Set<string>()
+        for (let i = 0; i < 1000; i++) {
+            ids.add(mintCorrelationId())
+        }
+        // Collisions across 1000 draws from a 64^8 space should be vanishingly
+        // rare; allow a tiny margin rather than asserting perfect uniqueness.
+        expect(ids.size).toBeGreaterThanOrEqual(998)
+    })
+})
+
+describe('tagCorrelationIdToSentry', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('sets the Sentry tag when Sentry is enabled', () => {
+        mockIsSentryEnabled.mockReturnValue(true)
+
+        tagCorrelationIdToSentry('abc123xy')
+
+        expect(mockSetTag).toHaveBeenCalledWith('correlationId', 'abc123xy')
+    })
+
+    it('is a no-op when Sentry is disabled', () => {
+        mockIsSentryEnabled.mockReturnValue(false)
+
+        tagCorrelationIdToSentry('abc123xy')
+
+        expect(mockSetTag).not.toHaveBeenCalled()
+    })
+})

--- a/packages/shared/src/utils/support/correlationId.ts
+++ b/packages/shared/src/utils/support/correlationId.ts
@@ -1,0 +1,36 @@
+import { randomBytes } from 'crypto'
+import { isSentryEnabled } from '../monitoring/sentry'
+import * as Sentry from '@sentry/node'
+
+const CHARSET =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+
+/**
+ * Mints a short, URL-safe correlation ID for tracking errors across logs and Sentry.
+ * Format: 8 base62-like characters drawn from a URL-safe alphabet.
+ * Non-empty, stable across multiple calls (creates a new ID each time).
+ *
+ * @returns A 8-character URL-safe correlation ID
+ */
+export function mintCorrelationId(): string {
+    // Generate 6 bytes of random data = 48 bits, enough for 8 base62-like chars
+    const bytes = randomBytes(6)
+    let id = ''
+    for (let i = 0; i < bytes.length; i++) {
+        id += CHARSET[bytes[i] % CHARSET.length]
+    }
+    return id
+}
+
+/**
+ * Attaches a correlation ID as a Sentry tag for cross-referencing.
+ * If Sentry is disabled, this is a no-op (graceful).
+ *
+ * @param correlationId The correlation ID to tag
+ */
+export function tagCorrelationIdToSentry(correlationId: string): void {
+    if (!isSentryEnabled()) {
+        return
+    }
+    Sentry.setTag('correlationId', correlationId)
+}

--- a/packages/shared/src/utils/support/correlationId.ts
+++ b/packages/shared/src/utils/support/correlationId.ts
@@ -1,23 +1,23 @@
-import { randomBytes } from 'crypto'
+import { randomInt } from 'crypto'
 import { isSentryEnabled } from '../monitoring/sentry'
 import * as Sentry from '@sentry/node'
 
 const CHARSET =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+const ID_LENGTH = 8
 
 /**
  * Mints a short, URL-safe correlation ID for tracking errors across logs and Sentry.
- * Format: 8 base62-like characters drawn from a URL-safe alphabet.
- * Non-empty, stable across multiple calls (creates a new ID each time).
+ * Returns a fresh, non-empty 8-character id on every call (the shape is stable;
+ * the value is not).
  *
- * @returns A 8-character URL-safe correlation ID
+ * @returns A fresh 8-character URL-safe correlation ID
  */
 export function mintCorrelationId(): string {
-    // One random byte per output char, mapped into the URL-safe alphabet.
-    const bytes = randomBytes(8)
+    // randomInt draws uniformly from [0, CHARSET.length) with no modulo bias.
     let id = ''
-    for (let i = 0; i < bytes.length; i++) {
-        id += CHARSET[bytes[i] % CHARSET.length]
+    for (let i = 0; i < ID_LENGTH; i++) {
+        id += CHARSET[randomInt(CHARSET.length)]
     }
     return id
 }

--- a/packages/shared/src/utils/support/correlationId.ts
+++ b/packages/shared/src/utils/support/correlationId.ts
@@ -13,8 +13,8 @@ const CHARSET =
  * @returns A 8-character URL-safe correlation ID
  */
 export function mintCorrelationId(): string {
-    // Generate 6 bytes of random data = 48 bits, enough for 8 base62-like chars
-    const bytes = randomBytes(6)
+    // One random byte per output char, mapped into the URL-safe alphabet.
+    const bytes = randomBytes(8)
     let id = ''
     for (let i = 0; i < bytes.length; i++) {
         id += CHARSET[bytes[i] % CHARSET.length]

--- a/packages/shared/src/utils/support/errorSupportContext.spec.ts
+++ b/packages/shared/src/utils/support/errorSupportContext.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals'
+import { buildErrorSupportContext } from './errorSupportContext'
+
+describe('errorSupportContext', () => {
+    const originalEnv = process.env.SUPPORT_URL
+
+    afterEach(() => {
+        if (originalEnv === undefined) {
+            delete process.env.SUPPORT_URL
+        } else {
+            process.env.SUPPORT_URL = originalEnv
+        }
+    })
+
+    describe('buildErrorSupportContext', () => {
+        it('returns graceful result when SUPPORT_URL is not set', () => {
+            delete process.env.SUPPORT_URL
+            const result = buildErrorSupportContext('test-id-123')
+
+            expect(result.supportLink).toBeNull()
+            expect(result.footerText).toBe(
+                'An error occurred. Please try again or contact support.',
+            )
+        })
+
+        it('builds correct support link with correlation ID only', () => {
+            process.env.SUPPORT_URL = 'https://example.com/support'
+            const result = buildErrorSupportContext('abc123xy')
+
+            expect(result.supportLink).toBe(
+                'https://example.com/support?cid=abc123xy',
+            )
+            expect(result.footerText).toContain('Error ID: abc123xy')
+        })
+
+        it('includes all context fields in the support link', () => {
+            process.env.SUPPORT_URL = 'https://example.com/support'
+            const result = buildErrorSupportContext('abc123xy', {
+                guildId: 'guild-456',
+                command: '/play',
+                errorCategory: 'playback-error',
+            })
+
+            expect(result.supportLink).toContain('cid=abc123xy')
+            expect(result.supportLink).toContain('guildId=guild-456')
+            expect(result.supportLink).toContain('command=%2Fplay') // URL-encoded /
+            expect(result.supportLink).toContain('category=playback-error')
+        })
+
+        it('omits undefined context fields from the link', () => {
+            process.env.SUPPORT_URL = 'https://example.com/support'
+            const result = buildErrorSupportContext('abc123xy', {
+                guildId: 'guild-456',
+                // command and errorCategory are undefined
+            })
+
+            expect(result.supportLink).toContain('cid=abc123xy')
+            expect(result.supportLink).toContain('guildId=guild-456')
+            expect(result.supportLink).not.toContain('command=')
+            expect(result.supportLink).not.toContain('category=')
+        })
+
+        it('includes correct footer text with link', () => {
+            process.env.SUPPORT_URL = 'https://example.com/support'
+            const result = buildErrorSupportContext('xyz789ab')
+
+            expect(result.footerText).toContain('Error ID: xyz789ab')
+            expect(result.footerText).toContain('[Report this error]')
+            expect(result.footerText).toContain(
+                '(https://example.com/support?cid=xyz789ab)',
+            )
+        })
+
+        it('handles empty context object gracefully', () => {
+            process.env.SUPPORT_URL = 'https://example.com/support'
+            const result = buildErrorSupportContext('test-id', {})
+
+            expect(result.supportLink).toBe(
+                'https://example.com/support?cid=test-id',
+            )
+            expect(result.supportLink).not.toContain('guildId=')
+            expect(result.supportLink).not.toContain('command=')
+            expect(result.supportLink).not.toContain('category=')
+        })
+
+        it('handles context with only errorCategory', () => {
+            process.env.SUPPORT_URL = 'https://example.com/support'
+            const result = buildErrorSupportContext('error-123', {
+                errorCategory: 'timeout-error',
+            })
+
+            expect(result.supportLink).toContain('cid=error-123')
+            expect(result.supportLink).toContain('category=timeout-error')
+            expect(result.supportLink).not.toContain('guildId=')
+            expect(result.supportLink).not.toContain('command=')
+        })
+    })
+})

--- a/packages/shared/src/utils/support/errorSupportContext.spec.ts
+++ b/packages/shared/src/utils/support/errorSupportContext.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from '@jest/globals'
+import { describe, expect, it, afterEach } from '@jest/globals'
 import { buildErrorSupportContext } from './errorSupportContext'
 
 describe('errorSupportContext', () => {
@@ -93,6 +93,28 @@ describe('errorSupportContext', () => {
             expect(result.supportLink).toContain('category=timeout-error')
             expect(result.supportLink).not.toContain('guildId=')
             expect(result.supportLink).not.toContain('command=')
+        })
+
+        it('preserves query params already present on SUPPORT_URL', () => {
+            process.env.SUPPORT_URL = 'https://example.com/support?ref=embed'
+            const result = buildErrorSupportContext('abc123xy')
+
+            expect(result.supportLink).toContain('ref=embed')
+            expect(result.supportLink).toContain('cid=abc123xy')
+        })
+
+        it('treats an empty SUPPORT_URL as not configured', () => {
+            process.env.SUPPORT_URL = '   '
+            const result = buildErrorSupportContext('abc123xy')
+
+            expect(result.supportLink).toBeNull()
+        })
+
+        it('degrades gracefully when SUPPORT_URL is malformed', () => {
+            process.env.SUPPORT_URL = 'not a url'
+            const result = buildErrorSupportContext('abc123xy')
+
+            expect(result.supportLink).toBeNull()
         })
     })
 })

--- a/packages/shared/src/utils/support/errorSupportContext.ts
+++ b/packages/shared/src/utils/support/errorSupportContext.ts
@@ -26,32 +26,40 @@ export function buildErrorSupportContext(
         errorCategory?: string
     },
 ): ErrorSupportContextResult {
-    const supportUrl = process.env.SUPPORT_URL ?? undefined
+    const supportUrl = process.env.SUPPORT_URL?.trim() || undefined
+
+    const gracefulAbsent: ErrorSupportContextResult = {
+        supportLink: null,
+        footerText: 'An error occurred. Please try again or contact support.',
+    }
 
     if (!supportUrl) {
         // Graceful absent state: support URL is optional
-        return {
-            supportLink: null,
-            footerText:
-                'An error occurred. Please try again or contact support.',
-        }
+        return gracefulAbsent
     }
 
-    // Build query params: cid (correlation ID) + optional context fields
-    const params = new URLSearchParams()
-    params.set('cid', correlationId)
+    // Use the URL API so query params already present on SUPPORT_URL are
+    // preserved rather than clobbered by a naive `?` concatenation.
+    let url: URL
+    try {
+        url = new URL(supportUrl)
+    } catch {
+        // Malformed SUPPORT_URL: degrade gracefully rather than emit a bad link.
+        return gracefulAbsent
+    }
 
+    url.searchParams.set('cid', correlationId)
     if (context?.guildId) {
-        params.set('guildId', context.guildId)
+        url.searchParams.set('guildId', context.guildId)
     }
     if (context?.command) {
-        params.set('command', context.command)
+        url.searchParams.set('command', context.command)
     }
     if (context?.errorCategory) {
-        params.set('category', context.errorCategory)
+        url.searchParams.set('category', context.errorCategory)
     }
 
-    const supportLink = `${supportUrl}?${params.toString()}`
+    const supportLink = url.toString()
     const footerText = `Error ID: ${correlationId} — [Report this error](${supportLink})`
 
     return {

--- a/packages/shared/src/utils/support/errorSupportContext.ts
+++ b/packages/shared/src/utils/support/errorSupportContext.ts
@@ -1,3 +1,5 @@
+import { getSupportUrl } from '../../config/config'
+
 /**
  * Result of building error support context.
  */
@@ -26,7 +28,7 @@ export function buildErrorSupportContext(
         errorCategory?: string
     },
 ): ErrorSupportContextResult {
-    const supportUrl = process.env.SUPPORT_URL?.trim() || undefined
+    const supportUrl = getSupportUrl()
 
     const gracefulAbsent: ErrorSupportContextResult = {
         supportLink: null,

--- a/packages/shared/src/utils/support/errorSupportContext.ts
+++ b/packages/shared/src/utils/support/errorSupportContext.ts
@@ -1,0 +1,61 @@
+/**
+ * Result of building error support context.
+ */
+export interface ErrorSupportContextResult {
+    supportLink: string | null // null if SUPPORT_URL is not configured
+    footerText: string
+}
+
+/**
+ * Builds a support link + footer text for display in error surfaces.
+ * The support link includes the correlation ID and optional context as query params.
+ *
+ * If SUPPORT_URL is not configured (graceful), returns supportLink: null and a
+ * fallback footer. This ensures error surfaces don't break when support infrastructure
+ * is optional in certain deployments.
+ *
+ * @param correlationId Short, URL-safe correlation ID (required)
+ * @param context Optional object with light context fields (guildId, command, category)
+ * @returns Object with supportLink (or null) and footerText
+ */
+export function buildErrorSupportContext(
+    correlationId: string,
+    context?: {
+        guildId?: string
+        command?: string
+        errorCategory?: string
+    },
+): ErrorSupportContextResult {
+    const supportUrl = process.env.SUPPORT_URL ?? undefined
+
+    if (!supportUrl) {
+        // Graceful absent state: support URL is optional
+        return {
+            supportLink: null,
+            footerText:
+                'An error occurred. Please try again or contact support.',
+        }
+    }
+
+    // Build query params: cid (correlation ID) + optional context fields
+    const params = new URLSearchParams()
+    params.set('cid', correlationId)
+
+    if (context?.guildId) {
+        params.set('guildId', context.guildId)
+    }
+    if (context?.command) {
+        params.set('command', context.command)
+    }
+    if (context?.errorCategory) {
+        params.set('category', context.errorCategory)
+    }
+
+    const supportLink = `${supportUrl}?${params.toString()}`
+    const footerText = `Error ID: ${correlationId} — [Report this error](${supportLink})`
+
+    return {
+        supportLink,
+        footerText,
+    }
+}

--- a/packages/shared/src/utils/support/index.ts
+++ b/packages/shared/src/utils/support/index.ts
@@ -1,0 +1,8 @@
+export { mintCorrelationId, tagCorrelationIdToSentry } from './correlationId.js'
+export type {} from './correlationId.js'
+
+export { validateSupportImage } from './supportImageValidation.js'
+export type { ImageValidationResult } from './supportImageValidation.js'
+
+export { buildErrorSupportContext } from './errorSupportContext.js'
+export type { ErrorSupportContextResult } from './errorSupportContext.js'

--- a/packages/shared/src/utils/support/supportImageValidation.spec.ts
+++ b/packages/shared/src/utils/support/supportImageValidation.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from '@jest/globals'
+import { validateSupportImage } from './supportImageValidation'
+
+describe('supportImageValidation', () => {
+    describe('validateSupportImage', () => {
+        it('accepts a valid PNG image', () => {
+            const result = validateSupportImage({
+                size: 1024 * 1024, // 1 MB
+                mimetype: 'image/png',
+            })
+
+            expect(result.valid).toBe(true)
+            expect(result.error).toBeUndefined()
+        })
+
+        it('accepts a valid JPEG image', () => {
+            const result = validateSupportImage({
+                size: 2 * 1024 * 1024, // 2 MB
+                mimetype: 'image/jpeg',
+            })
+
+            expect(result.valid).toBe(true)
+            expect(result.error).toBeUndefined()
+        })
+
+        it('accepts a valid WebP image', () => {
+            const result = validateSupportImage({
+                size: 512 * 1024, // 512 KB
+                mimetype: 'image/webp',
+            })
+
+            expect(result.valid).toBe(true)
+            expect(result.error).toBeUndefined()
+        })
+
+        it('accepts exactly 5 MB (boundary)', () => {
+            const result = validateSupportImage({
+                size: 5 * 1024 * 1024,
+                mimetype: 'image/png',
+            })
+
+            expect(result.valid).toBe(true)
+            expect(result.error).toBeUndefined()
+        })
+
+        it('rejects image exceeding 5 MB', () => {
+            const result = validateSupportImage({
+                size: 5.1 * 1024 * 1024,
+                mimetype: 'image/png',
+            })
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Image exceeds 5 MB limit')
+        })
+
+        it('rejects unsupported MIME type (GIF)', () => {
+            const result = validateSupportImage({
+                size: 1024 * 1024,
+                mimetype: 'image/gif',
+            })
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Unsupported image type')
+        })
+
+        it('rejects unsupported MIME type (BMP)', () => {
+            const result = validateSupportImage({
+                size: 1024 * 1024,
+                mimetype: 'image/bmp',
+            })
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Unsupported image type')
+        })
+
+        it('rejects missing size', () => {
+            const result = validateSupportImage({
+                mimetype: 'image/png',
+            })
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Missing image size or type')
+        })
+
+        it('rejects missing MIME type', () => {
+            const result = validateSupportImage({
+                size: 1024 * 1024,
+            })
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Missing image size or type')
+        })
+
+        it('rejects missing both size and MIME type', () => {
+            const result = validateSupportImage({})
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Missing image size or type')
+        })
+    })
+})

--- a/packages/shared/src/utils/support/supportImageValidation.spec.ts
+++ b/packages/shared/src/utils/support/supportImageValidation.spec.ts
@@ -97,5 +97,35 @@ describe('supportImageValidation', () => {
             expect(result.valid).toBe(false)
             expect(result.error).toContain('Missing image size or type')
         })
+
+        it('rejects NaN size', () => {
+            const result = validateSupportImage({
+                size: Number.NaN,
+                mimetype: 'image/png',
+            })
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Invalid image size')
+        })
+
+        it('rejects Infinity size', () => {
+            const result = validateSupportImage({
+                size: Number.POSITIVE_INFINITY,
+                mimetype: 'image/png',
+            })
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Invalid image size')
+        })
+
+        it('rejects negative size', () => {
+            const result = validateSupportImage({
+                size: -1,
+                mimetype: 'image/png',
+            })
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain('Invalid image size')
+        })
     })
 })

--- a/packages/shared/src/utils/support/supportImageValidation.ts
+++ b/packages/shared/src/utils/support/supportImageValidation.ts
@@ -35,6 +35,13 @@ export function validateSupportImage(input: {
         }
     }
 
+    if (!Number.isFinite(input.size) || input.size < 0) {
+        return {
+            valid: false,
+            error: 'Invalid image size',
+        }
+    }
+
     if (input.size > MAX_IMAGE_SIZE_BYTES) {
         return {
             valid: false,

--- a/packages/shared/src/utils/support/supportImageValidation.ts
+++ b/packages/shared/src/utils/support/supportImageValidation.ts
@@ -1,0 +1,53 @@
+/**
+ * Result of image validation.
+ */
+export interface ImageValidationResult {
+    valid: boolean
+    error?: string
+}
+
+const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024 // 5 MB
+const ALLOWED_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp'])
+
+/**
+ * Validates an uploaded support image against size and type constraints.
+ *
+ * Acceptance criteria:
+ * - Size <= 5 MB
+ * - MIME type in {image/png, image/jpeg, image/webp}
+ *
+ * Rejection criteria:
+ * - Size > 5 MB → "Image exceeds 5 MB limit"
+ * - MIME type not in allowlist → "Unsupported image type"
+ * - Missing size or type → "Missing image size or type"
+ *
+ * @param input Object with size (bytes) and mimetype
+ * @returns Validation result with valid flag and optional error message
+ */
+export function validateSupportImage(input: {
+    size?: number
+    mimetype?: string
+}): ImageValidationResult {
+    if (input.size === undefined || input.mimetype === undefined) {
+        return {
+            valid: false,
+            error: 'Missing image size or type',
+        }
+    }
+
+    if (input.size > MAX_IMAGE_SIZE_BYTES) {
+        return {
+            valid: false,
+            error: `Image exceeds 5 MB limit (received ${(input.size / (1024 * 1024)).toFixed(2)} MB)`,
+        }
+    }
+
+    if (!ALLOWED_MIME_TYPES.has(input.mimetype)) {
+        return {
+            valid: false,
+            error: `Unsupported image type: ${input.mimetype}. Supported: PNG, JPEG, WebP`,
+        }
+    }
+
+    return { valid: true }
+}

--- a/prisma/migrations/20260604000000_add_support_report/migration.sql
+++ b/prisma/migrations/20260604000000_add_support_report/migration.sql
@@ -41,6 +41,11 @@ ALTER TABLE "support_reports"
     ADD CONSTRAINT "support_reports_image_mimetype_pair_check"
     CHECK (("image" IS NULL) = ("imageMimeType" IS NULL));
 
+-- Restrict image MIME type to the supported allowlist.
+ALTER TABLE "support_reports"
+    ADD CONSTRAINT "support_reports_image_mimetype_allowlist_check"
+    CHECK ("imageMimeType" IS NULL OR "imageMimeType" IN ('image/png', 'image/jpeg', 'image/webp'));
+
 -- Constrain the finite state fields to their allowed values.
 ALTER TABLE "support_reports"
     ADD CONSTRAINT "support_reports_surface_check"

--- a/prisma/migrations/20260604000000_add_support_report/migration.sql
+++ b/prisma/migrations/20260604000000_add_support_report/migration.sql
@@ -26,3 +26,26 @@ CREATE INDEX "support_reports_createdAt_idx" ON "support_reports"("createdAt");
 
 -- CreateIndex
 CREATE INDEX "support_reports_status_idx" ON "support_reports"("status");
+
+-- CreateIndex: status-filtered listing ordered by createdAt
+CREATE INDEX "support_reports_status_createdAt_idx" ON "support_reports"("status", "createdAt");
+
+-- Defense-in-depth DB constraints (the app validation layer is the primary gate).
+-- Cap stored image bytes at the documented 5 MB limit.
+ALTER TABLE "support_reports"
+    ADD CONSTRAINT "support_reports_image_size_check"
+    CHECK ("image" IS NULL OR octet_length("image") <= 5242880);
+
+-- Keep image bytes and their MIME type consistent: both present or both absent.
+ALTER TABLE "support_reports"
+    ADD CONSTRAINT "support_reports_image_mimetype_pair_check"
+    CHECK (("image" IS NULL) = ("imageMimeType" IS NULL));
+
+-- Constrain the finite state fields to their allowed values.
+ALTER TABLE "support_reports"
+    ADD CONSTRAINT "support_reports_surface_check"
+    CHECK ("surface" IN ('bot', 'web'));
+
+ALTER TABLE "support_reports"
+    ADD CONSTRAINT "support_reports_status_check"
+    CHECK ("status" IN ('new', 'triaged', 'promoted', 'dismissed'));

--- a/prisma/migrations/20260604000000_add_support_report/migration.sql
+++ b/prisma/migrations/20260604000000_add_support_report/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable support_reports
+CREATE TABLE "support_reports" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "context" TEXT NOT NULL,
+    "image" BYTEA,
+    "imageMimeType" TEXT,
+    "correlationId" TEXT,
+    "guildId" TEXT,
+    "surface" TEXT NOT NULL,
+    "errorCategory" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'new',
+    "rateLimitKey" TEXT,
+
+    CONSTRAINT "support_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "support_reports_correlationId_idx" ON "support_reports"("correlationId");
+
+-- CreateIndex
+CREATE INDEX "support_reports_guildId_idx" ON "support_reports"("guildId");
+
+-- CreateIndex
+CREATE INDEX "support_reports_createdAt_idx" ON "support_reports"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "support_reports_status_idx" ON "support_reports"("status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -881,3 +881,27 @@ model StripeWebhookEvent {
   @@index([type, createdAt])
   @@map("stripe_webhook_events")
 }
+
+// Support Report — user-submitted error reports with optional screenshot.
+// Carries a correlation ID for cross-reference with logs/Sentry.
+// Images are stored as Bytes (capped at validation limit, currently 5 MB).
+// Status tracks triage workflow: new → triaged → promoted (to issue) → dismissed.
+model SupportReport {
+  id              String   @id @default(cuid())
+  createdAt       DateTime @default(now())
+  context         String   // free-text user context ("what I was doing")
+  image           Bytes?   // capped image bytes (nullable)
+  imageMimeType   String?  // "image/png" | "image/jpeg" | "image/webp" (nullable)
+  correlationId   String?  // short, URL-safe correlation ID; indexed for cross-reference with logs
+  guildId         String?  // guild that submitted the report (nullable, for web reports)
+  surface         String   // "bot" | "web" — where the error was encountered
+  errorCategory   String?  // light categorization hint ("playback-error", "command-error", etc.)
+  status          String   @default("new") // "new" | "triaged" | "promoted" | "dismissed"
+  rateLimitKey    String?  // opaque key for rate-limiting; never raw IP/PII
+
+  @@index([correlationId])
+  @@index([guildId])
+  @@index([createdAt])
+  @@index([status])
+  @@map("support_reports")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -903,5 +903,9 @@ model SupportReport {
   @@index([guildId])
   @@index([createdAt])
   @@index([status])
+  // Status-filtered listing sorts by createdAt; composite keeps that ordered.
+  @@index([status, createdAt])
+  // DB CHECK constraints (image <=5MB, image/mimeType pairwise, surface/status
+  // allowed values) are enforced in the migration — Prisma cannot model them.
   @@map("support_reports")
 }


### PR DESCRIPTION
Phase 1 of PRD #1222. 

Implements SupportReport Prisma model + migration, SupportReportService with create/get/list, plus three pure deep modules (correlationId, supportImageValidation, errorSupportContext) and optional getSupportUrl() config getter. 

Full test coverage (27 tests, all passing); exports added per policy ADR. Does NOT wire error surfaces/routes (P2/P3).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Foundation for user support reports: Prisma model, a service to create/get/list with image validation and safe pagination, plus utilities for correlation IDs, image checks, and error links. Phase 1 for Linear #1222; no UI or routes yet.

- **New Features**
  - Added `SupportReport` Prisma model and `SupportReportService` with `create`, `get`, and `list` (list omits image bytes; ordered by `createdAt` then `id`; `take` clamped to [1,100] with default 20 and guards NaN/Infinity/negative).
  - `create` validates image payload before persist (PNG/JPEG/WebP ≤ 5MB; rejects invalid size or MIME).
  - Support utils: `mintCorrelationId` 8-char URL-safe via `crypto.randomInt`; `tagCorrelationIdToSentry` (gated); `validateSupportImage`; `buildErrorSupportContext` (uses URL API, preserves existing query params, degrades gracefully); optional `getSupportUrl()`; exports added in `shared` and `utils/support`.

- **Migration**
  - Creates `support_reports` table with indexes on `correlationId`, `guildId`, `createdAt`, `status`, and composite `(status, createdAt)`; adds DB checks for image ≤ 5MB, image/MIME-type pairing, image MIME allowlist (`image/png|image/jpeg|image/webp`), and allowed values for `surface` (`bot|web`) and `status` (`new|triaged|promoted|dismissed`). Run Prisma migration to apply.

<sup>Written for commit 012d5b4f07a8f1bd54e1e3ff96c17d9b46c69033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support report submission with optional image uploads (PNG, JPEG, WebP; up to 5MB)
  * Implemented automatic correlation IDs for tracking errors and support requests
  * Enabled customizable support URL configuration for error reporting and user assistance links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->