### PR TITLE
ci: add test-shared job + honest shared coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,28 @@ jobs:
             - name: Build project
               run: npm run build
 
+    test-shared:
+        name: Test — shared
+        runs-on: ubuntu-latest
+        needs: build-shared
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+            - run: npm ci --legacy-peer-deps --ignore-scripts
+            - name: Download shared artifact
+              uses: actions/download-artifact@v8
+              with:
+                  name: shared-build
+                  path: packages/shared
+            - name: Run shared tests
+              run: npm run test --workspace=packages/shared -- --ci --coverage
+              env:
+                  # Some shared service modules eagerly init Prisma at import time (#1249)
+                  DATABASE_URL: postgresql://localhost:5432/test
+
     test-backend:
         name: Test — backend
         runs-on: ubuntu-latest
@@ -229,17 +251,18 @@ jobs:
         # test-youtube-smoke intentionally excluded: advisory-only, runs on YouTube dependency PRs only
         name: Quality Gates
         runs-on: ubuntu-latest
-        needs: [build-shared, checks, test-backend, test-bot, test-frontend]
+        needs: [build-shared, checks, test-shared, test-backend, test-bot, test-frontend]
         if: always()
         steps:
             - name: Assert all jobs passed
               run: |
                   checks="${{ needs.checks.result }}"
+                  shared="${{ needs.test-shared.result }}"
                   backend="${{ needs.test-backend.result }}"
                   bot="${{ needs.test-bot.result }}"
                   frontend="${{ needs.test-frontend.result }}"
-                  if [[ "$checks" != "success" || "$backend" != "success" || "$bot" != "success" || "$frontend" != "success" ]]; then
-                      echo "Job results: checks=$checks  test-backend=$backend  test-bot=$bot  test-frontend=$frontend"
+                  if [[ "$checks" != "success" || "$shared" != "success" || "$backend" != "success" || "$bot" != "success" || "$frontend" != "success" ]]; then
+                      echo "Job results: checks=$checks  test-shared=$shared  test-backend=$backend  test-bot=$bot  test-frontend=$frontend"
                       exit 1
                   fi
 

--- a/packages/shared/jest.config.cjs
+++ b/packages/shared/jest.config.cjs
@@ -24,12 +24,16 @@ module.exports = {
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov'],
+  // Honest gate (#1277): set just below coverage measured on 2026-06-09
+  // (47.08/41.83/38.82/46.76). The previous 89/89/90/89 was never enforced —
+  // no CI job ran shared tests — and had drifted far from reality. Ratchet
+  // these up as coverage improves; never raise above measured coverage.
   coverageThreshold: {
     global: {
-      statements: 89,
-      branches: 89,
-      functions: 90,
-      lines: 89
+      statements: 46,
+      branches: 41,
+      functions: 38,
+      lines: 46
     }
   },
   testTimeout: 30000,


### PR DESCRIPTION
## What

Adds the missing `test-shared` CI job and makes the shared coverage gate honest. Closes #1277.

## Why

`packages/shared` tests ran **nowhere in CI**: ci.yml tests only backend/bot/frontend, and the reusable Quality Gates workflow runs SAST/lint/knip — no jest. Cost of the gap is documented history: three "passes CI, breaks prod" incidents were shared-package issues, and #1262's failing tests sat invisible until this session's test sweep.

## Changes

- **ci.yml**: new `test-shared` job mirroring `test-backend` (needs `build-shared`, downloads the shared-build artifact for the generated Prisma client, dummy `DATABASE_URL` for import-time Prisma init per the #1249 precedent). Wired into `quality-gate` needs + assertion so it blocks merge like the other suites.
- **packages/shared/jest.config.cjs**: coverageThreshold 89/89/90/89 → **46/41/38/46**. The old gate was enforced by nothing and actual coverage is 47.08/41.83/38.82/46.76 (generated code + barrels already excluded) — wiring the job against 89 would be permanently red. This follows the honest-gate pattern from #1076: threshold just below measured, ratchet up as coverage improves. Raising real shared coverage is separate work.

## Verification

- Local `npm run test --workspace=packages/shared -- --ci --coverage` → exit 0, 733/733 pass, gate satisfied
- `actionlint` clean on the workflow
- This PR's own CI run exercises the new job live

## Sequencing

Built on top of #1292 (env-test isolation fix) — without it the new job would fail on the first run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `test-shared` CI job and makes the shared coverage gate enforceable so `packages/shared` tests run in CI and block merges when failing. Closes #1277.

- New Features
  - Added `test-shared` job that mirrors backend tests, downloads the `shared-build` artifact, sets `DATABASE_URL` for Prisma init, and is included in Quality Gates.

- Bug Fixes
  - Set an honest coverage gate for `packages/shared` at 46/41/38/46 to match current coverage and prevent perma-red, with room to ratchet up over time.

<sup>Written for commit 1ad8696c88fdcd698359cecc22e0b90bb08fedd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

