### PR TITLE
fix(bot): catch settings fetch errors in idle disconnect scheduling

### DIFF
--- a/packages/bot/src/utils/music/idleDisconnect.ts
+++ b/packages/bot/src/utils/music/idleDisconnect.ts
@@ -1,6 +1,6 @@
 import type { GuildQueue } from 'discord-player'
 import { guildSettingsService } from '@lucky/shared/services'
-import { debugLog } from '@lucky/shared/utils'
+import { debugLog, errorLog } from '@lucky/shared/utils'
 import { musicWatchdogService } from './watchdog'
 import { collaborativePlaylistService } from './collaborativePlaylist'
 import type { QueueMetadata } from '../../types/QueueMetadata'
@@ -30,7 +30,12 @@ export function scheduleIdleDisconnect(queue: GuildQueue): void {
         )
 
         idleTimers.set(guildId, timer)
-    })()
+    })().catch((error: unknown) => {
+        errorLog({
+            message: `Failed to schedule idle disconnect in guild ${guildId}`,
+            error,
+        })
+    })
 }
 
 export function clearIdleTimer(guildId: string): void {


### PR DESCRIPTION
Fixes #1356.

`scheduleIdleDisconnect`'s `void (async () => {...})()` IIFE had no rejection handling — a rejected `guildSettingsService.getGuildSettings()` became an unhandled rejection. Applies the same `.catch` → `errorLog` house pattern as skip.ts / previous.ts (#1353/#1347). `disconnectIdle` already has internal try/catch and needed no change.

## Verification
- bot suite: 2471 passed (184 suites)
- `type:check` clean; eslint on the changed file clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unhandled promise rejections during idle disconnect scheduling by catching settings fetch errors and logging them. Improves stability of the music bot’s idle timer.

- **Bug Fixes**
  - Add `.catch` to the `scheduleIdleDisconnect` IIFE and log via `errorLog`, avoiding unhandled rejections from `guildSettingsService.getGuildSettings()`.
  - Import `errorLog` from `@lucky/shared/utils`; no changes to `disconnectIdle`.

<sup>Written for commit f2bd36523ba6b1bf1fb8ede58d544004a6d6658b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

