### PR TITLE
fix(deploy): record auto-rollback last-good from image commit-sha

### DIFF
--- a/docs/decisions/2026-06-05-rollback-last-good-from-image-commit-sha.md
+++ b/docs/decisions/2026-06-05-rollback-last-good-from-image-commit-sha.md
@@ -1,0 +1,85 @@
+# Record auto-rollback last-good from the deployed image's COMMIT_SHA, not git HEAD
+
+- Status: accepted
+- Date: 2026-06-05
+- Deciders: Lucas Santana
+- Supersedes: refines the auto-rollback added in [2026-06-04-deploy-time-active-rollback-over-bake-timer](2026-06-04-deploy-time-active-rollback-over-bake-timer.md)
+
+## Context
+
+`scripts/deploy.sh` `attempt_rollback()` redeploys the last known-good commit on a
+failed health check by pulling `:${last_good:0:7}` images. Last-good is recorded on
+each healthy deploy.
+
+The recorded value was **git HEAD** (`git rev-parse HEAD`). But the
+"Build & Push Docker Images" workflow (`docker-publish.yml`) is **path-filtered** —
+it only builds on changes under `packages/** prisma/** Dockerfile* nginx/**
+package*.json`. So an infra-only commit (`.gitignore`, `scripts/`, `deploy.yml`,
+docs) advances git HEAD **without building images**. Recording such a HEAD as
+last-good points the rollback at a `:<sha>` tag that does not exist in the registry,
+so `attempt_rollback`'s pull misses and the self-healing rollback fails
+("manual intervention required") — exactly when it is most needed.
+
+This was proven live on the homelab: `git HEAD = ee23de19` while the running bot
+container's baked `COMMIT_SHA = 9448de4b` (the real built image). `:ee23de1` images
+do not exist; `:9448de4` images do. (Separately, no `.deploy-last-good-sha` existed
+on the host — auto-rollback had no target at all — and the gitignore fix #1234 only
+prevents future `git clean` wipes; it does not seed one.)
+
+The manual `rollback_sha` path is unaffected — it takes an explicit built short-SHA.
+Only the automatic self-healing rollback was broken.
+
+## Decision
+
+Record last-good as the **deployed image's baked `COMMIT_SHA`**, read from
+`docker inspect lucky-bot` `.Config.Env`, instead of `git rev-parse HEAD`.
+
+- The baked `COMMIT_SHA` is, by construction, the git SHA of the commit that built
+  the running image — which therefore has `:<short>` images in the registry.
+- Source it via `docker inspect` (daemon metadata), not `docker exec printenv`, so it
+  resolves even when the container process is unhealthy/restarting.
+- Empty-guard: if the value can't be read, **keep the prior last-good** and log a
+  WARN — never overwrite a valid target with nothing.
+- `attempt_rollback` is unchanged: it still truncates to `:${last_good:0:7}`, which is
+  the registry's short-SHA tag.
+
+## Alternatives considered
+
+- **Validate git HEAD against the registry before recording** — requires ghcr auth +
+  API latency at deploy-record time, and still records HEAD (which can drift); on a
+  miss it silently keeps a stale/older target. Rejected: trades the bug for a new
+  failure point without fixing the HEAD≠image root cause.
+- **Remove the build path filter** so every push builds — wastes CI minutes and
+  registry storage on docs/infra commits and still wouldn't validate image existence.
+  Rejected: cargo-cult; root cause is "trust git HEAD", not "missing images".
+- **Pull-time fallback to `:latest` on a tag miss in `attempt_rollback`** — a band-aid
+  that masks recording a bad SHA and can roll back to a moving, unintended target.
+  Rejected: patch, not fix.
+- **Derive the last build-path-touching commit via `git log -- <paths>`** — reimplements
+  the CI path filter in bash (drifts from the workflow) and answers "which SHA can we
+  derive", not "which SHA is actually running and healthy". Rejected: solves the wrong
+  problem.
+
+## Consequences
+
+Positive:
+
+- Last-good is always an image-backed SHA → auto-rollback's pull cannot miss.
+- Semantically exact: last-good = the image that is currently running and just passed
+  health checks (true even after a local-build fallback or a pinned rollback deploy).
+- Robust to an unhealthy container at record time (inspect, not exec).
+
+Negative / neutral:
+
+- Depends on `COMMIT_SHA` being baked into the image (true since the Dockerfile ARG→ENV
+  was added; pre-baking images would read empty → keep prior last-good, safe).
+- Reads from `lucky-bot` specifically; bot and backend are built from the same commit
+  in one pipeline matrix, so their `COMMIT_SHA` always match.
+
+## Revisit when
+
+- Cascading failed deploys suggest rollback targets are unreliable → add explicit
+  registry existence validation before recording.
+- The image prune window (24h) ever races a rollback → extend retention or add a
+  pre-flight check in `attempt_rollback`.
+- The bot stops baking `COMMIT_SHA`, or bot/backend stop sharing a build → re-source.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -623,9 +623,14 @@ if run_health_checks; then
         _last_good_sha=$(docker inspect lucky-bot \
             --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null \
             | sed -n 's/^COMMIT_SHA=//p' | head -1)
