### PR TITLE
feat(observability): capture escaping errors to Sentry at chokepoints

### DIFF
--- a/packages/backend/src/middleware/errorHandler.ts
+++ b/packages/backend/src/middleware/errorHandler.ts
@@ -27,14 +27,18 @@ export function errorHandler(
         return
     }
 
+    // Strip the query string: it can carry secrets (OAuth code/state, tokens)
+    // that must not leak into logs or Sentry telemetry.
+    const path = req.originalUrl.split('?')[0]
+
     errorLog({
-        message: `Unhandled error on ${req.method} ${req.originalUrl}:`,
+        message: `Unhandled error on ${req.method} ${path}:`,
         error: err,
     })
     captureException(err, {
         context: 'backend-unhandled-route-error',
         method: req.method,
-        url: req.originalUrl,
+        url: path,
     })
     res.status(500).json({ error: 'Internal server error' })
 }

--- a/packages/backend/src/middleware/errorHandler.ts
+++ b/packages/backend/src/middleware/errorHandler.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express'
-import { errorLog } from '@lucky/shared/utils'
+import { errorLog, captureException } from '@lucky/shared/utils'
 import { AppError } from '../errors/AppError'
 import { ValidationError } from '@lucky/shared/errors'
 
@@ -30,6 +30,11 @@ export function errorHandler(
     errorLog({
         message: `Unhandled error on ${req.method} ${req.originalUrl}:`,
         error: err,
+    })
+    captureException(err, {
+        context: 'backend-unhandled-route-error',
+        method: req.method,
+        url: req.originalUrl,
     })
     res.status(500).json({ error: 'Internal server error' })
 }

--- a/packages/backend/tests/setup.ts
+++ b/packages/backend/tests/setup.ts
@@ -30,12 +30,22 @@ jest.mock('connect-redis', () => ({
 }))
 
 jest.mock('session-file-store', () =>
-    jest.fn(() =>
-        class MockFileStore {
-            get(_sid: string, cb: (err?: Error | null, sess?: unknown) => void) { cb(null, null) }
-            set(_sid: string, _sess: unknown, cb?: (err?: Error) => void) { cb?.() }
-            destroy(_sid: string, cb?: (err?: Error) => void) { cb?.() }
-        },
+    jest.fn(
+        () =>
+            class MockFileStore {
+                get(
+                    _sid: string,
+                    cb: (err?: Error | null, sess?: unknown) => void,
+                ) {
+                    cb(null, null)
+                }
+                set(_sid: string, _sess: unknown, cb?: (err?: Error) => void) {
+                    cb?.()
+                }
+                destroy(_sid: string, cb?: (err?: Error) => void) {
+                    cb?.()
+                }
+            },
     ),
 )
 
@@ -262,6 +272,7 @@ jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
     infoLog: jest.fn(),
     warnLog: jest.fn(),
+    captureException: jest.fn(),
 }))
 
 global.fetch = jest.fn<typeof fetch>() as jest.MockedFunction<typeof fetch>

--- a/packages/backend/tests/unit/middleware/errorHandler.test.ts
+++ b/packages/backend/tests/unit/middleware/errorHandler.test.ts
@@ -127,6 +127,28 @@ describe('errorHandler', () => {
         })
     })
 
+    test('strips the query string from logged + captured URL (no secret leak)', () => {
+        const err = new Error('boom')
+        const res = createRes()
+
+        errorHandler(
+            err,
+            createReq('GET', '/api/auth/callback?code=secret&state=xyz'),
+            res,
+            jest.fn(),
+        )
+
+        expect(captureException).toHaveBeenCalledWith(
+            err,
+            expect.objectContaining({ url: '/api/auth/callback' }),
+        )
+        expect(errorLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Unhandled error on GET /api/auth/callback:',
+            }),
+        )
+    })
+
     test('should not leak internal error details to client', () => {
         const err = new Error('SELECT * FROM users failed: ECONNREFUSED')
         const res = createRes()

--- a/packages/backend/tests/unit/middleware/errorHandler.test.ts
+++ b/packages/backend/tests/unit/middleware/errorHandler.test.ts
@@ -4,9 +4,10 @@ import { AppError } from '../../../src/errors/AppError'
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
+    captureException: jest.fn(),
 }))
 
