### PR TITLE
fix(backend): log swallowed spotify search errors (#1285)

### DIFF
--- a/packages/backend/src/services/artistSuggestion.ts
+++ b/packages/backend/src/services/artistSuggestion.ts
@@ -335,8 +335,12 @@ export class ArtistSuggestionService {
                         out.push(artist)
                     }
                 }
-            } catch {
-                // continue to next query
+            } catch (error) {
+                // continue to next query — but leave a trace (#1285)
+                debugLog({
+                    message: 'Spotify popular-artist search failed',
+                    data: { query, error: String(error) },
+                })
             }
         }
 


### PR DESCRIPTION
## What

`fetchPopularArtists` in `packages/backend/src/services/artistSuggestion.ts` swallowed per-query Spotify search failures with a bare `catch { /* continue */ }` — transient errors (429s, network) were invisible.

The catch now emits a `debugLog` with the failed query and stringified error, then continues exactly as before. No behavior change beyond the log line (`debugLog` was already imported).

Closes #1285

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs per-query Spotify search failures in `fetchPopularArtists` via `debugLog`, recording the query and error so 429/network issues are visible. No behavior change; the loop still continues to the next query. Addresses #1285.

<sup>Written for commit a30502949472f4532110f12642917343d2a5c9bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

