### PR TITLE
chore(autoplay): telemetry read SQL (validate tuning with data)

### DIFF
--- a/scripts/autoplay-telemetry.sql
+++ b/scripts/autoplay-telemetry.sql
@@ -1,0 +1,84 @@
+-- Autoplay telemetry read — turn on the instrument panel.
+--
+-- Validates the autoplay tuning arc (#1268 seed-similarity, #1272 provenance
+-- guards, #1273 popularity-over-name) against the `recommendations` table the
+-- engine has been writing all along, instead of tuning by ear.
+--
+-- Run against PROD (homelab) Postgres:
+--   psql "$DATABASE_URL" -f scripts/autoplay-telemetry.sql
+-- or on the homelab host:
+--   docker compose -p lucky exec -T postgres \
+--     psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f - < scripts/autoplay-telemetry.sql
+--
+-- Acceptance rate mirrors recommendationTelemetryReadService:
+--   accepted / (accepted + rejected)   — pending (neither flag) excluded.
+-- Window is the last 14 days; edit the interval below to widen/narrow.
+
+\echo '=== 1. Overall summary (last 14 days) ==='
+SELECT
+    count(*)                                                   AS picks,
+    count(*) FILTER (WHERE "isAccepted")                       AS accepted,
+    count(*) FILTER (WHERE "isRejected")                       AS rejected,
+    count(*) FILTER (WHERE "isAccepted" IS NULL
+                      AND "isRejected" IS NULL)                AS pending,
+    round(count(*) FILTER (WHERE "isAccepted")::numeric
+          / nullif(count(*) FILTER (WHERE "isAccepted")
+                 + count(*) FILTER (WHERE "isRejected"), 0), 3) AS acceptance_rate
+FROM "recommendations"
+WHERE "createdAt" >= now() - interval '14 days';
+
+\echo '=== 2. Per-source acceptance (is seed-similar winning? is SPOTIFY_REC dead weight?) ==='
+SELECT
+    coalesce("source"::text, '(null)')                         AS source,
+    count(*)                                                   AS picks,
+    count(*) FILTER (WHERE "isAccepted")                       AS accepted,
+    count(*) FILTER (WHERE "isRejected")                       AS rejected,
+    count(*) FILTER (WHERE "isAccepted" IS NULL
+                      AND "isRejected" IS NULL)                AS pending,
+    round(count(*) FILTER (WHERE "isAccepted")::numeric
+          / nullif(count(*) FILTER (WHERE "isAccepted")
+                 + count(*) FILTER (WHERE "isRejected"), 0), 3) AS acceptance_rate
+FROM "recommendations"
+WHERE "createdAt" >= now() - interval '14 days'
+GROUP BY 1
+ORDER BY picks DESC;
+
+\echo '=== 3. Per-mode acceptance (similar/discover/popular) ==='
+SELECT
+    coalesce("mode", '(null)')                                 AS mode,
+    count(*)                                                   AS picks,
+    count(*) FILTER (WHERE "isAccepted")                       AS accepted,
+    count(*) FILTER (WHERE "isRejected")                       AS rejected,
+    round(count(*) FILTER (WHERE "isAccepted")::numeric
+          / nullif(count(*) FILTER (WHERE "isAccepted")
+                 + count(*) FILTER (WHERE "isRejected"), 0), 3) AS acceptance_rate
+FROM "recommendations"
+WHERE "createdAt" >= now() - interval '14 days'
+GROUP BY 1
+ORDER BY picks DESC;
+
+\echo '=== 4. Artist concentration (low distinct_ratio = looping few artists) ==='
+SELECT
+    count(*)                                                   AS picks,
+    count(DISTINCT lower("author"))                            AS distinct_artists,
+    round(count(DISTINCT lower("author"))::numeric
+          / nullif(count(*), 0), 3)                            AS distinct_ratio
+FROM "recommendations"
+WHERE "createdAt" >= now() - interval '14 days';
+
+\echo '--- top 15 artists by pick count (the same-artist-loop check) ---'
+SELECT lower("author") AS artist, count(*) AS picks
+FROM "recommendations"
+WHERE "createdAt" >= now() - interval '14 days'
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 15;
+
+\echo '=== 5. Duplicate-ish picks (same artist+title recommended multiple times) ==='
+SELECT lower("author") AS artist, lower("title") AS title, count(*) AS times
+FROM "recommendations"
+WHERE "createdAt" >= now() - interval '14 days'
+GROUP BY 1, 2
+HAVING count(*) > 1
+ORDER BY 3 DESC
+LIMIT 20;


### PR DESCRIPTION
Turns on the instrument panel we already built. One-shot SQL report over the `recommendations` table to validate the autoplay tuning arc (#1268/#1272/#1273) with data instead of by ear:

1. Overall acceptance (last 14d)
2. **Per-source acceptance** — is `SEED_SIMILAR` winning? is the deprecated `SPOTIFY_REC` dead weight (high count / ~zero acceptance)?
3. Per-mode acceptance (similar/discover/popular)
4. **Artist concentration** + top-15 artists — the same-artist-loop check
5. **Duplicate-ish picks** — same artist+title recommended multiple times

Acceptance mirrors `recommendationTelemetryReadService`: `accepted/(accepted+rejected)`, pending excluded. Run: `psql "$DATABASE_URL" -f scripts/autoplay-telemetry.sql`. Feeds the ADR 2026-06-22 revisit. No app-code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-shot SQL telemetry report over the `recommendations` table to validate recent autoplay tuning (#1268/#1272/#1273) with data. Produces 14‑day acceptance rates and drift checks to support the ADR revisit.

- **New Features**
  - `scripts/autoplay-telemetry.sql` 14‑day report: overall, per-source, and per-mode acceptance.
  - Artist concentration (distinct ratio) + top‑15 artists; duplicate picks (same artist+title).
  - Acceptance = accepted/(accepted+rejected), pending excluded. Run: psql "$DATABASE_URL" -f scripts/autoplay-telemetry.sql.

<sup>Written for commit 63f9da489aac851ccb5ccfa23475db6020be8fe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

