### PR TITLE
chore(deps): drop orphaned @vercel/flags-core + uuid from shared (#1290)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12147,58 +12147,6 @@
                 }
             }
         },
-        "node_modules/@vercel/flags-core": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@vercel/flags-core/-/flags-core-1.4.0.tgz",
-            "integrity": "sha512-VeWaNAMZoBmOC5B0POjYXkuP+Llt9MtMDg0DFJObBRLKQ/zTtc9lY4hVVcOIx1JjJmO3JKMZDv43WtX/1jDbmg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vercel/functions": "^3.4.3",
-                "jose": "5.2.1",
-                "js-xxhash": "4.0.0"
-            },
-            "peerDependencies": {
-                "@openfeature/server-sdk": "1.18.0",
-                "next": "*"
-            },
-            "peerDependenciesMeta": {
-                "@openfeature/server-sdk": {
-                    "optional": true
-                },
-                "next": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@vercel/functions": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.5.0.tgz",
-            "integrity": "sha512-+RokZ+4gkYyOsKBuJ29cQ8iSZG123LLJbZfPry20kkTgrN9U0277La4feP4DnWVo3sGoYa4plCEKY9XKUYoX9g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@vercel/oidc": "3.4.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "@aws-sdk/credential-provider-web-identity": "*"
-            },
-            "peerDependenciesMeta": {
-                "@aws-sdk/credential-provider-web-identity": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@vercel/oidc": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.0.tgz",
-            "integrity": "sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">= 20"
-            }
-        },
         "node_modules/@vitejs/plugin-react": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
@@ -18869,15 +18817,6 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
-        "node_modules/jose": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.1.tgz",
-            "integrity": "sha512-qiaQhtQRw6YrOaOj0v59h3R6hUY9NvxBmmnMfKemkqYmBB0tEc97NbLP7ix44VP5p9/0YHG8Vyhzuo5YBNwviA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/panva"
-            }
-        },
         "node_modules/joycon": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -18893,15 +18832,6 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/js-xxhash": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-xxhash/-/js-xxhash-4.0.0.tgz",
-            "integrity": "sha512-3Q2eIqG6s1KEBBmkj9tGM9lef8LJbuRyTVBdI3GpTnrvtytunjLPO0wqABp5qhtMzfA32jYn1FlnIV7GH1RAHQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.0.0"
-            }
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
@@ -24342,19 +24272,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
         },
-        "node_modules/uuid": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist-node/bin/uuid"
-            }
-        },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -25928,12 +25845,10 @@
             "dependencies": {
                 "@prisma/client": "^7.8.0",
                 "@sentry/node": "^10.53.1",
-                "@vercel/flags-core": "^1.4.0",
                 "axios": "^1.16.1",
                 "chalk": "^5.6.2",
                 "dotenv": "^17.4.2",
                 "ioredis": "^5.10.1",
-                "uuid": "^14.0.0",
                 "zod": "^4.4.3"
             },
             "devDependencies": {

--- a/packages/backend/tests/setup.ts
+++ b/packages/backend/tests/setup.ts
@@ -225,10 +225,6 @@ jest.mock('chalk', () => ({
     },
 }))
 
