### PR TITLE
fix(docker): add C toolchain to deps-production for opus source-build fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,12 @@ RUN npm run build --workspace=packages/frontend
 FROM node:${NODE_VERSION} AS deps-production
 ARG NPM_CACHE_KEY
 
-RUN apk add --no-cache python3 && rm -rf /var/cache/apk/*
+# build-base + python3-dev + opus-dev: @discordjs/opus falls back to a source
+# build whenever its musl prebuilt is missing for the current base image
+# (alpine/musl bumps rename the prebuilt — 404'd 2026-06-12, #1309). Same
+# toolchain the build stage carries (L50) and the same failure class the
+# frontend stage comment below documents from PR #846.
+RUN apk add --no-cache build-base python3 python3-dev opus-dev && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Closes #1309 — **pipeline blocker**: every backend/bot image build fails since ~00:28Z today.

## Root cause

The floating `node:22-alpine` base bumped Alpine/musl (musl 1.2.6, node 22.22.3) → `@discordjs/opus`'s expected musl prebuilt name changed to one that **doesn't exist** (verified 404) → `node-pre-gyp --fallback-to-build` runs in the `deps-production` stage → fails, because that stage only had `python3` while the `build` stage carries the full toolchain. Exact failure class documented inline at Dockerfile L77-81 from PR #846.

## Fix

Mirror the build stage's toolchain in deps-production: `build-base python3 python3-dev opus-dev`. Fallback now compiles regardless of prebuilt availability — robust against future base-image bumps (relates #847).

## Verification

This PR's own docker-build matrix is the proof — it exercises the failing stage directly. (A rerun of the failed jobs on #1308 reproduced the failure, confirming determinism.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the C toolchain to the Docker deps-production stage so `@discordjs/opus` can source-build when its `musl` prebuilt is missing after the `node:22-alpine` bump. Closes #1309 and unblocks all backend/bot image builds.

- **Bug Fixes**
  - Mirror the build stage toolchain in deps-production: `build-base`, `python3`, `python3-dev`, `opus-dev`.
  - `node-pre-gyp --fallback-to-build` now succeeds even if the prebuilt 404s.

<sup>Written for commit 975c0f5881be3f41baf9d0cdfd0ccbc138390b86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

