### PR TITLE
fix(autoplay): capture skip rejections (symmetric completion threshold)

### DIFF
--- a/packages/bot/src/handlers/player/trackHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.spec.ts
@@ -457,7 +457,7 @@ describe('trackHandlers autoplay replenishment', () => {
             })
         })
 
-        it('does not record outcome for ambiguous mid-play skip (after 5s but before 30%)', async () => {
+        it('records rejected outcome on playerSkip when autoplay track skipped before 30% (the prior dead zone)', async () => {
             jest.useFakeTimers()
             const handlers = setupHandlers()
             const playerStart = handlers.playerStart
@@ -470,10 +470,56 @@ describe('trackHandlers autoplay replenishment', () => {
             } as unknown as Track
 
             await playerStart(queue, autoplayTrack)
-            jest.advanceTimersByTime(15000) // 15% through (after 5s, before 30%)
+            jest.advanceTimersByTime(15000) // 15% — was the lost "ambiguous" band
+            await playerSkip(queue, autoplayTrack)
+
+            expect(recordRecommendationOutcomeMock).toHaveBeenCalledWith({
+                guildId: 'guild-1',
+                trackId: 'autoplay-track-3',
+                outcome: 'rejected',
+            })
+        })
+
+        it('does not record outcome for an ambiguous skip after 30%', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const playerStart = handlers.playerStart
+            const playerSkip = handlers.playerSkip
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const autoplayTrack = {
+                ...createAutoplayTrack('listener-1'),
+                id: 'autoplay-track-3b',
+                durationMS: 100000,
+            } as unknown as Track
+
+            await playerStart(queue, autoplayTrack)
+            jest.advanceTimersByTime(55000) // 55% — meaningful listen, ambiguous
             await playerSkip(queue, autoplayTrack)
 
             expect(recordRecommendationOutcomeMock).not.toHaveBeenCalled()
+        })
+
+        it('records rejected outcome on playerFinish when an autoplay track ends at or below 30% (skip routed through finish)', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const playerStart = handlers.playerStart
+            const playerFinish = handlers.playerFinish
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const autoplayTrack = {
+                ...createAutoplayTrack('listener-1'),
+                id: 'autoplay-track-finish-reject',
+                durationMS: 100000,
+            } as unknown as Track
+
+            await playerStart(queue, autoplayTrack)
+            jest.advanceTimersByTime(12000) // 12% — early end / skip via finish
+            await playerFinish(queue, autoplayTrack)
+
+            expect(recordRecommendationOutcomeMock).toHaveBeenCalledWith({
+                guildId: 'guild-1',
+                trackId: 'autoplay-track-finish-reject',
+                outcome: 'rejected',
+            })
         })
 
         it('does not record outcome for non-autoplay tracks on playerFinish', async () => {

--- a/packages/bot/src/handlers/player/trackHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.spec.ts
@@ -204,18 +204,6 @@ describe('trackHandlers autoplay replenishment', () => {
         jest.useRealTimers()
     })
 
-
-
-
-
-
-
-
-
-
-
-
-
     it('evicts old track entries when playerStart runs beyond the per-guild cap', async () => {
         for (let index = 0; index < 501; index += 1) {
             lastPlayedTracks.set(
@@ -255,12 +243,6 @@ describe('trackHandlers autoplay replenishment', () => {
         expect(recentlyPlayedTracks.has('history-guild-0')).toBe(false)
         expect(recentlyPlayedTracks.get('guild-1')).toHaveLength(500)
     })
-
-
-
-
-
-
 
     it('does not record feedback on playerFinish when track played < 80%', async () => {
         jest.useFakeTimers()
@@ -518,6 +500,29 @@ describe('trackHandlers autoplay replenishment', () => {
             expect(recordRecommendationOutcomeMock).toHaveBeenCalledWith({
                 guildId: 'guild-1',
                 trackId: 'autoplay-track-finish-reject',
+                outcome: 'rejected',
+            })
+        })
+
+        it('records outcomes for short (≤20s) autoplay tracks too — consistent across paths', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const playerStart = handlers.playerStart
+            const playerSkip = handlers.playerSkip
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const shortTrack = {
+                ...createAutoplayTrack('listener-1'),
+                id: 'autoplay-short-1',
+                durationMS: 15000, // ≤20s — previously suppressed on the skip path
+            } as unknown as Track
+
+            await playerStart(queue, shortTrack)
+            jest.advanceTimersByTime(2000) // ~13% in
+            await playerSkip(queue, shortTrack)
+
+            expect(recordRecommendationOutcomeMock).toHaveBeenCalledWith({
+                guildId: 'guild-1',
+                trackId: 'autoplay-short-1',
                 outcome: 'rejected',
             })
         })

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -35,7 +35,7 @@ const TRACK_STATE_TTL_MS = 30 * 60 * 1000
 // Autoplay recommendation outcome threshold: a track played past this fraction
 // is "accepted"; ended/skipped before it is "rejected" (symmetric across the
 // playerFinish + playerSkip paths). Tune via Phase C data.
-export const OUTCOME_ACCEPT_PLAY_RATIO = 0.30
+export const OUTCOME_ACCEPT_PLAY_RATIO = 0.3
 
 export const lastPlayedTracks = new LRUCache<string, Track>({
     max: MAX_GUILD_ENTRIES,
@@ -318,10 +318,12 @@ const handlePlayerFinish = async (
                     await recordRecommendationOutcome({
                         guildId: queue.guild.id,
                         trackId: track.id,
+                        // < threshold = rejected (same condition as the skip
+                        // path, so the 30% boundary classifies identically).
                         outcome:
-                            completionRatio > OUTCOME_ACCEPT_PLAY_RATIO
-                                ? 'accepted'
-                                : 'rejected',
+                            completionRatio < OUTCOME_ACCEPT_PLAY_RATIO
+                                ? 'rejected'
+                                : 'accepted',
                     })
                 }
             }
@@ -358,15 +360,21 @@ const handlePlayerSkip = async (
 
         if (track) {
             const startTime = guildTrackStartTimes.get(queue.guild.id)
-            if (startTime && track.durationMS && track.durationMS > 20_000) {
+            if (startTime && track.durationMS) {
                 const skipRatio = (Date.now() - startTime) / track.durationMS
-                if (skipRatio < OUTCOME_ACCEPT_PLAY_RATIO) {
+                // Implicit-dislike noise filter: only for tracks long enough that
+                // an early-skip ratio is meaningful (>20s).
+                if (
+                    track.durationMS > 20_000 &&
+                    skipRatio < OUTCOME_ACCEPT_PLAY_RATIO
+                ) {
                     await recordImplicitTrackFeedback(track, 'implicit_dislike')
                     const current =
                         guildRecentSkipCounts.get(queue.guild.id) ?? 0
                     guildRecentSkipCounts.set(queue.guild.id, current + 1)
                 }
-                // Record autoplay recommendation outcome on skip: a skip before
+                // Record the autoplay recommendation outcome on skip — duration-
+                // agnostic, consistent with the playerFinish path: a skip before
                 // 30% played is a rejection (mirror of the accept threshold).
                 // Skips after 30% are ambiguous (a meaningful chunk was heard)
                 // and left unrecorded. Previously only sub-5s skips counted, so

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -32,9 +32,10 @@ import { recordRecommendationOutcome } from '../../services/musicRecommendation/
 const MAX_GUILD_ENTRIES = 500
 const TRACK_STATE_TTL_MS = 30 * 60 * 1000
 
-// Autoplay recommendation outcome thresholds (tune via Phase C data)
+// Autoplay recommendation outcome threshold: a track played past this fraction
+// is "accepted"; ended/skipped before it is "rejected" (symmetric across the
+// playerFinish + playerSkip paths). Tune via Phase C data.
 export const OUTCOME_ACCEPT_PLAY_RATIO = 0.30
-export const OUTCOME_REJECT_EARLY_SKIP_MS = 5_000
 
 export const lastPlayedTracks = new LRUCache<string, Track>({
     max: MAX_GUILD_ENTRIES,
@@ -306,12 +307,21 @@ const handlePlayerFinish = async (
                     await recordImplicitTrackFeedback(track, 'implicit_like')
                     guildRecentSkipCounts.delete(queue.guild.id)
                 }
-                // Record autoplay recommendation outcome on natural finish
-                if (isRecommendationAutoplay(track) && completionRatio > OUTCOME_ACCEPT_PLAY_RATIO) {
+                // Record the autoplay recommendation outcome. playerFinish fires
+                // for BOTH a natural end (high completion) and an early
+                // termination — including manual skips that route through
+                // 'playerFinish' rather than 'playerSkip' in discord-player v7.
+                // Classify by completion (mirror of the skip path): >30% played
+                // = accepted, ≤30% = rejected. Previously a ≤30% finish recorded
+                // nothing, so real skips were lost as 'pending' (issue #1275).
+                if (isRecommendationAutoplay(track)) {
                     await recordRecommendationOutcome({
                         guildId: queue.guild.id,
                         trackId: track.id,
-                        outcome: 'accepted',
+                        outcome:
+                            completionRatio > OUTCOME_ACCEPT_PLAY_RATIO
+                                ? 'accepted'
+                                : 'rejected',
                     })
                 }
             }
@@ -350,24 +360,26 @@ const handlePlayerSkip = async (
             const startTime = guildTrackStartTimes.get(queue.guild.id)
             if (startTime && track.durationMS && track.durationMS > 20_000) {
                 const skipRatio = (Date.now() - startTime) / track.durationMS
-                const skipElapsedMs = Date.now() - startTime
-                if (skipRatio < 0.3) {
+                if (skipRatio < OUTCOME_ACCEPT_PLAY_RATIO) {
                     await recordImplicitTrackFeedback(track, 'implicit_dislike')
                     const current =
                         guildRecentSkipCounts.get(queue.guild.id) ?? 0
                     guildRecentSkipCounts.set(queue.guild.id, current + 1)
                 }
-                // Record autoplay recommendation outcome on skip
-                if (isRecommendationAutoplay(track)) {
-                    if (skipElapsedMs <= OUTCOME_REJECT_EARLY_SKIP_MS) {
-                        // Early skip within 5s threshold: rejected
-                        await recordRecommendationOutcome({
-                            guildId: queue.guild.id,
-                            trackId: track.id,
-                            outcome: 'rejected',
-                        })
-                    }
-                    // else: skip after 5s but before 30% is ambiguous, do not record
+                // Record autoplay recommendation outcome on skip: a skip before
+                // 30% played is a rejection (mirror of the accept threshold).
+                // Skips after 30% are ambiguous (a meaningful chunk was heard)
+                // and left unrecorded. Previously only sub-5s skips counted, so
+                // the common "heard ~15s, wrong, skip" rejection was lost (#1275).
+                if (
+                    isRecommendationAutoplay(track) &&
+                    skipRatio < OUTCOME_ACCEPT_PLAY_RATIO
+                ) {
+                    await recordRecommendationOutcome({
+                        guildId: queue.guild.id,
+                        trackId: track.id,
+                        outcome: 'rejected',
+                    })
                 }
             }
             guildTrackStartTimes.delete(queue.guild.id)


### PR DESCRIPTION
Closes #1275.

## Evidence
Prod, last 14 days (via `scripts/autoplay-telemetry.sql`): **68 accepted, 0 rejected, 119 pending** → acceptance rate a meaningless `1.000` everywhere. The rejection signal — the input for all autoplay tuning + the ADR 2026-06-22 revisit — was never being captured.

## Two root causes, one symmetric fix
Classify outcomes around the existing `OUTCOME_ACCEPT_PLAY_RATIO` (30%) in **both** event handlers:

1. **`playerSkip` dead zone:** only sub-5s skips recorded `rejected`; a skip between 5s and 30% was dropped as "ambiguous", so the common *"heard ~15s, wrong track, skip"* rejection vanished. Now **skip before 30% = rejected** (mirrors `>30% = accepted`; aligns with the existing implicit-dislike band). Removed `OUTCOME_REJECT_EARLY_SKIP_MS`.
2. **Wrong event:** discord-player v7 routes many manual skips through **`playerFinish`** (low completion) rather than `playerSkip` — which recorded *nothing* → the 119 pending. `playerFinish` now records `accepted` (>30%) **or** `rejected` (≤30%).

`guildTrackStartTimes` is deleted by whichever handler fires first, so a skip that emits both events still records exactly once (no double-count).

## Tests
Repurposed the now-incorrect "ambiguous before 30%" test → asserts `rejected`; added an "ambiguous *after* 30% → not recorded" test and a "`playerFinish` ≤30% → rejected" test. Full `trackHandlers` suite green (16); bot typecheck clean.

## Verify post-deploy
Re-run `scripts/autoplay-telemetry.sql` in ~a week: rejected count should be non-zero and per-source acceptance should finally show a real spread.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes autoplay rejection telemetry by using a consistent 30% play-ratio threshold across finish and skip, including short tracks. Skips before 30% are rejected; finishes are rejected below 30% and accepted at ≥30%, closing the dead zone and removing the old 5s-only rule.

- **Bug Fixes**
  - playerSkip: reject skips before 30%; skips at or after 30% remain unrecorded. Short tracks (≤20s) now record outcomes too.
  - playerFinish: record accepted (≥30%) or rejected (<30%) to capture manual skips routed through finish in `discord-player` v7.
  - Prevent double recording by clearing start-time when the first handler fires.

<sup>Written for commit a2755fff11d265b6f075e3ca1e272bbc76229eb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated autoplay recommendation outcome tracking to consistently record results when tracks are skipped or finished.
  * Changed threshold logic from time-based to play-ratio-based for more predictable autoplay behavior.

* **Tests**
  * Expanded test coverage for autoplay skip and completion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->