### PR TITLE
security(ci): pin third-party actions and container images to immutable versions

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -38,7 +38,7 @@ jobs:
             # run the npm script; pnpm executes `package.json#scripts.build`
             # natively without needing a pnpm-lock.yaml.
             - name: Setup pnpm (shim for compressed-size-action pm detection)
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               with:
                   version: 9
                   run_install: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
               id: sonar_pr
               if: env.SONAR_TOKEN_PRESENT == 'true' && github.event_name == 'pull_request'
               continue-on-error: true
-              uses: SonarSource/sonarqube-scan-action@v8
+              uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
               with:
                   args: -Dsonar.qualitygate.wait=true
               env:
@@ -320,7 +320,7 @@ jobs:
             # download 403 clears on the retry.
             - name: SonarCloud Scan (PR) — retry once on transient failure
               if: env.SONAR_TOKEN_PRESENT == 'true' && github.event_name == 'pull_request' && steps.sonar_pr.outcome == 'failure'
-              uses: SonarSource/sonarqube-scan-action@v8
+              uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
               with:
                   args: -Dsonar.qualitygate.wait=true
               env:
@@ -331,7 +331,7 @@ jobs:
             - name: SonarCloud Scan (main — informational, non-blocking)
               if: env.SONAR_TOKEN_PRESENT == 'true' && github.event_name == 'push'
               continue-on-error: true
-              uses: SonarSource/sonarqube-scan-action@v8
+              uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
               with:
                   args: -Dsonar.qualitygate.wait=false
               env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,8 +208,8 @@ jobs:
                     release="$PUSH_SHA"
                   fi
                   echo "==> Creating Sentry release $release"
-                  npx --yes @sentry/cli@^3 releases new "$release"
-                  npx --yes @sentry/cli@^3 releases set-commits "$release" --local --ignore-missing || true
+                  npx --yes @sentry/cli@3.5.0 releases new "$release"
+                  npx --yes @sentry/cli@3.5.0 releases set-commits "$release" --local --ignore-missing || true
 
             - name: Trigger deploy webhook
               env:
@@ -441,7 +441,7 @@ jobs:
                     release="${{ github.sha }}"
                   fi
                   echo "==> Finalizing Sentry release $release"
-                  npx --yes @sentry/cli@^3 releases finalize "$release"
+                  npx --yes @sentry/cli@3.5.0 releases finalize "$release"
 
             - name: Auth config smoke check
               env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -109,7 +109,7 @@ jobs:
                 echo "ref=${IMAGE}:${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
 
             - name: Trivy image scan (audit-only)
-              uses: aquasecurity/trivy-action@v0.36.0
+              uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
               with:
                   image-ref: ${{ steps.imgref.outputs.ref }}
                   format: sarif

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Label PR by size
-              uses: codelytv/pr-size-labeler@v1
+              uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   xs_label: 'size/xs'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
                   } >> "$GITHUB_OUTPUT"
 
             - name: Create GitHub Release
-              uses: softprops/action-gh-release@v3
+              uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
               with:
                   name: v${{ steps.version.outputs.VERSION }}
                   body: ${{ steps.changelog.outputs.BODY }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,7 +248,7 @@ services:
     # Cloudflare Tunnel — exposes nginx to lucky.lucassantana.tech
     cloudflared:
         <<: *small-svc
-        image: cloudflare/cloudflared:latest
+        image: cloudflare/cloudflared:2026.6.0
         container_name: lucky-tunnel
         command: tunnel --config /etc/cloudflared/config-lucky.yml run
         volumes:


### PR DESCRIPTION
## What

Closes #1185. Queue item under ADR 2026-06-10 (CI/compose-only — no image rebuild, no deploy on merge).

## Pins (11 sites, 7 files)

- `softprops/action-gh-release` → `b430933…` (v3)
- `aquasecurity/trivy-action` → `ed142fd…` (v0.36.0)
- `codelytv/pr-size-labeler` → `095a41f…` (v1)
- `pnpm/action-setup` → `0e279bb…` (v6)
- `SonarSource/sonarqube-scan-action` → `7138816…` (v8, ×3)
- `@sentry/cli@^3` → exact `3.5.0` (×3 in deploy.yml)
- `cloudflare/cloudflared:latest` → `2026.6.0` (takes effect at next compose-up on the homelab)

First-party `actions/*` / `github/*` / `docker/*` org actions stay on major tags per convention. Tag comments preserved so Renovate keeps tracking updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins third-party CI actions and the `cloudflare/cloudflared` image to immutable versions to harden the supply chain and ensure reproducible runs. First‑party `actions/*`, `github/*`, and `docker/*` stay on major tags by convention.

- **Dependencies**
  - Third-party GitHub Actions pinned to commit SHAs (with tag comments for Renovate): `softprops/action-gh-release@b430933` (v3), `aquasecurity/trivy-action@ed142fd` (v0.36.0), `codelytv/pr-size-labeler@095a41f` (v1), `pnpm/action-setup@0e279bb` (v6), `SonarSource/sonarqube-scan-action@7138816` (v8).
  - Locked `@sentry/cli` to `3.5.0` in deploy; set `cloudflare/cloudflared` to `2026.6.0` in `docker-compose.yml`.

- **Migration**
  - No deploy on merge. `cloudflared` version applies on the next `docker compose up -d` on the homelab.

<sup>Written for commit 5ae46b98f7a8ba38191b490030076a06ffcb4b87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

