### PR TITLE
fix(deploy): probe nginx health on container port 8080 not 80

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -355,7 +355,7 @@ run_health_checks() {
 
     if ! wait_for_http_ready \
         "API health" \
-        "http://nginx/api/health" \
+        "http://nginx:8080/api/health" \
         '"status"[[:space:]]*:[[:space:]]*"ok"'; then
         print_targeted_logs
         log "HEALTH: API health endpoint did not become ready"
@@ -364,7 +364,7 @@ run_health_checks() {
 
     if ! wait_for_http_ready \
         "Auth config health" \
-        "http://nginx/api/health/auth-config" \
+        "http://nginx:8080/api/health/auth-config" \
         '"auth"[[:space:]]*:'; then
         print_targeted_logs
         log "HEALTH: Auth config endpoint did not become ready"


### PR DESCRIPTION
## Problem

`run_health_checks` in `scripts/deploy.sh` probes `http://nginx/api/health` and `http://nginx/api/health/auth-config` — **port 80**. But the nginx container listens on **8080** (non-root nginx; see the `docker-compose.yml` comment "Container now listens on 8080"). `deploy.sh` runs inside the `lucky-webhook` container and reaches nginx over the docker network, where port 80 has nothing listening.

**Verified live from the webhook container:**
```
http://nginx/api/health        -> 000  (wget: Connection refused)
http://nginx:8080/api/health   -> 200  {"status":"ok","redis":true,...}
```

So the deploy **health gate has been failing on every webhook-triggered deploy** since nginx moved to 8080. Containers still came up (compose `up` runs before the health check), so deploys *looked* fine, but `deploy.sh` reported failure → went to `attempt_rollback`. This **silently broke auto-rollback**: the post-rollback health check would fail the same way, so even a correct rollback target couldn't be confirmed healthy.

Surfaced while validating the auto-rollback path after #1235.

## Fix

Point both internal health probes at `http://nginx:8080/...` (the container's actual listen port; stable container-to-container regardless of the published host port).

## Validation

- `bash -n scripts/deploy.sh` ✓
- Ran `scripts/http-probe.sh` inside the webhook container: `:8080` → `200 {"status":"ok"}` ✓
- **Post-merge:** sync homelab, re-run the seed deploy (should now pass health and record last-good), then the simulated-health-fail auto-rollback trial.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deploy health checks to hit nginx on port 8080 instead of 80, restoring accurate health gating. This also re-enables auto-rollback verification that was falsely failing.

- **Bug Fixes**
  - Pointed `scripts/deploy.sh` probes to `http://nginx:8080/api/health` and `/auth-config` over the Docker network.
  - Stops false failures when nginx listens on 8080, ensuring deploys and rollbacks validate correctly.

<sup>Written for commit 540b376610da929c875dbce7c9f5c9a6f398fdb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

