### PR TITLE
fix(autoplay): weight popularity over name similarity in similar mode

### DIFF
--- a/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
@@ -182,6 +182,22 @@ describe('candidateScorer', () => {
             expect(result.signals).toContain(signal)
         })
 
+        it('does not reward cross-artist title-word overlap (name similarity removed)', () => {
+            const result = calculateRecommendationScore({
+                candidate: createTrack({
+                    title: 'Purple Rain Forever',
+                    author: 'Different Artist',
+                    source: 'youtube',
+                }),
+                currentTrack: createTrack({
+                    title: 'Purple Rain',
+                    author: 'Prince',
+                }),
+                recentArtists: new Set(),
+            })
+            expect(result.signals).not.toContain('similar title mood')
+        })
+
         it('boosts popular mode based on liked weight', () => {
             const result = calculateRecommendationScore({
                 candidate: createTrack({

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.ts
@@ -399,14 +399,12 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
     } else if (candidate.source && candidate.source !== currentTrack.source) {
         signals.push('source variety')
     }
-    const tokenScore = sharedTitleTokenScore(
-        candidate.title,
-        currentTrack.title,
-    )
-    score += tokenScore
-    if (tokenScore > 0) {
-        signals.push('similar title mood')
-    }
+    // NOTE: the cross-artist title-token bonus ("similar title mood") was
+    // removed — rewarding shared title words across different artists is name
+    // similarity, not musical similarity, and it pulled in near-identically
+    // named tracks (often variants of the same song → duplicate-ish entries).
+    // Same-artist album coherence is still captured by the 'album match' signal
+    // above; musical similarity comes from Last.fm match + genre families.
     if (
         currentTrack.durationMS &&
         candidate.durationMS &&

--- a/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest, beforeEach } from '@jest/globals'
 import type { Track, GuildQueue } from 'discord-player'
-import { replenishQueue } from './replenisher'
+import { replenishQueue, popularityBoost } from './replenisher'
 
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: jest.fn(),
@@ -424,5 +424,23 @@ describe('clearSessionMoodCache', () => {
 
         // The cache should be cleared (we verify by checking the function exists and is callable)
         expect(typeof clearSessionMoodCache).toBe('function')
+    })
+})
+
+describe('popularityBoost', () => {
+    it('boosts high-popularity artists in popular mode, nothing below the threshold', () => {
+        expect(popularityBoost('popular', 80)).toBeCloseTo(0.12, 5)
+        expect(popularityBoost('popular', 50)).toBe(0)
+    })
+
+    it('boosts low-popularity artists in discover mode, nothing above the threshold', () => {
+        expect(popularityBoost('discover', 30)).toBeCloseTo(0.12, 5)
+        expect(popularityBoost('discover', 60)).toBe(0)
+    })
+
+    it('applies a mild popularity gradient in similar mode', () => {
+        expect(popularityBoost('similar', 100)).toBeCloseTo(0.12, 5)
+        expect(popularityBoost('similar', 50)).toBeCloseTo(0.06, 5)
+        expect(popularityBoost('similar', 0)).toBe(0)
     })
 })

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -60,6 +60,25 @@ const MAX_TRACKS_PER_SOURCE = 3
 // favoured over obscure name-matches without pulling in new (off-genre) tracks.
 const SIMILAR_POPULARITY_WEIGHT = 0.12
 const POPULARITY_RERANK_HEAD = 5
+// Flat boost for the discover/popular mode thresholds.
+const POPULARITY_MODE_BOOST = 0.12
+
+/**
+ * Post-selection popularity boost for a candidate, by autoplay mode. Applied to
+ * already-selected (genre-safe, de-duped) candidates only, so it reorders
+ * vetted tracks without introducing new (off-genre) ones.
+ * - popular:  flat boost for high-popularity (≥70) artists
+ * - discover: flat boost for low-popularity (≤40) artists
+ * - similar:  mild gradient favouring well-known artists (tie-breaker)
+ */
+export function popularityBoost(
+    mode: 'similar' | 'discover' | 'popular',
+    popularity: number,
+): number {
+    if (mode === 'popular') return popularity >= 70 ? POPULARITY_MODE_BOOST : 0
+    if (mode === 'discover') return popularity <= 40 ? POPULARITY_MODE_BOOST : 0
+    return (popularity / 100) * SIMILAR_POPULARITY_WEIGHT
+}
 
 // Concurrency lock: prevents duplicate queue insertions when playerStart and
 // playerFinish events fire within milliseconds (playerStart + playerFinish) cannot both read
@@ -488,20 +507,7 @@ async function _replenishQueue(
                             track.track.author,
                         ).catch(() => null)
                         if (popularity === null) return
-                        if (autoplayMode === 'popular' && popularity >= 70) {
-                            track.score += 0.12
-                        } else if (
-                            autoplayMode === 'discover' &&
-                            popularity <= 40
-                        ) {
-                            track.score += 0.12
-                        } else if (autoplayMode === 'similar') {
-                            // Mild gradient — favour well-known songs/artists
-                            // among related candidates (tie-breaker, not an
-                            // override).
-                            track.score +=
-                                (popularity / 100) * SIMILAR_POPULARITY_WEIGHT
-                        }
+                        track.score += popularityBoost(autoplayMode, popularity)
                     }),
                 )
                 enriched.sort((a, b) => b.score - a.score)

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -55,6 +55,11 @@ const AUTOPLAY_BUFFER_SIZE_PREMIUM = 16
 const HISTORY_SEED_LIMIT = 3
 const MAX_TRACKS_PER_ARTIST = 2
 const MAX_TRACKS_PER_SOURCE = 3
