### PR TITLE
fix(bot): validate text-based channel before send in embed command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1468,7 +1468,7 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1478,7 +1478,7 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1512,7 +1512,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
             "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -1810,7 +1810,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -2654,6 +2654,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
             "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2665,6 +2666,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
             "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2675,6 +2677,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
             "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -4839,7 +4842,7 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
             "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -10219,7 +10222,7 @@
             "version": "1.15.40",
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
             "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10464,14 +10467,14 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@swc/types": {
             "version": "0.1.26",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
             "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -11434,6 +11437,7 @@
             "version": "19.2.15",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
             "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -11443,7 +11447,7 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -14561,6 +14565,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/dargs": {
@@ -19765,7 +19770,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
             "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -20272,7 +20277,7 @@
             "version": "3.3.12",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
             "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -21216,7 +21221,7 @@
             "version": "8.5.15",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
             "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -23419,6 +23424,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
             "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/tailwindcss-animate": {
@@ -23945,7 +23951,7 @@
             "version": "4.22.3",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
             "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.28.0"
@@ -24880,7 +24886,7 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"

--- a/packages/bot/src/functions/management/commands/embed.spec.ts
+++ b/packages/bot/src/functions/management/commands/embed.spec.ts
@@ -47,6 +47,7 @@ function createChatInputInteraction(
 		channel: {
 			id: 'channel-123',
 			send: jest.fn(),
+			isTextBased: jest.fn().mockReturnValue(true),
 		},
 		user: {
 			id: 'user-123',
@@ -201,6 +202,7 @@ describe('embed command', () => {
 			const mockChannel = {
 				id: 'channel-456',
 				send: jest.fn(),
+				isTextBased: jest.fn().mockReturnValue(true),
 			}
 
 			embedBuilderServiceMock.getTemplate.mockResolvedValue({
@@ -339,6 +341,47 @@ describe('embed command', () => {
 
 			await embedCommand.execute({ interaction })
 
+			expect(interactionReplyMock).toHaveBeenCalledWith({
+				interaction,
+				content: {
+					content: '❌ Invalid channel.',
+				},
+			})
+		})
+
+		it('rejects send to non-text-based channel', async () => {
+			embedBuilderServiceMock.getTemplate.mockResolvedValue({
+				id: 'template-1',
+				name: 'test',
+				guildId: 'guild-123',
+				title: 'Test',
+				description: null,
+				color: null,
+				footer: null,
+				thumbnail: null,
+				image: null,
+				fields: null,
+				useCount: 0,
+				createdBy: 'user-123',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			})
+
+			// Channel with a send method but not text-based (isTextBased() false)
+			const nonTextChannel = {
+				id: 'channel-456',
+				send: jest.fn(),
+				isTextBased: jest.fn().mockReturnValue(false),
+			}
+
+			const interaction = createChatInputInteraction('send', {
+				template: 'test',
+				channel: nonTextChannel,
+			})
+
+			await embedCommand.execute({ interaction })
+
+			expect(nonTextChannel.send).not.toHaveBeenCalled()
 			expect(interactionReplyMock).toHaveBeenCalledWith({
 				interaction,
 				content: {

--- a/packages/bot/src/functions/management/commands/embed.ts
+++ b/packages/bot/src/functions/management/commands/embed.ts
@@ -180,6 +180,18 @@ export default new Command({
                     return
                 }
 
+                const targetChannel =
+                    channel && 'send' in channel && channel.isTextBased()
+                        ? (channel as TextChannel)
+                        : null
+                if (!targetChannel) {
+                    await interactionReply({
+                        interaction,
+                        content: { content: '❌ Invalid channel.' },
+                    })
+                    return
+                }
+
                 const embed = new EmbedBuilder()
                 if (template.title) embed.setTitle(template.title)
                 if (template.description)
@@ -195,31 +207,20 @@ export default new Command({
                     embed.addFields(template.fields as EmbedField[])
                 }
 
-                const targetChannel =
-                    channel && 'send' in channel
-                        ? (channel as TextChannel)
-                        : null
-                if (targetChannel) {
-                    await targetChannel.send({ embeds: [embed] })
-                    await embedBuilderService.incrementUsage(
-                        interaction.guild.id,
-                        templateName,
-                    )
+                await targetChannel.send({ embeds: [embed] })
+                await embedBuilderService.incrementUsage(
+                    interaction.guild.id,
+                    templateName,
+                )
 
-                    await interactionReply({
-                        interaction,
-                        content: { content: `✅ Embed sent to ${channel}` },
-                    })
+                await interactionReply({
+                    interaction,
+                    content: { content: `✅ Embed sent to ${channel}` },
+                })
 
-                    infoLog({
-                        message: `Embed template "${templateName}" sent by ${interaction.user.tag} in ${interaction.guild.name}`,
-                    })
-                } else {
-                    await interactionReply({
-                        interaction,
-                        content: { content: '❌ Invalid channel.' },
-                    })
-                }
+                infoLog({
+                    message: `Embed template "${templateName}" sent by ${interaction.user.tag} in ${interaction.guild.name}`,
+                })
             } else if (subcommand === 'list') {
                 const templates = await embedBuilderService.listTemplates(
                     interaction.guild.id,


### PR DESCRIPTION
Closes #1192.

The embed `send` subcommand attempted `channel.send()` without checking the channel is text-based, so a voice/category channel silently no-op'd. Now guards `channel.isTextBased()` up front and replies `❌ Invalid channel.` otherwise.

Added a test for the non-text-channel path. embed.spec green (116 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded the embed `send` subcommand to only send to text-based channels. If the channel isn’t text-based, it replies "❌ Invalid channel." and stops, preventing silent no-ops on voice/category channels.

- **Bug Fixes**
  - Check `channel.isTextBased()` and `send` before sending; return early on invalid channels.
  - Updated tests: default mocks set `isTextBased: true`; added a case that rejects sending to non-text channels.

<sup>Written for commit 9b556e05db20593791f0c2f52917098bde7085bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

