### PR TITLE
fix(shared): env-isolate environment.test.ts (no secret dumps)

### DIFF
--- a/packages/shared/src/__tests__/config/environment.test.ts
+++ b/packages/shared/src/__tests__/config/environment.test.ts
@@ -1,4 +1,19 @@
-import { describe, expect, it, beforeEach, afterEach } from '@jest/globals'
+import {
+    describe,
+    expect,
+    it,
+    beforeEach,
+    afterEach,
+    jest,
+} from '@jest/globals'
+
+// Mock dotenv so loadEnvironmentFiles() cannot re-populate process.env from
+// the repo's real .env — without this, deleting a required var in a test is
+// undone by the loader and the missing-vars branch never executes (#1262).
+jest.mock('dotenv', () => ({
+    config: jest.fn(() => ({ parsed: {} })),
+}))
+
 import {
     validateBackendEnvironment,
     ensureEnvironment,
@@ -10,13 +25,14 @@ import {
 // P3 #3: shared helper for assertion logic
 
 describe('environment.ts - cubic findings verification', () => {
-    const originalEnv = { ...process.env }
+    const originalEnv = process.env
 
     beforeEach(() => {
-        // Reset to a clean state for each test
-        process.env = {
-            ...originalEnv,
-        }
+        // Minimal fixture env, never a copy of the real one: keeps the
+        // missing-vars branch deterministic regardless of ambient env, and
+        // guarantees a failing assertion can only ever print fixture values,
+        // not real secrets (#1262).
+        process.env = { NODE_ENV: 'test' } as NodeJS.ProcessEnv
     })
 
     afterEach(() => {


### PR DESCRIPTION
## What

Fixes the two failing tests in `packages/shared/src/__tests__/config/environment.test.ts` and removes the secret-dump-on-failure hazard. Closes #1262.

## Root cause

- `ensureEnvironment()` → `loadEnvironmentFiles()` → dotenv `config()` re-populates `process.env` from the repo's real `.env` **after** the test deletes required vars, so the missing-vars branch never executes on any machine with a `.env` (promise resolves instead of rejects). dotenv not overriding existing vars is why the whitespace tests passed while the delete tests failed.
- The `beforeEach` seeded the fixture with `{...process.env}` (the full real env), so an unexpected resolve made Jest print the entire env — every secret — on failure.

## Fix (test-only, no production change)

- Factory-mock `dotenv` in the spec (same pattern as the prismaClient factory mocks in shared) so the loader can't re-populate the env.
- Replace the fixture with a minimal `{ NODE_ENV: 'test' }` object: deterministic regardless of ambient env, and a failing assertion can only print fixture values, never real secrets.

## Verification

- `npm run test:ci --workspace=packages/shared` → **53 suites / 733 tests, all pass** (was 2 failures)
- Full `type:check` across all workspaces green (pre-commit hook)
- Sibling sweep (acceptance #3): no other package has the rejects-on-env pattern — `sentryTest.spec.ts` asserts on mocks only; `FeatureToggleService.spec.ts` touches `FLAGS` only

## Note

This failure was invisible to CI because shared tests run nowhere in CI — #1277 (next PR) adds the test-shared job that would have caught it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing env tests in shared by isolating `process.env` and mocking `dotenv`, removing the secret-dump risk on test failures. Addresses #1262.

- **Bug Fixes**
  - Mocked `dotenv.config()` in the spec so the loader can’t repopulate from the real `.env`.
  - Replaced `{...process.env}` with a minimal `{ NODE_ENV: 'test' }` fixture for deterministic tests and no secret leaks.

<sup>Written for commit 2d4511557114a0693813b02976cd7ceda83eb336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for environment variable handling by isolating test environments from system configuration, ensuring consistent and deterministic test results across different execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->