### PR TITLE
fix(bot): lastfm-similar score crushed ~100x by match/100

### DIFF
--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.spec.ts
@@ -299,7 +299,7 @@ describe('collectLastFmCandidates', () => {
             { title: 'T1', artist: 'A1' },
         ])
         getSimilarTracksMock.mockResolvedValue([
-            { title: 'Similar', artist: 'SimilarArtist', match: 80 },
+            { title: 'Similar', artist: 'SimilarArtist', match: 0.8 },
         ])
         const track = createTrack()
         const queue = createQueue({ tracks: [track] })
@@ -314,6 +314,10 @@ describe('collectLastFmCandidates', () => {
         const similarCall = upsertScoredCandidateMock.mock.calls[1]
         const source = (similarCall?.[2] as { source: string })?.source
         expect(source).toBe('lastfm-similar')
+        // Verify corrected match weighting: (rec.score + LASTFM_SCORE_BOOST) * (0.5 + 0.5*match)
+        // = (0.5 + 0.2) * (0.5 + 0.5*0.8) = 0.7 * 0.9 = 0.63
+        const scoreArg = (similarCall?.[2] as { score: number })?.score
+        expect(scoreArg).toBeCloseTo(0.63, 5)
     })
 
     it('skips excluded tracks in similar-tracks loop (line 155 continue)', async () => {
@@ -321,7 +325,7 @@ describe('collectLastFmCandidates', () => {
             { title: 'T1', artist: 'A1' },
         ])
         getSimilarTracksMock.mockResolvedValue([
-            { title: 'Similar', artist: 'SimilarArtist', match: 80 },
+            { title: 'Similar', artist: 'SimilarArtist', match: 0.8 },
         ])
         // seed: include, similar: exclude
         shouldIncludeCandidateMock
@@ -343,7 +347,7 @@ describe('collectLastFmCandidates', () => {
             { title: 'T1', artist: 'A1' },
         ])
         getSimilarTracksMock.mockResolvedValue([
-            { title: 'Similar', artist: 'SimilarArtist', match: 80 },
+            { title: 'Similar', artist: 'SimilarArtist', match: 0.8 },
         ])
         normalizeTrackKeyMock
             .mockReturnValueOnce('seed-key')

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
@@ -185,7 +185,8 @@ export async function collectLastFmCandidates(
                     track,
                     {
                         score:
-                            (rec.score + LASTFM_SCORE_BOOST) * (s.match / 100),
+                            (rec.score + LASTFM_SCORE_BOOST) *
+                            (0.5 + 0.5 * Math.min(Math.max(s.match, 0), 1)),
                         source: 'lastfm-similar',
                         signals: rec.signals,
                     },


### PR DESCRIPTION
Closes #1267.

`lastFmSeeder.ts` scored `lastfm-similar` candidates as `(rec.score + LASTFM_SCORE_BOOST) * (s.match / 100)`, but `getSimilarTracks` returns `match` already on a 0..1 scale (`lastFmApi.ts:519`). So `/100` crushed every score ~100×, letting the genre-blind spotify-preferred boost beat seed-similar candidates — a contributor to the mainstream drift fixed in #1268.

Fix: weight by `0.5 + 0.5 * clamp(match, 0, 1)`, mirroring the (correct) `seedSimilarityCollector.ts`. Spec mocks updated from `match: 80` → `0.8` with a regression assertion on the corrected weighting.

Verified: full `packages/bot/src/utils/music/autoplay/` suite green (258 tests); bot typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected `lastfm-similar` scoring. Last.fm’s match is 0..1, so dividing by 100 crushed scores; we now weight by 0.5 + 0.5*clamp(match) to match `seedSimilarityCollector` and keep seed-similar tracks competitive.

Tests updated to use 0..1 match and include a regression assertion for the new weighting.

<sup>Written for commit 782613ef8375f770277b45ad929d60c39eecb7e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

