### PR TITLE
security(backend): trim auth tokens and secrets before empty checks

### DIFF
--- a/packages/backend/src/middleware/session.ts
+++ b/packages/backend/src/middleware/session.ts
@@ -273,7 +273,7 @@ function createLocalFallbackStore(sessionPath: string): session.Store {
 }
 
 export function setupSessionMiddleware(app: Express): void {
-    const sessionSecret = process.env.WEBAPP_SESSION_SECRET
+    const sessionSecret = process.env.WEBAPP_SESSION_SECRET?.trim()
 
     if (!sessionSecret) {
         throw new Error(

--- a/packages/backend/src/routes/internalNotify.ts
+++ b/packages/backend/src/routes/internalNotify.ts
@@ -7,7 +7,7 @@ import { errorLog } from '@lucky/shared/utils'
 const DISCORD_API = 'https://discord.com/api/v10'
 
 function requireKey(req: Request): void {
-    const provided = req.header('x-notify-key')
+    const provided = req.header('x-notify-key')?.trim()
     const expected = process.env.LUCKY_NOTIFY_API_KEY
     if (!expected || !provided || provided !== expected) {
         throw AppError.unauthorized('invalid notify key')
@@ -28,9 +28,7 @@ export function setupInternalNotifyRoutes(app: Express): void {
             requireKey(req)
             const body = (req.body ?? {}) as NotifyBody
             if (!body.channelId || (!body.content && !body.embeds)) {
-                throw AppError.badRequest(
-                    'channelId + content|embeds required',
-                )
+                throw AppError.badRequest('channelId + content|embeds required')
             }
             const token = process.env.DISCORD_TOKEN
             if (!token) {

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -80,7 +80,7 @@ function verifyTopggAuth(req: Request): void {
     if (!expected) {
         throw new AppError(503, 'TOPGG_AUTH_TOKEN not configured')
     }
-    const provided = req.header('authorization')
+    const provided = req.header('authorization')?.trim()
     if (!provided || !safeEqualString(provided, expected)) {
         throw AppError.unauthorized('invalid top.gg webhook token')
     }
@@ -88,7 +88,7 @@ function verifyTopggAuth(req: Request): void {
 
 function verifyInternalKey(req: Request): void {
     const expected = process.env.LUCKY_NOTIFY_API_KEY
-    const provided = req.header('x-notify-key')
+    const provided = req.header('x-notify-key')?.trim()
     if (!expected || !provided || !safeEqualString(provided, expected)) {
         throw AppError.unauthorized('invalid internal key')
     }

--- a/packages/backend/tests/unit/middleware/session.test.ts
+++ b/packages/backend/tests/unit/middleware/session.test.ts
@@ -49,6 +49,23 @@ describe('Session Middleware', () => {
         }
     })
 
+    test('should throw when WEBAPP_SESSION_SECRET is whitespace-only', async () => {
+        const { setupSessionMiddleware } =
+            await import('../../../src/middleware/session')
+        const originalSecret = process.env.WEBAPP_SESSION_SECRET
+        process.env.WEBAPP_SESSION_SECRET = '   '
+
+        expect(() => {
+            setupSessionMiddleware(app)
+        }).toThrow('WEBAPP_SESSION_SECRET environment variable is required')
+
+        if (originalSecret) {
+            process.env.WEBAPP_SESSION_SECRET = originalSecret
+        } else {
+            delete process.env.WEBAPP_SESSION_SECRET
+        }
+    })
+
     test('should configure session with correct settings', async () => {
         const { setupSessionMiddleware } =
             await import('../../../src/middleware/session')

--- a/packages/backend/tests/unit/routes/internalNotify.test.ts
+++ b/packages/backend/tests/unit/routes/internalNotify.test.ts
@@ -124,4 +124,12 @@ describe('POST /api/internal/notify', () => {
             .send({ channelId: '1', content: 'x' })
         expect(res.status).toBe(500)
     })
+
+    it('rejects whitespace-only x-notify-key header', async () => {
+        const res = await request(buildApp())
+            .post('/api/internal/notify')
+            .set('x-notify-key', '   ')
+            .send({ channelId: '1', content: 'hi' })
+        expect(res.status).toBe(401)
+    })
 })

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -116,6 +116,14 @@ describe('POST /webhooks/topgg-votes', () => {
         expect(res.status).toBe(401)
     })
 
+    it('rejects whitespace-only authorization header', async () => {
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', '   ')
+            .send({ user: '1', type: 'upvote' })
+        expect(res.status).toBe(401)
+    })
+
     it('accepts test-type payload and returns { ok, test }', async () => {
         const res = await request(buildApp())
             .post('/webhooks/topgg-votes')
@@ -166,6 +174,13 @@ describe('GET /api/internal/votes/:userId', () => {
         const res = await request(buildApp())
             .get('/api/internal/votes/123456789012345678')
             .set('x-notify-key', 'wrong')
+        expect(res.status).toBe(401)
+    })
+
+    it('rejects GET with whitespace-only x-notify-key', async () => {
+        const res = await request(buildApp())
+            .get('/api/internal/votes/123456789012345678')
+            .set('x-notify-key', '   ')
         expect(res.status).toBe(401)
     })
 
@@ -281,7 +296,6 @@ describe('POST /webhooks/topgg-votes persistence', () => {
         expect(pipelineMock.expire).not.toHaveBeenCalled()
     })
 
-
     it('rejects unsafe non-snowflake user ids before writing to Redis', async () => {
         const res = await request(buildApp())
             .post('/webhooks/topgg-votes')
@@ -290,5 +304,4 @@ describe('POST /webhooks/topgg-votes persistence', () => {
         expect(res.status).toBe(400)
         expect(redisEval).not.toHaveBeenCalled()
     })
-
 })


### PR DESCRIPTION
Closes #1201.

Whitespace-only auth values bypassed empty checks. Trim before validating/comparing in:
- `routes/internalNotify.ts` — `x-notify-key` header
- `routes/webhooks.ts` — top.gg `authorization` header + internal `x-notify-key`
- `middleware/session.ts` — `WEBAPP_SESSION_SECRET` (whitespace-only no longer passes `!secret`)

Added focused tests asserting whitespace-only token/secret is rejected. Affected suites green (51 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim auth headers and env secrets before validation so whitespace-only values can’t bypass checks. Hardens webhook and internal routes, and fails fast on misconfigured session secrets.

- **Bug Fixes**
  - Trim `x-notify-key` in `internalNotify` and webhook routes; trim `authorization` for top.gg webhooks.
  - Trim `WEBAPP_SESSION_SECRET` before empty check to reject whitespace-only values.
  - Added tests for whitespace-only tokens/secrets; all affected suites pass.

<sup>Written for commit 4e625583a1596fbe741e4b784b8c30892b0c5ce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

