### PR TITLE
fix(shared): validate guildautomation json on read (#1194)

### DIFF
--- a/packages/shared/src/services/guildAutomation/guildAutomationHelpers.spec.ts
+++ b/packages/shared/src/services/guildAutomation/guildAutomationHelpers.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals'
+import { toManifestDocument } from './guildAutomationHelpers'
+import * as log from '../../utils/general/log'
+
+// Mock the errorLog function
+jest.mock('../../utils/general/log', () => ({
+    errorLog: jest.fn(),
+}))
+
+describe('guildAutomationHelpers', () => {
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('toManifestDocument', () => {
+        it('parses a valid manifest document', () => {
+            const validManifest = {
+                version: 1,
+                guild: {
+                    id: '123456789012345678',
+                    name: 'Test Guild',
+                },
+                source: 'manual',
+            }
+
+            const result = toManifestDocument(validManifest)
+
+            expect(result.version).toBe(1)
+            expect(result.guild.id).toBe('123456789012345678')
+        })
+
+        it('throws on malformed manifest JSON (missing required guild field)', () => {
+            const malformedManifest = {
+                version: 1,
+            }
+
+            expect(() => toManifestDocument(malformedManifest)).toThrow(
+                'Invalid manifest',
+            )
+            expect(log.errorLog).toHaveBeenCalled()
+        })
+
+        it('throws on invalid guild snowflake', () => {
+            const invalidGuildId = {
+                version: 1,
+                guild: {
+                    id: 'not-a-snowflake',
+                    name: 'Test Guild',
+                },
+            }
+
+            expect(() => toManifestDocument(invalidGuildId)).toThrow(
+                'Invalid manifest',
+            )
+            expect(log.errorLog).toHaveBeenCalled()
+        })
+
+        it('throws when value is not an object', () => {
+            expect(() => toManifestDocument('not an object')).toThrow(
+                'Manifest payload is invalid',
+            )
+        })
+
+        it('throws when value is null', () => {
+            expect(() => toManifestDocument(null)).toThrow(
+                'Manifest payload is invalid',
+            )
+        })
+
+        it('throws when value is an array', () => {
+            expect(() => toManifestDocument([1, 2, 3])).toThrow(
+                'Manifest payload is invalid',
+            )
+        })
+
+        it('logs validation errors with path and message', () => {
+            const malformedManifest = {
+                version: 1,
+                guild: {
+                    id: '999', // Too short for snowflake
+                    name: 'Test Guild',
+                },
+            }
+
+            expect(() => toManifestDocument(malformedManifest)).toThrow()
+
+            expect(log.errorLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Failed to parse GuildAutomationManifest JSON',
+                    error: expect.any(Array),
+                }),
+            )
+
+            const errorCall = (log.errorLog as jest.Mock).mock.calls[0]?.[0] as {
+                error: Array<{ path: string; message: string; code: string }>
+            }
+            expect(errorCall.error).toBeInstanceOf(Array)
+            expect(errorCall.error[0]).toHaveProperty('path')
+            expect(errorCall.error[0]).toHaveProperty('message')
+            expect(errorCall.error[0]).toHaveProperty('code')
+        })
+    })
+})

--- a/packages/shared/src/services/guildAutomation/guildAutomationHelpers.ts
+++ b/packages/shared/src/services/guildAutomation/guildAutomationHelpers.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '../../generated/prisma/client.js'
 import type { GuildAutomationManifestDocument } from './types.js'
 import { guildAutomationManifestSchema } from './manifestSchema.js'
+import { errorLog } from '../../utils/general/log.js'
 
 export function isObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -13,7 +14,24 @@ export function toManifestDocument(
         throw new Error('Manifest payload is invalid')
     }
 
-    return guildAutomationManifestSchema.parse(value)
+    const result = guildAutomationManifestSchema.safeParse(value)
+
+    if (!result.success) {
+        const errors = result.error.issues.map((issue) => ({
+            path: issue.path.join('.'),
+            message: issue.message,
+            code: issue.code,
+        }))
+        errorLog({
+            message: 'Failed to parse GuildAutomationManifest JSON',
+            error: errors,
+        })
+        throw new Error(
+            `Invalid manifest: ${result.error.issues[0]?.message ?? 'unknown error'}`,
+        )
+    }
+
+    return result.data
 }
 
 export function toJsonValue(value: unknown): Prisma.InputJsonValue {

--- a/prisma/migrations/20260612151012_add_recommendation_compound_index/migration.sql
+++ b/prisma/migrations/20260612151012_add_recommendation_compound_index/migration.sql
@@ -1,0 +1,9 @@
+-- Add compound index on (guildId, discordUserId, trackId) to support
+-- deduplication queries for event-log semantics in recommendation tracking.
+-- This index allows efficient identification of duplicate recommendation
+-- events without enforcing uniqueness (multiple recommendations of the same
+-- track to the same user over time are intentional and tracked separately).
+-- See issue #1194 for decision on event-log vs. uniqueness trade-off.
+
+CREATE INDEX "recommendations_guildId_discordUserId_trackId_idx"
+  ON "recommendations"("guildId", "discordUserId", "trackId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -509,6 +509,7 @@ model Recommendation {
   @@index([guildId, createdAt])
   @@index([guildId, source, createdAt])
   @@index([guildId, mode, createdAt])
+  @@index([guildId, discordUserId, trackId])
   @@map("recommendations")
 }
 


### PR DESCRIPTION
Closes #1194.

- `toManifestDocument()` now `safeParse`s the `GuildAutomationManifest` JSON columns with structured `errorLog` + throw (mirrors the #1165 embed zod-on-read pattern) — malformed JSON is caught at the read boundary instead of propagating mis-shaped objects
- `Recommendation`: chose `@@index([guildId, discordUserId, trackId])` over `@@unique` — `recordRecommendationOutcome()` selects the most-recent row by design, i.e. re-recommending the same track over time is legitimate event-log semantics and prod likely already has such rows; the index supports dedup-style aggregation queries without breaking those semantics
- hand-written migration (index-only, no data rewrite); 7 new specs for the zod-on-read validation

Verification: shared suite 58 suites / 772 tests pass; build:shared + type:check pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `GuildAutomationManifest` JSON on read and add a compound index for recommendation dedup queries. This addresses #1194 by catching bad manifest data early and enabling efficient aggregation without changing event-log semantics.

- **Bug Fixes**
  - `toManifestDocument()` now uses `safeParse`, logs structured validation errors (path, message, code), and throws on invalid or non-object payloads.
  - Added tests for valid manifests, malformed JSON, invalid snowflakes, and error logging.

- **Migration**
  - Added `@@index([guildId, discordUserId, trackId])` on `Recommendation` to support dedup queries while allowing repeated recommendations over time (no data rewrite).

<sup>Written for commit 5218272e0a88956a7eed4c2f41186cb73428337f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

