### PR TITLE
fix(backend): validate guildId snowflake on all 18 music routes

### DIFF
--- a/packages/backend/src/routes/music/autoplayRoutes.ts
+++ b/packages/backend/src/routes/music/autoplayRoutes.ts
@@ -1,6 +1,8 @@
 import type { Express, Response } from 'express'
 import { requireAuth, type AuthenticatedRequest } from '../../middleware/auth'
 import { asyncHandler } from '../../middleware/asyncHandler'
+import { validateParams } from '../../middleware/validate'
+import { guildIdParam } from '../../schemas/common'
 import { guildSettingsService } from '@lucky/shared/services'
 import { param } from './helpers'
 
@@ -9,9 +11,11 @@ export function setupAutoplayRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/autoplay/genres',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
-            const settings = await guildSettingsService.getGuildSettings(guildId)
+            const settings =
+                await guildSettingsService.getGuildSettings(guildId)
             const genres = settings?.autoplayGenres ?? []
             res.json({ genres })
         }),
@@ -21,6 +25,7 @@ export function setupAutoplayRoutes(app: Express): void {
     app.put(
         '/api/guilds/:guildId/autoplay/genres',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const { genres } = req.body as Record<string, unknown>
@@ -43,11 +48,16 @@ export function setupAutoplayRoutes(app: Express): void {
             }
 
             // Normalize and deduplicate
-            const normalized = [...new Set(genres.map(g => String(g).toLowerCase().trim()))].filter(Boolean)
+            const normalized = [
+                ...new Set(genres.map((g) => String(g).toLowerCase().trim())),
+            ].filter(Boolean)
 
-            const updated = await guildSettingsService.updateGuildSettings(guildId, {
-                autoplayGenres: normalized,
-            })
+            const updated = await guildSettingsService.updateGuildSettings(
+                guildId,
+                {
+                    autoplayGenres: normalized,
+                },
+            )
 
             if (!updated) {
                 res.status(500).json({

--- a/packages/backend/src/routes/music/playbackRoutes.ts
+++ b/packages/backend/src/routes/music/playbackRoutes.ts
@@ -56,65 +56,31 @@ export function setupPlaybackRoutes(app: Express): void {
         }),
     )
 
-    app.post(
-        '/api/guilds/:guildId/music/pause',
-        requireAuth,
-        validateParams(guildIdParam),
-        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-            const guildId = param(req.params.guildId)
-            const userId = requireUserId(req)
-            res.json(
-                await musicControlService.sendCommand(
-                    buildCommand(guildId, userId, 'pause'),
-                ),
-            )
-        }),
-    )
-
-    app.post(
-        '/api/guilds/:guildId/music/resume',
-        requireAuth,
-        validateParams(guildIdParam),
-        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-            const guildId = param(req.params.guildId)
-            const userId = requireUserId(req)
-            res.json(
-                await musicControlService.sendCommand(
-                    buildCommand(guildId, userId, 'resume'),
-                ),
-            )
-        }),
-    )
-
-    app.post(
-        '/api/guilds/:guildId/music/skip',
-        requireAuth,
-        validateParams(guildIdParam),
-        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-            const guildId = param(req.params.guildId)
-            const userId = requireUserId(req)
-            res.json(
-                await musicControlService.sendCommand(
-                    buildCommand(guildId, userId, 'skip'),
-                ),
-            )
-        }),
-    )
-
-    app.post(
-        '/api/guilds/:guildId/music/stop',
-        requireAuth,
-        validateParams(guildIdParam),
-        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-            const guildId = param(req.params.guildId)
-            const userId = requireUserId(req)
-            res.json(
-                await musicControlService.sendCommand(
-                    buildCommand(guildId, userId, 'stop'),
-                ),
-            )
-        }),
-    )
+    // pause/resume/skip/stop/shuffle share one shape: no body, fire the
+    // command named by the path segment.
+    const simpleCommands = [
+        'pause',
+        'resume',
+        'skip',
+        'stop',
+        'shuffle',
+    ] as const
+    for (const command of simpleCommands) {
+        app.post(
+            `/api/guilds/:guildId/music/${command}`,
+            requireAuth,
+            validateParams(guildIdParam),
+            asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+                const guildId = param(req.params.guildId)
+                const userId = requireUserId(req)
+                res.json(
+                    await musicControlService.sendCommand(
+                        buildCommand(guildId, userId, command),
+                    ),
+                )
+            }),
+        )
+    }
 
     app.post(
         '/api/guilds/:guildId/music/volume',
@@ -134,21 +100,6 @@ export function setupPlaybackRoutes(app: Express): void {
                     buildCommand(guildId, userId, 'volume', {
                         volume: body.data.volume,
                     }),
-                ),
-            )
-        }),
-    )
-
-    app.post(
-        '/api/guilds/:guildId/music/shuffle',
-        requireAuth,
-        validateParams(guildIdParam),
-        asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-            const guildId = param(req.params.guildId)
-            const userId = requireUserId(req)
-            res.json(
-                await musicControlService.sendCommand(
-                    buildCommand(guildId, userId, 'shuffle'),
                 ),
             )
         }),

