### PR TITLE
fix(ci): quality/Lint green again — core rules off for bot/shared at root lint (#1364)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -124,6 +124,11 @@ export default [
             "@typescript-eslint": pluginTs,
         },
         rules: {
+            // Core-rule handling at repo-root lint: the cwd-relative TS block
+            // (files: ["src/**/*.ts"]) doesn't match from the root, so without
+            // these the @eslint/js recommended core rules fire as errors (#1364)
+            "no-unused-vars": "off",
+            "no-empty": ["warn", { allowEmptyCatch: false }],
             "@typescript-eslint/no-non-null-assertion": "warn",
             "@typescript-eslint/no-unsafe-assignment": "warn",
             "@typescript-eslint/no-unsafe-call": "warn",


### PR DESCRIPTION
## Summary
`quality / Lint` has been failing on main since #1362 (292 errors in CI). Root cause: the ratchet block's `basePath` pin pulls `packages/{bot,shared}/src/**/*.ts` into repo-root `eslint .`, but the cwd-relative TS rules block (`files: ["src/**/*.ts"]`) doesn't match from the root — so those files were linted with @eslint/js recommended core rules at error severity (296× `no-unused-vars` incl. interface param names, 2× `no-empty`).

Fix: inside the ratchet block, set `no-unused-vars: off` (its @typescript-eslint variant is already active at warn) and `no-empty: warn` (mirrors the TS block's setting).

## Verification
- Repo root `npx eslint .` on this branch: 0 CI-relevant errors (54 remaining locally are all in gitignored `.agents/`, never seen by CI; 346−54 = 292 = exact CI error count match)
- Package-cwd lints unchanged: bot exit 0, shared exit 0, backend exit 0
- Diff is 6 lines in one config block

Fixes #1364

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix root lint failures by overriding core ESLint rules in the ratchet block so repo-root `eslint .` matches our TS settings. Restores the `quality / Lint` job to green. Fixes #1364.

- **Bug Fixes**
  - Root cause: ratchet `basePath` pulled `packages/{bot,shared}/src/**/*.ts` into root lint, but the cwd-relative TS block (`files: ["src/**/*.ts"]`) didn’t apply, so `@eslint/js` core rules errored.
  - Change: in the ratchet block set `"no-unused-vars": "off"` (TS variant via `@typescript-eslint` already warns) and `"no-empty": ["warn", { allowEmptyCatch: false }]`; package-level lints remain unchanged.

<sup>Written for commit 122f3ddd78ea3a8654f6460f3f77023a7b8142f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

