### PR TITLE
perf(bot): bound external scrobbler track cache with lru+ttl (#1282)

### DIFF
--- a/packages/bot/src/handlers/externalScrobbler.ts
+++ b/packages/bot/src/handlers/externalScrobbler.ts
@@ -4,6 +4,7 @@ import {
     type Message,
     type VoiceChannel,
 } from 'discord.js'
+import { LRUCache } from 'lru-cache'
 import { infoLog, errorLog, debugLog } from '@lucky/shared/utils'
 import { lastFmLinkService } from '@lucky/shared/services'
 import {
@@ -19,10 +20,13 @@ const KNOWN_MUSIC_BOT_NAMES = ['rythm', 'groovy', 'fredboat', 'hydra', 'jockie']
 const NOW_PLAYING_PREFIX = 'Now playing:'
 const NOW_PLAYING_SEPARATORS = [' – ', ' — ', ' - ']
 
-const lastExternalTrack = new Map<
+// Bounded per-guild cache: external bots that go silent would otherwise
+// leave their last track here forever (#1282). A track older than the TTL
+// is no longer scrobble-worthy anyway.
+const lastExternalTrack = new LRUCache<
     string,
     { title: string; artist: string; timestamp: number }
->()
+>({ max: 10_000, ttl: 10 * 60 * 1000 })
 
 function isMusicBot(message: Message): boolean {
     if (!message.author.bot) return false


### PR DESCRIPTION
## What

`lastExternalTrack` in `packages/bot/src/handlers/externalScrobbler.ts` was a bare `Map` keyed by guild id with no eviction or TTL — unbounded growth in a long-lived bot process (same bug class as the #1206 sweep; this site was missed).

Swapped to `LRUCache` (already a bot dependency, `lru-cache@^11.5.0`) with `max: 10000, ttl: 10min` per the issue's acceptance criteria. `get/set/delete` semantics are unchanged, so scrobble dedup behavior is identical — covered by the existing spec (5/5 green).

A track idle past the TTL is no longer scrobble-worthy anyway (the scrobble path already requires the *next* now-playing message to arrive; a 10-min-stale entry means the external bot stopped playing).

Closes #1282

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the external scrobbler per-guild track cache with an LRU+TTL to stop unbounded memory growth in long-lived bot processes. Swapped the plain Map for `lru-cache` (max 10,000, TTL 10 min); cache ops and scrobble dedup behavior remain the same.

<sup>Written for commit c067cca3eaa846f8281916be18422687ef683cf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

