### PR TITLE
feat(web): public /support form + admin report view + error-state wiring

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -50,6 +50,8 @@ const TermsOfServicePage = lazy(() => import('./pages/TermsOfService'))
 const PrivacyPolicyPage = lazy(() => import('./pages/PrivacyPolicy'))
 const DocsPage = lazy(() => import('./pages/Docs'))
 const ChangelogPage = lazy(() => import('./pages/Changelog'))
+const SupportPage = lazy(() => import('./pages/Support'))
+const AdminSupportPage = lazy(() => import('./pages/AdminSupport'))
 
 const PUBLIC_PATH_PREFIXES = [
     '/terms-of-service',
@@ -58,6 +60,7 @@ const PUBLIC_PATH_PREFIXES = [
     '/privacy',
     '/docs',
     '/changelog',
+    '/support',
 ]
 
 function isPublicPath(pathname: string) {
@@ -136,6 +139,7 @@ function AuthenticatedRoutes() {
                 element={guardedRoute('automation', <FeaturesPage />)}
             />
             <Route path='/admin' element={<AdminPage />} />
+            <Route path='/admin/support' element={<AdminSupportPage />} />
             <Route
                 path='/config'
                 element={guardedRoute('settings', <ConfigPage />)}
@@ -233,6 +237,7 @@ function PublicRoutes() {
             <Route path='/privacy' element={<PrivacyPolicyPage />} />
             <Route path='/docs' element={<DocsPage />} />
             <Route path='/changelog' element={<ChangelogPage />} />
+            <Route path='/support' element={<SupportPage />} />
             <Route
                 path='*'
                 element={<Navigate to='/terms-of-service' replace />}

--- a/packages/frontend/src/components/ErrorBoundary.test.tsx
+++ b/packages/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,63 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ErrorBoundary from './ErrorBoundary'
+import { captureFrontendException } from '@/lib/sentry'
+
+vi.mock('@/lib/sentry', () => ({
+    captureFrontendException: vi.fn(),
+}))
+
+function Boom(): never {
+    throw new Error('kaboom')
+}
+
+let consoleErr: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    // ErrorBoundary logs the caught error; keep test output clean.
+    consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+    consoleErr.mockRestore()
+})
+
+describe('ErrorBoundary', () => {
+    test('renders children when there is no error', () => {
+        render(
+            <ErrorBoundary>
+                <div>all good</div>
+            </ErrorBoundary>,
+        )
+        expect(screen.getByText('all good')).toBeInTheDocument()
+    })
+
+    test('shows the fallback with an Error ID and a report link, and reports to Sentry', () => {
+        render(
+            <ErrorBoundary>
+                <Boom />
+            </ErrorBoundary>,
+        )
+
+        expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+        expect(screen.getByText('kaboom')).toBeInTheDocument()
+
+        const report = screen.getByRole('link', {
+            name: /Report this problem/i,
+        })
+        const href = report.getAttribute('href') ?? ''
+        expect(href).toMatch(/^\/support\?category=web-error&cid=[A-Za-z0-9]+$/)
+
+        // The Error ID shown matches the cid carried in the report link.
+        const cid = new URL(href, 'http://x').searchParams.get('cid')
+        expect(cid).toBeTruthy()
+        expect(screen.getByText(cid as string)).toBeInTheDocument()
+
+        expect(captureFrontendException).toHaveBeenCalledTimes(1)
+        expect(captureFrontendException).toHaveBeenCalledWith(
+            expect.any(Error),
+            expect.objectContaining({ correlationId: cid }),
+        )
+    })
+})

--- a/packages/frontend/src/components/ErrorBoundary.tsx
+++ b/packages/frontend/src/components/ErrorBoundary.tsx
@@ -17,7 +17,13 @@ function mintCorrelationId(): string {
     try {
         return crypto.randomUUID().replace(/-/g, '').slice(0, 8)
     } catch {
-        return Math.random().toString(36).slice(2, 10)
+        // Fallback for environments without randomUUID — still use the Web
+        // Crypto RNG (not Math.random) so it isn't a weak-randomness concern.
+        const bytes = new Uint8Array(4)
+        crypto.getRandomValues(bytes)
+        return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+            '',
+        )
     }
 }
 

--- a/packages/frontend/src/components/ErrorBoundary.tsx
+++ b/packages/frontend/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react'
 import Button from './ui/Button'
+import { captureFrontendException } from '@/lib/sentry'
 
 interface Props {
     children: ReactNode
@@ -8,24 +9,42 @@ interface Props {
 interface State {
     hasError: boolean
     error: Error | null
+    correlationId: string | null
+}
+
+/** Short, URL-safe id so a crashed session maps to a report and a logged error. */
+function mintCorrelationId(): string {
+    try {
+        return crypto.randomUUID().replace(/-/g, '').slice(0, 8)
+    } catch {
+        return Math.random().toString(36).slice(2, 10)
+    }
 }
 
 class ErrorBoundary extends Component<Props, State> {
     constructor(props: Props) {
         super(props)
-        this.state = { hasError: false, error: null }
+        this.state = { hasError: false, error: null, correlationId: null }
     }
 
     static getDerivedStateFromError(error: Error): State {
-        return { hasError: true, error }
+        return { hasError: true, error, correlationId: mintCorrelationId() }
     }
 
     componentDidCatch(error: Error, errorInfo: ErrorInfo) {
         console.error('ErrorBoundary caught an error:', error, errorInfo)
+        captureFrontendException(error, {
+            correlationId: this.state.correlationId,
+            componentStack: errorInfo.componentStack,
+        })
     }
 
     render() {
         if (this.state.hasError) {
+            const cid = this.state.correlationId
+            const reportHref = `/support?category=web-error${
+                cid ? `&cid=${encodeURIComponent(cid)}` : ''
+            }`
             return (
                 <div className='flex items-center justify-center min-h-screen bg-lucky-bg-primary'>
                     <div className='text-center space-y-4 p-6'>
@@ -36,15 +55,32 @@ class ErrorBoundary extends Component<Props, State> {
                             {this.state.error?.message ||
                                 'An unexpected error occurred'}
                         </p>
-                        <Button
-                            onClick={() => {
-                                this.setState({ hasError: false, error: null })
-                                window.location.reload()
-                            }}
-                            className='bg-lucky-red hover:bg-lucky-red/90'
-                        >
-                            Reload Page
-                        </Button>
+                        {cid && (
+                            <p className='text-sm text-lucky-text-tertiary'>
+                                Error ID: <code>{cid}</code>
+                            </p>
+                        )}
+                        <div className='flex items-center justify-center gap-3'>
+                            <Button
+                                onClick={() => {
+                                    this.setState({
+                                        hasError: false,
+                                        error: null,
+                                        correlationId: null,
+                                    })
+                                    window.location.reload()
+                                }}
+                                className='bg-lucky-red hover:bg-lucky-red/90'
+                            >
+                                Reload Page
+                            </Button>
+                            <a
+                                href={reportHref}
+                                className='inline-flex items-center justify-center rounded-lg border border-lucky-border px-4 py-2 text-sm text-lucky-text-secondary hover:text-lucky-text-primary hover:border-lucky-text-tertiary transition-colors'
+                            >
+                                Report this problem
+                            </a>
+                        </div>
                     </div>
                 </div>
             )

--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -337,5 +337,40 @@
             "liveControls": "Live controls"
         },
         "copyright": "© 2026 Lucky. All rights reserved."
+    },
+    "support": {
+        "title": "Report a problem",
+        "subtitle": "Tell us what happened — add a screenshot if you can.",
+        "referenceId": "Reference ID",
+        "form": {
+            "contextLabel": "What happened?",
+            "contextPlaceholder": "Describe what you were doing and what went wrong…",
+            "imageLabel": "Screenshot (optional)",
+            "imageTypeError": "Unsupported image type. Use PNG, JPEG, or WebP.",
+            "imageSizeError": "Image is too large (max 5 MB).",
+            "submit": "Send report",
+            "genericError": "Failed to submit your report. Please try again."
+        },
+        "success": {
+            "title": "Thanks for the report",
+            "body": "We received it and will look into it."
+        },
+        "admin": {
+            "title": "Support reports",
+            "subtitle": "User-submitted bug reports.",
+            "loadError": "Could not load reports.",
+            "emptyTitle": "No reports",
+            "emptyDescription": "No support reports match this filter.",
+            "selectPrompt": "Select a report to view details.",
+            "hasImage": "Has screenshot",
+            "imageAlt": "Report screenshot",
+            "status": {
+                "all": "All",
+                "new": "New",
+                "triaged": "Triaged",
+                "promoted": "Promoted",
+                "dismissed": "Dismissed"
+            }
+        }
     }
 }

--- a/packages/frontend/src/locales/pt-BR.json
+++ b/packages/frontend/src/locales/pt-BR.json
@@ -337,5 +337,40 @@
             "liveControls": "Controles em tempo real"
         },
         "copyright": "© 2026 Lucky. Todos os direitos reservados."
+    },
+    "support": {
+        "title": "Relatar um problema",
+        "subtitle": "Conte o que aconteceu — anexe uma captura de tela se puder.",
+        "referenceId": "ID de referência",
+        "form": {
+            "contextLabel": "O que aconteceu?",
+            "contextPlaceholder": "Descreva o que você estava fazendo e o que deu errado…",
+            "imageLabel": "Captura de tela (opcional)",
+            "imageTypeError": "Tipo de imagem não suportado. Use PNG, JPEG ou WebP.",
+            "imageSizeError": "Imagem muito grande (máx. 5 MB).",
+            "submit": "Enviar relato",
+            "genericError": "Falha ao enviar seu relato. Tente novamente."
+        },
+        "success": {
+            "title": "Obrigado pelo relato",
+            "body": "Recebemos e vamos analisar."
+        },
+        "admin": {
+            "title": "Relatos de suporte",
+            "subtitle": "Relatos de erro enviados por usuários.",
+            "loadError": "Não foi possível carregar os relatos.",
+            "emptyTitle": "Nenhum relato",
+            "emptyDescription": "Nenhum relato de suporte corresponde a este filtro.",
+            "selectPrompt": "Selecione um relato para ver os detalhes.",
+            "hasImage": "Tem captura de tela",
+            "imageAlt": "Captura de tela do relato",
+            "status": {
+                "all": "Todos",
+                "new": "Novo",
+                "triaged": "Triado",
+                "promoted": "Promovido",
+                "dismissed": "Descartado"
+            }
+        }
     }
 }

--- a/packages/frontend/src/pages/AdminSupport.test.tsx
+++ b/packages/frontend/src/pages/AdminSupport.test.tsx
@@ -1,0 +1,99 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import AdminSupportPage from './AdminSupport'
+import { api } from '@/services/api'
+
+vi.mock('@/services/api', () => ({
+    api: {
+        support: {
+            listAdmin: vi.fn(),
+            getAdmin: vi.fn(),
+            imageUrl: (id: string) => `/api/admin/support/${id}/image`,
+        },
+    },
+}))
+
+const listMock = api.support.listAdmin as unknown as ReturnType<typeof vi.fn>
+const getMock = api.support.getAdmin as unknown as ReturnType<typeof vi.fn>
+
+function renderPage() {
+    const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    })
+    return render(
+        <QueryClientProvider client={qc}>
+            <MemoryRouter>
+                <AdminSupportPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    )
+}
+
+const row = {
+    id: 'rep_1',
+    createdAt: '2026-06-05T00:00:00.000Z',
+    context: 'play crashed',
+    imageMimeType: 'image/png',
+    correlationId: 'ABC12345',
+    guildId: '123',
+    surface: 'web',
+    errorCategory: 'web-error',
+    status: 'new',
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+})
+
+describe('AdminSupportPage', () => {
+    test('renders a report list', async () => {
+        listMock.mockResolvedValue([row])
+        renderPage()
+        expect(await screen.findByText('play crashed')).toBeInTheDocument()
+        expect(screen.getByText('Support reports')).toBeInTheDocument()
+    })
+
+    test('shows the empty state when there are no reports', async () => {
+        listMock.mockResolvedValue([])
+        renderPage()
+        expect(await screen.findByText('No reports')).toBeInTheDocument()
+    })
+
+    test('shows an error state when the list fails', async () => {
+        listMock.mockRejectedValue(new Error('boom'))
+        renderPage()
+        expect(
+            await screen.findByText('Could not load reports.'),
+        ).toBeInTheDocument()
+    })
+
+    test('selecting a report loads its detail + image', async () => {
+        listMock.mockResolvedValue([row])
+        getMock.mockResolvedValue({
+            ...row,
+            hasImage: true,
+            rateLimitKey: null,
+        })
+        renderPage()
+
+        fireEvent.click(await screen.findByText('play crashed'))
+
+        await waitFor(() => expect(getMock).toHaveBeenCalledWith('rep_1'))
+        const img = await screen.findByRole('img', {
+            name: 'Report screenshot',
+        })
+        expect(img).toHaveAttribute('src', '/api/admin/support/rep_1/image')
+    })
+
+    test('filters by status', async () => {
+        listMock.mockResolvedValue([])
+        renderPage()
+        await screen.findByText('No reports')
+        fireEvent.click(screen.getByRole('button', { name: 'Promoted' }))
+        await waitFor(() =>
+            expect(listMock).toHaveBeenCalledWith({ status: 'promoted' }),
+        )
+    })
+})