+// 'similar' mode popularity re-rank: a mild gradient (popularity/100 × weight)
+// applied POST-selection to the genre-safe candidates, so well-known songs are
+// favoured over obscure name-matches without pulling in new (off-genre) tracks.
+const SIMILAR_POPULARITY_WEIGHT = 0.12
+const POPULARITY_RERANK_HEAD = 5
 
 // Concurrency lock: prevents duplicate queue insertions when playerStart and
 // playerFinish events fire within milliseconds (playerStart + playerFinish) cannot both read
@@ -464,16 +469,20 @@ async function _replenishQueue(
             currentTrack.author,
         )
 
-        if (
-            (autoplayMode === 'discover' || autoplayMode === 'popular') &&
-            requestedBy?.id
-        ) {
+        if (requestedBy?.id) {
             const token = await Promise.resolve(
                 spotifyLinkService.getValidAccessToken(requestedBy.id),
             ).catch(() => null)
             if (token) {
+                // Re-rank a bounded head of the already-selected (genre-safe,
+                // de-duped) candidates by artist popularity. Post-selection
+                // only: it reorders vetted candidates and never introduces new
+                // ones, so popularity weighting can't reintroduce off-genre
+                // mainstream drift.
+                const rerankHead =
+                    autoplayMode === 'similar' ? POPULARITY_RERANK_HEAD : 3
                 await Promise.all(
-                    enriched.slice(0, 3).map(async (track) => {
+                    enriched.slice(0, rerankHead).map(async (track) => {
                         const popularity = await getArtistPopularity(
                             token,
                             track.track.author,
@@ -486,6 +495,12 @@ async function _replenishQueue(
                             popularity <= 40
                         ) {
                             track.score += 0.12
+                        } else if (autoplayMode === 'similar') {
+                            // Mild gradient — favour well-known songs/artists
+                            // among related candidates (tie-breaker, not an
+                            // override).
+                            track.score +=
+                                (popularity / 100) * SIMILAR_POPULARITY_WEIGHT
                         }
                     }),
                 )


### PR DESCRIPTION
## Listen-test feedback (post-#1272)
Autoplay was picking by **title/name similarity** — and surfacing **near-duplicate name variants** — rather than musical fit. Request: weight **song/artist popularity** instead.

## Changes
1. **Remove the cross-artist title-token bonus** (`similar title mood`, +0.2 in `candidateScorer`). Rewarding shared title words across *different* artists is name similarity, not musical similarity, and it actively pulled in near-identically-named tracks — which are frequently variants of the same song (the duplicate-ish entries). Same-artist album coherence still comes from the `album match` signal; real musical similarity comes from Last.fm `match` + genre families.
2. **Extend the post-selection artist-popularity re-rank to `similar` mode** (was discover/popular only): a mild gradient `(popularity/100) × 0.12` over the top of the already-selected candidates.

## Why this doesn't re-introduce drift
Popularity weighting is what *caused* the original mainstream drift — so it's applied **post-selection only**, re-ranking the already-genre-safe, de-duped candidate set. It reorders vetted tracks and **never introduces new (off-genre) ones**, and it's token-gated + bounded to the head of the queue (cached `getArtistPopularity`). So popular tracks rank higher *within the safe neighborhood*, without rescuing cross-genre mainstream.

## Notes
- Only **artist-level** popularity is cheaply available; **song-level** popularity would need track-popularity plumbing — follow-up if you want finer control.
- Tests: scorer asserts the name-similarity signal is gone; full `autoplay/` suite green (261→262); bot typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Autoplay “similar” mode now favors artist popularity over title/name matching to reduce near-duplicate picks and improve musical fit.

- **Bug Fixes**
  - Removed the cross-artist title-token bonus (the “similar title mood” signal).
  - Added a mild, post-selection artist-popularity re-rank in “similar” mode: `(popularity/100) × 0.12` applied to the top 5 candidates to break ties without changing the pool.
  - Added a test to ensure cross-artist name overlap no longer boosts scoring.

- **Refactors**
  - Extracted popularityBoost into a pure function and unit-tested all mode branches (“similar”, “discover”, “popular”); no behavior change.

<sup>Written for commit f6dd468148515e1fe8194d1287ac746aafedc02d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

