### PR TITLE
feat(deploy): SHA-pinned deploys + auto-rollback on health failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
                 required: false
                 default: 'false'
                 type: boolean
+            rollback_sha:
+                description: 'Roll back: deploy this exact prior commit SHA (its :<sha> images must still exist in the registry). Leave blank for a normal deploy.'
+                required: false
+                default: ''
+                type: string
     workflow_run:
         workflows: ["Build & Push Docker Images"]
         types: [completed]
@@ -56,6 +61,13 @@ jobs:
                   GH_PAGER: cat
               run: |
                   set -euo pipefail
+                  # Rollback deploys an already-published prior image; its build
+                  # finished long ago, so skip the docker-publish wait entirely.
+                  if [ -n "${{ inputs.rollback_sha }}" ]; then
+                    echo "==> Rollback to ${{ inputs.rollback_sha }} — skipping docker build wait (image already published)"
+                    echo "docker_rebuilt=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
                   if [ "${{ github.event_name }}" = "workflow_run" ]; then
                     commit_sha="${{ github.event.workflow_run.head_sha }}"
                   else
@@ -191,11 +203,24 @@ jobs:
                   set -euo pipefail
                   echo "==> Triggering deploy webhook..."
 
+                  # Resolve the image SHA to deploy: an explicit rollback target
+                  # when given, else the commit that triggered this run. Sent to
+                  # the homelab so it deploys that exact :<sha> image tag.
+                  if [ -n "${{ inputs.rollback_sha }}" ]; then
+                    DEPLOY_SHA="${{ inputs.rollback_sha }}"
+                    echo "==> Manual rollback to $DEPLOY_SHA"
+                  elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+                    DEPLOY_SHA="${{ github.event.workflow_run.head_sha }}"
+                  else
+                    DEPLOY_SHA="${{ github.sha }}"
+                  fi
+
                   call_webhook() {
                     local url="$1"
                     curl -s -w "\n%{http_code}" \
                       -X POST \
                       -H "X-Webhook-Secret: $WEBHOOK_SECRET" \
+                      -H "X-Deploy-SHA: $DEPLOY_SHA" \
                       --connect-timeout 10 \
                       --max-time 30 \
                       "$url"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,12 +59,13 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   GH_PAGER: cat
+                  ROLLBACK_SHA: ${{ inputs.rollback_sha }}
               run: |
                   set -euo pipefail
                   # Rollback deploys an already-published prior image; its build
                   # finished long ago, so skip the docker-publish wait entirely.
-                  if [ -n "${{ inputs.rollback_sha }}" ]; then
-                    echo "==> Rollback to ${{ inputs.rollback_sha }} — skipping docker build wait (image already published)"
+                  if [ -n "$ROLLBACK_SHA" ]; then
+                    echo "==> Rollback to $ROLLBACK_SHA — skipping docker build wait (image already published)"
                     echo "docker_rebuilt=false" >> "$GITHUB_OUTPUT"
                     exit 0
                   fi
@@ -184,12 +185,21 @@ jobs:
             - name: Sentry release — create
               if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
               continue-on-error: true
+              env:
+                  ROLLBACK_SHA: ${{ inputs.rollback_sha }}
+                  WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+                  PUSH_SHA: ${{ github.sha }}
+                  EVENT_NAME: ${{ github.event_name }}
               run: |
                   set -euo pipefail
-                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
-                    release="${{ github.event.workflow_run.head_sha }}"
+                  # Attribute the Sentry release to the SHA actually deployed
+                  # (the rollback target on a rollback) for runtime traceability.
+                  if [ -n "$ROLLBACK_SHA" ]; then
+                    release="$ROLLBACK_SHA"
+                  elif [ "$EVENT_NAME" = "workflow_run" ]; then
+                    release="$WORKFLOW_RUN_SHA"
                   else
-                    release="${{ github.sha }}"
+                    release="$PUSH_SHA"
                   fi
                   echo "==> Creating Sentry release $release"
                   npx --yes @sentry/cli@^3 releases new "$release"
@@ -199,6 +209,10 @@ jobs:
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
                   WEBHOOK_SECRET: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}
