### PR TITLE
fix(deploy): persist last-good across deploys (gitignore it)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ docs/FRONTEND_AI_STUDIO_CONTEXT.md
 # Rebuild with `/graphify --update`; do not track.
 graphify-out/
 
+
+# Deploy auto-rollback state (must survive `git clean -fd` between deploys)
+.deploy-last-good-sha


### PR DESCRIPTION
## Why (found while setting up the auto-rollback trial)
`attempt_rollback` reverts to the SHA in `.deploy-last-good-sha`, but that file is **untracked and inside the repo**, and `sync_checkout_to_origin_main` runs `git clean -fd` at the **start** of every deploy. `git clean -fd` removes untracked-not-ignored files — so each deploy **wiped the previous deploy's last-good before `attempt_rollback` could read it**. Net: auto-rollback always hit the "no distinct last-good" branch — it could never actually roll back. (Confirmed on the homelab: the file was absent.)

## Fix
Add `.deploy-last-good-sha` to `.gitignore`. `git clean -fd` (no `-x`) **skips ignored files**, so the last-good now survives between deploys. It lives in the host-bind-mounted repo dir, so it also persists across webhook-container recreates — no new mount needed.

After this lands, the first healthy deploy records last-good (persisted), and subsequent failed deploys can auto-revert to it.

@cubic-dev-ai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the last-good deploy SHA across deploys to restore working auto-rollback. Add `.deploy-last-good-sha` to `.gitignore` so `git clean -fd` doesn’t remove it; the state also survives container restarts.

<sup>Written for commit 31b3564de12cafc9b3b5806718d5e431f268755e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

