### PR TITLE
test(web): add vitest coverage threshold gate to frontend (#1284)

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -117,5 +117,15 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      thresholds: {
+        statements: 85.3,
+        branches: 79.2,
+        functions: 79.3,
+        lines: 87.3,
+      },
+    },
   },
 })


### PR DESCRIPTION
Closes #1284

Adds a v8 coverage gate to the frontend vitest config so coverage regressions fail CI (which already runs the frontend suite with `--coverage`, `.github/workflows/ci.yml:200`).

**Honest thresholds** (measured 85.85/79.76/79.84/87.85, set at actual − 0.5pp):
statements 85.3 · branches 79.2 · functions 79.3 · lines 87.3

Implemented by a sandboxed agent; independently verified by the orchestrator:
- diff reviewed (single 10-line `coverage` block in `vite.config.ts`, no collateral)
- exact CI command re-run locally: 72 files / 735 tests pass, gate satisfied
- agent sanity-checked the gate fails when a threshold is set above actual (95% → vitest ERROR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `vitest` coverage threshold gate in the frontend to fail CI on coverage regressions.
Set honest thresholds (current − 0.5pp): statements 85.3, branches 79.2, functions 79.3, lines 87.3.

<sup>Written for commit 18feff5df828502cf1e3547f1a6fb5fe8f8cf508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