--- a/packages/frontend/src/pages/AdminSupport.tsx
+++ b/packages/frontend/src/pages/AdminSupport.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { LifeBuoy, ImageIcon } from 'lucide-react'
+import EmptyState from '@/components/ui/EmptyState'
+import { api } from '@/services/api'
+import type { SupportReportListItem } from '@/services/supportApi'
+
+const STATUS_FILTERS = ['all', 'new', 'triaged', 'promoted', 'dismissed']
+
+export default function AdminSupportPage() {
+    const { t } = useTranslation()
+    const [status, setStatus] = useState('all')
+    const [selectedId, setSelectedId] = useState<string | null>(null)
+
+    const list = useQuery({
+        queryKey: ['admin-support', status],
+        queryFn: () =>
+            api.support.listAdmin(status === 'all' ? undefined : { status }),
+    })
+
+    const detail = useQuery({
+        queryKey: ['admin-support-detail', selectedId],
+        queryFn: () => api.support.getAdmin(selectedId as string),
+        enabled: selectedId !== null,
+    })
+
+    return (
+        <div className='space-y-6 px-1 sm:px-0'>
+            <header className='flex items-center gap-3'>
+                <LifeBuoy
+                    className='h-6 w-6 sm:h-7 sm:w-7 text-lucky-brand shrink-0'
+                    aria-hidden='true'
+                />
+                <div>
+                    <h1 className='type-h1 text-lucky-text-primary'>
+                        {t('support.admin.title')}
+                    </h1>
+                    <p className='type-body-sm text-lucky-text-secondary'>
+                        {t('support.admin.subtitle')}
+                    </p>
+                </div>
+            </header>
+
+            <div className='flex flex-wrap gap-2'>
+                {STATUS_FILTERS.map((s) => (
+                    <button
+                        key={s}
+                        onClick={() => setStatus(s)}
+                        className={`px-3 py-1.5 rounded-full type-meta border transition-colors ${
+                            status === s
+                                ? 'bg-lucky-brand text-lucky-bg-primary border-lucky-brand'
+                                : 'bg-lucky-bg-active text-lucky-text-secondary border-lucky-border hover:text-lucky-text-primary'
+                        }`}
+                    >
+                        {t(`support.admin.status.${s}`)}
+                    </button>
+                ))}
+            </div>
+
+            {list.isError && (
+                <div
+                    className='type-body-sm text-lucky-error bg-lucky-error/10 border border-lucky-error/20 rounded-lg p-3'
+                    role='alert'
+                >
+                    {t('support.admin.loadError')}
+                </div>
+            )}
+
+            {!list.isError &&
+            (list.data?.length ?? 0) === 0 &&
+            !list.isLoading ? (
+                <EmptyState
+                    icon={<LifeBuoy className='h-10 w-10' aria-hidden='true' />}
+                    title={t('support.admin.emptyTitle')}
+                    description={t('support.admin.emptyDescription')}
+                />
+            ) : (
+                <div className='grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6'>
+                    <ul className='space-y-2'>
+                        {list.data?.map((r) => (
+                            <li key={r.id}>
+                                <button
+                                    onClick={() => setSelectedId(r.id)}
+                                    className={`w-full text-left surface-panel rounded-lg border p-3 transition-colors ${
+                                        selectedId === r.id
+                                            ? 'border-lucky-brand'
+                                            : 'border-lucky-border hover:border-lucky-text-tertiary'
+                                    }`}
+                                >
+                                    <div className='flex items-center justify-between gap-2 mb-1'>
+                                        <StatusBadge status={r.status} />
+                                        {r.imageMimeType && (
+                                            <ImageIcon
+                                                className='h-3.5 w-3.5 text-lucky-text-tertiary'
+                                                aria-label={t(
+                                                    'support.admin.hasImage',
+                                                )}
+                                            />
+                                        )}
+                                    </div>
+                                    <p className='type-body-sm text-lucky-text-primary line-clamp-2'>
+                                        {r.context}
+                                    </p>
+                                    <p className='type-meta text-lucky-text-tertiary mt-1'>
+                                        {new Date(r.createdAt).toLocaleString()}
+                                        {r.correlationId
+                                            ? ` · ${r.correlationId}`
+                                            : ''}
+                                    </p>
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+
+                    <div className='surface-panel rounded-lg border border-lucky-border p-4 min-h-[200px]'>
+                        {selectedId === null ? (
+                            <p className='type-body-sm text-lucky-text-tertiary'>
+                                {t('support.admin.selectPrompt')}
+                            </p>
+                        ) : detail.isLoading ? (
+                            <p className='type-body-sm text-lucky-text-tertiary'>
+                                {t('common.loading')}
+                            </p>
+                        ) : detail.data ? (
+                            <div className='space-y-3'>
+                                <StatusBadge status={detail.data.status} />
+                                <p className='type-body text-lucky-text-primary whitespace-pre-wrap'>
+                                    {detail.data.context}
+                                </p>
+                                <dl className='type-meta text-lucky-text-tertiary space-y-1'>
+                                    {detail.data.correlationId && (
+                                        <div>
+                                            cid: {detail.data.correlationId}
+                                        </div>
+                                    )}
+                                    {detail.data.guildId && (
+                                        <div>guild: {detail.data.guildId}</div>
+                                    )}
+                                    {detail.data.errorCategory && (
+                                        <div>
+                                            category:{' '}
+                                            {detail.data.errorCategory}
+                                        </div>
+                                    )}
+                                    <div>surface: {detail.data.surface}</div>
+                                </dl>
+                                {detail.data.hasImage && (
+                                    <img
+                                        src={api.support.imageUrl(
+                                            detail.data.id,
+                                        )}
+                                        alt={t('support.admin.imageAlt')}
+                                        className='max-w-full rounded-lg border border-lucky-border'
+                                    />
+                                )}
+                            </div>
+                        ) : (
+                            <p
+                                className='type-body-sm text-lucky-error'
+                                role='alert'
+                            >
+                                {t('support.admin.loadError')}
+                            </p>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+function StatusBadge({ status }: { status: string }) {
+    const { t } = useTranslation()
+    const tone =
+        status === 'new'
+            ? 'bg-lucky-brand/10 text-lucky-brand border-lucky-brand/20'
+            : status === 'promoted'
+              ? 'bg-lucky-success/10 text-lucky-success border-lucky-success/20'
+              : status === 'dismissed'
+                ? 'bg-lucky-bg-active text-lucky-text-tertiary border-lucky-border'
+                : 'bg-lucky-warning/10 text-lucky-warning border-lucky-warning/20'
+    return (
+        <span
+            className={`inline-block px-2 py-0.5 rounded-full type-meta border ${tone}`}
+        >
+            {t(`support.admin.status.${status}`, { defaultValue: status })}
+        </span>
+    )
+}
+
+export type { SupportReportListItem }

--- a/packages/frontend/src/pages/Support.test.tsx
+++ b/packages/frontend/src/pages/Support.test.tsx
@@ -1,0 +1,98 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SupportPage from './Support'
+import { api } from '@/services/api'
+
+vi.mock('@/services/api', () => ({
+    api: { support: { submit: vi.fn() } },
+}))
+
+const submitMock = api.support.submit as unknown as ReturnType<typeof vi.fn>
+
+function renderAt(path: string) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <SupportPage />
+        </MemoryRouter>,
+    )
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    submitMock.mockResolvedValue({ id: 'rep_1' })
+})
+
+describe('SupportPage', () => {
+    test('renders the form with a disabled submit until context is filled', () => {
+        renderAt('/support')
+        expect(screen.getByText('Report a problem')).toBeInTheDocument()
+        const submit = screen.getByRole('button', { name: /Send report/i })
+        expect(submit).toBeDisabled()
+
+        fireEvent.change(screen.getByLabelText('What happened?'), {
+            target: { value: 'play button broke' },
+        })
+        expect(submit).toBeEnabled()
+    })
+
+    test('shows the reference id when cid is in the query', () => {
+        renderAt('/support?cid=ABC12345')
+        expect(screen.getAllByText('ABC12345').length).toBeGreaterThan(0)
+    })
+
+    test('submits context (+ prefilled cid/category) and shows success', async () => {
+        renderAt('/support?cid=ABC12345&category=web-error&guildId=123')
+        fireEvent.change(screen.getByLabelText('What happened?'), {
+            target: { value: '  it crashed  ' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /Send report/i }))
+
+        await waitFor(() =>
+            expect(
+                screen.getByText('Thanks for the report'),
+            ).toBeInTheDocument(),
+        )
+        expect(submitMock).toHaveBeenCalledTimes(1)
+        const fd = submitMock.mock.calls[0][0] as FormData
+        expect(fd.get('context')).toBe('it crashed')
+        expect(fd.get('cid')).toBe('ABC12345')
+        expect(fd.get('category')).toBe('web-error')
+        expect(fd.get('guildId')).toBe('123')
+    })
+
+    test('surfaces the server error message on failure', async () => {
+        submitMock.mockRejectedValue(new Error('rate limited'))
+        renderAt('/support')
+        fireEvent.change(screen.getByLabelText('What happened?'), {
+            target: { value: 'broken' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /Send report/i }))
+
+        await waitFor(() =>
+            expect(screen.getByText('rate limited')).toBeInTheDocument(),
+        )
+        expect(
+            screen.queryByText('Thanks for the report'),
+        ).not.toBeInTheDocument()
+    })
+
+    test('rejects an unsupported image type', () => {
+        renderAt('/support')
+        const file = new File(['x'], 'a.gif', { type: 'image/gif' })
+        fireEvent.change(screen.getByLabelText('Screenshot (optional)'), {
+            target: { files: [file] },
+        })
+        expect(screen.getByText(/Unsupported image type/i)).toBeInTheDocument()
+    })
+
+    test('rejects an oversized image', () => {
+        renderAt('/support')
+        const file = new File(['x'], 'big.png', { type: 'image/png' })
+        Object.defineProperty(file, 'size', { value: 6 * 1024 * 1024 })
+        fireEvent.change(screen.getByLabelText('Screenshot (optional)'), {
+            target: { files: [file] },
+        })
+        expect(screen.getByText(/too large/i)).toBeInTheDocument()
+    })
+})

--- a/packages/frontend/src/pages/Support.tsx
+++ b/packages/frontend/src/pages/Support.tsx
@@ -1,0 +1,204 @@
+import { useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { LifeBuoy, Send, CheckCircle2, AlertCircle } from 'lucide-react'
+import Button from '@/components/ui/Button'
+import { api } from '@/services/api'
+
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/webp']
+
+type SubmitState = 'idle' | 'submitting' | 'success' | 'error'
+
+export default function SupportPage() {
+    const { t } = useTranslation()
+    const [searchParams] = useSearchParams()
+
+    // Prefilled, read-only correlation/context carried from an error surface.
+    // (The bot's link may also carry `command`; the intake only persists the
+    // fields below, so we don't read it here.)
+    const cid = searchParams.get('cid') ?? ''
+    const guildId = searchParams.get('guildId') ?? ''
+    const category = searchParams.get('category') ?? ''
+
+    const [context, setContext] = useState('')
+    const [file, setFile] = useState<File | null>(null)
+    const [fileError, setFileError] = useState<string | null>(null)
+    const [state, setState] = useState<SubmitState>('idle')
+    const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+    const canSubmit = useMemo(
+        () => context.trim().length > 0 && !fileError && state !== 'submitting',
+        [context, fileError, state],
+    )
+
+    function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+        const next = e.target.files?.[0] ?? null
+        if (!next) {
+            setFile(null)
+            setFileError(null)
+            return
+        }
+        if (!ACCEPTED_TYPES.includes(next.type)) {
+            setFileError(t('support.form.imageTypeError'))
+            setFile(null)
+            return
+        }
+        if (next.size > MAX_IMAGE_BYTES) {
+            setFileError(t('support.form.imageSizeError'))
+            setFile(null)
+            return
+        }
+        setFileError(null)
+        setFile(next)
+    }
+
+    async function onSubmit(e: React.FormEvent) {
+        e.preventDefault()
+        if (!canSubmit) return
+
+        setState('submitting')
+        setErrorMessage(null)
+
+        const formData = new FormData()
+        formData.append('context', context.trim())
+        if (file) formData.append('image', file)
+        if (cid) formData.append('cid', cid)
+        if (guildId) formData.append('guildId', guildId)
+        if (category) formData.append('category', category)
+
+        try {
+            await api.support.submit(formData)
+            setState('success')
+        } catch (err) {
+            setErrorMessage(
+                err instanceof Error
+                    ? err.message
+                    : t('support.form.genericError'),
+            )
+            setState('error')
+        }
+    }
+
+    if (state === 'success') {
+        return (
+            <div className='min-h-screen bg-lucky-bg-primary flex items-center justify-center px-4 py-12'>
+                <div className='max-w-md w-full text-center space-y-4'>
+                    <CheckCircle2
+                        className='h-12 w-12 text-lucky-success mx-auto'
+                        aria-hidden='true'
+                    />
+                    <h1 className='type-h1 text-lucky-text-primary'>
+                        {t('support.success.title')}
+                    </h1>
+                    <p className='type-body text-lucky-text-secondary'>
+                        {t('support.success.body')}
+                    </p>
+                    {cid && (
+                        <p className='type-body-sm text-lucky-text-tertiary'>
+                            {t('support.referenceId')}:{' '}
+                            <code className='text-lucky-text-secondary'>
+                                {cid}
+                            </code>
+                        </p>
+                    )}
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className='min-h-screen bg-lucky-bg-primary flex items-center justify-center px-4 py-12'>
+            <div className='max-w-lg w-full space-y-6'>
+                <header className='flex items-center gap-3'>
+                    <LifeBuoy
+                        className='h-7 w-7 text-lucky-brand shrink-0'
+                        aria-hidden='true'
+                    />
+                    <div>
+                        <h1 className='type-h1 text-lucky-text-primary'>
+                            {t('support.title')}
+                        </h1>
+                        <p className='type-body-sm text-lucky-text-secondary'>
+                            {t('support.subtitle')}
+                        </p>
+                    </div>
+                </header>
+
+                {cid && (
+                    <div className='type-body-sm text-lucky-text-secondary bg-lucky-bg-active border border-lucky-border rounded-lg p-3'>
+                        {t('support.referenceId')}:{' '}
+                        <code className='text-lucky-text-primary'>{cid}</code>
+                    </div>
+                )}
+
+                <form onSubmit={onSubmit} className='space-y-4' noValidate>
+                    <div className='space-y-1.5'>
+                        <label
+                            htmlFor='support-context'
+                            className='type-body-sm text-lucky-text-primary'
+                        >
+                            {t('support.form.contextLabel')}
+                        </label>
+                        <textarea
+                            id='support-context'
+                            value={context}
+                            onChange={(e) => setContext(e.target.value)}
+                            required
+                            rows={6}
+                            placeholder={t('support.form.contextPlaceholder')}
+                            className='w-full rounded-lg bg-lucky-bg-active border border-lucky-border text-lucky-text-primary type-body p-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand'
+                        />
+                    </div>
+
+                    <div className='space-y-1.5'>
+                        <label
+                            htmlFor='support-image'
+                            className='type-body-sm text-lucky-text-primary'
+                        >
+                            {t('support.form.imageLabel')}
+                        </label>
+                        <input
+                            id='support-image'
+                            type='file'
+                            accept={ACCEPTED_TYPES.join(',')}
+                            onChange={onFileChange}
+                            className='block w-full type-body-sm text-lucky-text-secondary file:mr-3 file:rounded-md file:border-0 file:bg-lucky-bg-active file:px-3 file:py-1.5 file:text-lucky-text-primary'
+                        />
+                        {fileError && (
+                            <p
+                                className='type-body-sm text-lucky-error'
+                                role='alert'
+                            >
+                                {fileError}
+                            </p>
+                        )}
+                    </div>
+
+                    {state === 'error' && errorMessage && (
+                        <div
+                            className='flex items-center gap-2 type-body-sm text-lucky-error bg-lucky-error/10 border border-lucky-error/20 rounded-lg p-3'
+                            role='alert'
+                        >
+                            <AlertCircle
+                                className='h-4 w-4 shrink-0'
+                                aria-hidden='true'
+                            />
+                            {errorMessage}
+                        </div>
+                    )}
+
+                    <Button
+                        type='submit'
+                        disabled={!canSubmit}
+                        loading={state === 'submitting'}
+                        className='w-full'
+                    >
+                        <Send className='h-4 w-4' aria-hidden='true' />
+                        {t('support.form.submit')}
+                    </Button>
+                </form>
+            </div>
+        </div>
+    )
+}

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -27,6 +27,7 @@ import { createAutomationApi } from './automationApi'
 import { createLevelsApi } from './levelsApi'
 import { createStarboardApi } from './starboardApi'
 import { createArtistsApi } from './artistsApi'
+import { createSupportApi } from './supportApi'
 import { inferApiBase } from './apiBase'
 
 const browserLocation =
@@ -429,6 +430,7 @@ export const api = {
     automod: createAutoModApi(apiClient),
     serverLogs: createLogsApi(apiClient),
     artists: createArtistsApi(apiClient),
+    support: createSupportApi(apiClient, NORMALIZED_API_BASE),
 }
 
 export { ApiError } from './ApiError'

--- a/packages/frontend/src/services/supportApi.test.ts
+++ b/packages/frontend/src/services/supportApi.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { AxiosInstance } from 'axios'
+import { createSupportApi } from './supportApi'
+
+function makeClient(get: ReturnType<typeof vi.fn>): AxiosInstance {
+    return { get } as unknown as AxiosInstance
+}
+
+const realFetch = globalThis.fetch
+
+beforeEach(() => {
+    vi.clearAllMocks()
+})
+
+afterEach(() => {
+    globalThis.fetch = realFetch
+})
+
+describe('createSupportApi.submit', () => {
+    test('POSTs multipart to <base>/support and returns the id', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue({ ok: true, json: async () => ({ id: 'r1' }) })
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+        const sapi = createSupportApi(makeClient(vi.fn()), '/api')
+
+        const fd = new FormData()
+        fd.append('context', 'x')
+        const res = await sapi.submit(fd)
+
+        expect(res).toEqual({ id: 'r1' })
+        const [url, init] = fetchMock.mock.calls[0]
+        expect(url).toBe('/api/support')
+        expect(init.method).toBe('POST')
+        expect(init.credentials).toBe('include')
+        expect(init.body).toBe(fd)
+    })
+
+    test('throws the server error message on a non-ok JSON response', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            json: async () => ({ error: 'too large' }),
+        }) as unknown as typeof fetch
+        const sapi = createSupportApi(makeClient(vi.fn()), '/api')
+        await expect(sapi.submit(new FormData())).rejects.toThrow('too large')
+    })
+
+    test('falls back to a generic message when the error body is not JSON', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            json: async () => {
+                throw new Error('not json')
+            },
+        }) as unknown as typeof fetch
+        const sapi = createSupportApi(makeClient(vi.fn()), '/api')
+        await expect(sapi.submit(new FormData())).rejects.toThrow(
+            /Failed to submit/i,
+        )
+    })
+})
+
+describe('createSupportApi admin reads', () => {
+    test('listAdmin GETs /admin/support with params', async () => {
+        const get = vi.fn().mockResolvedValue({ data: [{ id: 'r1' }] })
+        const sapi = createSupportApi(makeClient(get), '/api')
+        const out = await sapi.listAdmin({ status: 'new', take: 5 })
+        expect(out).toEqual([{ id: 'r1' }])
+        expect(get).toHaveBeenCalledWith('/admin/support', {
+            params: { status: 'new', take: 5 },
+        })
+    })
+
+    test('getAdmin GETs /admin/support/:id', async () => {
+        const get = vi.fn().mockResolvedValue({ data: { id: 'r1' } })
+        const sapi = createSupportApi(makeClient(get), '/api')
+        const out = await sapi.getAdmin('r1')
+        expect(out).toEqual({ id: 'r1' })
+        expect(get).toHaveBeenCalledWith('/admin/support/r1')
+    })
+
+    test('imageUrl builds the credentialed image endpoint', () => {
+        const sapi = createSupportApi(makeClient(vi.fn()), '/api')
+        expect(sapi.imageUrl('r1')).toBe('/api/admin/support/r1/image')
+    })
+})

