### PR TITLE
fix(deploy): pin to short image tag; never build under a pinned tag

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -404,7 +404,8 @@ attempt_rollback() {
     post_deploy_status "failure" "Auto-rolled back to ${last_good} after failed health checks"
     notify 16753920 "Auto-rollback" "Deploy of ${DEPLOYED_SHA} failed ($reason); reverting to ${last_good}"
 
-    export IMAGE_TAG="$last_good"
+    # Registry images are tagged with the 7-char short SHA, so pin to that.
+    export IMAGE_TAG="${last_good:0:7}"
     if ! docker_compose pull bot backend frontend nginx; then
         log "ROLLBACK ERROR: could not pull last-good images (${last_good})"
         notify 16711680 "Rollback Failed" "Could not pull ${last_good} images — manual intervention required"
@@ -436,9 +437,12 @@ fi
 
 # SHA-pinned deploy: run the :<sha> image tag the caller asked for. When no SHA
 # is supplied (e.g. a manual call) fall back to :latest for backward compatibility.
+# Registry images are tagged with the 7-char short SHA (docker/metadata-action
+# type=sha), so pin to that — the full 40-char SHA would miss the pull and (per
+# the pull guard below) abort instead of silently shipping rebuilt current code.
 if [[ -n "$DEPLOY_SHA" ]]; then
-    export IMAGE_TAG="$DEPLOY_SHA"
-    log "Deploying pinned image tag: $DEPLOY_SHA"
+    export IMAGE_TAG="${DEPLOY_SHA:0:7}"
+    log "Deploying pinned image tag: $IMAGE_TAG (from $DEPLOY_SHA)"
 fi
 
 incoming_sha=""
@@ -515,6 +519,14 @@ fi
 
 log "Pulling images..."
 if ! docker_compose pull bot backend frontend nginx; then
+    if [[ -n "$DEPLOY_SHA" ]]; then
+        # A pinned/rollback deploy MUST run the requested image. Building from the
+        # current checkout would silently ship different code under the pinned
+        # tag (the exact failure mode that broke the first rollback trial).
+        log "ERROR: pull of pinned tag $IMAGE_TAG failed — refusing to build current source under a pinned tag"
+        notify 16711680 "Deploy Failed" "Pinned image $IMAGE_TAG not found in registry"
+        exit 1
+    fi
     log "WARN: Pull failed, falling back to local build..."
     _build_commit_sha=$(git -C "$DEPLOY_DIR" rev-parse HEAD 2>/dev/null || echo "")
     if ! docker_compose build --parallel \


### PR DESCRIPTION
## What the trial actually found (correcting the earlier "passed")
The re-run rollback trial (`rollback_sha=3b26b727`, after the webhook fix #1231) **did not roll back** — it shipped *current* code mislabeled as the target. The webhook fix worked (the SHA reached `deploy.sh`), but the SHA itself was the wrong format:

- Registry images are tagged with the **7-char short SHA** (`docker/metadata-action` `type=sha,prefix=` → e.g. `3b26b72`). Confirmed: `:3b26b72` exists in ghcr, the full `:3b26b727…` does **not**.
- `rollback_sha` / `X-Deploy-SHA` passes the **full 40-char SHA**, so `deploy.sh` set `IMAGE_TAG=<full>`, the `docker compose pull` **missed**, and the existing fallback **rebuilt the current checkout** and tagged it as the target.
- Smoking gun: the running `lucky-backend:3b26b727…` image had `COMMIT_SHA=e559f426` baked in — i.e. it was a local build of current `main`, not the real `3b26b727` image. `/api/health/version` honestly reported `e559f426` (so the version endpoint was **right** — my earlier "version-source decoupling" was a misdiagnosis).

Net: rollback silently deployed current code; SHA-pinned forward deploys would needlessly rebuild every time too.

## Fix
- **Truncate `IMAGE_TAG` to the 7-char short SHA** on both the main pinned path and the auto-rollback path, so the pull hits the real registry image.
- **Abort a pinned deploy if the pull fails** instead of building current source under the pinned tag — a rollback that can't find its image should fail loudly, not ship the wrong code.
- Non-pinned (`:latest`) deploys keep the build fallback unchanged.

## Validation
- `bash -n` clean; shellcheck clean on new code.
- Homelab can't run locally; verify by re-running the rollback trial after merge + deploy: live should run the *actual* `3b26b727` image (its baked `COMMIT_SHA` = `3b26b727`, and `docker ps` shows the real tag).

## Current prod state
Healthy (HTTP 200) on current-`main` code (`e559f426`, includes all session work). The redundant roll-forward run was cancelled.

@cubic-dev-ai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rollback and pinned deploys that were rebuilding current code by using full SHAs. We now pin to 7-char image tags and fail fast if the registry image isn’t found.

- **Bug Fixes**
  - Truncate `IMAGE_TAG` to the 7-char short SHA for both pinned deploys and auto-rollback (matches `docker/metadata-action` tags).
  - For pinned/rollback deploys, abort on pull failure instead of building current source under the pinned tag; non-pinned (`:latest`) still falls back to build.

<sup>Written for commit 12b9b38088630bcfe1332573ff11d48510bd5c12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

