### PR TITLE
fix(shared): export utils/support subpath for prod esm resolution

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,6 +34,10 @@
             "types": "./dist/utils/monitoring/index.d.ts",
             "default": "./dist/utils/monitoring/index.js"
         },
+        "./utils/support": {
+            "types": "./dist/utils/support/index.d.ts",
+            "default": "./dist/utils/support/index.js"
+        },
         "./utils/*": {
             "types": "./dist/utils/*.d.ts",
             "default": "./dist/utils/*.js"


### PR DESCRIPTION
## P1 — production deploy regression (prod stuck on #1240)

**Symptom:** every "Deploy to Homelab" since #1240 fails — the backend `/api/health` never becomes ready, so the auto-rollback reverts to last-good `1cc004b` (#1240). Prod has been stuck on #1240 all session (6 merges unshipped). Containers themselves are healthy; the rollback kept prod up.

**Root cause** (reproduced on the homelab by running the failing backend image):
```
ERR_MODULE_NOT_FOUND: Cannot find module '/app/node_modules/@lucky/shared/dist/utils/support.js'
  imported from /app/packages/backend/dist/routes/support.js
```
The backend support route (#1241) imports `@lucky/shared/utils/support` — a **directory barrel** (`dist/utils/support/index.js`). Shared's `exports` map only covered it via the `./utils/*` wildcard → `./dist/utils/support.js` (a flat file that doesn't exist). Node ESM exports resolution does **not** fall back to a directory index, so the backend crashed at `setupRoutes` on boot. It passed CI + local build + tests because workspace/TypeScript resolution *does* do directory→index — only the prod ESM image hit it (same "passes CI, breaks prod" shape as the prior prisma/esbuild deploy breaks).

## Fix
Add an explicit `"./utils/support"` export entry pointing at `dist/utils/support/index.js`, mirroring the existing `"./utils/monitoring"` entry. 4-line additive change.

## Verified
- `node -e import('@lucky/shared/utils/support')` now resolves with all 4 exports (was `ERR_MODULE_NOT_FOUND` before).
- Confirmed on the homelab: `multer` resolves, DB migration applied — `utils/support` was the sole blocker.
- `verify:shared-exports` passes; backend type:check clean.

## Follow-up (not in this PR)
`scripts/verify-shared-exports.mjs` only scans `@lucky/shared/services/*` imports — it never checked `utils/*`, which is why this shipped. Hardening it to verify every consumer-imported subpath is filed separately.

@cubic-dev-ai please review — this is a P1 to restore deploys.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix production ESM resolution by explicitly exporting `./utils/support` in `@lucky/shared`, so `@lucky/shared/utils/support` resolves in Node and the backend boots. This unblocks stuck deploys since #1240.

- **Bug Fixes**
  - Add `./utils/support` export pointing to `dist/utils/support/index.js` (matches the directory barrel import and mirrors `./utils/monitoring`).

<sup>Written for commit 74cc148f509ca0366fa3236dd226fe41d71523fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public export path for the support utilities module, making it available for direct imports from the shared package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->