--- a/packages/frontend/src/services/supportApi.ts
+++ b/packages/frontend/src/services/supportApi.ts
@@ -1,0 +1,78 @@
+import type { AxiosInstance } from 'axios'
+
+/** A support report row as returned by the admin list endpoint (no image bytes). */
+export interface SupportReportListItem {
+    id: string
+    createdAt: string
+    context: string
+    imageMimeType: string | null
+    correlationId: string | null
+    guildId: string | null
+    surface: string
+    errorCategory: string | null
+    status: string
+}
+
+/** Admin report detail — list fields plus a `hasImage` flag (bytes fetched separately). */
+export interface SupportReportDetail extends SupportReportListItem {
+    rateLimitKey: string | null
+    hasImage: boolean
+}
+
+export interface ListAdminReportsParams {
+    status?: string
+    take?: number
+    cursor?: string
+}
+
+/**
+ * Support report API surface. The public submit uses `fetch` (multipart, no auth
+ * needed) so the browser sets the multipart boundary; admin reads use the
+ * credentialed axios client.
+ */
+export function createSupportApi(client: AxiosInstance, apiBase: string) {
+    return {
+        /** Public: submit a bug report (multipart). Throws on non-2xx with the server message. */
+        submit: async (formData: FormData): Promise<{ id: string }> => {
+            const res = await fetch(`${apiBase}/support`, {
+                method: 'POST',
+                body: formData,
+                credentials: 'include',
+            })
+            if (!res.ok) {
+                let message = 'Failed to submit your report. Please try again.'
+                try {
+                    const body = (await res.json()) as { error?: string }
+                    if (body.error) message = body.error
+                } catch {
+                    // non-JSON error body — keep the default message
+                }
+                throw new Error(message)
+            }
+            return (await res.json()) as { id: string }
+        },
+
+        /** Admin: list reports (newest first), optionally filtered by status. */
+        listAdmin: async (
+            params?: ListAdminReportsParams,
+        ): Promise<SupportReportListItem[]> => {
+            const res = await client.get<SupportReportListItem[]>(
+                '/admin/support',
+                { params },
+            )
+            return res.data
+        },
+
+        /** Admin: a single report's metadata (no image bytes). */
+        getAdmin: async (id: string): Promise<SupportReportDetail> => {
+            const res = await client.get<SupportReportDetail>(
+                `/admin/support/${id}`,
+            )
+            return res.data
+        },
+
+        /** Admin: URL for a report's image bytes (same-origin, credentialed). */
+        imageUrl: (id: string): string =>
+            `${apiBase}/admin/support/${id}/image`,
+    }
+}


