### PR TITLE
fix(shared): export config/* subpath for prod esm resolution

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,10 @@
             "types": "./dist/config/index.d.ts",
             "default": "./dist/config/index.js"
         },
+        "./config/*": {
+            "types": "./dist/config/*.d.ts",
+            "default": "./dist/config/*.js"
+        },
         "./services": {
             "types": "./dist/services/index.d.ts",
             "default": "./dist/services/index.js"


### PR DESCRIPTION
## P1 follow-on — second layer of the deploy break

#1248 fixed `@lucky/shared/utils/support`; the prod backend then failed one import deeper:
```
ERR_PACKAGE_PATH_NOT_EXPORTED: './config/config' is not defined by "exports"
  imported from backend/dist/routes/support.js
```
The #1241 support route also imports `@lucky/shared/config/config` (`getSupportUrl`). Shared's exports map had only `./config` (the barrel) — no `./config/*` wildcard — so the specific file subpath wasn't exported → backend crash → auto-rollback (prod still on #1240).

## Fix
Add a `./config/*` wildcard export (mirroring the existing `./utils/*` and `./services/*`), resolving `config/config` → `dist/config/config.js`.

## Why this is the last layer (whole-class check)
Rather than peel one import per deploy, I scanned **all 21 distinct `@lucky/shared/*` subpath imports** across backend/bot/frontend and `import()`-tested each against the built exports map:
- Before: `config/config` + `utils/support` (fixed in #1248) unresolved.
- After this PR: **all runtime subpaths resolve.** The only remaining unexported specifier is `@lucky/shared/generated/prisma/models/CustomCommand` — an **`import type`** (erased at compile; never executed — it's been running in prod on #1240), so not a runtime risk. (The `verify-shared-exports` hardening #1249 will formalize this scan.)

## Verified
`import('@lucky/shared/config/config')` → `getSupportUrl` resolves; `verify:shared-exports` passes; backend type:check clean.

@cubic-dev-ai please review — P1, restores deploys.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export `config/*` subpaths from `@lucky/shared` to fix ESM resolution for `@lucky/shared/config/config`. This resolves runtime import errors in the backend and unblocks deploys.

- Bug Fixes
  - Added `./config/*` to the `exports` map with `types` and `default` pointing to `dist/config/*.d.ts` and `dist/config/*.js`.
  - Confirmed all runtime `@lucky/shared/*` subpath imports resolve; only a type-only generated Prisma import remains (not executed at runtime).

<sup>Written for commit 25d3f1df5137226ef1fa9966482d6e0f33cb94d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