-jest.mock('uuid', () => ({
-    v4: jest.fn(() => 'mock-uuid-v4'),
-}))
-
 const passthrough = (_req: any, _res: any, next: any) => next()
 jest.mock('../src/middleware/rateLimit', () => ({
     apiLimiter: passthrough,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -74,12 +74,10 @@
     "dependencies": {
         "@prisma/client": "^7.8.0",
         "@sentry/node": "^10.53.1",
-        "@vercel/flags-core": "^1.4.0",
         "axios": "^1.16.1",
         "chalk": "^5.6.2",
         "dotenv": "^17.4.2",
         "ioredis": "^5.10.1",
-        "uuid": "^14.0.0",
         "zod": "^4.4.3"
     },
     "optionalDependencies": {

--- a/packages/shared/src/utils/error/errorWrapper.spec.ts
+++ b/packages/shared/src/utils/error/errorWrapper.spec.ts
@@ -11,16 +11,11 @@ jest.mock('../monitoring', () => ({
     addBreadcrumb: jest.fn(),
 }))
 
-// Mock uuid
-jest.doMock('uuid', () => ({
-    v4: jest.fn(() => 'mock-uuid-12345'),
-}))
-
 import {
     createCorrelationId,
     wrapError,
     createUserErrorMessage,
-    logError
+    logError,
 } from './errorWrapper'
 import { MusicError } from '../../types/errors/music'
 import { VALIDATION_ERROR_CODES } from '../../types/errors/validation'
@@ -41,16 +36,20 @@ describe('Error Wrapper', () => {
             expect(id.length).toBeGreaterThan(0)
         })
 
-        it('should call uuid.v4', () => {
-            const { v4 } = require('uuid')
-            createCorrelationId()
-            expect(v4).toHaveBeenCalled()
+        it('should generate a v4 uuid shape', () => {
+            const id = createCorrelationId()
+            expect(id).toMatch(
+                /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+            )
         })
     })
 
     describe('wrapError', () => {
         it('should return MusicError as-is', () => {
-            const error = new MusicError('Test error', 'ERR_MUSIC_TRACK_NOT_FOUND')
+            const error = new MusicError(
+                'Test error',
+                'ERR_MUSIC_TRACK_NOT_FOUND',
+            )
             const result = wrapError(error)
 
             expect(result).toBe(error)
@@ -88,7 +87,7 @@ describe('Error Wrapper', () => {
                 guildId: 'guild456',
                 commandName: 'play',
                 correlationId: 'test-correlation-123',
-                additionalInfo: { extra: 'data' }
+                additionalInfo: { extra: 'data' },
             }
 
             const result = wrapError(error, undefined, context)
@@ -139,28 +138,36 @@ describe('Error Wrapper', () => {
             const error = new Error('network connection failed')
             const result = createUserErrorMessage(error)
 
-            expect(result).toBe('Network error occurred. Please check your connection.')
+            expect(result).toBe(
+                'Network error occurred. Please check your connection.',
+            )
         })
 
         it('should map permission errors to user-friendly message', () => {
             const error = new Error('permission denied')
             const result = createUserErrorMessage(error)
 
-            expect(result).toBe("You don't have permission to perform this action.")
+            expect(result).toBe(
+                "You don't have permission to perform this action.",
+            )
         })
 
         it('should return generic message for unknown errors', () => {
             const error = new Error('Unknown error')
             const result = createUserErrorMessage(error)
 
-            expect(result).toBe('An unexpected error occurred. Please try again.')
+            expect(result).toBe(
+                'An unexpected error occurred. Please try again.',
+            )
         })
 
         it('should handle non-Error objects', () => {
             const error = 'String error'
             const result = createUserErrorMessage(error)
 
-            expect(result).toBe('An unexpected error occurred. Please try again.')
+            expect(result).toBe(
+                'An unexpected error occurred. Please try again.',
+            )
         })
     })
 
@@ -181,7 +188,7 @@ describe('Error Wrapper', () => {
                 {
                     correlationId: expect.any(String),
                     context,
-                }
+                },
             )
         })
 
@@ -224,7 +231,10 @@ describe('Error Wrapper', () => {
         })
 
         it('should handle MusicError without wrapping', () => {
-            const error = new MusicError('Music error', 'ERR_MUSIC_TRACK_NOT_FOUND')
+            const error = new MusicError(
+                'Music error',
+                'ERR_MUSIC_TRACK_NOT_FOUND',
+            )
             const context = { userId: 'user123' }
 
             const wrappedError = wrapError(error, undefined, context)

--- a/packages/shared/src/utils/error/errorWrapper.ts
+++ b/packages/shared/src/utils/error/errorWrapper.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto'
+import { randomUUID } from 'node:crypto'
 import { errorLog } from '../general/log'
 import { MusicError, type MusicErrorCode } from '../../types/errors/music'
 import { captureException } from '../monitoring'

--- a/packages/shared/src/utils/error/errorWrapper.ts
+++ b/packages/shared/src/utils/error/errorWrapper.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid'
+import { randomUUID } from 'crypto'
 import { errorLog } from '../general/log'
 import { MusicError, type MusicErrorCode } from '../../types/errors/music'
 import { captureException } from '../monitoring'
@@ -8,7 +8,7 @@ import type { ErrorContext } from './types'
  * Creates a correlation ID for error tracking
  */
 export function createCorrelationId(): string {
-    return uuidv4()
+    return randomUUID()
 }
 
 /**


### PR DESCRIPTION
## What

Two dependency prunes in `packages/shared` (found by /dependency-scout, issue #1290):

- **`@vercel/flags-core`** — zero imports anywhere in `packages/shared/src` since #1256 removed the never-configured Vercel Flags layer; the declared dep was leftover.
- **`uuid`** — was down to one call-site, `createCorrelationId()` in `utils/error/errorWrapper.ts`. Now uses Node's built-in `crypto.randomUUID()` (same v4 shape, zero deps). The spec's `uuid` module mock is replaced with a v4-shape assertion.

## Acceptance (from the issue)
- [x] `@vercel/flags-core` removed + lockfile regenerated
- [x] `errorWrapper.ts` uses `crypto.randomUUID()`; `uuid` dropped (no other consumer — verified by grep)
- [x] `npm run verify:shared-exports` passes (18 specifiers across backend, bot, frontend)
- [x] shared suite: errorWrapper spec 20/20; full suite was 702/702 with only the uuid-mock failure, now fixed

Closes #1290

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes orphaned dependencies in `packages/shared` to address #1290. Removes `@vercel/flags-core`, replaces `uuid` with Node’s `randomUUID()` from `node:crypto` in `createCorrelationId()`, and drops a stale backend test mock to fix CI.

- **Dependencies**
  - Removed `@vercel/flags-core` (unused).
  - Switched `createCorrelationId()` to `randomUUID()` from `node:crypto` and removed `uuid`.
  - Updated tests to assert v4 UUID shape; regenerated the lockfile.

- **Bug Fixes**
  - Removed global `uuid` mock in `packages/backend/tests/setup.ts` to prevent CI failures after dropping the package.

<sup>Written for commit 41ed89aba944b8fe81f84f2e9b4509a58cbfe3bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

