### PR TITLE
test(deploy): one-shot health-fail sentinel for rollback validation

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -330,6 +330,16 @@ post_deploy_status() {
 # failure (no `exit`, so the caller can decide to roll back). A slow/absent bot
 # gateway after the timeout is a non-fatal WARN, matching prior behavior.
 run_health_checks() {
+    # Test affordance (NOT for normal use): a one-shot sentinel forces a single
+    # health-check failure so the auto-rollback path can be validated against a
+    # real deploy. Lives in /tmp so the deploy's `git clean` can't remove it, and
+    # self-deletes after one use. Absent in all normal operation.
+    if [[ -f /tmp/lucky-simulate-health-fail ]]; then
+        rm -f /tmp/lucky-simulate-health-fail
+        log "TEST: simulated health-check failure (one-shot sentinel consumed)"
+        return 1
+    fi
+
     log "Waiting for health checks..."
     sleep 10
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -335,7 +335,8 @@ run_health_checks() {
     # real deploy. Lives in /tmp so the deploy's `git clean` can't remove it, and
     # self-deletes after one use. Absent in all normal operation.
     if [[ -f /tmp/lucky-simulate-health-fail ]]; then
-        rm -f /tmp/lucky-simulate-health-fail
+        # Best-effort delete; never let an undeletable sentinel abort the deploy.
+        rm -f /tmp/lucky-simulate-health-fail 2>/dev/null || true
         log "TEST: simulated health-check failure (one-shot sentinel consumed)"
         return 1
     fi


### PR DESCRIPTION
## Why
Auto-rollback (`attempt_rollback` — auto-reverts to last-good when a deploy fails its health checks) is the one part of the active-rollback deploy that's still unvalidated. It can't be safely triggered on a single-stack prod without a deliberately-broken image, and a local `deploy.sh` edit gets reverted by the deploy's own `git reset`/`git clean`.

## What
A **one-shot, file-gated test hook** at the top of `run_health_checks`: if `/tmp/lucky-simulate-health-fail` exists, it deletes the file and returns failure **once**. Outside the repo (survives `git clean`), self-clearing, and absent in all normal operation (zero impact unless someone deliberately creates the sentinel on the homelab).

## How it'll validate auto-rollback (after merge)
1. Sync homelab; confirm `.deploy-last-good-sha = 9448de4b` (proven-healthy target).
2. `touch /tmp/lucky-simulate-health-fail` on the homelab.
3. Deploy `rollback_sha=3b26b727` (a real, different image; timer is now 0 so it fires immediately).
4. Expected: deploy `3b26b727` → `run_health_checks` consumes the sentinel → returns 1 → `attempt_rollback` redeploys last-good `9448de4b` → health passes → recovers. Logs show `Auto-rollback` + `Rolled Back`; final live = `9448de4b`, healthy.

Worst case (if auto-rollback misbehaves): prod is left on `3b26b727`, a known-good version — and I'm watching via SSH with manual rollback ready.

@cubic-dev-ai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-shot test hook in `run_health_checks` to safely simulate a single health-check failure and validate auto-rollback end-to-end. If `/tmp/lucky-simulate-health-fail` exists, it's removed best-effort (`rm -f ... || true`) and the function returns failure once; otherwise behavior is unchanged.

<sup>Written for commit ded12e76d276d81c9f8f967e2ba5f6ac2d0efc16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal deployment testing capabilities to improve rollback verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->