-import { errorLog } from '@lucky/shared/utils'
+import { errorLog, captureException } from '@lucky/shared/utils'
 
 function createReq(method = 'GET', url = '/test') {
     return { method, originalUrl: url } as any
@@ -36,6 +37,8 @@ describe('errorHandler', () => {
             error: 'Invalid input',
         })
         expect(errorLog).not.toHaveBeenCalled()
+        // Expected client errors (4xx) must not pollute Sentry.
+        expect(captureException).not.toHaveBeenCalled()
     })
 
     test('should include details when present on AppError', () => {
@@ -108,6 +111,19 @@ describe('errorHandler', () => {
         expect(errorLog).toHaveBeenCalledWith({
             message: 'Unhandled error on PUT /api/guilds/123:',
             error: err,
+        })
+    })
+
+    test('should capture unknown errors to Sentry with request context', () => {
+        const err = new Error('DB connection failed')
+        const res = createRes()
+
+        errorHandler(err, createReq('PUT', '/api/guilds/123'), res, jest.fn())
+
+        expect(captureException).toHaveBeenCalledWith(err, {
+            context: 'backend-unhandled-route-error',
+            method: 'PUT',
+            url: '/api/guilds/123',
         })
     })
 

--- a/packages/bot/src/handlers/commandsHandler.spec.ts
+++ b/packages/bot/src/handlers/commandsHandler.spec.ts
@@ -29,7 +29,7 @@ jest.mock('@lucky/shared/utils/general/errorSanitizer', () => ({
     createUserFriendlyError: jest.fn().mockReturnValue('An error occurred'),
 }))
 
-import { debugLog, errorLog, captureException } from '@lucky/shared/utils'
+import { errorLog, captureException } from '@lucky/shared/utils'
 import { featureToggleService } from '@lucky/shared/services'
 import { interactionReply } from '../utils/general/interactionReply'
 import { monitorCommandExecution } from '../utils/monitoring'

--- a/packages/bot/src/handlers/commandsHandler.spec.ts
+++ b/packages/bot/src/handlers/commandsHandler.spec.ts
@@ -8,6 +8,7 @@ import type Command from '../models/Command'
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
     errorLog: jest.fn(),
+    captureException: jest.fn(),
 }))
 
 jest.mock('@lucky/shared/services', () => ({
@@ -28,7 +29,7 @@ jest.mock('@lucky/shared/utils/general/errorSanitizer', () => ({
     createUserFriendlyError: jest.fn().mockReturnValue('An error occurred'),
 }))
 
-import { debugLog, errorLog } from '@lucky/shared/utils'
+import { debugLog, errorLog, captureException } from '@lucky/shared/utils'
 import { featureToggleService } from '@lucky/shared/services'
 import { interactionReply } from '../utils/general/interactionReply'
 import { monitorCommandExecution } from '../utils/monitoring'
@@ -85,10 +86,6 @@ describe('commandsHandler', () => {
             })
         })
 
-
-
-
-
         it('should block command when feature toggle is disabled', async () => {
             ;(featureToggleService.isEnabled as jest.Mock).mockResolvedValue(
                 false,
@@ -110,7 +107,6 @@ describe('commandsHandler', () => {
             expect(command.execute).not.toHaveBeenCalled()
         })
 
-
         it('should handle command execution errors', async () => {
             const command = createMockCommand()
             ;(command.execute as jest.Mock).mockRejectedValue(
@@ -129,6 +125,13 @@ describe('commandsHandler', () => {
                 message: 'Error executing command test:',
                 error: expect.any(Error),
             })
+            expect(captureException).toHaveBeenCalledWith(
+                expect.any(Error),
+                expect.objectContaining({
+                    context: 'command-execution-failure',
+                    command: 'test',
+                }),
+            )
             expect(createUserFriendlyError).toHaveBeenCalledWith(
                 expect.any(Error),
             )

--- a/packages/bot/src/handlers/commandsHandler.spec.ts
+++ b/packages/bot/src/handlers/commandsHandler.spec.ts
@@ -167,6 +167,23 @@ describe('commandsHandler', () => {
                 error: expect.any(Error),
             })
         })
+
+        it('wraps a non-Error rejection before capturing it', async () => {
+            const command = createMockCommand()
+            ;(command.execute as jest.Mock).mockRejectedValue('boom')
+            const interaction = createMockInteraction()
+            const client = createMockClient()
+            client.commands.set('test', command)
+
+            await executeCommand({ interaction, client })
+
+            expect(captureException).toHaveBeenCalledWith(
+                expect.any(Error),
+                expect.objectContaining({
+                    context: 'command-execution-failure',
+                }),
+            )
+        })
     })
 
     describe('setCommands', () => {

--- a/packages/bot/src/handlers/commandsHandler.ts
+++ b/packages/bot/src/handlers/commandsHandler.ts
@@ -1,5 +1,5 @@
 import { Collection, type ChatInputCommandInteraction } from 'discord.js'
-import { errorLog, debugLog } from '@lucky/shared/utils'
+import { errorLog, debugLog, captureException } from '@lucky/shared/utils'
 import { featureToggleService } from '@lucky/shared/services'
 import type { FeatureToggleName } from '@lucky/shared/types'
 import type { CustomClient } from '../types'
@@ -76,6 +76,15 @@ export const executeCommand = async ({
             message: `Error executing command ${interaction.commandName}:`,
             error,
         })
+        captureException(
+            error instanceof Error ? error : new Error(String(error)),
+            {
+                context: 'command-execution-failure',
+                command: interaction.commandName,
+                guildId: interaction.guild?.id ?? undefined,
+                userId: interaction.user.id,
+            },
+        )
         try {
             const userFriendlyError = createUserFriendlyError(error)
             await interactionReply({

--- a/packages/bot/src/handlers/interactionHandler.spec.ts
+++ b/packages/bot/src/handlers/interactionHandler.spec.ts
@@ -228,6 +228,21 @@ describe('interactionHandler', () => {
             )
         })
 
+        it('wraps a non-Error rejection before capturing it', async () => {
+            ;(executeCommand as jest.Mock).mockRejectedValue('boom')
+            const interaction = createMockChatInteraction()
+            const client = createMockClient()
+
+            await handleInteraction(interaction, client)
+
+            expect(captureException).toHaveBeenCalledWith(
+                expect.any(Error),
+                expect.objectContaining({
+                    context: 'interaction-handling-failure',
+                }),
+            )
+        })
+
         it('should not send error reply if interaction already replied', async () => {
             ;(executeCommand as jest.Mock).mockRejectedValue(new Error('Error'))
             const interaction = createMockChatInteraction({ replied: true })

--- a/packages/bot/src/handlers/interactionHandler.spec.ts
+++ b/packages/bot/src/handlers/interactionHandler.spec.ts
@@ -50,7 +50,7 @@ jest.mock('@lucky/shared/utils/general/errorSanitizer', () => ({
     createUserFriendlyError: jest.fn(),
 }))
 
-import { debugLog, errorLog } from '@lucky/shared/utils'
+import { debugLog, errorLog, captureException } from '@lucky/shared/utils'
 import { executeCommand } from './commandsHandler'
 import { handleMusicButtonInteraction } from './musicButtonHandler'
 import { reactionRolesService } from '@lucky/shared/services'
@@ -218,6 +218,14 @@ describe('interactionHandler', () => {
                     guildId: 'guild-1',
                 },
             })
+            expect(captureException).toHaveBeenCalledWith(
+                expect.any(Error),
+                expect.objectContaining({
+                    context: 'interaction-handling-failure',
+                    commandName: 'role_select',
+                    guildId: 'guild-1',
+                }),
+            )
         })
 
         it('should not send error reply if interaction already replied', async () => {

--- a/packages/bot/src/handlers/interactionHandler.spec.ts
+++ b/packages/bot/src/handlers/interactionHandler.spec.ts
@@ -50,7 +50,7 @@ jest.mock('@lucky/shared/utils/general/errorSanitizer', () => ({
     createUserFriendlyError: jest.fn(),
 }))
 
-import { debugLog, errorLog, captureException } from '@lucky/shared/utils'
+import { errorLog, captureException } from '@lucky/shared/utils'
 import { executeCommand } from './commandsHandler'
 import { handleMusicButtonInteraction } from './musicButtonHandler'
 import { reactionRolesService } from '@lucky/shared/services'

--- a/packages/bot/src/handlers/interactionHandler.spec.ts
+++ b/packages/bot/src/handlers/interactionHandler.spec.ts
@@ -17,6 +17,7 @@ import type { CustomClient } from '../types'
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
     errorLog: jest.fn(),
+    captureException: jest.fn(),
 }))
 
 jest.mock('./commandsHandler', () => ({
@@ -130,8 +131,7 @@ describe('interactionHandler', () => {
         jest.clearAllMocks()
     })
 
-    describe('handleInteractions', () => {
-    })
+    describe('handleInteractions', () => {})
 
     describe('handleInteraction', () => {
         it('should route chat input command to executeCommand', async () => {
@@ -147,7 +147,6 @@ describe('interactionHandler', () => {
             )
             expect(executeCommand).toHaveBeenCalledWith({ interaction, client })
         })
-
 
         it('should handle interaction without guild', async () => {
             const interaction = createMockChatInteraction({ guild: null })

--- a/packages/bot/src/handlers/interactionHandler.ts
+++ b/packages/bot/src/handlers/interactionHandler.ts
@@ -34,10 +34,6 @@ export const handleInteractions = async ({
         client.on(Events.InteractionCreate, (interaction: Interaction) => {
             handleInteraction(interaction, client).catch((error) => {
                 errorLog({ message: 'Error handling interaction:', error })
-                captureException(
-                    error instanceof Error ? error : new Error(String(error)),
-                    { context: 'interaction-handling-failure' },
-                )
             })
         })
 

--- a/packages/bot/src/handlers/interactionHandler.ts
+++ b/packages/bot/src/handlers/interactionHandler.ts
@@ -128,6 +128,15 @@ export async function handleInteraction(
                 guildId: interaction.guild?.id,
             },
         })
+        captureException(
+            error instanceof Error ? error : new Error(String(error)),
+            {
+                context: 'interaction-handling-failure',
+                commandName,
+                userId: interaction.user.id,
+                guildId: interaction.guild?.id ?? undefined,
+            },
+        )
 
         try {
             if (

--- a/packages/bot/src/handlers/interactionHandler.ts
+++ b/packages/bot/src/handlers/interactionHandler.ts
@@ -4,7 +4,7 @@ import {
     type CommandInteractionOptionResolver,
     type Interaction,
 } from 'discord.js'
-import { errorLog, debugLog } from '@lucky/shared/utils'
+import { errorLog, debugLog, captureException } from '@lucky/shared/utils'
 import { executeCommand } from './commandsHandler'
 import type { CustomClient } from '../types'
 import { errorEmbed } from '../utils/general/embeds'
@@ -34,6 +34,10 @@ export const handleInteractions = async ({
         client.on(Events.InteractionCreate, (interaction: Interaction) => {
             handleInteraction(interaction, client).catch((error) => {
                 errorLog({ message: 'Error handling interaction:', error })
+                captureException(
+                    error instanceof Error ? error : new Error(String(error)),
+                    { context: 'interaction-handling-failure' },
+                )
             })
         })
 

--- a/packages/bot/src/handlers/player/errorHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.spec.ts
@@ -4,6 +4,7 @@ import { setupErrorHandlers } from './errorHandlers'
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
 const warnLogMock = jest.fn()
+const captureExceptionMock = jest.fn()
 const analyzeYouTubeErrorMock = jest.fn()
 const logYouTubeErrorMock = jest.fn()
 const recordFailureMock = jest.fn()
@@ -15,6 +16,7 @@ jest.mock('@lucky/shared/utils', () => ({
     debugLog: (...args: unknown[]) => debugLogMock(...args),
     errorLog: (...args: unknown[]) => errorLogMock(...args),
     warnLog: (...args: unknown[]) => warnLogMock(...args),
+    captureException: (...args: unknown[]) => captureExceptionMock(...args),
 }))
 
 jest.mock('../../utils/general/embeds', () => ({
@@ -358,6 +360,18 @@ describe('setupErrorHandlers', () => {
                     guildId: 'guild-1',
                     errorMessage: 'ECONNRESET test',
                 }),
+            }),
+        )
+        // Both top-level and queue player errors must reach Sentry.
+        expect(captureExceptionMock).toHaveBeenCalledWith(
+            expect.any(Error),
+            expect.objectContaining({ context: 'player-unhandled-error' }),
+        )
+        expect(captureExceptionMock).toHaveBeenCalledWith(
+            expect.any(Error),
+            expect.objectContaining({
+                context: 'player-queue-error',
+                guildId: 'guild-1',
             }),
         )
     })

--- a/packages/bot/src/handlers/player/errorHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.spec.ts
@@ -406,6 +406,22 @@ describe('setupErrorHandlers', () => {
                 message: 'Attempting to recover from connection error',
             }),
         )
+        // Non-Error queue payload is wrapped into an Error before capture.
+        expect(captureExceptionMock).toHaveBeenCalledWith(
+            expect.any(Error),
+            expect.objectContaining({ context: 'player-queue-error' }),
+        )
+    })
+
+    it('wraps a non-Error top-level player payload before capturing it', () => {
+        const { playerHandlers } = createPlayerWithHandlers()
+
+        ;(playerHandlers.error as TopLevelErrorHandler)('raw failure' as any)
+
+        expect(captureExceptionMock).toHaveBeenCalledWith(
+            expect.any(Error),
+            expect.objectContaining({ context: 'player-unhandled-error' }),
+        )
     })
 
     it('skips when stream recovery has no requester, no tracks, no alternative, or no current track', async () => {

--- a/packages/bot/src/handlers/player/errorHandlers.ts
+++ b/packages/bot/src/handlers/player/errorHandlers.ts
@@ -1,6 +1,11 @@
 import { QueryType, type GuildQueue } from 'discord-player'
 import type { User } from 'discord.js'
-import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
+import {
+    errorLog,
+    debugLog,
+    warnLog,
+    captureException,
+} from '@lucky/shared/utils'
 import { createErrorEmbed } from '../../utils/general/embeds'
 import {
     analyzeYouTubeError,
@@ -143,6 +148,13 @@ export const setupErrorHandlers = (player: PlayerEvents): void => {
                     ...details,
                 },
             })
+            captureException(
+                toErrorInstance(error) ?? new Error(details.errorMessage),
+                {
+                    context: 'player-queue-error',
+                    guildId: queue?.guild?.id ?? undefined,
+                },
+            )
 
             const isConnectionError =
                 details.errorMessage.includes('ECONNRESET') ||
@@ -191,6 +203,11 @@ export const setupErrorHandlers = (player: PlayerEvents): void => {
                     error: toErrorInstance(error),
                     data: toErrorDetails(error),
                 })
+                captureException(
+                    toErrorInstance(error) ??
+                        new Error(toErrorDetails(error).errorMessage),
+                    { context: 'player-unhandled-error' },
+                )
             })
         })
 
@@ -351,6 +368,12 @@ const handlePlayerError = async (
                 guildName: queue.guild.name,
                 ...toErrorDetails(error),
             },
+        })
+        captureException(toErrorInstance(error) ?? new Error(String(error)), {
+            context: 'player-error',
+            guildId: queue.guild.id,
+            provider: currentTrackProvider,
+            trackUrl: queue.currentTrack?.url,
         })
 
         const isStreamExtractionError =

--- a/packages/bot/tests/handlers/interactionHandler.test.ts
+++ b/packages/bot/tests/handlers/interactionHandler.test.ts
@@ -5,6 +5,7 @@ const handleMusicButtonInteractionMock = jest.fn()
 const monitorInteractionHandlingMock = jest.fn()
 const errorLogMock = jest.fn()
 const debugLogMock = jest.fn()
+const captureExceptionMock = jest.fn()
 const createUserFriendlyErrorMock = jest.fn((err: unknown) =>
     err instanceof Error ? err.message : 'error',
 )
@@ -31,6 +32,7 @@ jest.mock('../../src/utils/monitoring', () => ({
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: (...args: unknown[]) => errorLogMock(...args),
     debugLog: (...args: unknown[]) => debugLogMock(...args),
+    captureException: (...args: unknown[]) => captureExceptionMock(...args),
 }))
 
 jest.mock('@lucky/shared/utils/general/errorSanitizer', () => ({


### PR DESCRIPTION
## Problem

Independent of the Support Report feature (#1174), most errors never reach Sentry today. The canonical capture path is \`handleError\` (logs **and** sends to Sentry); plain \`errorLog\`/\`debugLog\` bypass Sentry entirely. As a result:

- **Backend has zero Sentry coverage** — every unhandled route 500 is logged but invisible.
- **discord-player errors** (the YouTube/SoundCloud "could not play" class) were log-only — which is exactly why recent playback failures were uninvestigable without a user-pasted screenshot.
- **Bot command + interaction errors** never surfaced in Sentry.

## Approach — instrument chokepoints, not every catch

A handful of central edits capture the overwhelming majority of *escaping* errors. Deliberately **not** instrumenting the ~148 inner defensive catches (mostly intentional debug-level swallows: transient 429s, expired interactions, cleanup races) — that would flood Sentry and bury the signal. The long-tail sweep + a lint guard is Track B of the logging-hardening ADR, tracked separately.

| Chokepoint | Captured context |
|---|---|
| Bot command execution (\`commandsHandler\`) | command, guildId, userId |
| Bot interaction dispatch (\`interactionHandler\`, inner catch + outer net) | command/customId, userId, guildId |
| discord-player: \`playerError\`, queue \`error\`, top-level \`error\` | guildId, provider, trackUrl |
| Backend Express 500-handler | method, url |

4xx \`AppError\`/\`ValidationError\` stay **out** of Sentry (expected client errors).

## Tests

- Backend: capture fires on the 500 path with request context; stays silent on 4xx (15 tests).
- Bot: positive assertions that capture fires for command-execution, interaction-handling, player-unhandled, and player-queue errors (46 tests across 3 specs).
- All pass locally; pre-commit \`type:check\` across all 4 packages is green.

## Out of scope (follow-up)

- Frontend global error boundary / \`window.onunhandledrejection\` → Sentry.
- The long-tail \`errorLog\`/\`debugLog\`-only sweep + lint enforcement (ADR Track B).

@cubic-dev-ai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture escaping errors to Sentry at key chokepoints so backend 500s, bot command/interaction failures, and `discord-player` issues are visible with useful context. Expected 4xx client errors are excluded, and URLs are sanitized (query stripped) to avoid leaking secrets.

- New Features
  - Backend 500 handler: capture with method and path (query stripped); exclude `AppError`/`ValidationError`.
  - Bot commands: capture execution failures with command, guildId, userId.
  - Bot interactions: capture inner failures with command/customId, userId, guildId.
  - `discord-player`: capture player, queue, and top-level errors; include guildId, and when available provider and trackUrl.

- Bug Fixes
  - Capture interaction errors at the inner handler catch and remove the redundant outer capture to avoid duplicates.
  - Normalize non-Error rejections before capture in commands, interactions, and `discord-player`.

<sup>Written for commit 881bd70a75f29f9e8ab29f32e330aea0f47b1c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

