### PR TITLE
perf(shared): batch recommendation telemetry counts in one groupBy

### DIFF
--- a/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
@@ -45,26 +45,28 @@ describe('recommendationTelemetryReadService', () => {
         })
 
         it('returns single row for single source with mixed outcomes', async () => {
-            const mockGroupResult = [
+            // One groupBy over [source, isAccepted, isRejected] — one bucket
+            // per outcome combination (#1187)
+            mockGroupBy.mockResolvedValue([
                 {
                     source: RecommendationSource.SPOTIFY_REC,
-                    _count: {
-                        id: 10,
-                    },
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 7 },
                 },
-            ]
-            mockGroupBy.mockResolvedValue(mockGroupResult)
-
-            // Mock count calls for accepted, rejected, pending
-            const countCalls = [
-                { count: 7 }, // accepted
-                { count: 2 }, // rejected
-                { count: 1 }, // pending
-            ]
-            mockCount
-                .mockResolvedValueOnce(countCalls[0])
-                .mockResolvedValueOnce(countCalls[1])
-                .mockResolvedValueOnce(countCalls[2])
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 2 },
+                },
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    isAccepted: null,
+                    isRejected: null,
+                    _count: { id: 1 },
+                },
+            ])
 
             const result = await getPerSourceAcceptance('guild-123')
 
@@ -77,38 +79,65 @@ describe('recommendationTelemetryReadService', () => {
                 pendingCount: 1,
                 acceptanceRate: 7 / 9, // 7 / (7 + 2)
             })
+            // The N+1 per-source count loop is gone: exactly one query total
+            expect(mockGroupBy).toHaveBeenCalledTimes(1)
+            expect(mockCount).not.toHaveBeenCalled()
         })
 
         it('returns multiple rows for multiple sources', async () => {
-            const mockGroupResult = [
+            mockGroupBy.mockResolvedValue([
+                // Spotify: 7 accepted, 2 rejected, 1 pending
                 {
                     source: RecommendationSource.SPOTIFY_REC,
-                    _count: { id: 10 },
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 7 },
+                },
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 2 },
+                },
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    isAccepted: null,
+                    isRejected: null,
+                    _count: { id: 1 },
+                },
+                // LastFM: 3 accepted, 1 rejected, 1 pending
+                {
+                    source: RecommendationSource.LASTFM_LOVED,
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 3 },
                 },
                 {
                     source: RecommendationSource.LASTFM_LOVED,
-                    _count: { id: 5 },
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 1 },
+                },
+                {
+                    source: RecommendationSource.LASTFM_LOVED,
+                    isAccepted: null,
+                    isRejected: null,
+                    _count: { id: 1 },
+                },
+                // Artist: 2 accepted, 1 rejected, 0 pending
+                {
+                    source: RecommendationSource.ARTIST_FALLBACK,
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 2 },
                 },
                 {
                     source: RecommendationSource.ARTIST_FALLBACK,
-                    _count: { id: 3 },
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 1 },
                 },
-            ]
-            mockGroupBy.mockResolvedValue(mockGroupResult)
-
-            // Spotify: 7 accepted, 2 rejected, 1 pending
-            mockCount
-                .mockResolvedValueOnce({ count: 7 })
-                .mockResolvedValueOnce({ count: 2 })
-                .mockResolvedValueOnce({ count: 1 })
-                // LastFM: 3 accepted, 1 rejected, 1 pending
-                .mockResolvedValueOnce({ count: 3 })
-                .mockResolvedValueOnce({ count: 1 })
-                .mockResolvedValueOnce({ count: 1 })
-                // Artist: 2 accepted, 1 rejected, 0 pending
-                .mockResolvedValueOnce({ count: 2 })
-                .mockResolvedValueOnce({ count: 1 })
-                .mockResolvedValueOnce({ count: 0 })
+            ])
 
             const result = await getPerSourceAcceptance('guild-123')
 
