### PR TITLE
ci: retry sonarcloud scan on transient 403; push scan non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,15 +280,34 @@ jobs:
             - name: Skip Sonar scan for Dependabot without token
               if: env.SONAR_TOKEN_PRESENT != 'true' && github.actor == 'dependabot[bot]'
               run: echo "Skipping SonarCloud scan — no token for Dependabot."
+            # First attempt is allowed to fail: the scanner-engine download from
+            # scanner.sonarcloud.io intermittently 403s (transient CDN/provisioning),
+            # which otherwise fails this required check and blocks merge on a flake.
             - name: SonarCloud Scan (PR — quality gate blocks merge)
+              id: sonar_pr
               if: env.SONAR_TOKEN_PRESENT == 'true' && github.event_name == 'pull_request'
+              continue-on-error: true
               uses: SonarSource/sonarqube-scan-action@v8
               with:
                   args: -Dsonar.qualitygate.wait=true
               env:
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+            # Retry once only when the first attempt failed. A real quality-gate
+            # failure fails both attempts (so merge stays blocked); a transient
+            # download 403 clears on the retry.
+            - name: SonarCloud Scan (PR) — retry once on transient failure
+              if: env.SONAR_TOKEN_PRESENT == 'true' && github.event_name == 'pull_request' && steps.sonar_pr.outcome == 'failure'
+              uses: SonarSource/sonarqube-scan-action@v8
+              with:
+                  args: -Dsonar.qualitygate.wait=true
+              env:
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+            # Push-to-main scan is informational only — its failure must never fail
+            # the job (and thereby block the build→deploy chain). continue-on-error
+            # makes "non-blocking" actually true.
             - name: SonarCloud Scan (main — informational, non-blocking)
               if: env.SONAR_TOKEN_PRESENT == 'true' && github.event_name == 'push'
+              continue-on-error: true
               uses: SonarSource/sonarqube-scan-action@v8
               with:
                   args: -Dsonar.qualitygate.wait=false


### PR DESCRIPTION
## Problem

`SonarCloud Scan` (a required check on `main` via the repo ruleset) intermittently fails because `SonarSource/sonarqube-scan-action@v8` gets **HTTP 403 downloading the scanner engine** from `scanner.sonarcloud.io` — a transient CDN/provisioning flake unrelated to code. This has blocked nearly every PR merge this cycle and even stalled the push→build→deploy chain. The push-event step is labeled *"informational, non-blocking"* yet its failure still failed the required job.

## Fix

- **PR scan:** first attempt is `continue-on-error`, then a single retry runs only `if` the first failed. A genuine quality-gate failure fails both attempts (merge stays blocked); a transient 403 clears on retry.
- **Push scan:** `continue-on-error: true` so the informational scan can never fail the required job (matching its label) — this is what was blocking the deploy chain.

Quality coverage is unchanged: the PR quality gate (`-Dsonar.qualitygate.wait=true`, ≥80% new-code coverage) still blocks merge on real failures.

## Validation

- `ci.yml` parses as valid YAML.
- Distinguishes flake from real failure by construction (real failures fail both attempts).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry the PR SonarCloud scan once on transient 403s and make the push-to-main scan truly non-blocking with continue-on-error. This stops flaky CI from blocking merges and the build/deploy chain while still failing on real quality-gate issues.

<sup>Written for commit e68384ea88c075b7876c507865512f00fc200c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

