### PR TITLE
fix(web): route handled errors to Sentry, enforce no-console

### DIFF
--- a/packages/frontend/eslint.config.js
+++ b/packages/frontend/eslint.config.js
@@ -37,6 +37,9 @@ export default [
             'no-undef': 'off', // Typescript handles global and type symbols
             'no-unused-vars': 'off',
             'no-empty': 'off',
+            // Bare console.error hides errors from Sentry — use
+            // reportError() from '@/lib/sentry' instead (#1278)
+            'no-console': ['error', { allow: ['warn'] }],
             'react-hooks/rules-of-hooks': 'error',
             'react-hooks/exhaustive-deps': 'off',
         },
@@ -45,6 +48,13 @@ export default [
         files: ['tests/e2e/**/*.ts'],
         rules: {
             'react-hooks/rules-of-hooks': 'off',
+        },
+    },
+    {
+        // Node build/CLI scripts — console output is their interface
+        files: ['scripts/**/*.ts'],
+        rules: {
+            'no-console': 'off',
         },
     },
 ]

--- a/packages/frontend/src/components/Config/CommandsConfig.tsx
+++ b/packages/frontend/src/components/Config/CommandsConfig.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import { useState, useEffect, useMemo } from 'react'
 import { Terminal, Search, Filter } from 'lucide-react'
 import Card from '@/components/ui/Card'
@@ -33,7 +34,10 @@ export default function CommandsConfig({ guildId }: CommandsConfigProps) {
             const response = await api.commands.list(guildId)
             setCommands(response.data.commands)
         } catch (error) {
-            console.error('Failed to load commands:', error)
+            reportError('Failed to load commands:', error, {
+                component: 'CommandsConfig',
+                action: 'loadCommands',
+            })
             toast.error('Failed to load commands')
         }
     }
@@ -67,7 +71,10 @@ export default function CommandsConfig({ guildId }: CommandsConfigProps) {
             toast.success(`Command ${enabled ? 'enabled' : 'disabled'}`)
         } catch (error) {
             toast.error('Failed to update command')
-            console.error('Error toggling command:', error)
+            reportError('Error toggling command:', error, {
+                component: 'CommandsConfig',
+                action: 'toggleCommand',
+            })
         }
     }
 

--- a/packages/frontend/src/components/Config/ModerationConfig.tsx
+++ b/packages/frontend/src/components/Config/ModerationConfig.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -74,7 +75,10 @@ export default function ModerationConfig({ guildId }: ModerationConfigProps) {
                 form.reset(response.data.settings as ModerationConfigValues)
             }
         } catch (error) {
-            console.error('Failed to load moderation settings:', error)
+            reportError('Failed to load moderation settings:', error, {
+                component: 'ModerationConfig',
+                action: 'load',
+            })
         }
     }
 
@@ -85,7 +89,10 @@ export default function ModerationConfig({ guildId }: ModerationConfigProps) {
             toast.success('Moderation configuration saved successfully!')
         } catch (error) {
             toast.error('Failed to save moderation configuration')
-            console.error('Error saving moderation config:', error)
+            reportError('Error saving moderation config:', error, {
+                component: 'ModerationConfig',
+                action: 'save',
+            })
         } finally {
             setIsLoading(false)
         }

--- a/packages/frontend/src/components/Config/MusicConfig.tsx
+++ b/packages/frontend/src/components/Config/MusicConfig.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -67,7 +68,10 @@ export default function MusicConfig({ guildId }: MusicConfigProps) {
                 })
             }
         } catch (error) {
-            console.error('Failed to load music settings:', error)
+            reportError('Failed to load music settings:', error, {
+                component: 'MusicConfig',
+                action: 'load',
+            })
         }
     }
 
@@ -79,7 +83,10 @@ export default function MusicConfig({ guildId }: MusicConfigProps) {
             toast.success('Music configuration saved successfully!')
         } catch (error) {
             toast.error('Failed to save music configuration')
-            console.error('Error saving music config:', error)
+            reportError('Error saving music config:', error, {
+                component: 'MusicConfig',
+                action: 'save',
+            })
         } finally {
             setIsLoading(false)
         }