--- a/packages/backend/src/routes/music/playbackRoutes.ts
+++ b/packages/backend/src/routes/music/playbackRoutes.ts
@@ -2,6 +2,8 @@ import type { Express, Response } from 'express'
 import { z } from 'zod'
 import { requireAuth, type AuthenticatedRequest } from '../../middleware/auth'
 import { asyncHandler } from '../../middleware/asyncHandler'
+import { validateParams } from '../../middleware/validate'
+import { guildIdParam } from '../../schemas/common'
 import { AppError } from '../../errors/AppError'
 import { musicControlService } from '@lucky/shared/services'
 import { param, buildCommand } from './helpers'
@@ -35,6 +37,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/play',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -56,6 +59,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/pause',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -70,6 +74,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/resume',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -84,6 +89,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/skip',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -98,6 +104,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/stop',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -112,6 +119,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/volume',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -134,6 +142,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/shuffle',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -148,6 +157,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/repeat',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -172,6 +182,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/seek',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)

--- a/packages/backend/src/routes/music/queueRoutes.ts
+++ b/packages/backend/src/routes/music/queueRoutes.ts
@@ -2,6 +2,8 @@ import type { Express, Response } from 'express'
 import { z } from 'zod'
 import { requireAuth, type AuthenticatedRequest } from '../../middleware/auth'
 import { asyncHandler } from '../../middleware/asyncHandler'
+import { validateParams } from '../../middleware/validate'
+import { guildIdParam } from '../../schemas/common'
 import { AppError } from '../../errors/AppError'
 import { musicControlService } from '@lucky/shared/services'
 import { param, buildCommand } from './helpers'
@@ -32,6 +34,7 @@ export function setupQueueRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/music/queue',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const state = await musicControlService.getState(guildId)
@@ -46,6 +49,7 @@ export function setupQueueRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/queue/move',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -66,6 +70,7 @@ export function setupQueueRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/queue/remove',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -85,6 +90,7 @@ export function setupQueueRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/queue/clear',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)
@@ -99,6 +105,7 @@ export function setupQueueRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/import',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const userId = requireUserId(req)

--- a/packages/backend/src/routes/music/stateRoutes.ts
+++ b/packages/backend/src/routes/music/stateRoutes.ts
@@ -1,6 +1,8 @@
 import type { Express, Response } from 'express'
 import { requireAuth, type AuthenticatedRequest } from '../../middleware/auth'
 import { asyncHandler } from '../../middleware/asyncHandler'
+import { validateParams } from '../../middleware/validate'
+import { guildIdParam } from '../../schemas/common'
 import { musicControlService, type QueueState } from '@lucky/shared/services'
 import { param, sseClients } from './helpers'
 
@@ -8,6 +10,7 @@ export function setupStateRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/music/stream',
         requireAuth,
+        validateParams(guildIdParam),
         async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
 
