### PR TITLE
chore: align workspace config drift (#1289)

### DIFF
--- a/packages/backend/jest.config.cjs
+++ b/packages/backend/jest.config.cjs
@@ -36,6 +36,7 @@ module.exports = {
   resolver: '<rootDir>/jest-resolver.cjs',
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   testTimeout: 30000,
+  // Limit parallelism for stability with large test suite
   maxWorkers: '50%',
   moduleNameMapper: {
     '^@lucky/shared$': '<rootDir>/../shared/src/index',

--- a/packages/bot/jest.config.cjs
+++ b/packages/bot/jest.config.cjs
@@ -66,5 +66,6 @@ module.exports = {
     clearMocks: true,
     resetMocks: true,
     restoreMocks: true,
+    // Deliberate: Discord integration tests use shorter timeout than backend (30000)
     testTimeout: 15000,
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,6 +8,7 @@
         "build": "tsc && vite build && tsx scripts/prerender-seo.ts",
         "preview": "vite preview",
         "lint": "eslint . --config eslint.config.js --max-warnings 0",
+        "lint:fix": "eslint . --config eslint.config.js --max-warnings 0 --fix",
         "type:check": "tsc --noEmit",
         "test": "vitest run",
         "test:watch": "vitest",

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES2020",
+        "target": "ES2022",
         "useDefineForClassFields": true,
         "lib": [
             "ES2020",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,7 +5,7 @@
         "lib": [
             "ES2022"
         ],
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,


### PR DESCRIPTION
Closes #1289. One commit per knob so breakage bisects cleanly:

- `packages/shared` tsconfig `moduleResolution: node` → `bundler`
- `packages/frontend` tsconfig `target: ES2020` → `ES2022`
- jest drift documented in-place (bot `testTimeout: 15000` and backend `maxWorkers: '50%'` are deliberate; one-line comments added)
- `lint:fix` added to `packages/frontend` (shared/bot already had it via root)

The jest shared-src module mapping was NOT touched (documented ts-jest barrel quirk).

Verification: type:check pass on all 4 packages; frontend build (incl. prerender-seo) pass; backend 1012, bot 2468, shared 765 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns workspace configs and documents intentional Jest differences to resolve drift from #1289. Improves consistency across packages and test stability.

- **Refactors**
  - `packages/shared`: TypeScript `moduleResolution` set to `bundler`.
  - `packages/frontend`: TypeScript `target` moved from `ES2020` to `ES2022`.
  - Jest: documented backend `maxWorkers: '50%'` and bot `testTimeout: 15000` as intentional.
  - `packages/frontend`: added `lint:fix` script.

<sup>Written for commit 968eb7cadcbacaa2a7dd6d003ca2960eef66813f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

