### PR TITLE
fix(music): re-target music guild FKs to discordId (P2003 write failures)

### DIFF
--- a/packages/bot/src/utils/music/sessionSnapshots.spec.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.spec.ts
@@ -174,6 +174,40 @@ describe('MusicSessionSnapshotService', () => {
 
             expect(await service.saveSnapshot(queue)).toBeNull()
         })
+
+        it('surfaces the Prisma error code + meta when the create fails', async () => {
+            mockCreate.mockRejectedValueOnce({
+                name: 'PrismaClientKnownRequestError',
+                code: 'P2003',
+                meta: { field_name: 'guildId' },
+                message: 'Invalid `prisma.musicSessionSnapshot.create()` invocation:',
+            })
+            const service = new MusicSessionSnapshotService()
+            const queue = {
+                guild: { id: 'guild-err' },
+                currentTrack: {
+                    title: 't',
+                    author: 'a',
+                    url: 'u',
+                    duration: '1',
+                    source: 'youtube',
+                },
+                tracks: { toArray: () => [] },
+            } as unknown as GuildQueue
+
+            expect(await service.saveSnapshot(queue)).toBeNull()
+
+            const { errorLog } = require('@lucky/shared/utils')
+            expect(errorLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Failed to save music session snapshot',
+                    data: {
+                        prismaCode: 'P2003',
+                        prismaMeta: { field_name: 'guildId' },
+                    },
+                }),
+            )
+        })
     })
 
     describe('getSnapshot', () => {

--- a/packages/bot/src/utils/music/sessionSnapshots.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.ts
@@ -7,6 +7,20 @@ import type { Prisma } from '@lucky/shared/utils'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 
+/**
+ * Extracts the structured Prisma error fields (`code` + `meta`) for logging.
+ * Prisma's `KnownRequestError.message` is truncated ("Invalid `…create()`
+ * invocation:") and hides the offending field; the code (e.g. P2003) + meta
+ * carry the real cause. Returns undefined for non-Prisma errors.
+ */
+function prismaErrorMeta(error: unknown): Record<string, unknown> | undefined {
+    if (error && typeof error === 'object' && 'code' in error) {
+        const e = error as { code?: unknown; meta?: unknown }
+        return { prismaCode: e.code, prismaMeta: e.meta }
+    }
+    return undefined
+}
+
 export type SnapshotTrack = {
     title: string
     author: string
@@ -173,6 +187,7 @@ export class MusicSessionSnapshotService {
             errorLog({
                 message: 'Failed to save music session snapshot',
                 error,
+                data: prismaErrorMeta(error),
             })
             return null
         }

--- a/packages/shared/src/services/GuildSettingsService.spec.ts
+++ b/packages/shared/src/services/GuildSettingsService.spec.ts
@@ -82,6 +82,21 @@ describe('GuildSettingsService — counters (Postgres) + rate limit (in-memory)'
             mockUpsert.mockRejectedValueOnce(new Error('db down'))
             expect(await service.incrementAutoplayCounter(GUILD)).toBe(0)
         })
+
+        it('returns false when reset fails with a Prisma error (code + meta)', async () => {
+            mockUpsert.mockRejectedValueOnce({
+                name: 'PrismaClientKnownRequestError',
+                code: 'P2003',
+                meta: { field_name: 'guildId' },
+                message: 'Invalid invocation',
+            })
+            expect(await service.resetAutoplayCounter(GUILD)).toBe(false)
+        })
+
+        it('returns false when reset fails with a non-Prisma error', async () => {
+            mockUpsert.mockRejectedValueOnce(new Error('db down'))
+            expect(await service.resetAutoplayCounter(GUILD)).toBe(false)
+        })
     })
 
     describe('repeat counter', () => {

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -1,6 +1,20 @@
 import { getPrismaClient } from '../utils/database/prismaClient'
 import { infoLog, errorLog } from '../utils/general/log'
 
+/**
+ * Extracts structured Prisma error fields (`code` + `meta`) for logging.
+ * `KnownRequestError.message` is truncated and hides the offending field; the
+ * code (e.g. P2003 FK violation) + meta carry the real cause. Returns undefined
+ * for non-Prisma errors.
+ */
+function prismaErrorMeta(error: unknown): Record<string, unknown> | undefined {
+    if (error && typeof error === 'object' && 'code' in error) {
+        const e = error as { code?: unknown; meta?: unknown }
+        return { prismaCode: e.code, prismaMeta: e.meta }
+    }
+    return undefined
+}
+
 /** Guild-specific music and command settings cached in Redis. */
 export interface GuildSettings {
     guildId: string
@@ -287,7 +301,11 @@ export class GuildSettingsService {
             })
             return true
         } catch (error) {
-            errorLog({ message: 'Failed to reset autoplay counter', error })
+            errorLog({
+                message: 'Failed to reset autoplay counter',
+                error,
+                data: prismaErrorMeta(error),
+            })
             return false
         }
     }