@@ -40,7 +43,11 @@ export function setupStateRoutes(app: Express): void {
 
             try {
                 heartbeat = setInterval(() => {
-                    if (controller.signal.aborted || res.writableEnded || res.destroyed) {
+                    if (
+                        controller.signal.aborted ||
+                        res.writableEnded ||
+                        res.destroyed
+                    ) {
                         return
                     }
                     try {
@@ -69,6 +76,7 @@ export function setupStateRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/music/state',
         requireAuth,
+        validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
             const state = await musicControlService.getState(guildId)

--- a/packages/backend/tests/integration/routes/autoplay.test.ts
+++ b/packages/backend/tests/integration/routes/autoplay.test.ts
@@ -19,8 +19,17 @@ jest.mock('@lucky/shared/services', () => ({
 }))
 
 jest.mock('../../../src/middleware/auth', () => ({
-    requireAuth: (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
-        req.user = { id: 'test-discord-id', username: 'test', discriminator: '0000', avatar: null }
+    requireAuth: (
+        req: AuthenticatedRequest,
+        _res: Response,
+        next: NextFunction,
+    ) => {
+        req.user = {
+            id: 'test-discord-id',
+            username: 'test',
+            discriminator: '0000',
+            avatar: null,
+        }
         next()
     },
 }))
@@ -47,7 +56,7 @@ describe('Autoplay Routes', () => {
             mockGuildSettingsService.getGuildSettings.mockResolvedValue(null)
 
             const res = await request(app).get(
-                '/api/guilds/guild-123/autoplay/genres',
+                '/api/guilds/123456789012345678/autoplay/genres',
             )
 
             expect(res.status).toBe(200)
@@ -60,7 +69,7 @@ describe('Autoplay Routes', () => {
             })
 
             const res = await request(app).get(
-                '/api/guilds/guild-123/autoplay/genres',
+                '/api/guilds/123456789012345678/autoplay/genres',
             )
 
             expect(res.status).toBe(200)
@@ -75,21 +84,21 @@ describe('Autoplay Routes', () => {
             mockGuildSettingsService.updateGuildSettings.mockResolvedValue(true)
 
             const res = await request(app)
-                .put('/api/guilds/guild-123/autoplay/genres')
+                .put('/api/guilds/123456789012345678/autoplay/genres')
                 .send({ genres: ['rock', 'pop'] })
 
             expect(res.status).toBe(200)
             expect(res.body).toEqual({ genres: ['rock', 'pop'] })
             expect(
                 mockGuildSettingsService.updateGuildSettings,
-            ).toHaveBeenCalledWith('guild-123', {
+            ).toHaveBeenCalledWith('123456789012345678', {
                 autoplayGenres: ['rock', 'pop'],
             })
         })
 
         it('rejects when genres is not an array', async () => {
             const res = await request(app)
-                .put('/api/guilds/guild-123/autoplay/genres')
+                .put('/api/guilds/123456789012345678/autoplay/genres')
                 .send({ genres: 'rock' })
 
             expect(res.status).toBe(400)
@@ -98,9 +107,16 @@ describe('Autoplay Routes', () => {
 
         it('rejects when more than 5 genres', async () => {
             const res = await request(app)
-                .put('/api/guilds/guild-123/autoplay/genres')
+                .put('/api/guilds/123456789012345678/autoplay/genres')
                 .send({
-                    genres: ['rock', 'pop', 'indie', 'jazz', 'metal', 'electronic'],
+                    genres: [
+                        'rock',
+                        'pop',
+                        'indie',
+                        'jazz',
+                        'metal',
+                        'electronic',
+                    ],
                 })
 
             expect(res.status).toBe(400)
@@ -111,7 +127,7 @@ describe('Autoplay Routes', () => {
             mockGuildSettingsService.updateGuildSettings.mockResolvedValue(true)
 
             const res = await request(app)
-                .put('/api/guilds/guild-123/autoplay/genres')
+                .put('/api/guilds/123456789012345678/autoplay/genres')
                 .send({ genres: ['Rock', 'ROCK', '  rock  ', 'pop'] })
 
             expect(res.status).toBe(200)
@@ -119,10 +135,12 @@ describe('Autoplay Routes', () => {
         })
 
         it('handles update failure', async () => {
-            mockGuildSettingsService.updateGuildSettings.mockResolvedValue(false)
+            mockGuildSettingsService.updateGuildSettings.mockResolvedValue(
+                false,
+            )
 
             const res = await request(app)
-                .put('/api/guilds/guild-123/autoplay/genres')
+                .put('/api/guilds/123456789012345678/autoplay/genres')
                 .send({ genres: ['rock'] })
 
             expect(res.status).toBe(500)

--- a/packages/backend/tests/unit/routes/snowflakeValidation.test.ts
+++ b/packages/backend/tests/unit/routes/snowflakeValidation.test.ts
@@ -33,6 +33,16 @@ jest.mock('@lucky/shared/services', () => ({
         addReward: jest.fn().mockResolvedValue({}),
         removeReward: jest.fn().mockResolvedValue({}),
     },
+    musicControlService: {
+        getState: jest.fn().mockResolvedValue(null),
+        sendCommand: jest.fn().mockResolvedValue({ success: true }),
+    },
+    guildSettingsService: {
+        getGuildSettings: jest.fn().mockResolvedValue(null),
+        updateGuildSettings: jest.fn().mockResolvedValue({
+            autoplayGenres: [],
+        }),
+    },
 }))
 
 jest.mock('../../../src/services/GuildService', () => ({
@@ -69,6 +79,10 @@ import request from 'supertest'
 import { setupStarboardRoutes } from '../../../src/routes/starboard'
 import { setupLevelsRoutes } from '../../../src/routes/levels'
 import { setupGuildRoutes } from '../../../src/routes/guilds'
+import { setupAutoplayRoutes } from '../../../src/routes/music/autoplayRoutes'
+import { setupStateRoutes } from '../../../src/routes/music/stateRoutes'
+import { setupPlaybackRoutes } from '../../../src/routes/music/playbackRoutes'
+import { setupQueueRoutes } from '../../../src/routes/music/queueRoutes'
 
 function createApp(setupRoutes: (app: express.Express) => void) {
     const app = express()
@@ -341,6 +355,170 @@ describe('Guild ID Snowflake Validation', () => {
                 expect(res.body).toHaveProperty('error')
             },
         )
+    })
+
+    describe('Music Routes (#1200)', () => {
+        const validGuildId = '123456789012345678'
+        const invalidGuildId = 'not-a-snowflake'
+
+        type MusicRoute = {
+            name: string
+            setup: (app: express.Express) => void
+            method: 'get' | 'post' | 'put'
+            path: (guildId: string) => string
+            body?: Record<string, unknown>
+        }
+
+        const routes: MusicRoute[] = [
+            {
+                name: 'GET autoplay/genres',
+                setup: setupAutoplayRoutes,
+                method: 'get',
+                path: (g) => `/api/guilds/${g}/autoplay/genres`,
+            },
+            {
+                name: 'PUT autoplay/genres',
+                setup: setupAutoplayRoutes,
+                method: 'put',
+                path: (g) => `/api/guilds/${g}/autoplay/genres`,
+                body: { genres: ['rock'] },
+            },
+            {
+                name: 'GET music/state',
+                setup: setupStateRoutes,
+                method: 'get',
+                path: (g) => `/api/guilds/${g}/music/state`,
+            },
+            {
+                name: 'POST music/play',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/play`,
+                body: { query: 'song' },
+            },
+            {
+                name: 'POST music/pause',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/pause`,
+            },
+            {
+                name: 'POST music/resume',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/resume`,
+            },
+            {
+                name: 'POST music/skip',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/skip`,
+            },
+            {
+                name: 'POST music/stop',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/stop`,
+            },
+            {
+                name: 'POST music/volume',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/volume`,
+                body: { volume: 50 },
+            },
+            {
+                name: 'POST music/shuffle',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/shuffle`,
+            },
+            {
+                name: 'POST music/repeat',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/repeat`,
+                body: { mode: 'off' },
+            },
+            {
+                name: 'POST music/seek',
+                setup: setupPlaybackRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/seek`,
+                body: { position: 0 },
+            },
+            {
+                name: 'GET music/queue',
+                setup: setupQueueRoutes,
+                method: 'get',
+                path: (g) => `/api/guilds/${g}/music/queue`,
+            },
+            {
+                name: 'POST music/queue/move',
+                setup: setupQueueRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/queue/move`,
+                body: { from: 0, to: 1 },
+            },
+            {
+                name: 'POST music/queue/remove',
+                setup: setupQueueRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/queue/remove`,
+                body: { index: 0 },
+            },
+            {
+                name: 'POST music/queue/clear',
+                setup: setupQueueRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/queue/clear`,
+            },
+            {
+                name: 'POST music/import',
+                setup: setupQueueRoutes,
+                method: 'post',
+                path: (g) => `/api/guilds/${g}/music/import`,
+                body: { url: 'https://example.com/playlist' },
+            },
+        ]
+
+        test.each(routes)(
+            '$name rejects invalid guildId with 400',
+            async ({ setup, method, path, body }) => {
+                const app = createApp(setup)
+                let req = request(app)[method](path(invalidGuildId))
+                if (body) {
+                    req = req.send(body)
+                }
+                const res = await req
+                expect(res.status).toBe(400)
+                expect(res.body).toHaveProperty('error')
+            },
+        )
+
+        test.each(routes)(
+            '$name accepts a valid guildId',
+            async ({ setup, method, path, body }) => {
+                const app = createApp(setup)
+                let req = request(app)[method](path(validGuildId))
+                if (body) {
+                    req = req.send(body)
+                }
+                const res = await req
+                expect(res.status).not.toBe(400)
+            },
+        )
+
+        // GET music/stream is SSE — a valid request never terminates, so only
+        // the rejection path is testable here.
+        test('GET music/stream rejects invalid guildId with 400', async () => {
+            const app = createApp(setupStateRoutes)
+            const res = await request(app).get(
+                `/api/guilds/${invalidGuildId}/music/stream`,
+            )
+            expect(res.status).toBe(400)
+            expect(res.body).toHaveProperty('error')
+        })
     })
 
     describe('Guilds Routes', () => {


### PR DESCRIPTION
## What

Closes #1200 — extends the snowflake-validation pattern from #1158/#1172 to the music surface, the last unguarded `:guildId` route family.

## Changes

- `validateParams(guildIdParam)` inserted **after `requireAuth`, before handler logic** (the ordering point from #1172) on every music route: autoplayRoutes (2), stateRoutes (2, including the SSE stream), playbackRoutes (9), queueRoutes (5) = **18 routes** (the issue title says 14; its own enumeration lists 18 — all covered).
- `snowflakeValidation.test.ts` gains a parametrized Music Routes block: strict `toBe(400)` on malformed guildId + a valid-id non-400 pass per route. The SSE stream route is rejection-only (a valid SSE request never terminates under supertest).
- Autoplay integration fixture `guild-123` → valid snowflake — the old fixture was itself malformed and is now (correctly) rejected by the guard.

## Verification

- Backend: **989/989** (35 new tests), lint clean, type:check green across workspaces (pre-commit)
- Handler-level validation tests (genres array shape/limit) still hit the handler's own checks with the valid fixture — no behavior change for well-formed requests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `:guildId` as a snowflake on all 18 music routes, applied right after auth to block bad IDs before handler logic; also deduplicates playback route registrations. Completes #1200 and aligns with the pattern from #1158/#1172.

- **Bug Fixes**
  - Added `validateParams(guildIdParam)` to every music route in `autoplayRoutes`, `stateRoutes` (incl. SSE), `playbackRoutes`, and `queueRoutes` (18 total), placed after `requireAuth`.
  - Expanded `snowflakeValidation.test.ts` with a parameterized Music Routes suite: invalid IDs return 400; valid IDs do not; SSE stream covered for rejection only.
  - Updated autoplay integration fixtures to a valid snowflake ID; no change for well-formed requests.

- **Refactors**
  - Collapsed identical no-body playback routes (`pause`, `resume`, `skip`, `stop`, `shuffle`) into a single registration loop; behavior and paths unchanged.

<sup>Written for commit 4d6b62231a6cfc283d2426779135d7a4c4960a91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added guild ID validation across all music API endpoints to prevent invalid requests.
  * Improved genre data normalization for consistency in autoplay settings.

* **Tests**
  * Added comprehensive test suite verifying parameter validation for music endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->