### PR TITLE
test(shared): fix undefined fail() and unmasked matcher misuse in env test

### DIFF
--- a/packages/shared/src/__tests__/config/environment.test.ts
+++ b/packages/shared/src/__tests__/config/environment.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, beforeEach, afterEach } from '@jest/globals'
-import { validateBackendEnvironment, ensureEnvironment } from '../../config/environment'
+import {
+    validateBackendEnvironment,
+    ensureEnvironment,
+} from '../../config/environment'
 
 // These tests verify the cubic findings applied to environment.ts:
 // P2 #1: isMissingVariable treats whitespace-only strings as missing
@@ -29,7 +32,9 @@ describe('environment.ts - cubic findings verification', () => {
 
             expect(() => {
                 validateBackendEnvironment()
-            }).toThrow('Missing required backend environment variables: REDIS_HOST')
+            }).toThrow(
+                'Missing required backend environment variables: REDIS_HOST',
+            )
         })
 
         it('should reject tab-only REDIS_HOST', () => {
@@ -84,7 +89,7 @@ describe('environment.ts - cubic findings verification', () => {
             delete process.env.DATABASE_URL
 
             await expect(ensureEnvironment()).rejects.toThrow(
-                'Missing required environment variables: DATABASE_URL'
+                'Missing required environment variables: DATABASE_URL',
             )
         })
 
@@ -94,7 +99,7 @@ describe('environment.ts - cubic findings verification', () => {
             process.env.DATABASE_URL = 'url'
 
             await expect(ensureEnvironment()).rejects.toThrow(
-                'Missing required environment variables: DISCORD_TOKEN'
+                'Missing required environment variables: DISCORD_TOKEN',
             )
         })
 
@@ -103,14 +108,11 @@ describe('environment.ts - cubic findings verification', () => {
             delete process.env.CLIENT_ID
             delete process.env.DATABASE_URL
 
-            try {
-                await ensureEnvironment()
-                fail('should have thrown')
-            } catch (e: any) {
-                expect(e.message).toContain('DISCORD_TOKEN')
-                expect(e.message).toContain('CLIENT_ID')
-                expect(e.message).toContain('DATABASE_URL')
-            }
+            const error = await ensureEnvironment().catch((e: any) => e)
+            expect(error).toBeInstanceOf(Error)
+            expect(error.message).toContain('DISCORD_TOKEN')
+            expect(error.message).toContain('CLIENT_ID')
+            expect(error.message).toContain('DATABASE_URL')
         })
 
         it('should not throw when all required environment variables are present', async () => {
@@ -129,7 +131,7 @@ describe('environment.ts - cubic findings verification', () => {
             process.env.DATABASE_URL = 'url'
 
             await expect(ensureEnvironment()).rejects.toThrow(
-                expect.stringContaining('Missing required environment variables')
+                'Missing required environment variables',
             )
         })
 
@@ -141,21 +143,13 @@ describe('environment.ts - cubic findings verification', () => {
 
             expect(() => {
                 validateBackendEnvironment()
-            }).toThrow(
-                expect.stringContaining('Missing required backend environment variables')
-            )
+            }).toThrow('Missing required backend environment variables')
         })
 
         it('should include variable names in both assertion types', () => {
             delete process.env.DISCORD_TOKEN
             process.env.CLIENT_ID = 'id'
             process.env.DATABASE_URL = 'url'
-
-            // Test required vars assertion format
-            expect(() => {
-                // We can't directly call the private function, but we test via ensureEnvironment
-                // which internally calls the assertion
-            }).not.toThrow()
 
             delete process.env.REDIS_HOST
             process.env.SPOTIFY_CLIENT_ID = 'id'
@@ -164,7 +158,7 @@ describe('environment.ts - cubic findings verification', () => {
 
             expect(() => {
                 validateBackendEnvironment()
-            }).toThrow(expect.stringContaining('REDIS_HOST'))
+            }).toThrow('REDIS_HOST')
         })
 
         it('should handle multiple missing backend variables', () => {


### PR DESCRIPTION
Closes #1243.

`packages/shared/src/__tests__/config/environment.test.ts` had a jasmine `fail()` (undefined under jest-circus → TS2304 + runtime error) whose compile failure was masking three `toThrow(expect.stringContaining(...))` assertions (`toThrow` does not accept asymmetric matchers).

- Replace `fail()` with controlled error-message assertions — a failing assertion now prints only the error message (var names), never raw `process.env`.
- Fix the three `toThrow(expect.stringContaining(...))` → plain-string substring match.

Whole suite green: 13/13 passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes environment tests in `packages/shared` to prevent `process.env` leakage on failures and keep the suite green.

- **Bug Fixes**
  - Replaced `jasmine` `fail()` with explicit error assertions and safe async capture; removed a redundant no-op assertion for clarity.
  - Replaced all `toThrow(expect.stringContaining(...))` uses with plain-string checks and explicit variable names (e.g., `REDIS_HOST`, `DATABASE_URL`) for deterministic messages.

<sup>Written for commit ecad87805fe53f7141f8705cbd17d03c3a83ccf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved environment validation test coverage with more precise error message assertions and refactored test structure for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->