--- a/prisma/migrations/20260608000000_fix_music_guild_fks/migration.sql
+++ b/prisma/migrations/20260608000000_fix_music_guild_fks/migration.sql
@@ -1,0 +1,32 @@
+-- music_session_snapshots.guildId, guild_counters.guildId, and named_queues.guildId
+-- have always held Discord snowflakes (queue.guild.id), but their FKs were
+-- pointed at guilds.id (CUID) instead of guilds.discordId — so every write
+-- failed with P2003 (foreign key violation). This is the same defect already
+-- fixed for track_history in 20260603000000_fix_track_history_guild_fk; here we
+-- re-target the three remaining music FKs to the correct column.
+--
+-- Because the writes were failing, these tables should hold no CUID-keyed rows.
+-- The pre-emptive DELETE removes any row whose guildId is not a real Discord
+-- guild id (such rows cannot satisfy the new FK and would only block its
+-- creation); it is a no-op on the expected empty/consistent tables.
+
+DELETE FROM "music_session_snapshots"
+    WHERE "guildId" NOT IN (SELECT "discordId" FROM "guilds");
+ALTER TABLE "music_session_snapshots" DROP CONSTRAINT "music_session_snapshots_guildId_fkey";
+ALTER TABLE "music_session_snapshots" ADD CONSTRAINT "music_session_snapshots_guildId_fkey"
+    FOREIGN KEY ("guildId") REFERENCES "guilds"("discordId")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+DELETE FROM "guild_counters"
+    WHERE "guildId" NOT IN (SELECT "discordId" FROM "guilds");
+ALTER TABLE "guild_counters" DROP CONSTRAINT "guild_counters_guildId_fkey";
+ALTER TABLE "guild_counters" ADD CONSTRAINT "guild_counters_guildId_fkey"
+    FOREIGN KEY ("guildId") REFERENCES "guilds"("discordId")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+DELETE FROM "named_queues"
+    WHERE "guildId" NOT IN (SELECT "discordId" FROM "guilds");
+ALTER TABLE "named_queues" DROP CONSTRAINT "named_queues_guildId_fkey";
+ALTER TABLE "named_queues" ADD CONSTRAINT "named_queues_guildId_fkey"
+    FOREIGN KEY ("guildId") REFERENCES "guilds"("discordId")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -279,7 +279,7 @@ model GuildSession {
 model NamedQueue {
   id      String @id @default(cuid())
   guildId String
-  guild   Guild  @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  guild   Guild  @relation(fields: [guildId], references: [discordId], onDelete: Cascade)
 
   name           String
   savedBy        String
@@ -301,7 +301,7 @@ model NamedQueue {
 model MusicSessionSnapshot {
   id      String @id @default(cuid())
   guildId String @unique
-  guild   Guild  @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  guild   Guild  @relation(fields: [guildId], references: [discordId], onDelete: Cascade)
 
   sessionSnapshotId String
   savedAt           DateTime @default(now())
@@ -319,7 +319,7 @@ model MusicSessionSnapshot {
 model GuildCounter {
   id      String @id @default(cuid())
   guildId String @unique
-  guild   Guild  @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  guild   Guild  @relation(fields: [guildId], references: [discordId], onDelete: Cascade)
 
   autoplayCount     Int      @default(0)
   autoplayLastReset DateTime @default(now())


### PR DESCRIPTION
Closes #1266.

## Root cause
Prod `lucky-bot` logged 23× `musicSessionSnapshot.create()` and 15× `resetAutoplayCounter` `PrismaClientKnownRequestError` failures (P2003 — FK violation). The music code passes **Discord snowflakes** (`queue.guild.id`), but the FKs on `music_session_snapshots`, `guild_counters`, and `named_queues` pointed at `guilds.id` (internal CUID) — so every write failed the FK check.

This is the **identical** defect already fixed for `track_history` in `20260603000000_fix_track_history_guild_fk`, which documents: *"…has always held Discord snowflakes… The FK was incorrectly pointed at guilds.id (CUID) instead of guilds.discordId."*

## Fix
Migration `20260608000000_fix_music_guild_fks` re-targets all three FKs to `guilds.discordId`, mirroring the precedent — so the existing code becomes correct with **no per-write ID resolution**. Schema updated to match. A pre-emptive `DELETE` of any unreferenceable rows guards the constraint re-creation (no-op on the expected empty tables, since writes were failing).

`named_queues` had the same latent bug (failures unreported only because saves are rare) — fixed for consistency rather than left to fail later.

Per acceptance #3, both failing catch sites now log the structured Prisma error (`code` + `meta`) instead of Prisma's truncated invocation string.

## Why it matters
`musicSessionSnapshot` backs the session history autoplay reconstructs into `sessionMood`/`sessionGenreFamilies`. Fixing the write strengthens that signal, making the genre guard from #1268 more effective.

## Verification
- `prisma validate` clean; schema↔migration constraint names verified against the creating migrations.
- shared + bot typecheck clean; bot autoplay/snapshot suites (280) + shared `GuildSettingsService` spec (12) green.
- Post-deploy: confirm the two error counts drop to ~0 in `lucky-bot` logs.

> Note: an implementer subagent first proposed code-side Discord→internal-ID resolution; rejected in review as inconsistent with the repo's documented FK convention (adds per-write lookups + silent no-ops). This schema-retarget is the consistent fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1266 by retargeting music guild foreign keys to `guilds.discordId` to stop P2003 write failures for session snapshots, autoplay counters, and named queues. Adds structured Prisma error logging (`code` + `meta`) for clearer diagnostics.

- **Bug Fixes**
  - Migration `20260608000000_fix_music_guild_fks` updates FKs on `music_session_snapshots`, `guild_counters`, and `named_queues` to reference `guilds.discordId`, deletes unreferenceable rows, and updates the schema.
  - Keeps existing writes that use Discord snowflakes; no per-write ID lookup.
  - Adds `prismaErrorMeta` and logs it in snapshot create and autoplay counter reset; includes tests that cover Prisma-coded and non-Prisma error branches.

<sup>Written for commit 4967164dcaf3d758d1f2d78812df50aad8afd5d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

