### PR TITLE
ci: harden verify-shared-exports to cover all @lucky/shared subpaths

### DIFF
--- a/scripts/verify-shared-exports.mjs
+++ b/scripts/verify-shared-exports.mjs
@@ -35,8 +35,14 @@ async function collectSourceFiles(dir) {
     let entries
     try {
         entries = await readdir(dir, { withFileTypes: true })
-    } catch {
-        return [] // package may be absent in some checkouts
+    } catch (error) {
+        // The three consumer roots are this gate's contract. A missing/renamed
+        // src tree must fail loudly — silently returning [] would pass green with
+        // reduced coverage, exactly the blind spot this check exists to close.
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(
+            `Unable to scan consumer source dir "${path.relative(repoRoot, dir)}": ${message}`,
+        )
     }
     const nested = await Promise.all(
         entries.map(async (entry) => {

--- a/scripts/verify-shared-exports.mjs
+++ b/scripts/verify-shared-exports.mjs
@@ -2,54 +2,99 @@ import { readdir, readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 
+// Verifies that every `@lucky/shared/<subpath>` specifier imported by a consumer
+// package resolves against the BUILT shared package + its `exports` map — i.e. the
+// thing that crashes the prod ESM Docker image but passes ts-jest/tsc (which resolve
+// from source). Run AFTER `build:shared`. See incident: a `@lucky/shared/utils/support`
+// directory-barrel import only matched the `./utils/*` wildcard (flat file) →
+// ERR_MODULE_NOT_FOUND in prod → backend crash → auto-rollback (#1248/#1249).
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(scriptDir, '..')
-const backendSrcDir = path.join(repoRoot, 'packages/backend/src')
-const requiredSubpaths = new Set(['guildAutomation/manifestSchema'])
 
-async function collectTsFiles(dir) {
-    const entries = await readdir(dir, { withFileTypes: true })
-    const files = await Promise.all(
+// Consumer packages whose PROD source imports @lucky/shared at runtime.
+const consumerSrcDirs = [
+    'packages/backend/src',
+    'packages/bot/src',
+    'packages/frontend/src',
+].map((p) => path.join(repoRoot, p))
+
+// Only these codes mean "the build/exports map cannot resolve this specifier" — the
+// deploy-break class. A module that RESOLVES but throws at load (missing env, side
+// effects) is out of scope here and must not fail this gate.
+const RESOLUTION_ERROR_CODES = new Set([
+    'ERR_MODULE_NOT_FOUND',
+    'ERR_PACKAGE_PATH_NOT_EXPORTED',
+    'ERR_UNSUPPORTED_DIR_IMPORT',
+    'ERR_PACKAGE_IMPORT_NOT_DEFINED',
+])
+
+const isTestFile = (name) => /\.(spec|test)\.(ts|tsx)$/.test(name)
+
+async function collectSourceFiles(dir) {
+    let entries
+    try {
+        entries = await readdir(dir, { withFileTypes: true })
+    } catch {
+        return [] // package may be absent in some checkouts
+    }
+    const nested = await Promise.all(
         entries.map(async (entry) => {
             const entryPath = path.join(dir, entry.name)
             if (entry.isDirectory()) {
-                return collectTsFiles(entryPath)
+                if (entry.name === '__tests__' || entry.name === 'node_modules')
+                    return []
+                return collectSourceFiles(entryPath)
             }
-            return entry.isFile() && entry.name.endsWith('.ts') ? [entryPath] : []
+            return entry.isFile() &&
+                /\.(ts|tsx)$/.test(entry.name) &&
+                !isTestFile(entry.name)
+                ? [entryPath]
+                : []
         }),
     )
-    return files.flat()
+    return nested.flat()
 }
 
-async function collectSharedSubpaths() {
-    const tsFiles = await collectTsFiles(backendSrcDir)
-    for (const filePath of tsFiles) {
-        const fileContent = await readFile(filePath, 'utf8')
-        for (const match of fileContent.matchAll(/@lucky\/shared\/services\/([^'"]+)/g)) {
-            requiredSubpaths.add(match[1])
+// `import …/export … from '@lucky/shared…'` — group 1 captures a leading `type ` so
+// type-only statements (erased at build, never resolved at runtime) are skipped.
+const FROM_RE =
+    /(?:import|export)\s+(type\s+)?[^;'"]*?from\s+['"](@lucky\/shared[^'"]*)['"]/g
+// Bare side-effect import: `import '@lucky/shared/x'`.
+const BARE_RE = /(?:^|\n)\s*import\s+['"](@lucky\/shared[^'"]*)['"]/g
+
+async function collectSpecifiers() {
+    const specifiers = new Set()
+    for (const dir of consumerSrcDirs) {
+        for (const filePath of await collectSourceFiles(dir)) {
+            const content = await readFile(filePath, 'utf8')
+            for (const m of content.matchAll(FROM_RE)) {
+                if (m[1]) continue // `import type …` — erased, no runtime resolution
+                specifiers.add(m[2])
+            }
+            for (const m of content.matchAll(BARE_RE)) specifiers.add(m[1])
         }
     }
+    return [...specifiers].sort()
 }
 
 const failures = []
-
+let specifiers = []
 try {
-    await collectSharedSubpaths()
-
-    for (const subpath of requiredSubpaths) {
-        const specifier = `@lucky/shared/services/${subpath}`
+    specifiers = await collectSpecifiers()
+    for (const specifier of specifiers) {
         try {
             await import(specifier)
         } catch (error) {
-            const message = error instanceof Error ? error.message : String(error)
             const code =
-                typeof error === 'object' &&
-                error !== null &&
-                'code' in error &&
-                typeof error.code === 'string'
-                    ? error.code
+                error && typeof error === 'object' && 'code' in error
+                    ? String(error.code)
                     : 'UNKNOWN'
-            failures.push(`${specifier} -> ${code}: ${message}`)
+            if (RESOLUTION_ERROR_CODES.has(code)) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                failures.push(`${specifier} -> ${code}: ${message}`)
+            }
         }
     }
 } catch (error) {
@@ -59,10 +104,16 @@ try {
 
 if (failures.length > 0) {
     console.error('Shared export verification failed:')
-    for (const failure of failures) {
-        console.error(`- ${failure}`)
-    }
+    for (const failure of failures) console.error(`- ${failure}`)
+    console.error(
+        '\nFix: add an explicit `exports` entry in packages/shared/package.json for the\n' +
+            'subpath. Directory barrels need their own entry — the `./utils/*` / `./services/*`\n' +
+            'style wildcards map only FLAT files, not directories. Or import via an\n' +
+            'already-exported barrel (e.g. `@lucky/shared/utils`).',
+    )
     process.exit(1)
 }
 
-console.log(`Shared export verification passed (${requiredSubpaths.size} imports).`)
+console.log(
+    `Shared export verification passed (${specifiers.length} @lucky/shared specifiers across backend, bot, frontend).`,
+)

--- a/scripts/verify-shared-exports.mjs
+++ b/scripts/verify-shared-exports.mjs
@@ -42,6 +42,7 @@ async function collectSourceFiles(dir) {
         const message = error instanceof Error ? error.message : String(error)
         throw new Error(
             `Unable to scan consumer source dir "${path.relative(repoRoot, dir)}": ${message}`,
+            { cause: error },
         )
     }
     const nested = await Promise.all(


### PR DESCRIPTION
Closes #1249. Resolves the prevention half of #1196.

## Why
The #1240 P1 deploy regression (backend crash → auto-rollback) shipped because
`scripts/verify-shared-exports.mjs` only scanned `backend/src` for `@lucky/shared/services/*`
imports — it never checked `utils/*`, `config`, `errors`, the root, or the bot/frontend packages.
A `@lucky/shared/utils/support` directory-barrel import matched only the `./utils/*` wildcard
(→ a flat `dist/utils/support.js` that doesn't exist) and crashed the prod ESM image.

## What
Generalize the gate to:
1. Scan **prod** source of **backend + bot + frontend** (skips `__tests__`/`*.spec`/`*.test`).
2. Collect **every** `@lucky/shared` specifier (root + any subpath), skipping erased `import type`.
3. `import()`-check each against the built dist/exports map; fail only on resolution errors
   (`ERR_MODULE_NOT_FOUND` / `ERR_PACKAGE_PATH_NOT_EXPORTED` / dir-import), ignoring env/runtime throws.

## Verified
- Passes today: **19 specifiers** across the 3 packages all resolve (no exports-map change needed —
  also confirms #1196's deep imports are fine, since Node's `*` spans slashes; the real risk is
  directory-barrel-via-wildcard, now guarded).
- **Regression caught:** temporarily removing the `./utils/support` exports entry reproduces
  `ERR_MODULE_NOT_FOUND … dist/utils/support.js` and fails the gate (the #1240 break).

This is the 3rd 'passes CI, breaks in the prod ESM Docker image' class — this gate closes the
export-map subclass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `scripts/verify-shared-exports.mjs` to verify all `@lucky/shared` specifiers across backend, bot, and frontend against the built package exports, and to fail fast when a consumer source tree can’t be scanned. Prevents prod ESM crashes from missing/incorrect exports; aligns with #1249 and covers the prevention half of #1196.

- **New Features**
  - Scans prod sources in `packages/backend/src`, `packages/bot/src`, and `packages/frontend/src`; skips tests; fails fast if a consumer `src` cannot be read and preserves the original error as `cause`.
  - Collects every `@lucky/shared` import (root + subpaths, including bare); ignores `import type`.
  - Uses `import()` on the built dist and fails only on resolution errors (`ERR_MODULE_NOT_FOUND`, `ERR_PACKAGE_PATH_NOT_EXPORTED`, `ERR_UNSUPPORTED_DIR_IMPORT`, `ERR_PACKAGE_IMPORT_NOT_DEFINED`); ignores runtime/env throws.
  - Adds clear failure guidance about `exports` entries; directory barrels need explicit entries.
  - Verified: 19 specifiers pass today; removing `./utils/support` export reproduces and is caught.

<sup>Written for commit 360c0ce0a4e71800c5ecbdc51871d90dadb56ad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal validation tooling to more effectively detect package configuration issues across code consumers, with improved error categorization and clearer resolution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->