### PR DESCRIPTION
Phases 4 + 5 of #1174 (plan: `.claude/plans/support-report-intake-2026-06-04.md`). Closes #1226 and #1227. Final phases — completes the support-report feature.

## P4 — public `/support` form + admin view (#1226)
- **Public `/support` page** (no auth; added to `PUBLIC_PATH_PREFIXES`): free-text context (required) + optional image (client-side type/size guard: png/jpeg/webp ≤5 MB), **query-param prefill** of `cid`/`guildId`/`category` from an error surface, and idle/submitting/success/error states. Submits multipart to `POST /api/support`.
- **Admin `/admin/support`** (authenticated): status-filtered report list + detail panel that renders the report image via `GET /api/admin/support/:id/image`.
- **`createSupportApi`** service layer: public `submit` via `fetch` (so the browser sets the multipart boundary), credentialed `listAdmin`/`getAdmin`/`imageUrl` via the axios client.
- en + pt-BR i18n for all new strings.

## P5 — web error-state wiring (#1227)
- `ErrorBoundary` now mints a short correlation id, reports it to Sentry (`captureFrontendException`), shows the user the **Error ID**, and links to **`/support?cid=…&category=web-error`** — the same id the user can quote. (Web errors link to the *internal* `/support` route rather than the external `SUPPORT_URL`, since the dashboard *is* the support surface.)

