### PR TITLE
chore(deps): bump esbuild override to 0.28.1 for high advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1468,7 +1468,7 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1478,7 +1478,7 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1512,7 +1512,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
             "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -1810,7 +1810,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -2654,6 +2654,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
             "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2665,6 +2666,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
             "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2675,6 +2677,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
             "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2682,9 +2685,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-            "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -2698,9 +2701,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-            "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
             "cpu": [
                 "arm"
             ],
@@ -2714,9 +2717,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-            "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
             "cpu": [
                 "arm64"
             ],
@@ -2730,9 +2733,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-            "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
             "cpu": [
                 "x64"
             ],
@@ -2746,9 +2749,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-            "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2762,9 +2765,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-            "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
             "cpu": [
                 "x64"
             ],
@@ -2778,9 +2781,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
             "cpu": [
                 "arm64"
             ],
@@ -2794,9 +2797,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-            "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
             "cpu": [
                 "x64"
             ],
@@ -2810,9 +2813,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-            "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
             "cpu": [
                 "arm"
             ],
@@ -2826,9 +2829,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-            "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
             "cpu": [
                 "arm64"
             ],
@@ -2842,9 +2845,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-            "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
             "cpu": [
                 "ia32"
             ],
@@ -2858,9 +2861,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-            "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
             "cpu": [
                 "loong64"
             ],
@@ -2874,9 +2877,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-            "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -2890,9 +2893,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-            "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -2906,9 +2909,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-            "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -2922,9 +2925,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-            "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
             "cpu": [
                 "s390x"
             ],
@@ -2938,9 +2941,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-            "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
             "cpu": [
                 "x64"
             ],
@@ -2954,9 +2957,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
             "cpu": [
                 "arm64"
             ],
@@ -2970,9 +2973,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-            "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
             "cpu": [
                 "x64"
             ],
@@ -2986,9 +2989,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3002,9 +3005,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-            "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
             "cpu": [
                 "x64"
             ],
@@ -3018,9 +3021,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-            "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
             "cpu": [
                 "arm64"
             ],
@@ -3034,9 +3037,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-            "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
             "cpu": [
                 "x64"
             ],
@@ -3050,9 +3053,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-            "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
             "cpu": [
                 "arm64"
             ],
@@ -3066,9 +3069,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-            "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
             "cpu": [
                 "ia32"
             ],
@@ -3082,9 +3085,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-            "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
             "cpu": [
                 "x64"
             ],
@@ -4839,7 +4842,7 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
             "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -10219,7 +10222,7 @@
             "version": "1.15.40",
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
             "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10464,14 +10467,14 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@swc/types": {
             "version": "0.1.26",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
             "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -11434,6 +11437,7 @@
             "version": "19.2.15",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
             "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -11443,7 +11447,7 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -14509,6 +14513,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/dargs": {
@@ -15144,9 +15149,9 @@
             ]
         },
         "node_modules/esbuild": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-            "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -15156,32 +15161,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.3",