@@ -137,22 +166,19 @@ describe('recommendationTelemetryReadService', () => {
                 pendingCount: 0,
                 acceptanceRate: 2 / 3,
             })
+            expect(mockGroupBy).toHaveBeenCalledTimes(1)
+            expect(mockCount).not.toHaveBeenCalled()
         })
 
         it('returns null acceptanceRate when denominator is zero (all pending)', async () => {
-            const mockGroupResult = [
+            mockGroupBy.mockResolvedValue([
                 {
                     source: RecommendationSource.SPOTIFY_REC,
+                    isAccepted: null,
+                    isRejected: null,
                     _count: { id: 5 },
                 },
-            ]
-            mockGroupBy.mockResolvedValue(mockGroupResult)
-
-            // All pending
-            mockCount
-                .mockResolvedValueOnce({ count: 0 }) // accepted
-                .mockResolvedValueOnce({ count: 0 }) // rejected
-                .mockResolvedValueOnce({ count: 5 }) // pending
+            ])
 
             const result = await getPerSourceAcceptance('guild-123')
 
@@ -160,25 +186,32 @@ describe('recommendationTelemetryReadService', () => {
         })
 
         it('handles null source value (legacy/fallback)', async () => {
-            const mockGroupResult = [
+            mockGroupBy.mockResolvedValue([
                 {
                     source: null,
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 1 },
+                },
+                {
+                    source: null,
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 1 },
+                },
+                {
+                    source: RecommendationSource.SPOTIFY_REC,
+                    isAccepted: true,
+                    isRejected: null,
                     _count: { id: 2 },
                 },
                 {
                     source: RecommendationSource.SPOTIFY_REC,
-                    _count: { id: 3 },
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 1 },
                 },
-            ]
-            mockGroupBy.mockResolvedValue(mockGroupResult)
-
-            mockCount
-                .mockResolvedValueOnce({ count: 1 }) // null: accepted
-                .mockResolvedValueOnce({ count: 1 }) // null: rejected
-                .mockResolvedValueOnce({ count: 0 }) // null: pending
-                .mockResolvedValueOnce({ count: 2 }) // spotify: accepted
-                .mockResolvedValueOnce({ count: 1 }) // spotify: rejected
-                .mockResolvedValueOnce({ count: 0 }) // spotify: pending
+            ])
 
             const result = await getPerSourceAcceptance('guild-123')
 
@@ -244,26 +277,65 @@ describe('recommendationTelemetryReadService', () => {
         })
 
         it('returns rows for all three modes', async () => {
-            const mockGroupResult = [
-                { mode: 'similar', _count: { id: 10 } },
-                { mode: 'discover', _count: { id: 8 } },
-                { mode: 'popular', _count: { id: 6 } },
-            ]
-            mockGroupBy.mockResolvedValue(mockGroupResult)
-
-            // similar: 7 accepted, 2 rejected, 1 pending
-            mockCount
-                .mockResolvedValueOnce({ count: 7 })
-                .mockResolvedValueOnce({ count: 2 })
-                .mockResolvedValueOnce({ count: 1 })
+            mockGroupBy.mockResolvedValue([
+                // similar: 7 accepted, 2 rejected, 1 pending
+                {
+                    mode: 'similar',
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 7 },
+                },
+                {
+                    mode: 'similar',
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 2 },
+                },
+                {
+                    mode: 'similar',
+                    isAccepted: null,
+                    isRejected: null,
+                    _count: { id: 1 },
+                },
                 // discover: 5 accepted, 2 rejected, 1 pending
-                .mockResolvedValueOnce({ count: 5 })
-                .mockResolvedValueOnce({ count: 2 })
-                .mockResolvedValueOnce({ count: 1 })
+                {
+                    mode: 'discover',
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 5 },
+                },
+                {
+                    mode: 'discover',
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 2 },
+                },
+                {
+                    mode: 'discover',
+                    isAccepted: null,
+                    isRejected: null,
+                    _count: { id: 1 },
+                },
                 // popular: 4 accepted, 1 rejected, 1 pending
-                .mockResolvedValueOnce({ count: 4 })
-                .mockResolvedValueOnce({ count: 1 })
-                .mockResolvedValueOnce({ count: 1 })
+                {
+                    mode: 'popular',
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 4 },
+                },
+                {
+                    mode: 'popular',
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 1 },
+                },
+                {
+                    mode: 'popular',
+                    isAccepted: null,
+                    isRejected: null,
+                    _count: { id: 1 },
+                },
+            ])
 
             const result = await getPerModeAcceptance('guild-123')
 
