### PR TITLE
ci(deploy): gate rollout on db readiness + idempotent migrations (#1193)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -264,6 +264,29 @@ sync_checkout_to_origin_main() {
     return 0
 }
 
+wait_for_postgres_ready() {
+    local label="$1"
+    local attempt max_attempts
+    max_attempts=30
+
+    for attempt in $(seq 1 "$max_attempts"); do
+        # pg_isready exits 0 only when postgres is accepting connections.
+        # Run inside the postgres container since the database host is only
+        # resolvable from within the compose network.
+        if docker_compose exec -T postgres pg_isready \
+            -U postgres >/dev/null 2>&1; then
+            log "$label ready"
+            return 0
+        fi
+
+        log "$label not ready - attempt $attempt/$max_attempts"
+        sleep 2
+    done
+
+    log "ERROR: timed out waiting for $label readiness (pg_isready failed after $max_attempts attempts)"
+    return 1
+}
+
 wait_for_http_ready() {
     local label="$1"
     local url="$2"
@@ -550,6 +573,13 @@ fi
 
 log "Starting database services..."
 docker_compose up -d postgres redis
+
+log "Waiting for PostgreSQL to accept connections..."
+if ! wait_for_postgres_ready "PostgreSQL"; then
+    log "ERROR: DATABASE_NOT_READY (postgres failed to become ready)"
+    notify 16711680 "Deploy Failed" "PostgreSQL did not become ready before migration timeout"
+    exit 1
+fi
 
 log "Running database migrations..."
 if ! docker_compose run --rm --no-deps backend \


### PR DESCRIPTION
Closes #1193

State-checked against current main first — of the three acceptance criteria, two were already satisfied:

- **Rollback on failed health gate** — already shipped in PR #1230: `attempt_rollback()` (`scripts/deploy.sh:402-437`) invoked from the health-check failure handler, rolling back to the last-good baked COMMIT_SHA.
- **Idempotent migration phase** — `prisma migrate deploy` skips already-applied migrations by design; replays are safe.

This PR implements only the residual gap:

- **DB readiness gate before rollout** — new `wait_for_postgres_ready()` runs `pg_isready` inside the postgres container (compose-network host), 30 × 2s retries, and hard-fails the deploy with a Discord notify BEFORE migrations or any service rollout.

Implemented by a sandboxed agent; independently verified by the orchestrator. Verification caught one real defect in the agent's version: it compared `pg_isready` *stdout* to the exact string `"accepting connections"`, but pg_isready prints `<host>:<port> - accepting connections` — the gate would never pass and would block every deploy. Fixed to test the exit code (the documented contract). `bash -n` clean; shellcheck shows only the pre-existing SC1007 on line 15.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PostgreSQL readiness gate to the deploy script so we only run `prisma migrate deploy` and roll out services after the DB accepts connections. Completes Linear #1193 by failing fast (30 retries, 2s intervals) with a Discord alert if Postgres never becomes ready; rollback-on-health-check remains in place and `prisma migrate deploy` is idempotent.

- **Bug Fixes**
  - Check `pg_isready` exit code instead of parsing stdout to avoid false negatives that could block deploys.

<sup>Written for commit 11e655a01268ad971b11fdbd60c869cb625c8ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