--- a/packages/frontend/src/components/ErrorBoundary.tsx
+++ b/packages/frontend/src/components/ErrorBoundary.tsx
@@ -38,6 +38,7 @@ class ErrorBoundary extends Component<Props, State> {
     }
 
     componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        // eslint-disable-next-line no-console -- keep errorInfo visible locally; Sentry capture follows
         console.error('ErrorBoundary caught an error:', error, errorInfo)
         captureFrontendException(error, {
             correlationId: this.state.correlationId,

--- a/packages/frontend/src/components/Music/AutoplayGenres.tsx
+++ b/packages/frontend/src/components/Music/AutoplayGenres.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import { useState, useEffect } from 'react'
 import { Music2, Plus, X, AlertCircle } from 'lucide-react'
 import Card from '@/components/ui/Card'
@@ -10,7 +11,9 @@ import { inferApiBase } from '@/services/apiBase'
 
 const API_BASE = inferApiBase(
     import.meta.env.VITE_API_BASE_URL,
-    typeof globalThis !== 'undefined' && 'window' in globalThis ? globalThis.window.location : undefined,
+    typeof globalThis !== 'undefined' && 'window' in globalThis
+        ? globalThis.window.location
+        : undefined,
 )
 
 const apiClient = axios.create({
@@ -55,7 +58,10 @@ export default function AutoplayGenres({ guildId }: AutoplayGenresProps) {
             )
             setGenres(response.data.genres || [])
         } catch (err) {
-            console.error('Failed to load genres:', err)
+            reportError('Failed to load genres:', err, {
+                component: 'AutoplayGenres',
+                action: 'loadGenres',
+            })
             setError('Failed to load autoplay genres')
         }
     }
@@ -98,7 +104,10 @@ export default function AutoplayGenres({ guildId }: AutoplayGenresProps) {
             setGenres(updatedGenres)
             toast.success('Autoplay genres updated')
         } catch (err) {
-            console.error('Failed to update genres:', err)
+            reportError('Failed to update genres:', err, {
+                component: 'AutoplayGenres',
+                action: 'updateGenres',
+            })
             setError('Failed to update autoplay genres')
             toast.error('Failed to update autoplay genres')
         } finally {
@@ -115,8 +124,8 @@ export default function AutoplayGenres({ guildId }: AutoplayGenresProps) {
                 </h3>
             </div>
             <p className='text-lucky-text-secondary mb-6'>
-                Select genres to focus your autoplay recommendations on specific music styles.
-                Leave empty for no genre filtering.
+                Select genres to focus your autoplay recommendations on specific
+                music styles. Leave empty for no genre filtering.
             </p>
 
             {error && (
@@ -190,20 +199,20 @@ export default function AutoplayGenres({ guildId }: AutoplayGenresProps) {
                         Suggested Genres
                     </Label>
                     <div className='flex flex-wrap gap-2 mt-3'>
-                        {SUGGESTED_GENRES
-                            .filter((g) => !genres.includes(g))
-                            .map((genre) => (
-                                <button
-                                    key={genre}
-                                    onClick={() => {
-                                        setNewGenre(genre)
-                                    }}
-                                    disabled={isLoading}
-                                    className='px-3 py-1 bg-lucky-border rounded-full text-lucky-text-secondary hover:bg-lucky-border/80 transition-colors disabled:opacity-50'
-                                >
-                                    {genre}
-                                </button>
-                            ))}
+                        {SUGGESTED_GENRES.filter(
+                            (g) => !genres.includes(g),
+                        ).map((genre) => (
+                            <button
+                                key={genre}
+                                onClick={() => {
+                                    setNewGenre(genre)
+                                }}
+                                disabled={isLoading}
+                                className='px-3 py-1 bg-lucky-border rounded-full text-lucky-text-secondary hover:bg-lucky-border/80 transition-colors disabled:opacity-50'
+                            >
+                                {genre}
+                            </button>
+                        ))}
                     </div>
                 </div>
             )}

--- a/packages/frontend/src/lib/sentry.ts
+++ b/packages/frontend/src/lib/sentry.ts
@@ -72,3 +72,19 @@ export function captureFrontendException(
 ): void {
     Sentry.captureException(error, context ? { extra: context } : undefined)
 }
+
+/**
+ * Report a handled error: forward it to Sentry and echo it to the console
+ * for local visibility (capture is a no-op without a DSN, e.g. in dev).
+ * Use instead of bare console.error in catch blocks — the frontend
+ * `no-console` lint rule enforces this.
+ */
+export function reportError(
+    message: string,
+    error: unknown,
+    context?: Record<string, unknown>,
+): void {
+    captureFrontendException(error, { message, ...context })
+    // eslint-disable-next-line no-console -- the one sanctioned console echo
+    console.error(message, error)
+}

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '@/stores/authStore'
@@ -81,7 +82,10 @@ export default function Landing() {
                 })
             } catch (error) {
                 if (!active) return
-                console.error('Failed to fetch bot stats:', error)
+                reportError('Failed to fetch bot stats:', error, {
+                    component: 'Landing',
+                    action: 'fetchBotStats',
+                })
                 setRepoStats((s) => ({ ...s, error: true, loading: false }))
             }
         }
@@ -369,7 +373,10 @@ function RepoCard({ stats, locale }: { stats: RepoStats; locale: string }) {
             setCopied(true)
             setTimeout(() => setCopied(false), 1800)
         } catch (error) {
-            console.error('Clipboard write failed:', error)
+            reportError('Clipboard write failed:', error, {
+                component: 'Landing',
+                action: 'copy',
+            })
         }
     }
 

--- a/packages/frontend/src/pages/Levels.tsx
+++ b/packages/frontend/src/pages/Levels.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import { useState, useEffect } from 'react'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
@@ -78,7 +79,10 @@ function Levels() {
             } catch (error) {
                 if (!mounted) return
                 if (error instanceof ApiError) {
-                    console.error(error)
+                    reportError('Failed to load levels data:', error, {
+                        component: 'Levels',
+                        action: 'loadData',
+                    })
                     toast.error('Failed to load level settings')
                 }
             } finally {
@@ -105,7 +109,10 @@ function Levels() {
             })
             toast.success('Level settings saved')
         } catch (error) {
-            console.error(error)
+            reportError('Failed to save level settings:', error, {
+                component: 'Levels',
+                action: 'saveSettings',
+            })
             toast.error('Failed to save settings')
         } finally {
             setSaving(false)
@@ -129,7 +136,10 @@ function Levels() {
             setNewRoleId('')
             toast.success(`Reward added for level ${levelNum}`)
         } catch (error) {
-            console.error(error)
+            reportError('Failed to add level reward:', error, {
+                component: 'Levels',
+                action: 'addReward',
+            })
             toast.error('Failed to add reward')
         } finally {
             setAdding(false)
@@ -144,7 +154,10 @@ function Levels() {
             setRewards(rewards.filter((r) => r.level !== level))
             toast.success('Reward removed')
         } catch (error) {
-            console.error(error)
+            reportError('Failed to remove level reward:', error, {
+                component: 'Levels',
+                action: 'removeReward',
+            })
             toast.error('Failed to remove reward')
         }
     }

--- a/packages/frontend/src/pages/ServerLogs.tsx
+++ b/packages/frontend/src/pages/ServerLogs.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import { useState, useEffect, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
@@ -186,7 +187,10 @@ export default function ServerLogsPage() {
             setLogs(allLogs.slice((page - 1) * limit, page * limit))
             setTotal(res.data.total)
         } catch (error) {
-            console.error('Failed to load logs:', error)
+            reportError('Failed to load logs:', error, {
+                component: 'ServerLogs',
+                action: 'loadLogs',
+            })
             toast.error('Failed to load logs. Please try again.')
             setLogs([])
             setTotal(0)

--- a/packages/frontend/src/pages/ServerSettings.tsx
+++ b/packages/frontend/src/pages/ServerSettings.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import {
     useState,
     useEffect,
@@ -162,7 +163,10 @@ export default function ServerSettingsPage() {
                 )
             }
         } catch (error) {
-            console.error(error)
+            reportError('Failed to load server roles:', error, {
+                component: 'ServerSettings',
+                action: 'loadRbacRoles',
+            })
             if (requestId !== rbacRequestIdRef.current) {
                 return
             }

--- a/packages/frontend/src/pages/Starboard.tsx
+++ b/packages/frontend/src/pages/Starboard.tsx
@@ -1,3 +1,4 @@
+import { reportError } from '@/lib/sentry'
 import { useState, useEffect } from 'react'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
@@ -59,7 +60,10 @@ function Starboard() {
             } catch (error) {
                 if (!mounted) return
                 if (error instanceof ApiError) {
-                    console.error(error)
+                    reportError('Failed to load starboard data:', error, {
+                        component: 'Starboard',
+                        action: 'loadData',
+                    })
                     toast.error('Failed to load starboard settings')
                 }
             } finally {
@@ -88,7 +92,10 @@ function Starboard() {
             })
             toast.success('Starboard settings saved')
         } catch (error) {
-            console.error(error)
+            reportError('Failed to save starboard settings:', error, {
+                component: 'Starboard',
+                action: 'saveSettings',
+            })
             toast.error('Failed to save settings')
         } finally {
             setSaving(false)
@@ -108,7 +115,10 @@ function Starboard() {
             setSelfStar(false)
             toast.success('Starboard disabled')
         } catch (error) {
-            console.error(error)
+            reportError('Failed to disable starboard:', error, {
+                component: 'Starboard',
+                action: 'disable',
+            })
             toast.error('Failed to delete starboard config')
         } finally {
             setSaving(false)


### PR DESCRIPTION
## What

Closes #1278 — the frontend monitoring blind spot from the test-sweep/backlog audit, and the Track B remnant of ADR 2026-06-01-logging-observability-hardening.

## Changes

- **`lib/sentry.ts`**: new `reportError(message, error, context)` — forwards to `captureFrontendException` and echoes to the console so local dev (no DSN) keeps visibility.
- **19 catch blocks across 9 components** (Levels, Starboard, ServerSettings, ServerLogs, Landing, AutoplayGenres, ModerationConfig, MusicConfig, CommandsConfig) switch from bare `console.error` to `reportError` with `{ component, action }` context — bare sites gained descriptive messages derived from their enclosing handlers.
- **Enforcement**: frontend eslint `no-console: ['error', { allow: ['warn'] }]` so new bare `console.error` can't land. Overrides: `scripts/**` (Node CLI tooling — console is the interface), plus the two sanctioned echoes (inside `reportError` itself; ErrorBoundary's `errorInfo` dump, which already captures separately).

## Verification

- `eslint --max-warnings 0` clean (rule live, zero violations)
- 733/733 vitest pass
- `tsc --noEmit` clean across all workspaces (pre-commit hook)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes handled frontend errors to Sentry and blocks bare `console.error` usage to fix the monitoring blind spot. Improves production visibility and closes #1278.

- **Bug Fixes**
  - Added `reportError(message, error, context)` in `@/lib/sentry` to capture to Sentry and echo to console for dev without a DSN.
  - Replaced 19 `console.error` calls across 9 components with `reportError` including `{ component, action }` context.
  - Enforced `no-console: ['error', { allow: ['warn'] }]` in the frontend `eslint` config; override for `scripts/**`; allowed console echo inside `reportError` and `ErrorBoundary` only.

<sup>Written for commit 7b2a9f4a07154baa2d006c63d77b120370a96df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

