### PR TITLE
ci: queue overlapping production deploys (non-cancelling concurrency group)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,12 @@ on:
 permissions:
     contents: read
 
+# Overlapping deploys race on migrations + service rollout (#1182).
+# Queue them instead: never cancel an in-flight production deploy.
+concurrency:
+    group: deployment-production
+    cancel-in-progress: false
+
 jobs:
     deploy:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Closes #1182. Queue item under ADR 2026-06-10 (workflow-only — no image rebuild, no deploy trigger on merge).

## Change

`deploy.yml` gains the concurrency block its sibling workflows already have, but **non-cancelling**: overlapping production deploys queue instead of racing on migrations + service rollout, and an in-flight deploy is never killed mid-rollout.

## Verification

- actionlint runs in the Quality Gates workflow on this PR
- Workflow-only change — exercised by the next real deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queue overlapping production deploys by adding a non-cancelling `concurrency` group to `deploy.yml`, fixing #1182. This prevents migration/rollout races and ensures an in-flight deploy is never canceled.

<sup>Written for commit 61afe7535e16b20f4e5c97f92eb70ea7317ceb39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