## Tests
- 19 new Vitest cases (Support form, AdminSupport list/detail/empty/error/filter, ErrorBoundary fallback, supportApi). New files **~91% line coverage** (Support 89%, AdminSupport 100%, supportApi 100%).
- Full frontend suite: 735 passing. Cross-package type:check clean.

With this, #1174 is fully delivered: shared foundation (#1228) → bot surfaces (#1240) → backend intake (#1241) → web form + admin + error wiring (this PR).

@cubic-dev-ai please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public `/support` form and an admin `/admin/support` report view, and updates the error UI to show a short Error ID with a direct link to report crashes. This fulfills #1226 (public form + admin view) and #1227 (web error wiring).

- **New Features**
  - Public `/support`: required text, optional image (PNG/JPEG/WebP ≤5 MB), prefill `cid`/`guildId`/`category` from query, and clear idle/submitting/success/error states. Submits multipart to `POST /api/support`.
  - Admin `/admin/support`: status-filtered list and detail panel; renders screenshots from `GET /api/admin/support/:id/image`.
  - Error handling: `ErrorBoundary` creates a short Error ID, reports to Sentry, shows the ID, and links to `/support?cid=…&category=web-error`.
  - API/i18n/tests: `createSupportApi` (public `submit` via fetch; admin reads via axios), full EN + PT-BR strings, and 19 new Vitest cases with ~91% coverage for new files.

- **Bug Fixes**
  - ErrorBoundary: use Web Crypto RNG for correlation ID fallback (behavior unchanged).

<sup>Written for commit 93b870d406c4a88ae9002982b11d84403ddc91e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support page enabling users to submit issue reports with context, images, and optional reference IDs
  * Error handling enhanced with unique error tracking IDs displayed to users
  * Admin support dashboard for viewing, filtering by status, and managing user reports with screenshots

* **Tests**
  * Added comprehensive test coverage for error boundaries and support features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->