### PR TITLE
fix(deploy): read webhook hooks.json from live directory mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,7 +220,7 @@ services:
             dockerfile: Dockerfile
         container_name: lucky-webhook
         command: >
-            -hooks /hooks/hooks.json
+            -hooks /home/luk-server/Lucky/deploy/hooks.json
             -verbose
             -hotreload
         environment:
@@ -228,8 +228,12 @@ services:
             - DISCORD_DEPLOY_WEBHOOK=${DISCORD_DEPLOY_WEBHOOK:-}
             - DEPLOY_DIR=/home/luk-server/Lucky
         volumes:
+            # Read hooks.json from the directory-mounted repo (not a single-file
+            # mount): a single-file bind-mount freezes to the original inode, so
+            # a deploy's `git reset` that REPLACES the file is never seen, leaving
+            # the webhook on a stale hooks.json. The directory mount updates live,
+            # so -hotreload picks up changes (e.g. new pass-arguments entries).
             - .:/home/luk-server/Lucky
-            - ./deploy/hooks.json:/hooks/hooks.json:ro
             - ${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:ro
             - /var/run/docker.sock:/var/run/docker.sock
         working_dir: /home/luk-server/Lucky


### PR DESCRIPTION
## Why
The rollback trial for #1230 **failed**: a `workflow_dispatch` with `rollback_sha=3b26b727` ran and reported success, but the homelab never switched off `9448de4b` (no `homelab-deploy` status was ever posted for `3b26b727`).

**Root cause:** `hooks.json` was bind-mounted as a **single file** (`./deploy/hooks.json:/hooks/hooks.json`). Docker single-file mounts pin to the original **inode**, so when a deploy's `git reset --hard` *replaces* the file, the running webhook container never sees the new contents — and `-hotreload` watches the frozen path, so it never reloads. The webhook kept serving the pre-#1230 `hooks.json` (no `X-Deploy-SHA` argument), so `deploy.sh` received no SHA and defaulted to `IMAGE_TAG=latest` → redeployed the current version (a silent no-op rollback).

## Fix
Point `-hooks` at the **directory-mounted** repo path (`/home/luk-server/Lucky/deploy/hooks.json`, served by the existing `.:/home/luk-server/Lucky` mount) instead of the single-file mount. Directory mounts reflect replaced files live, so `-hotreload` picks up `hooks.json` changes (e.g. the new `pass-arguments-to-command` entry). The single-file mount is removed; the Dockerfile's `COPY hooks.json /hooks/hooks.json` stays as a harmless baked-in fallback.

## ⚠️ Requires a one-time homelab action
Because the running webhook container still has the old single-file mount + command, this change only takes effect after the webhook is recreated **once** on the homelab:

```
docker compose -p lucky up -d --force-recreate webhook
```

After that, re-run the rollback trial (`workflow_dispatch rollback_sha=<prior SHA>`) — it should pin and serve the requested SHA, with `live` flipping accordingly.

## Notes
- Auto-rollback (`attempt_rollback` in `deploy.sh`) does **not** depend on this — it reads `last-good` and redeploys internally.
- Keep the Production `wait_timer` at **5 min** (not 0) until the re-trial passes.

@cubic-dev-ai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes manual rollback by reading `hooks.json` from the live repo directory mount so `-hotreload` sees updates. Removes the single-file bind mount that pinned to a stale inode and blocked switching to the requested SHA.

- **Migration**
  - Recreate the webhook once: `docker compose -p lucky up -d --force-recreate webhook`
  - Then re-run the rollback trial (`workflow_dispatch rollback_sha=<sha>`)

<sup>Written for commit b1444ecbfd5b2c162a5e91c5a355df416614d648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved webhook service deployment configuration to enable automatic hot-reload of configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->