+                  ROLLBACK_SHA: ${{ inputs.rollback_sha }}
+                  WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+                  PUSH_SHA: ${{ github.sha }}
+                  EVENT_NAME: ${{ github.event_name }}
               run: |
                   set -euo pipefail
                   echo "==> Triggering deploy webhook..."
@@ -206,13 +220,15 @@ jobs:
                   # Resolve the image SHA to deploy: an explicit rollback target
                   # when given, else the commit that triggered this run. Sent to
                   # the homelab so it deploys that exact :<sha> image tag.
-                  if [ -n "${{ inputs.rollback_sha }}" ]; then
-                    DEPLOY_SHA="${{ inputs.rollback_sha }}"
+                  # All SHA sources are read from env (never inlined) to avoid
+                  # shell injection from the user-supplied rollback input.
+                  if [ -n "$ROLLBACK_SHA" ]; then
+                    DEPLOY_SHA="$ROLLBACK_SHA"
                     echo "==> Manual rollback to $DEPLOY_SHA"
-                  elif [ "${{ github.event_name }}" = "workflow_run" ]; then
-                    DEPLOY_SHA="${{ github.event.workflow_run.head_sha }}"
+                  elif [ "$EVENT_NAME" = "workflow_run" ]; then
+                    DEPLOY_SHA="$WORKFLOW_RUN_SHA"
                   else