-                "@esbuild/android-arm": "0.27.3",
-                "@esbuild/android-arm64": "0.27.3",
-                "@esbuild/android-x64": "0.27.3",
-                "@esbuild/darwin-arm64": "0.27.3",
-                "@esbuild/darwin-x64": "0.27.3",
-                "@esbuild/freebsd-arm64": "0.27.3",
-                "@esbuild/freebsd-x64": "0.27.3",
-                "@esbuild/linux-arm": "0.27.3",
-                "@esbuild/linux-arm64": "0.27.3",
-                "@esbuild/linux-ia32": "0.27.3",
-                "@esbuild/linux-loong64": "0.27.3",
-                "@esbuild/linux-mips64el": "0.27.3",
-                "@esbuild/linux-ppc64": "0.27.3",
-                "@esbuild/linux-riscv64": "0.27.3",
-                "@esbuild/linux-s390x": "0.27.3",
-                "@esbuild/linux-x64": "0.27.3",
-                "@esbuild/netbsd-arm64": "0.27.3",
-                "@esbuild/netbsd-x64": "0.27.3",
-                "@esbuild/openbsd-arm64": "0.27.3",
-                "@esbuild/openbsd-x64": "0.27.3",
-                "@esbuild/openharmony-arm64": "0.27.3",
-                "@esbuild/sunos-x64": "0.27.3",
-                "@esbuild/win32-arm64": "0.27.3",
-                "@esbuild/win32-ia32": "0.27.3",
-                "@esbuild/win32-x64": "0.27.3"
+                "@esbuild/aix-ppc64": "0.28.1",
+                "@esbuild/android-arm": "0.28.1",
+                "@esbuild/android-arm64": "0.28.1",
+                "@esbuild/android-x64": "0.28.1",
+                "@esbuild/darwin-arm64": "0.28.1",
+                "@esbuild/darwin-x64": "0.28.1",
+                "@esbuild/freebsd-arm64": "0.28.1",
+                "@esbuild/freebsd-x64": "0.28.1",
+                "@esbuild/linux-arm": "0.28.1",
+                "@esbuild/linux-arm64": "0.28.1",
+                "@esbuild/linux-ia32": "0.28.1",
+                "@esbuild/linux-loong64": "0.28.1",
+                "@esbuild/linux-mips64el": "0.28.1",
+                "@esbuild/linux-ppc64": "0.28.1",
+                "@esbuild/linux-riscv64": "0.28.1",
+                "@esbuild/linux-s390x": "0.28.1",
+                "@esbuild/linux-x64": "0.28.1",
+                "@esbuild/netbsd-arm64": "0.28.1",
+                "@esbuild/netbsd-x64": "0.28.1",
+                "@esbuild/openbsd-arm64": "0.28.1",
+                "@esbuild/openbsd-x64": "0.28.1",
+                "@esbuild/openharmony-arm64": "0.28.1",
+                "@esbuild/sunos-x64": "0.28.1",
+                "@esbuild/win32-arm64": "0.28.1",
+                "@esbuild/win32-ia32": "0.28.1",
+                "@esbuild/win32-x64": "0.28.1"
             }
         },
         "node_modules/escalade": {
@@ -19707,7 +19712,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
             "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -20214,7 +20219,7 @@
             "version": "3.3.12",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
             "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -21158,7 +21163,7 @@
             "version": "8.5.15",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
             "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -23361,6 +23366,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
             "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/tailwindcss-animate": {
@@ -23887,7 +23893,7 @@
             "version": "4.22.3",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
             "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.28.0"
@@ -24809,7 +24815,7 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -127,6 +127,6 @@
         "picomatch": ">=2.3.2",
         "follow-redirects": "1.16.0",
         "ip-address": ">=10.1.1",
-        "esbuild": "0.27.3"
+        "esbuild": "0.28.1"
     }
 }


### PR DESCRIPTION
Fixes #1359.

The required Security gate (`npm audit --audit-level=high`) fails repo-wide since today: new high advisories GHSA-gv7w-rqvm-qjhr (RCE via NPM_CONFIG_REGISTRY in the Deno module) and GHSA-g7r4-m6w7-qqqr (dev-server arbitrary file read on Windows) cover esbuild 0.17.0–0.28.0. The root `overrides` pinned 0.27.3; patched release is 0.28.1.

## Change
- `overrides.esbuild`: `0.27.3` → `0.28.1` (plus lockfile re-resolution — `npm install` alone does not re-resolve a changed override; required `npm update esbuild`).

## Verification
- `npm run audit:high` → 0 vulnerabilities
- `npm ls esbuild` → single 0.28.1, no dual-version (past deploy breaker)
- `npm run type:check`, `build:shared`, backend build, frontend vite build (esbuild minors are breaking by convention — vite 8.0.14 builds clean) → all pass

This unblocks the Security gate on every open PR once merged + branches updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `esbuild` to 0.28.1 via root `overrides` to fix new high-severity advisories and restore the security gate (npm audit --audit-level=high). This unblocks all PRs.

- **Dependencies**
  - Update `overrides.esbuild`: 0.27.3 → 0.28.1 (lockfile re-resolved).
  - Verified single `esbuild@0.28.1` in tree; builds and type checks pass.

<sup>Written for commit 0a95d17a94b497019b21f580cb3c9f96ca1735c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