@@ -292,22 +364,37 @@ describe('recommendationTelemetryReadService', () => {
                 pendingCount: 1,
                 acceptanceRate: 4 / 5,
             })
+            expect(mockGroupBy).toHaveBeenCalledTimes(1)
+            expect(mockCount).not.toHaveBeenCalled()
         })
 
         it('handles null mode value (pre-migration rows)', async () => {
-            const mockGroupResult = [
-                { mode: null, _count: { id: 2 } },
-                { mode: 'similar', _count: { id: 5 } },
-            ]
-            mockGroupBy.mockResolvedValue(mockGroupResult)
-
-            mockCount
-                .mockResolvedValueOnce({ count: 1 }) // null: accepted
-                .mockResolvedValueOnce({ count: 1 }) // null: rejected
-                .mockResolvedValueOnce({ count: 0 }) // null: pending
-                .mockResolvedValueOnce({ count: 4 }) // similar: accepted
-                .mockResolvedValueOnce({ count: 1 }) // similar: rejected
-                .mockResolvedValueOnce({ count: 0 }) // similar: pending
+            mockGroupBy.mockResolvedValue([
+                {
+                    mode: null,
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 1 },
+                },
+                {
+                    mode: null,
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 1 },
+                },
+                {
+                    mode: 'similar',
+                    isAccepted: true,
+                    isRejected: null,
+                    _count: { id: 4 },
+                },
+                {
+                    mode: 'similar',
+                    isAccepted: null,
+                    isRejected: true,
+                    _count: { id: 1 },
+                },
+            ])
 
             const result = await getPerModeAcceptance('guild-123')
 