-                    DEPLOY_SHA="${{ github.sha }}"
+                    DEPLOY_SHA="$PUSH_SHA"
                   fi
 
                   call_webhook() {
@@ -311,13 +327,23 @@ jobs:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
                   DOCKER_REBUILT: ${{ steps.docker_wait.outputs.docker_rebuilt }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  ROLLBACK_SHA: ${{ inputs.rollback_sha }}
+                  WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+                  PUSH_SHA: ${{ github.sha }}
+                  EVENT_NAME: ${{ github.event_name }}
               run: |
                   set -euo pipefail
                   base_url=$(node -e 'const u = new URL(process.env.WEBHOOK_URL); console.log(`${u.protocol}//${u.host}`)')
-                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
-                    expected="${{ github.event.workflow_run.head_sha }}"
+                  # Validate the SHA actually deployed. On a rollback this is the
+                  # rollback target, so we verify the homelab posted a successful
+                  # deploy status for it (deploy.sh posts success only after the
+                  # rollback passes health checks).
+                  if [ -n "$ROLLBACK_SHA" ]; then
+                    expected="$ROLLBACK_SHA"
+                  elif [ "$EVENT_NAME" = "workflow_run" ]; then
+                    expected="$WORKFLOW_RUN_SHA"
                   else
-                    expected="${{ github.sha }}"
+                    expected="$PUSH_SHA"
                   fi
 
                   if [ "${DOCKER_REBUILT:-false}" != "true" ]; then

--- a/deploy/hooks.json
+++ b/deploy/hooks.json
@@ -1,9 +1,14 @@
-[{
-  "id": "deploy",
-  "execute-command": "/home/luk-server/Lucky/scripts/deploy-wrapper.sh",
-  "command-working-directory": "/home/luk-server/Lucky",
-  "response-message": "Deploy triggered",
-  "include-command-output-in-response": true,
-  "include-command-output-in-response-on-error": true,
-  "pass-arguments-to-command": [{"source": "header", "name": "X-Webhook-Secret"}]
-}]
+[
+    {
+        "id": "deploy",
+        "execute-command": "/home/luk-server/Lucky/scripts/deploy-wrapper.sh",
+        "command-working-directory": "/home/luk-server/Lucky",
+        "response-message": "Deploy triggered",
+        "include-command-output-in-response": true,
+        "include-command-output-in-response-on-error": true,
+        "pass-arguments-to-command": [
+            { "source": "header", "name": "X-Webhook-Secret" },
+            { "source": "header", "name": "X-Deploy-SHA" }
+        ]
+    }
+]

--- a/docs/decisions/2026-06-04-deploy-time-active-rollback-over-bake-timer.md
+++ b/docs/decisions/2026-06-04-deploy-time-active-rollback-over-bake-timer.md
@@ -1,0 +1,138 @@
+---
+status: accepted
+date: 2026-06-04
+revisit_after: 2026-07-15
+supersedes_partial: 2026-05-25-release-cadence-gates.md (the 30-min wait-timer portion)
+---
+
+# Deploy time: replace the 30-min bake timer with active health-gated rollback
+
+## Context
+
+The `Production` GitHub Actions environment has a **30-minute `wait_timer`**
+protection rule. Merging to `main` auto-arms the homelab deploy (via the
+`workflow_run` trigger on a successful "Build & Push Docker Images"), and that
+deploy job then waits 30 minutes before running. The operator's complaint:
+**merge→live takes 30+ minutes for every change, and that's too slow.**
+
+The 30 minutes is **not** build or deploy machinery — the actual deploy work
+(Docker image wait, webhook, health/SHA/auth-config checks) is fast. It is a
+deliberate **passive bake window**, added in
+`2026-05-25-release-cadence-gates.md` after the husky bug left `main`'s image
+broken for ~24h. The intent: give time to revert before bad code reaches the
+homelab.
+
+Two problems with the bake timer as a safety mechanism:
+
+1. **The original bug-class is already caught earlier.** `docker-build-check` is
+   now a required PR gate, and the deploy only fires after "Build & Push Docker
+   Images" _succeeds_. A broken image no longer reaches the deploy step at all.
+2. **Passive bake time only protects if something is watching during the
+   window.** Nothing automated acts during the 30 minutes; the husky bug was
+   caught at 24h via phone, not by a timer. A silent wait with no active signal
+   is mostly just delay.
+
+## Decision
+
+**Replace the passive 30-minute bake timer with an active, health-gated,
+self-reverting deploy.** Goal: merge→live in deploy-time (a few minutes) for
+_all_ changes, not just hotfixes.
+
+Mechanism (entire pipeline is in-repo and editable: `deploy.yml` →
+`deploy/hooks.json` → `scripts/deploy.sh`, with `docker-compose.yml` already
+parameterizing `IMAGE_TAG`):
+
+1. **SHA-pinned deploys.** The deploy webhook passes the git SHA; `deploy.sh`
+   sets `IMAGE_TAG=<sha>` and runs `docker compose up -d`. Every commit is
+   already pushed as a `:sha` image, so any prior version is reachable.
+2. **Auto-rollback on health failure.** After recreate, `deploy.sh`
+   health-checks (`/api/health` + version-SHA + auth-config + the existing bot
+   health gate). On failure it **re-deploys the last-known-good SHA** (tracked
+   in a homelab state file); on success it records the new SHA as good.
+3. **Manual one-click rollback.** A `workflow_dispatch` that redeploys a chosen
+   prior SHA — for the "deployed healthy but logically broken" case that a
+   health check can't catch.
+4. **Staged timer reduction.** Cut `wait_timer` 30 → 5 min during a trial; drop
+   to 0 once auto-rollback has correctly fired on a real failed deploy.
+
+### Cutover model: recreate-in-place, not blue-green
+
+True blue-green (start-new → verify → swap → stop-old) was rejected:
+
+- The compose uses fixed `container_name`s — two instances of a service can't
+  coexist without restructuring.
+- **The bot is a single stateful instance with no sharding.** Two bot processes
+  = two Discord gateway connections = every command/event handled twice. Blue-
+  green is actively unsafe for the bot tier.
+
+So the model is **SHA-pinned recreate-in-place**: `docker compose up -d` swaps
+the changed services with a few seconds of reconnect — exactly what every deploy
+does today. Safety comes from health-gating + auto-rollback, not from running
+two versions side by side.
+
+## Alternatives considered
+
+- **Just shorten the timer (30 → 10).** The ADR's own fallback. Rejected as the
+  primary fix: it keeps the passive-bake model, which provides little real
+  protection, and still imposes a fixed delay on every change.
+- **Blue-green / health-gated cutover.** Rejected — incompatible with the
+  stateful single-instance bot and the fixed-container-name compose; large
+  restructure for a tier (the bot) that can't use it anyway.
+- **Manual rollback only + shorten timer.** Smaller change, but leaves recovery
+  human-initiated and keeps a bake window doing little. Chosen as a _subset_
+  (manual rollback is included) but not as the whole answer.
+- **Reinstating `release/*` buffer.** Already rejected in the prior ADR
+  (autosync direction, ceremony-without-bake-time, solo-dev branch orphan risk).
+
+## Consequences
+
+**Positive:**
+
+- merge→live drops from 30+ min to deploy-time for every change.
+- Bad deploys are _actively reverted_ (health-gated auto-rollback), not merely
+  _delayed_ — strictly stronger than passive bake time.
+- SHA-pinned deploys make "what's running" explicit and make rollback a
+  first-class, one-command operation.
+
+**Negative:**
+
+- Auto-rollback is new logic that can be wrong (e.g., rolling back on a flaky
+  health check). Mitigated by the staged timer cut — a trial window before the
+  last guardrail is removed.
+- Recreate-in-place keeps the few-seconds reconnect on every deploy (unchanged
+  from today; not eliminated).
+- Requires a homelab state file for last-known-good SHA; a corrupted/missing
+  state file degrades to "report failure, no auto-rollback" (current behavior).
+
+**Neutral:**
+
+- `release.yml` (tag-triggered) is unchanged.
+- The `docker-build-check` required PR gate and build-success deploy
+  precondition remain — they, not the timer, prevent the broken-image class.
+
+## Failure modes to handle in implementation
+
+- **Rollback target also unhealthy** → stop, alert/page, leave in failed state;
+  never loop.
+- **No last-known-good yet** (first deploy) → report failure, no auto-rollback.
+- **Health check flaky** → bounded retries before declaring failure (deploy.sh
+  already retries); tune thresholds during the trial.
+
+## Revisit when
+
+- **2026-07-15**: has auto-rollback fired correctly on a real failed deploy? If
+  yes, drop `wait_timer` 5 → 0. If it has produced false rollbacks, raise health
+  thresholds before cutting further.
+- If deploy frequency or the service set grows enough that recreate downtime
+  becomes user-visible: re-evaluate per-tier blue-green for the _web_ tiers
+  (backend/frontend/nginx) while keeping the bot on recreate.
+- If the bot gains sharding/clustering: blue-green for the bot becomes possible;
+  revisit the cutover model.
+
+## Cross-references
+
+- `2026-05-25-release-cadence-gates.md` — introduced the 30-min timer; this ADR
+  supersedes the timer portion (the `docker-build-check` gate stands).
+- `2026-05-24-deploy-bot-health-gate.md` — the bot health gate feeds the
+  health-gated rollback.
+- `2026-05-13-deploy-target-keep-homelab.md` — keeps deploys on homelab.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,9 @@
 set -e
 
 RECEIVED_SECRET="${1:-}"
+# Optional target image SHA (arg 2). When set, deploy that exact :<sha> image
+# tag instead of :latest, enabling SHA-pinned deploys + rollback to a prior SHA.
+DEPLOY_SHA="${2:-}"
 EXPECTED_SECRET="${DEPLOY_WEBHOOK_SECRET:-}"
 DEPLOY_DIR="${DEPLOY_DIR:-/repo}"
 DISCORD_WEBHOOK="${DISCORD_DEPLOY_WEBHOOK:-}"
@@ -17,6 +20,9 @@ GITHUB_REPO="${GITHUB_REPO:-LucasSantana-Dev/Lucky}"
 DEPLOY_FINAL_STATE="failure"
 DEPLOY_FINAL_DESC="Deploy failed"
 DEPLOYED_SHA=""
+# Records the last SHA that deployed AND passed all health checks. Used as the
+# auto-rollback target when a subsequent deploy fails its health checks.
+LAST_GOOD_FILE="${LAST_GOOD_FILE:-${DEPLOY_DIR}/.deploy-last-good-sha}"
 
 log() { echo "$LOG_PREFIX $(date '+%H:%M:%S') $1"; }
 
@@ -320,6 +326,104 @@ post_deploy_status() {
         -d "{\"state\":\"${1}\",\"description\":\"${2}\",\"context\":\"homelab-deploy\"}" || true
 }
 
+# Runs all post-rollout health checks. Returns 0 if healthy, 1 on the first hard
+# failure (no `exit`, so the caller can decide to roll back). A slow/absent bot
+# gateway after the timeout is a non-fatal WARN, matching prior behavior.
+run_health_checks() {
+    log "Waiting for health checks..."
+    sleep 10
+
+    log "Service status:"
+    docker_compose ps --format "table {{.Name}}\t{{.Status}}"
+
+    if ! require_running_containers; then
+        print_targeted_logs
+        log "HEALTH: required services are not running"
+        return 1
+    fi
+
+    if ! wait_for_http_ready \
+        "API health" \
+        "http://nginx/api/health" \
+        '"status"[[:space:]]*:[[:space:]]*"ok"'; then
+        print_targeted_logs
+        log "HEALTH: API health endpoint did not become ready"
+        return 1
+    fi
+
+    if ! wait_for_http_ready \
+        "Auth config health" \
+        "http://nginx/api/health/auth-config" \
+        '"auth"[[:space:]]*:'; then
+        print_targeted_logs
+        log "HEALTH: Auth config endpoint did not become ready"
+        return 1
+    fi
+
+    log "Waiting for bot gateway health (start-period: 45s, timeout: 90s)..."
+    local bot_deadline bot_health
+    bot_deadline=$(( SECONDS + 90 ))
+    while [[ $SECONDS -lt $bot_deadline ]]; do
+        bot_health=$(docker inspect lucky-bot --format '{{.State.Health.Status}}' 2>/dev/null || echo "none")
+        if [[ "$bot_health" == "healthy" ]]; then
+            log "Bot gateway healthy"
+            break
+        fi
+        if [[ "$bot_health" == "unhealthy" ]]; then
+            log "HEALTH: bot container unhealthy (Discord gateway not connected)"
+            docker logs lucky-bot --tail=40 --no-color 2>/dev/null || true
+            return 1
+        fi
+        sleep 5
+    done
+    bot_health=$(docker inspect lucky-bot --format '{{.State.Health.Status}}' 2>/dev/null || echo "none")
+    if [[ "$bot_health" != "healthy" ]]; then
+        log "WARN: bot health status '${bot_health}' after 90s (Discord may be slow — proceeding)"
+    fi
+
+    return 0
+}
+
+# Auto-rollback: when a deploy fails its health checks, redeploy the last SHA
+# that was known healthy (recorded in LAST_GOOD_FILE) and re-check. Returns 0 if
+# the rollback target is healthy (DEPLOYED_SHA is then repointed at it), 1 if no
+# usable target exists or the rollback target is also unhealthy.
+attempt_rollback() {
+    local reason="$1"
+    local last_good=""
+    [[ -f "$LAST_GOOD_FILE" ]] && last_good=$(cat "$LAST_GOOD_FILE" 2>/dev/null || true)
+
+    if [[ -z "$last_good" || "$last_good" == "$DEPLOYED_SHA" ]]; then
+        log "ROLLBACK: no distinct last-good SHA available (last_good='${last_good:-none}')"
+        notify 16711680 "Deploy Failed" "$reason (no rollback target available)"
+        return 1
+    fi
+
+    log "AUTO-ROLLBACK: ${DEPLOYED_SHA} failed ($reason); reverting to last-good ${last_good}"
+    # Mark the failed SHA's commit status before repointing DEPLOYED_SHA.
+    post_deploy_status "failure" "Auto-rolled back to ${last_good} after failed health checks"
+    notify 16753920 "Auto-rollback" "Deploy of ${DEPLOYED_SHA} failed ($reason); reverting to ${last_good}"
+
+    export IMAGE_TAG="$last_good"
+    if ! docker_compose pull bot backend frontend nginx; then
+        log "ROLLBACK ERROR: could not pull last-good images (${last_good})"
+        notify 16711680 "Rollback Failed" "Could not pull ${last_good} images — manual intervention required"
+        return 1
+    fi
+    docker_compose up -d --remove-orphans --no-deps bot backend frontend nginx
+
+    if run_health_checks; then
+        log "Rollback to ${last_good} is healthy"
+        notify 65280 "Rolled Back" "Now running last-good ${last_good}"
+        DEPLOYED_SHA="$last_good"
+        return 0
+    fi
+
+    log "ROLLBACK ERROR: last-good ${last_good} is ALSO unhealthy — manual intervention required"
+    notify 16711680 "Rollback Failed" "${last_good} also unhealthy — manual intervention required"
+    return 1
+}
+
 if [[ -z "$EXPECTED_SECRET" ]]; then
     log "ERROR: DEPLOY_WEBHOOK_SECRET not configured"
     exit 1
@@ -328,6 +432,13 @@ fi
 if [[ "$RECEIVED_SECRET" != "$EXPECTED_SECRET" ]]; then
     log "ERROR: invalid webhook secret"
     exit 1
+fi
+
+# SHA-pinned deploy: run the :<sha> image tag the caller asked for. When no SHA
+# is supplied (e.g. a manual call) fall back to :latest for backward compatibility.
+if [[ -n "$DEPLOY_SHA" ]]; then
+    export IMAGE_TAG="$DEPLOY_SHA"
+    log "Deploying pinned image tag: $DEPLOY_SHA"
 fi
 
 incoming_sha=""
@@ -379,7 +490,7 @@ if ! sync_checkout_to_origin_main; then
     exit 1
 fi
 
-DEPLOYED_SHA=$(git -C "$DEPLOY_DIR" rev-parse HEAD 2>/dev/null || true)
+DEPLOYED_SHA="${DEPLOY_SHA:-$(git -C "$DEPLOY_DIR" rev-parse HEAD 2>/dev/null || true)}"
 post_deploy_status "pending" "Deploy in progress"
 
 # Rebuild webhook early: after git pull lands new hooks.json/Dockerfile but
@@ -475,61 +586,29 @@ else
     log "WARN: Could not restart cloudflared (service unavailable)"
 fi
 
-log "Waiting for health checks..."
-sleep 10
-
-log "Service status:"
-docker_compose ps --format "table {{.Name}}\t{{.Status}}"
-
-if ! require_running_containers; then
-    print_targeted_logs
-    notify 16711680 "Deploy Failed" "Runtime precheck failed (required services)"
-    exit 1
-fi
-
-if ! wait_for_http_ready \
-    "API health" \
-    "http://nginx/api/health" \
-    '"status"[[:space:]]*:[[:space:]]*"ok"'; then
-    print_targeted_logs
-    notify 16711680 "Deploy Failed" "API health endpoint did not become ready"
-    exit 1
-fi
-
-if ! wait_for_http_ready \
-    "Auth config health" \
-    "http://nginx/api/health/auth-config" \
-    '"auth"[[:space:]]*:'; then
-    print_targeted_logs
-    notify 16711680 "Deploy Failed" "Auth config health endpoint did not become ready"
-    exit 1
-fi
-
-log "Waiting for bot gateway health (start-period: 45s, timeout: 90s)..."
-bot_deadline=$(( SECONDS + 90 ))
-while [[ $SECONDS -lt $bot_deadline ]]; do
-    bot_health=$(docker inspect lucky-bot --format '{{.State.Health.Status}}' 2>/dev/null || echo "none")
-    if [[ "$bot_health" == "healthy" ]]; then
-        log "Bot gateway healthy"
-        break
+if run_health_checks; then
+    # Record this SHA as the rollback target for future failed deploys.
+    if [[ -n "$DEPLOYED_SHA" ]]; then
+        echo "$DEPLOYED_SHA" >"$LAST_GOOD_FILE" 2>/dev/null \
+            || log "WARN: could not record last-good SHA to $LAST_GOOD_FILE"
     fi
-    if [[ "$bot_health" == "unhealthy" ]]; then
-        log "ERROR: RUNTIME_PRECHECK_FAILED (bot container unhealthy — Discord gateway not connected)"
-        docker logs lucky-bot --tail=40 --no-color 2>/dev/null || true
-        notify 16711680 "Deploy Failed" "Bot gateway not connected"
-        exit 1
-    fi
-    sleep 5
-done
-bot_health=$(docker inspect lucky-bot --format '{{.State.Health.Status}}' 2>/dev/null || echo "none")
-if [[ "$bot_health" != "healthy" ]]; then
-    log "WARN: bot health status '${bot_health}' after 90s (Discord may be slow — proceeding)"
+
+    log "Pruning old images..."
+    docker image prune -f --filter "until=24h"
+
+    DEPLOY_FINAL_STATE="success"
+    DEPLOY_FINAL_DESC="All services healthy"
+    log "Deploy complete!"
+    notify 65280 "Deploy Successful" "All services healthy and running"
+elif attempt_rollback "health checks failed"; then
+    # Service restored on the last-good version; the failed SHA already received
+    # a failure status inside attempt_rollback, and DEPLOYED_SHA now points at
+    # the healthy rollback target (the EXIT trap posts success for it).
+    DEPLOY_FINAL_STATE="success"
+    DEPLOY_FINAL_DESC="Auto-rolled back to ${DEPLOYED_SHA} after failed deploy"
+    log "Deploy failed; auto-rollback restored service on ${DEPLOYED_SHA}"
+else
+    DEPLOY_FINAL_STATE="failure"
+    DEPLOY_FINAL_DESC="Deploy failed and rollback unavailable"
+    exit 1
 fi
-
-log "Pruning old images..."
-docker image prune -f --filter "until=24h"
-
-DEPLOY_FINAL_STATE="success"
-DEPLOY_FINAL_DESC="All services healthy"
-log "Deploy complete!"
-notify 65280 "Deploy Successful" "All services healthy and running"


### PR DESCRIPTION
Implements ADR `docs/decisions/2026-06-04-deploy-time-active-rollback-over-bake-timer.md` (Phase 1). Plan: `.claude/plans/deploy-active-rollback-2026-06-04.md`.

## Why
The `Production` env has a 30-min `wait_timer` — passive bake time, not build time. Its original justification (broken-image class) is already caught by `docker-build-check` + the build-success deploy precondition, and passive bake time only helps if something watches during the window (nothing does). This replaces it with an **active** safety net.

## What
- **SHA-pinned deploys** — the webhook now sends `X-Deploy-SHA`; `deploy.sh` sets `IMAGE_TAG=<sha>` so the homelab runs that exact `:<sha>` image (already published per commit). No SHA → `latest` (backward compatible).
- **Auto-rollback on health failure** — `run_health_checks()` extracted; on failure, `attempt_rollback()` redeploys the **last-known-good SHA** (recorded in `.deploy-last-good-sha`) and re-checks. The failed commit gets a `failure` status; the restored commit gets `success`.
- **Manual rollback** — `workflow_dispatch` input `rollback_sha` deploys a chosen prior SHA (skips the docker-publish wait since the image already exists).

## Safety / compatibility
- First deploy has no last-good → rollback unavailable → preserves the prior `exit 1` behavior. Last-good is recorded only after a fully healthy deploy.
- Additive only; revert restores the prior linear deploy.
- Rollback assumes additive/backward-compatible migrations (the project's convention).

## Validation
- `bash -n scripts/deploy.sh` ✓; `shellcheck` clean on new code (only a pre-existing SC1007 on line 15).
- `jq` parses `hooks.json`; `deploy.yml` is valid YAML (actionlint runs in CI).
- Homelab deploy can't run locally — the PR's own deploy exercises the forward SHA-pinned path; the **auto-rollback branch needs a deliberate trial** (see plan Rollout).

## Not in this PR (gated follow-ups)
- Reducing the `wait_timer` 30 → 5 (a GitHub env setting, applied via API **after** this lands and the rollback trial passes), then → 0 (ADR Phase 2, revisit 2026-07-15).

@cubic-dev-ai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the 30-minute production bake timer with SHA-pinned deploys and active, health-gated auto-rollback to make deploys faster and safer. Hardened the rollback input path and fixed release attribution and validation on rollbacks.

- **New Features**
  - SHA-pinned deploys: `deploy.yml` sends `X-Deploy-SHA`, `deploy/hooks.json` forwards it, and `scripts/deploy.sh` sets `IMAGE_TAG=<sha>` (no SHA → `latest`).
  - Auto-rollback on health failure: `run_health_checks()` gates rollout; on failure, `attempt_rollback()` redeploys the last-known-good SHA from `.deploy-last-good-sha` and posts commit statuses accordingly.
  - Manual rollback: `workflow_dispatch` input `rollback_sha` deploys a chosen prior SHA and skips the docker publish wait.

- **Bug Fixes**
  - Routed `rollback_sha` via step env vars (no inlining) to prevent command injection in `deploy.yml` shell steps.
  - Validate-deployed-version now checks the rollback target SHA’s healthy status before passing.
  - Sentry release is attributed to the SHA actually deployed, including rollbacks.

<sup>Written for commit dfc76711fb07a1532570bdc3144b6423ec18abdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

