### PR TITLE
fix(shared): drop buggy token-overlap util + optimize levenshtein

### DIFF
--- a/decisions/2026-06-05-similarity-package-extraction.md
+++ b/decisions/2026-06-05-similarity-package-extraction.md
@@ -1,0 +1,45 @@
+# ADR 2026-06-05 — Defer publishing the `similarity` util as a standalone npm package
+
+**Status:** Accepted (decision: defer / keep internal)
+**Surfaced by:** `/extract-package` scan → `/research-and-decide`
+
+## Context
+
+`packages/shared/src/utils/similarity.ts` is a zero-dependency, ~100-LOC, well-tested
+string-similarity toolkit (`levenshteinDistance`, `levenshteinSimilarity` ratio,
+`jaccardSimilarity`, `tokenOverlapRatio`). The `/extract-package` scan flagged it as the
+repo's strongest "publishable" candidate: 0 internal-import coupling, 0 deps, and a real
+npm gap — the popular incumbent `string-similarity` is deprecated (last publish ~37 months
+ago) yet still pulls ~2M weekly downloads; alternatives are single-metric (`leven`,
+`fast-levenshtein`) or heavy (`natural`). The question: publish it as standalone OSS, or
+keep it internal to `@lucky/shared`?
+
+## Decision
+
+**Defer. Keep it internal to `@lucky/shared`.** Do not publish to npm now.
+
+Rationale (the operator is solo):
+
+- **Internal value is already captured** — it's a shared util used by 4 call sites; publishing adds zero value to Lucky's operation, only obligations.
+- **Zero demonstrated external demand.** No second project asks for it. Publishing without external pull is tax-on-future-maintenance (semver discipline, security response, issue triage) against ~zero guaranteed upside.
+- **The "2M downloads on the deprecated incumbent" is a vanity metric.** That inertia does not transfer to an unknown successor without marketing/SEO a solo operator won't do.
+- **The public API isn't ready.** `tokenOverlapRatio` is a near-duplicate of `jaccardSimilarity` (the spec even asserts they're equal), and `levenshteinDistance` uses a full O(n·m) matrix (not the two-row O(min(n,m)) variant). Shipping these bakes smells into a forever-public surface.
+- **Reversibility.** Deferring is free to reverse; a public name-claim-then-abandon damages the package and the operator's reputation. Asymmetric downside.
+
+## Alternatives considered
+
+- **Publish under a personal scope** (`@<user>/string-similarity`, best-effort/no-SLA) — rejected now: still a recurring support/semver obligation with no proven consumer. Becomes the path _if_ the revisit trigger fires.
+- **Publish unscoped as the `string-similarity` successor** — rejected: claims "community standard" stewardship a solo operator can't credibly sustain; abandonment risk is reputationally worse than never claiming it.
+- **Promote to a monorepo workspace package (unpublished)** — rejected as marginal: it already lives in a shared workspace package; no structural gain.
+- **Contribute the multi-metric API upstream to a maintained lib** — not pursued; no obvious healthy host, and it's more coordination than value right now.
+
+## Consequences
+
+- **Positive:** no new maintenance surface; Lucky keeps full freedom to evolve the similarity API; the code stays where it's already deployed and tested.
+- **Negative / watch:** the npm gap stays unfilled (acceptable — not the operator's problem to solve); if external interest ever appears it's reactive, not proactive.
+- **Independent follow-up (not gated on this decision):** the internal API has a redundant `tokenOverlapRatio` (≡ `jaccardSimilarity`) and an unoptimized Levenshtein. Worth a small internal cleanup regardless of publishing — tracked separately, optional.
+
+## Revisit when
+
+- **A concrete second consumer materializes** — another project (yours or someone else's) explicitly needs this as a standalone dependency. Then publish under a personal scope (Option 2), but FIRST make it publish-ready: consolidate `tokenOverlapRatio` into `jaccardSimilarity`, optimize Levenshtein to two-row space, add a README + CHANGELOG, and commit to a bounded (e.g. 6-month) maintenance window before reassessing.
+- Or if the operator deliberately wants a portfolio/OSS artifact and accepts the maintenance cost as a personal goal (different objective function than "ship Lucky").

--- a/packages/bot/src/services/musicRecommendation/similarityCalculator.ts
+++ b/packages/bot/src/services/musicRecommendation/similarityCalculator.ts
@@ -1,94 +1,108 @@
 import type { Track } from 'discord-player'
-import { tokenOverlapRatio } from '@lucky/shared/utils/similarity'
+import { jaccardSimilarity } from '@lucky/shared/utils/similarity'
 import type { RecommendationConfig } from './types'
 
 export function calculateTrackSimilarity(
-  trackA: Track,
-  trackB: Track,
-  config: RecommendationConfig,
+    trackA: Track,
+    trackB: Track,
+    config: RecommendationConfig,
 ): number {
-  const similarity = {
-    title: tokenOverlapRatio(trackA.title, trackB.title),
-    artist: calculateArtistSimilarity(trackA.author, trackB.author),
-    genre: calculateGenreSimilarity(trackA, trackB),
-    duration: calculateDurationSimilarity(
-      typeof trackA.duration === 'number' ? trackA.duration : parseInt(trackA.duration.toString(), 10),
-      typeof trackB.duration === 'number' ? trackB.duration : parseInt(trackB.duration.toString(), 10),
-    ),
-    tags: calculateTagSimilarity(trackA, trackB),
-  }
+    const similarity = {
+        title: jaccardSimilarity(trackA.title, trackB.title),
+        artist: calculateArtistSimilarity(trackA.author, trackB.author),
+        genre: calculateGenreSimilarity(trackA, trackB),
+        duration: calculateDurationSimilarity(
+            typeof trackA.duration === 'number'
+                ? trackA.duration
+                : parseInt(trackA.duration.toString(), 10),
+            typeof trackB.duration === 'number'
+                ? trackB.duration
+                : parseInt(trackB.duration.toString(), 10),
+        ),
+        tags: calculateTagSimilarity(trackA, trackB),
+    }
 
-  return (
-    similarity.title * 0.2 +
-    similarity.artist * config.artistWeight +
-    similarity.genre * config.genreWeight +
-    similarity.duration * config.durationWeight +
-    similarity.tags * config.tagWeight
-  )
+    return (
+        similarity.title * 0.2 +
+        similarity.artist * config.artistWeight +
+        similarity.genre * config.genreWeight +
+        similarity.duration * config.durationWeight +
+        similarity.tags * config.tagWeight
+    )
 }
 
 function calculateArtistSimilarity(artistA: string, artistB: string): number {
-  const normalizedA = artistA.toLowerCase().trim()
-  const normalizedB = artistB.toLowerCase().trim()
+    const normalizedA = artistA.toLowerCase().trim()
+    const normalizedB = artistB.toLowerCase().trim()
 
-  if (normalizedA === normalizedB) {
-    return 1.0
-  }
+    if (normalizedA === normalizedB) {
+        return 1.0
+    }
 
-  if (normalizedA.includes(normalizedB) || normalizedB.includes(normalizedA)) {
-    return 0.8
-  }
+    if (
+        normalizedA.includes(normalizedB) ||
+        normalizedB.includes(normalizedA)
+    ) {
+        return 0.8
+    }
 
-  const wordsA = normalizedA.split(/\s+/)
-  const wordsB = normalizedB.split(/\s+/)
-  const commonWords = wordsA.filter((word) => wordsB.includes(word))
+    const wordsA = normalizedA.split(/\s+/)
+    const wordsB = normalizedB.split(/\s+/)
+    const commonWords = wordsA.filter((word) => wordsB.includes(word))
 
-  if (commonWords.length > 0) {
-    return Math.min(commonWords.length / Math.max(wordsA.length, wordsB.length), 0.6)
-  }
+    if (commonWords.length > 0) {
+        return Math.min(
+            commonWords.length / Math.max(wordsA.length, wordsB.length),
+            0.6,
+        )
+    }
 
-  return 0.0
+    return 0.0
 }
 
 function calculateGenreSimilarity(_trackA: Track, _trackB: Track): number {
-  return 0.5
+    return 0.5
 }
 
-function calculateDurationSimilarity(durationA: number, durationB: number): number {
-  if (durationA === 0 || durationB === 0) {
-    return 0.5
-  }
-  const ratio = Math.min(durationA, durationB) / Math.max(durationA, durationB)
-  return ratio
+function calculateDurationSimilarity(
+    durationA: number,
+    durationB: number,
+): number {
+    if (durationA === 0 || durationB === 0) {
+        return 0.5
+    }
+    const ratio =
+        Math.min(durationA, durationB) / Math.max(durationA, durationB)
+    return ratio
 }
 
 function calculateTagSimilarity(_trackA: Track, _trackB: Track): number {
-  return 0.3
+    return 0.3
 }
 
 export function calculateDiversityScore(
-  recommendations: Track[],
-  config: RecommendationConfig,
+    recommendations: Track[],
+    config: RecommendationConfig,
 ): number {
-  if (recommendations.length <= 1) {
-    return 1.0
-  }
-
-  let totalSimilarity = 0
-  let comparisons = 0
-
-  for (let i = 0; i < recommendations.length; i++) {
-    for (let j = i + 1; j < recommendations.length; j++) {
-      const similarity = calculateTrackSimilarity(
-        recommendations[i],
-        recommendations[j],
-        config,
-      )
-      totalSimilarity += similarity
-      comparisons++
+    if (recommendations.length <= 1) {
+        return 1.0
     }
-  }
 
-  const avgSimilarity = comparisons > 0 ? totalSimilarity / comparisons : 0
-  return 1.0 - avgSimilarity
+    let totalSimilarity = 0
+    let comparisons = 0
+
+    for (let i = 0; i < recommendations.length; i++) {
+        for (let j = i + 1; j < recommendations.length; j++) {
+            const similarity = calculateTrackSimilarity(
+                recommendations[i],
+                recommendations[j],
+                config,
+            )
+            totalSimilarity += similarity
+            comparisons++
+        }
+    }
+
+    const avgSimilarity = comparisons > 0 ? totalSimilarity / comparisons : 0
+    return 1.0 - avgSimilarity
 }

--- a/packages/shared/src/utils/similarity.spec.ts
+++ b/packages/shared/src/utils/similarity.spec.ts
@@ -1,14 +1,9 @@
-import {
-    describe,
-    it,
-    expect,
-} from '@jest/globals'
+import { describe, it, expect } from '@jest/globals'
 
 import {
     levenshteinDistance,
     levenshteinSimilarity,
     jaccardSimilarity,
-    tokenOverlapRatio,
 } from './similarity'
 
 describe('Similarity Functions', () => {
@@ -80,6 +75,19 @@ describe('Similarity Functions', () => {
     })
 
     describe('jaccardSimilarity', () => {
+        it('stays bounded to [0,1] and symmetric with duplicate tokens', () => {
+            // Regression: the former tokenOverlapRatio counted duplicate tokens
+            // in the numerator but deduped the denominator, returning >1.0 and
+            // being asymmetric. Jaccard (set-based) must not.
+            expect(jaccardSimilarity('the the beatles', 'the beatles')).toBe(
+                1.0,
+            )
+            expect(jaccardSimilarity('the beatles', 'the the beatles')).toBe(
+                1.0,
+            )
+            expect(jaccardSimilarity('a a b', 'a b')).toBeLessThanOrEqual(1.0)
+        })
+
         it('should return 1.0 for identical token sets', () => {
             expect(jaccardSimilarity('hello world', 'hello world')).toBe(1.0)
         })
@@ -89,7 +97,9 @@ describe('Similarity Functions', () => {
         })
 
         it('should return 0.0 for completely disjoint token sets', () => {
-            expect(jaccardSimilarity('hello world', 'goodbye universe')).toBe(0.0)
+            expect(jaccardSimilarity('hello world', 'goodbye universe')).toBe(
+                0.0,
+            )
         })
 
         it('should calculate intersection/union correctly', () => {
@@ -124,63 +134,7 @@ describe('Similarity Functions', () => {
         })
     })
 
-    describe('tokenOverlapRatio', () => {
-        it('should return 1.0 for identical strings', () => {
-            expect(tokenOverlapRatio('hello world', 'hello world')).toBe(1.0)
-        })
-
-        it('should return 1.0 for empty strings', () => {
-            expect(tokenOverlapRatio('', '')).toBe(1.0)
-        })
-
-        it('should return 0.0 for completely disjoint tokens', () => {
-            expect(tokenOverlapRatio('hello world', 'goodbye universe')).toBe(0.0)
-        })
-
-        it('should calculate common tokens correctly', () => {
-            expect(tokenOverlapRatio('a b c', 'b c d')).toBeCloseTo(2 / 4, 5)
-        })
-
-        it('should be case-insensitive', () => {
-            expect(tokenOverlapRatio('Hello World', 'hello world')).toBe(1.0)
-        })
-
-        it('should match musicRecommendation behavior', () => {
-            const result = tokenOverlapRatio('The Beatles Greatest Hits', 'The Beatles Greatest Hits')
-            expect(result).toBe(1.0)
-        })
-
-        it('should handle single token', () => {
-            expect(tokenOverlapRatio('artist', 'artist')).toBe(1.0)
-            expect(tokenOverlapRatio('artist', 'other')).toBe(0.0)
-        })
-
-        it('should handle empty vs non-empty', () => {
-            expect(tokenOverlapRatio('', 'hello')).toBe(0.0)
-            expect(tokenOverlapRatio('hello', '')).toBe(0.0)
-        })
-
-        it('should be identical to Jaccard for token overlap', () => {
-            const str1 = 'iron maiden'
-            const str2 = 'maiden iron maiden'
-            expect(tokenOverlapRatio(str1, str2)).toBe(jaccardSimilarity(str1, str2))
-        })
-    })
-
     describe('Cross-algorithm consistency', () => {
-        it('should have Jaccard and tokenOverlapRatio produce same results', () => {
-            const testCases = [
-                ['hello world', 'hello world'],
-                ['the quick brown fox', 'quick fox'],
-                ['', ''],
-                ['single', 'multiple tokens here'],
-            ]
-
-            testCases.forEach(([str1, str2]) => {
-                expect(tokenOverlapRatio(str1, str2)).toBe(jaccardSimilarity(str1, str2))
-            })
-        })
-
         it('Levenshtein should work differently from token-based', () => {
             const str1 = 'hello'
             const str2 = 'hallo'
@@ -201,12 +155,13 @@ describe('Similarity Functions', () => {
 
         it('should handle whitespace-only strings', () => {
             expect(jaccardSimilarity('   ', '   ')).toBe(1.0)
-            expect(tokenOverlapRatio('   ', '   ')).toBe(1.0)
         })
 
         it('should handle special characters', () => {
             expect(levenshteinDistance('test!@#', 'test!@#')).toBe(0)
-            expect(jaccardSimilarity('hello world!', 'hello world?')).toBeGreaterThan(0)
+            expect(
+                jaccardSimilarity('hello world!', 'hello world?'),
+            ).toBeGreaterThan(0)
         })
     })
 })

--- a/packages/shared/src/utils/similarity.ts
+++ b/packages/shared/src/utils/similarity.ts
@@ -7,30 +7,48 @@
  * Calculate Levenshtein distance between two strings.
  * Measures the minimum number of single-character edits required to change one string into another.
  *
+ * Uses a two-row rolling buffer over the shorter string, so memory is O(min(n, m))
+ * rather than the O(n·m) of a full matrix.
+ *
  * @param str1 First string
  * @param str2 Second string
  * @returns Levenshtein distance (higher = more different)
  */
 export function levenshteinDistance(str1: string, str2: string): number {
-    const matrix: number[][] = Array(str2.length + 1)
-        .fill(0)
-        .map(() => Array(str1.length + 1).fill(0) as number[])
+    if (str1 === str2) return 0
 
-    for (let i = 0; i <= str1.length; i++) matrix[0][i] = i
-    for (let j = 0; j <= str2.length; j++) matrix[j][0] = j
-
-    for (let j = 1; j <= str2.length; j++) {
-        for (let i = 1; i <= str1.length; i++) {
-            const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1
-            matrix[j][i] = Math.min(
-                matrix[j][i - 1] + 1,
-                matrix[j - 1][i] + 1,
-                matrix[j - 1][i - 1] + indicator,
-            )
-        }
+    // Iterate columns over the shorter string so the buffers stay O(min(n, m)).
+    let a = str1
+    let b = str2
+    if (a.length > b.length) {
+        const tmp = a
+        a = b
+        b = tmp
     }
 
-    return matrix[str2.length][str1.length]
+    const m = a.length
+    const n = b.length
+    if (m === 0) return n
+
+    let prev: number[] = Array.from({ length: m + 1 }, (_, i) => i)
+    let curr: number[] = new Array(m + 1)
+
+    for (let j = 1; j <= n; j++) {
+        curr[0] = j
+        for (let i = 1; i <= m; i++) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1
+            curr[i] = Math.min(
+                curr[i - 1] + 1, // insertion
+                prev[i] + 1, // deletion
+                prev[i - 1] + cost, // substitution
+            )
+        }
+        const tmp = prev
+        prev = curr
+        curr = tmp
+    }
+
+    return prev[m]
 }
 
 /**
@@ -54,8 +72,9 @@ export function levenshteinSimilarity(str1: string, str2: string): number {
 
 /**
  * Calculate Jaccard similarity between two strings based on word/token overlap.
- * Treats strings as sets of space-separated tokens.
- * Returns 1.0 for identical token sets, 0.0 for disjoint sets.
+ * Treats strings as sets of space-separated tokens (duplicate tokens within a
+ * string collapse to one). Returns 1.0 for identical token sets, 0.0 for disjoint
+ * sets — always bounded to [0, 1] and symmetric in its arguments.
  *
  * @param strA First string
  * @param strB Second string
@@ -68,37 +87,8 @@ export function jaccardSimilarity(strA: string, strB: string): number {
     if (setA.size === 0 && setB.size === 0) return 1.0
     if (setA.size === 0 || setB.size === 0) return 0.0
 
-    const intersection = new Set([...setA].filter(x => setB.has(x)))
+    const intersection = new Set([...setA].filter((x) => setB.has(x)))
     const union = new Set([...setA, ...setB])
 
     return intersection.size / union.size
-}
-
-/**
- * Calculate token overlap ratio between two strings (custom Jaccard variant).
- * Used by musicRecommendation for its recommendation similarity metric.
- * Returns intersection size divided by union size.
- *
- * @param strA First string
- * @param strB Second string
- * @returns Token overlap ratio between 0 and 1
- */
-export function tokenOverlapRatio(strA: string, strB: string): number {
-    const normalizedA = strA.toLowerCase().trim()
-    const normalizedB = strB.toLowerCase().trim()
-
-    if (normalizedA === normalizedB) {
-        return 1.0
-    }
-
-    const wordsA = normalizedA.split(/\s+/)
-    const wordsB = normalizedB.split(/\s+/)
-    const commonWords = wordsA.filter((word) => wordsB.includes(word))
-
-    if (commonWords.length === 0) {
-        return 0.0
-    }
-
-    const union = new Set([...wordsA, ...wordsB])
-    return commonWords.length / union.size
 }


### PR DESCRIPTION
Internal cleanup of `shared/utils/similarity.ts`, surfaced by the `/extract-package` → `/research-and-decide` review of this module. Independent of the publish decision (which was **defer** — ADR bundled here).

## 1. Drop `tokenOverlapRatio` — it was buggy, not just redundant
It counted duplicate tokens in the numerator but deduped the denominator (union set), so it could return **>1.0** and was **asymmetric**:

| input | `tokenOverlapRatio` | `jaccardSimilarity` |
|---|---|---|
| `"iron maiden"` vs `"maiden iron maiden"` | 1.0 | 1.0 |
| `"maiden iron maiden"` vs `"iron maiden"` | **1.5** ❌ | 1.0 |
| `"the the beatles"` vs `"the beatles"` | **1.5** ❌ | 1.0 |

Its **one** caller — `musicRecommendation/similarityCalculator.ts`, the track-title score weighted `0.2` in the recommendation sum — now uses the set-based `jaccardSimilarity` (bounded `[0,1]`, symmetric). This **fixes latent score inflation** for titles with a repeated word. Removed the function + its tests; added a Jaccard duplicate-token regression test.

## 2. Optimize `levenshteinDistance`
Rewritten from a full `(n+1)×(m+1)` matrix to a **two-row rolling buffer over the shorter string** → `O(min(n,m))` space instead of `O(n·m)`. Behavior is identical; the existing `kitten/sitting → 3`, empty-string, unicode, and case tests cover it.

## Verification
- shared `similarity.spec` 29 pass · bot `similarityCalculator` 19 pass · **196** bot tests across similarity/dedup/recommendation suites pass · shared + bot type:check clean (nothing else imported the removed export).

Also bundles the deferral ADR `decisions/2026-06-05-similarity-package-extraction.md` (decision: keep `similarity` internal; don't publish — revisit on a real external consumer).

@cubic-dev-ai please review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the buggy token-overlap util with Jaccard similarity to fix inflated title scores in recommendations, and optimized Levenshtein distance to use O(min(n,m)) memory. Also includes an ADR deferring publishing the `similarity` util.

- **Bug Fixes**
  - Removed tokenOverlapRatio and switched the track-title metric to jaccardSimilarity (bounded [0,1], symmetric).
  - Added a duplicate-token regression test; cleaned up removed tests.

- **Performance**
  - Rewrote levenshteinDistance with a two-row rolling buffer over the shorter string to reduce memory from O(n·m) to O(min(n,m)) with identical results.

<sup>Written for commit 341c8fe829483251fc597bd357e04acd6f37677a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