@@ -318,13 +405,14 @@ describe('recommendationTelemetryReadService', () => {
         })
 
         it('returns null acceptanceRate when all pending', async () => {
-            const mockGroupResult = [{ mode: 'similar', _count: { id: 5 } }]
-            mockGroupBy.mockResolvedValue(mockGroupResult)
-
-            mockCount
-                .mockResolvedValueOnce({ count: 0 }) // accepted
-                .mockResolvedValueOnce({ count: 0 }) // rejected
-                .mockResolvedValueOnce({ count: 5 }) // pending
+            mockGroupBy.mockResolvedValue([
+                {
+                    mode: 'similar',
+                    isAccepted: null,
+                    isRejected: null,
+                    _count: { id: 5 },
+                },
+            ])
 
             const result = await getPerModeAcceptance('guild-123')
 

--- a/packages/shared/src/services/recommendationTelemetryReadService.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.ts
@@ -45,20 +45,28 @@ function getCreatedAtCutoff(days?: number): Date {
     return new Date(Date.now() - clampedDays * 86_400_000)
 }
 
+type AcceptanceCounts = {
+    count: number
+    acceptedCount: number
+    rejectedCount: number
+    pendingCount: number
+}
+
 /**
- * Returns one row per distinct source value seen in the Recommendation table
- * for this guild within the window. Null source is its own row.
+ * Single groupBy over [key, isAccepted, isRejected] folded into per-key
+ * acceptance counts — replaces the former per-group count loop, which issued
+ * three extra queries per distinct key (#1187).
  */
-export async function getPerSourceAcceptance(
+async function getAcceptanceByKey(
+    key: 'source' | 'mode',
     guildId: string,
     days?: number,
-): Promise<PerSourceRow[]> {
+): Promise<Map<string | null, AcceptanceCounts>> {
     const prisma = getPrismaClient()
     const createdAtGte = getCreatedAtCutoff(days)
 
-    // Group by source to get distinct sources and total count per source
-    const groupByResult = await prisma.recommendation.groupBy({
-        by: ['source'],
+    const groups = (await prisma.recommendation.groupBy({
+        by: [key, 'isAccepted', 'isRejected'],
         where: {
             guildId,
             createdAt: {
@@ -68,72 +76,62 @@ export async function getPerSourceAcceptance(
         _count: {
             id: true,
         },
-    })
+    })) as unknown as Array<{
+        source?: string | null
+        mode?: string | null
+        isAccepted: boolean | null
+        isRejected: boolean | null
+        _count: { id: number }
+    }>
 
-    // For each source, fetch accepted, rejected, and pending counts
-    const rows: PerSourceRow[] = []
-    for (const group of groupByResult) {
-        const source = group.source
-        const count = group._count.id
-
-        const getCountValue = (result: any): number =>
-            typeof result === 'number' ? result : result.count
-
-        const acceptedCount = getCountValue(
-            await prisma.recommendation.count({
-                where: {
-                    guildId,
-                    source,
-                    isAccepted: true,
-                    createdAt: {
-                        gte: createdAtGte,
-                    },
-                },
-            }),
-        )
-
-        const rejectedCount = getCountValue(
-            await prisma.recommendation.count({
-                where: {
-                    guildId,
-                    source,
-                    isRejected: true,
-                    createdAt: {
-                        gte: createdAtGte,
-                    },
-                },
-            }),
-        )
-
-        const pendingCount = getCountValue(
-            await prisma.recommendation.count({
-                where: {
-                    guildId,
-                    source,
-                    isAccepted: null,
-                    isRejected: null,
-                    createdAt: {
-                        gte: createdAtGte,
-                    },
-                },
-            }),
-        )
-
-        const denominator = acceptedCount + rejectedCount
-        const acceptanceRate =
-            denominator === 0 ? null : acceptedCount / denominator
-
-        rows.push({
-            source,
-            count,
-            acceptedCount,
-            rejectedCount,
-            pendingCount,
-            acceptanceRate,
-        })
+    const byKey = new Map<string | null, AcceptanceCounts>()
+    for (const group of groups) {
+        const groupKey = (key === 'source' ? group.source : group.mode) ?? null
+        const n = group._count.id
+        let acc = byKey.get(groupKey)
+        if (!acc) {
+            acc = {
+                count: 0,
+                acceptedCount: 0,
+                rejectedCount: 0,
+                pendingCount: 0,
+            }
+            byKey.set(groupKey, acc)
+        }
+        acc.count += n
+        if (group.isAccepted) {
+            acc.acceptedCount += n
+        } else if (group.isRejected) {
+            acc.rejectedCount += n
+        } else {
+            acc.pendingCount += n
+        }
     }
+    return byKey
+}
 
-    return rows
+function toAcceptanceRate(
+    acceptedCount: number,
+    rejectedCount: number,
+): number | null {
+    const denominator = acceptedCount + rejectedCount
+    return denominator === 0 ? null : acceptedCount / denominator
+}
+
+/**
+ * Returns one row per distinct source value seen in the Recommendation table
+ * for this guild within the window. Null source is its own row.
+ */
+export async function getPerSourceAcceptance(
+    guildId: string,
+    days?: number,
+): Promise<PerSourceRow[]> {
+    const byKey = await getAcceptanceByKey('source', guildId, days)
+    return [...byKey.entries()].map(([source, acc]) => ({
+        source: source as RecommendationSource | null,
+        ...acc,
+        acceptanceRate: toAcceptanceRate(acc.acceptedCount, acc.rejectedCount),
+    }))
 }
 
 /**
@@ -144,87 +142,12 @@ export async function getPerModeAcceptance(
     guildId: string,
     days?: number,
 ): Promise<PerModeRow[]> {
-    const prisma = getPrismaClient()
-    const createdAtGte = getCreatedAtCutoff(days)
-
-    // Group by mode to get distinct modes and total count per mode
-    const groupByResult = await prisma.recommendation.groupBy({
-        by: ['mode'],
-        where: {
-            guildId,
-            createdAt: {
-                gte: createdAtGte,
-            },
-        },
-        _count: {
-            id: true,
-        },
-    })
-
-    // For each mode, fetch accepted, rejected, and pending counts
-    const rows: PerModeRow[] = []
-    for (const group of groupByResult) {
-        const mode = group.mode
-        const count = group._count.id
-
-        const getCountValue = (result: any): number =>
-            typeof result === 'number' ? result : result.count
-
-        const acceptedCount = getCountValue(
-            await prisma.recommendation.count({
-                where: {
-                    guildId,
-                    mode,
-                    isAccepted: true,
-                    createdAt: {
-                        gte: createdAtGte,
-                    },
-                },
-            }),
-        )
-
-        const rejectedCount = getCountValue(
-            await prisma.recommendation.count({
-                where: {
-                    guildId,
-                    mode,
-                    isRejected: true,
-                    createdAt: {
-                        gte: createdAtGte,
-                    },
-                },
-            }),
-        )
-
-        const pendingCount = getCountValue(
-            await prisma.recommendation.count({
-                where: {
-                    guildId,
-                    mode,
-                    isAccepted: null,
-                    isRejected: null,
-                    createdAt: {
-                        gte: createdAtGte,
-                    },
-                },
-            }),
-        )
-
-        const denominator = acceptedCount + rejectedCount
-        const acceptanceRate =
-            denominator === 0 ? null : acceptedCount / denominator
-
-        rows.push({
-            mode,
-            count,
-            acceptedCount,
-            rejectedCount,
-            pendingCount,
-            acceptanceRate,
-        })
-    }
-
-    return rows
+    const byKey = await getAcceptanceByKey('mode', guildId, days)
+    return [...byKey.entries()].map(([mode, acc]) => ({
+        mode,
+        ...acc,
+        acceptanceRate: toAcceptanceRate(acc.acceptedCount, acc.rejectedCount),
+    }))
 }
 
 /**


### PR DESCRIPTION
## What

Closes #1187. Queue item under ADR 2026-06-10.

## Change

`getPerSourceAcceptance` / `getPerModeAcceptance` issued **1+3N queries** (groupBy + accepted/rejected/pending count per group). Now: **one** `groupBy([key, isAccepted, isRejected])` folded into per-key counts in JS via a shared helper. Returned metrics identical; `getSummary`/skip-rate untouched.

## Tests

- Specs reshaped to the bucket form; the mixed-outcome cases now assert `groupBy` called exactly once and `count` **never** — the N+1 can't silently return
- Shared 733/733 with the coverage gate passing (46.99/42.06/38.96/46.63)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batched recommendation telemetry acceptance counts into a single grouped query to remove N+1 queries. `getPerSourceAcceptance` and `getPerModeAcceptance` now run one DB query with identical metrics.

- **Refactors**
  - Replaced `1 + 3N` counts with one `groupBy([key, isAccepted, isRejected])`, folding counts via a shared helper.
  - Added `getAcceptanceByKey` and `toAcceptanceRate`; return shapes unchanged.
  - Updated tests to bucketed groups; assert one `groupBy` and no `count` calls.
  - No changes to `getSummary` or skip-rate; satisfies #1187.

<sup>Written for commit 88a48f35ef13660c34122d832c89c978c565c61a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated recommendation telemetry service test structure and assertions.

* **Refactor**
  * Restructured recommendation telemetry query and aggregation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->