-        if [[ -n "$_last_good_sha" ]]; then
-            echo "$_last_good_sha" >"$LAST_GOOD_FILE" 2>/dev/null \
+        # Only persist a well-formed git SHA (7-40 hex). A malformed value would
+        # reintroduce the very bug this guards against — rollback targeting a
+        # :<sha> tag that doesn't exist — so reject it and keep the prior last-good.
+        if [[ "$_last_good_sha" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+            printf '%s\n' "$_last_good_sha" >"$LAST_GOOD_FILE" 2>/dev/null \
                 || log "WARN: could not record last-good SHA to $LAST_GOOD_FILE"
+        elif [[ -n "$_last_good_sha" ]]; then
+            log "WARN: malformed COMMIT_SHA '$_last_good_sha' from lucky-bot; keeping prior last-good"
         else
             log "WARN: could not read COMMIT_SHA from lucky-bot; keeping prior last-good"
         fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -610,10 +610,25 @@ else
 fi
 
 if run_health_checks; then
-    # Record this SHA as the rollback target for future failed deploys.
+    # Record the rollback target for future failed deploys as the RUNNING image's
+    # baked COMMIT_SHA — not git HEAD. git HEAD drifts from the deployed image on
+    # commits that don't touch build paths (packages/prisma/Dockerfile/nginx/
+    # package.json), since those don't build new images; recording such a HEAD points
+    # attempt_rollback at a :<sha> tag that doesn't exist. The image's COMMIT_SHA is
+    # always registry-backed. Read via `docker inspect` (daemon metadata), so it
+    # resolves even if the container process is unhealthy. Empty read -> keep the
+    # prior last-good rather than clobber a valid target.
+    # See docs/decisions/2026-06-05-rollback-last-good-from-image-commit-sha.md
     if [[ -n "$DEPLOYED_SHA" ]]; then
-        echo "$DEPLOYED_SHA" >"$LAST_GOOD_FILE" 2>/dev/null \
-            || log "WARN: could not record last-good SHA to $LAST_GOOD_FILE"
+        _last_good_sha=$(docker inspect lucky-bot \
+            --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null \
+            | sed -n 's/^COMMIT_SHA=//p' | head -1)
+        if [[ -n "$_last_good_sha" ]]; then
+            echo "$_last_good_sha" >"$LAST_GOOD_FILE" 2>/dev/null \
+                || log "WARN: could not record last-good SHA to $LAST_GOOD_FILE"
+        else
+            log "WARN: could not read COMMIT_SHA from lucky-bot; keeping prior last-good"
+        fi
     fi
 
     log "Pruning old images..."


### PR DESCRIPTION
## Problem

`scripts/deploy.sh` `attempt_rollback()` redeploys the last known-good commit on a failed health check by pulling `:${last_good:0:7}` images. Last-good was recorded as **git HEAD**.

But "Build & Push Docker Images" is **path-filtered** (`packages/** prisma/** Dockerfile* nginx/** package*.json`), so infra-only commits (`.gitignore`, `scripts/`, `deploy.yml`, docs) advance git HEAD **without building images**. Recording such a HEAD points the rollback at a `:<sha>` tag that doesn't exist → pull misses → self-healing rollback fails ("manual intervention required"), exactly when it's needed.

**Proven live on the homelab:** `git HEAD = ee23de19` while the running bot image's baked `COMMIT_SHA = 9448de4b`. `:ee23de1` images don't exist; `:9448de4` do.

The manual `rollback_sha` path is unaffected (it takes an explicit built short-SHA). Only the automatic self-healing rollback was broken.

## Fix

Record last-good as the **running image's baked `COMMIT_SHA`** (always registry-backed), read via `docker inspect lucky-bot .Config.Env` so it resolves even if the container process is unhealthy. Empty read → keep the prior last-good (never clobber a valid target with nothing). `attempt_rollback` is unchanged — its `:${last_good:0:7}` truncation now always resolves to a real short-SHA tag.

~6-line change in one `run_health_checks` success branch; no interaction with the manual-rollback path.

## Decision record

Followed `/research-and-decide` (critic ACCEPT-WITH-CHANGES; the `docker inspect` source over `docker exec` came from the critic). ADR: `docs/decisions/2026-06-05-rollback-last-good-from-image-commit-sha.md`.

## Validation

- `bash -n scripts/deploy.sh` ✓; pre-commit `type:check` ✓
- Dry-tested the extraction: full SHA → `:9448de4` short tag; empty env → keep-prior branch ✓
- **Post-merge:** roll out via `workflow_dispatch` (deploy.sh isn't a build path, so merge won't auto-deploy), seed one healthy last-good, then run the simulated-health-fail trial (`/tmp/lucky-simulate-health-fail`) to confirm end-to-end auto-rollback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix auto-rollback by recording the last-good SHA from the running image’s baked `COMMIT_SHA` instead of git HEAD, and validating it’s a real hex SHA. This prevents rollbacks from pulling non-existent tags when infra-only commits advance HEAD.

- **Bug Fixes**
  - Read `COMMIT_SHA` via `docker inspect lucky-bot`; persist only if it matches a 7–40 char hex SHA. If empty or malformed, keep the prior value.
  - `attempt_rollback` unchanged; `:${last_good:0:7}` now resolves to an existing tag.
  - Manual `rollback_sha` path unaffected.

- **Migration**
  - After merge, trigger a manual deploy to seed a healthy last-good. Optional: run the simulated health-fail to verify auto-rollback.

<sup>Written for commit d906727a2a84ce3c7832dbeee3da1c07a8517ebb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced auto-rollback system to accurately record deployment version information from active containers. The system now includes safeguards to preserve existing rollback targets when version information is temporarily unavailable.

* **Documentation**
  * Added decision documentation outlining the auto-rollback version recording strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->