### PR TITLE
fix(backend): bound pagination limit on leaderboard + starboard entries

### DIFF
--- a/packages/backend/src/routes/levels.ts
+++ b/packages/backend/src/routes/levels.ts
@@ -1,6 +1,10 @@
 import type { Express, Response } from 'express'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
-import { validateBody, validateParams } from '../middleware/validate'
+import {
+    validateBody,
+    validateParams,
+    validateQuery,
+} from '../middleware/validate'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { AppError } from '../errors/AppError'
@@ -14,6 +18,10 @@ import {
 function p(val: string | string[]): string {
     return typeof val === 'string' ? val : val[0]
 }
+
+const leaderboardQuery = z.object({
+    limit: z.coerce.number().int().min(1).max(50).optional(),
+})
 
 const rankParams = guildIdParam.merge(commonUserIdParam)
 const levelParam = guildIdParam.extend({
@@ -62,6 +70,7 @@ export function setupLevelsRoutes(app: Express): void {
         '/api/guilds/:guildId/levels/leaderboard',
         requireAuth,
         validateParams(guildIdParam),
+        validateQuery(leaderboardQuery),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
             const limit = Number(req.query.limit) || 10

--- a/packages/backend/src/routes/starboard.ts
+++ b/packages/backend/src/routes/starboard.ts
@@ -1,6 +1,10 @@
 import type { Express, Response } from 'express'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
-import { validateBody, validateParams } from '../middleware/validate'
+import {
+    validateBody,
+    validateParams,
+    validateQuery,
+} from '../middleware/validate'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { AppError } from '../errors/AppError'
@@ -17,6 +21,10 @@ const upsertConfigBody = z.object({
     emoji: z.string().min(1).max(10).optional(),
     threshold: z.number().int().min(1).max(100).optional(),
     selfStar: z.boolean().optional(),
+})
+
+const entriesQuery = z.object({
+    limit: z.coerce.number().int().min(1).max(50).optional(),
 })
 
 export function setupStarboardRoutes(app: Express): void {
@@ -77,6 +85,7 @@ export function setupStarboardRoutes(app: Express): void {
         '/api/guilds/:guildId/starboard/entries',
         requireAuth,
         validateParams(guildIdParam),
+        validateQuery(entriesQuery),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
             const limit = Number(req.query.limit) || 10

--- a/packages/backend/tests/unit/routes/snowflakeValidation.test.ts
+++ b/packages/backend/tests/unit/routes/snowflakeValidation.test.ts
@@ -357,6 +357,50 @@ describe('Guild ID Snowflake Validation', () => {
         )
     })
 
+    describe('Pagination limit bounds (#1183)', () => {
+        const validGuildId = '123456789012345678'
+
+        test.each([
+            ['9999', 400],
+            ['0', 400],
+            ['-5', 400],
+            ['abc', 400],
+            ['25', 200],
+        ])(
+            'GET levels/leaderboard with limit=%s returns %s-class',
+            async (limit, expected) => {
+                const app = createApp(setupLevelsRoutes)
+                const res = await request(app).get(
+                    `/api/guilds/${validGuildId}/levels/leaderboard?limit=${limit}`,
+                )
+                if (expected === 400) {
+                    expect(res.status).toBe(400)
+                } else {
+                    expect(res.status).not.toBe(400)
+                }
+            },
+        )
+
+        test.each([
+            ['9999', 400],
+            ['0', 400],
+            ['25', 200],
+        ])(
+            'GET starboard/entries with limit=%s returns %s-class',
+            async (limit, expected) => {
+                const app = createApp(setupStarboardRoutes)
+                const res = await request(app).get(
+                    `/api/guilds/${validGuildId}/starboard/entries?limit=${limit}`,
+                )
+                if (expected === 400) {
+                    expect(res.status).toBe(400)
+                } else {
+                    expect(res.status).not.toBe(400)
+                }
+            },
+        )
+    })
+
     describe('Music Routes (#1200)', () => {
         const validGuildId = '123456789012345678'
         const invalidGuildId = 'not-a-snowflake'


### PR DESCRIPTION
## What

Closes #1183. Queue item under ADR 2026-06-10.

## Reality check vs the issue

The issue listed 3 files; current state differed: **trackHistory is already guarded** (`validateQuery(historyQuery/topQuery)` landed with earlier work — its acceptance criteria already hold). The real gaps were `levels/leaderboard` and `starboard/entries`, where `Number(req.query.limit) || 10` let negative/garbage values reach the service layer (only an upper `Math.min` cap existed).

## Changes

- `validateQuery` with `z.coerce.number().int().min(1).max(50).optional()` on both routes — out-of-range returns 400 **before** the DB query, mirroring trackHistory's established pattern.

## Tests

- 8 new bound cases (9999 / 0 / -5 / abc → 400; in-range → passes) in the shared validation harness
- Backend suite 997/997

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the `limit` query on `levels/leaderboard` and `starboard/entries` to 1-50 and return 400 for invalid values. Prevents bad inputs from reaching the service layer and satisfies #1183.

- **Bug Fixes**
  - Added `validateQuery` with `z.coerce.number().int().min(1).max(50).optional()` on both routes so invalid/out-of-range limits return 400 before any DB call.
  - Added tests for 9999, 0, -5, and non-numeric values → 400; valid values (e.g., 25) pass.

<sup>Written for commit 17b9b941feb955615fb7e05645c9c675f0d24fff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

