### PR TITLE
chore(db): drop dead CommandUsage model

### DIFF
--- a/packages/shared/src/services/database/DatabaseService.ts
+++ b/packages/shared/src/services/database/DatabaseService.ts
@@ -10,7 +10,6 @@ import type {
     DatabaseUser,
     DatabaseGuild,
     DatabaseTrackHistory,
-    DatabaseCommandUsage,
     DatabaseAnalytics,
     DatabaseArtistStats,
 } from './types'
@@ -54,18 +53,6 @@ type TrackHistoryModel = {
     isPlaylist: boolean | null
 }
 
-type CommandUsageModel = {
-    id: string
-    userId: string | null
-    guildId: string | null
-    command: string
-    category: string
-    success: boolean
-    errorCode: string | null
-    duration: number | null
-    createdAt: Date
-}
-
 function assertIsUserModel(value: unknown): asserts value is UserModel {
     if (
         !value ||
@@ -98,19 +85,6 @@ function assertIsTrackHistoryModel(
         !('trackId' in value)
     ) {
         throw new Error('Invalid TrackHistoryModel')
-    }
-}
-
-function assertIsCommandUsageModel(
-    value: unknown,
-): asserts value is CommandUsageModel {
-    if (
-        !value ||
-        typeof value !== 'object' ||
-        !('id' in value) ||
-        !('command' in value)
-    ) {
-        throw new Error('Invalid CommandUsageModel')
     }
 }
 
@@ -190,15 +164,6 @@ async function typedTrackHistoryFindMany(
 ): Promise<TrackHistoryModel[]> {
     const result: unknown = await prisma.trackHistory.findMany(params)
     assertIsArray<TrackHistoryModel>(result)
-    return result
-}
-
-async function typedCommandUsageCreate(
-    prisma: PrismaClient,
-    params: Parameters<PrismaClient['commandUsage']['create']>[0],
-): Promise<CommandUsageModel> {
-    const result: unknown = await prisma.commandUsage.create(params)
-    assertIsCommandUsageModel(result)
     return result
 }
 
@@ -604,65 +569,6 @@ export class DatabaseService {
         )
     }
 
-    // Command usage analytics
-    /** Records a bot command invocation for analytics. */
-    async recordCommandUsage(data: {
-        userId?: string
-        guildId?: string
-        command: string
-        category: string
-        success: boolean
-        errorCode?: string
-        duration?: number
-    }): Promise<Result<DatabaseCommandUsage>> {
-        return this.executeWithFallback(
-            async () => {
-                const usage = await typedCommandUsageCreate(this.prisma, {
-                    data: {
-                        user: data.userId
-                            ? { connect: { discordId: data.userId } }
-                            : undefined,
-                        guild: data.guildId
-                            ? { connect: { discordId: data.guildId } }
-                            : undefined,
-                        command: data.command,
-                        category: data.category,
-                        success: data.success,
-                        errorCode: data.errorCode,
-                        duration: data.duration,
-                    },
-                })
-                const result: DatabaseCommandUsage = {
-                    id: String(usage.id),
-                    userId: usage.userId ? String(usage.userId) : null,
-                    guildId: usage.guildId ? String(usage.guildId) : null,
-                    command: String(usage.command),
-                    category: String(usage.category),
-                    success: Boolean(usage.success),
-                    errorCode: usage.errorCode ? String(usage.errorCode) : null,
-                    duration: usage.duration ? Number(usage.duration) : null,
-                    createdAt:
-                        usage.createdAt instanceof Date
-                            ? usage.createdAt
-                            : new Date(usage.createdAt),
-                }
-                return result
-            },
-            {
-                id: '',
-                userId: null,
-                guildId: null,
-                command: '',
-                category: '',
-                success: false,
-                errorCode: null,
-                duration: null,
-                createdAt: new Date(),
-            } as DatabaseCommandUsage,
-            'record_command_usage',
-        )
-    }
-
     // Rate limiting
     /** Checks whether the given key is within the allowed rate limit window. */
     async checkRateLimit(
@@ -812,7 +718,7 @@ export class DatabaseService {
     }
 
     // Cleanup operations
-    /** Deletes track history, command usage, and expired rate limit records older than 30 days. */
+    /** Deletes track history and expired rate limit records older than 30 days. */
     async cleanupOldData(): Promise<Result<number>> {
         return this.executeWithFallback(
             async () => {
@@ -820,19 +726,16 @@ export class DatabaseService {
                     Date.now() - 30 * 24 * 60 * 60 * 1000,
                 )
 
-                const [tracks, usage, rateLimits] = await Promise.all([
+                const [tracks, rateLimits] = await Promise.all([
                     this.prisma.trackHistory.deleteMany({
                         where: { playedAt: { lt: thirtyDaysAgo } },
-                    }),
-                    this.prisma.commandUsage.deleteMany({
-                        where: { createdAt: { lt: thirtyDaysAgo } },
                     }),
                     this.prisma.rateLimit.deleteMany({
                         where: { resetAt: { lt: new Date() } },
                     }),
                 ])
 
-                return tracks.count + usage.count + rateLimits.count
+                return tracks.count + rateLimits.count
             },
             0,
             'cleanup_old_data',

--- a/packages/shared/src/services/database/analyticsOperations.ts
+++ b/packages/shared/src/services/database/analyticsOperations.ts
@@ -58,16 +58,3 @@ export async function queryTopArtists(
     )
 }
 
-export async function cleanupOldRecords(prisma: PrismaClient): Promise<number> {
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-    const [tracks, usage, rateLimits] = await Promise.all([
-        prisma.trackHistory.deleteMany({
-            where: { playedAt: { lt: thirtyDaysAgo } },
-        }),
-        prisma.commandUsage.deleteMany({
-            where: { createdAt: { lt: thirtyDaysAgo } },
-        }),
-        prisma.rateLimit.deleteMany({ where: { resetAt: { lt: new Date() } } }),
-    ])
-    return tracks.count + usage.count + rateLimits.count
-}

--- a/packages/shared/src/services/database/mappers.ts
+++ b/packages/shared/src/services/database/mappers.ts
@@ -2,13 +2,11 @@ import type {
     DatabaseUser,
     DatabaseGuild,
     DatabaseTrackHistory,
-    DatabaseCommandUsage,
 } from './types'
 import type {
     UserModel,
     GuildModel,
     TrackHistoryModel,
-    CommandUsageModel,
 } from './models'
 
 export function toUser(user: UserModel): DatabaseUser {
@@ -75,23 +73,6 @@ export function toTrackHistory(track: TrackHistoryModel): DatabaseTrackHistory {
     }
 }
 
-export function toCommandUsage(usage: CommandUsageModel): DatabaseCommandUsage {
-    return {
-        id: String(usage.id),
-        userId: usage.userId ? String(usage.userId) : null,
-        guildId: usage.guildId ? String(usage.guildId) : null,
-        command: String(usage.command),
-        category: String(usage.category),
-        success: Boolean(usage.success),
-        errorCode: usage.errorCode ? String(usage.errorCode) : null,
-        duration: usage.duration ? Number(usage.duration) : null,
-        createdAt:
-            usage.createdAt instanceof Date
-                ? usage.createdAt
-                : new Date(usage.createdAt),
-    }
-}
-
 export const EMPTY_USER: DatabaseUser = {
     id: '',
     discordId: '',
@@ -129,16 +110,4 @@ export const EMPTY_TRACK_HISTORY: DatabaseTrackHistory = {
     playDuration: null,
     skipped: false,
     isPlaylist: false,
-}
-
-export const EMPTY_COMMAND_USAGE: DatabaseCommandUsage = {
-    id: '',
-    userId: null,
-    guildId: null,
-    command: '',
-    category: '',
-    success: false,
-    errorCode: null,
-    duration: null,
-    createdAt: new Date(),
 }

--- a/packages/shared/src/services/database/models.ts
+++ b/packages/shared/src/services/database/models.ts
@@ -39,17 +39,6 @@ export type TrackHistoryModel = {
     isPlaylist: boolean | null
 }
 
-export type CommandUsageModel = {
-    id: string
-    userId: string | null
-    guildId: string | null
-    command: string
-    category: string
-    success: boolean
-    errorCode: string | null
-    duration: number | null
-    createdAt: Date
-}
 
 function assertIsUserModel(value: unknown): asserts value is UserModel {
     if (
@@ -86,18 +75,6 @@ function assertIsTrackHistoryModel(
     }
 }
 
-function assertIsCommandUsageModel(
-    value: unknown,
-): asserts value is CommandUsageModel {
-    if (
-        !value ||
-        typeof value !== 'object' ||
-        !('id' in value) ||
-        !('command' in value)
-    ) {
-        throw new Error('Invalid CommandUsageModel')
-    }
-}
 
 export function assertIsArray<T>(value: unknown): asserts value is T[] {
     if (!Array.isArray(value)) {
@@ -178,14 +155,6 @@ export async function typedTrackHistoryFindMany(
     return result
 }
 
-export async function typedCommandUsageCreate(
-    prisma: PrismaClient,
-    params: Parameters<PrismaClient['commandUsage']['create']>[0],
-): Promise<CommandUsageModel> {
-    const result: unknown = await prisma.commandUsage.create(params)
-    assertIsCommandUsageModel(result)
-    return result
-}
 
 export async function typedRateLimitFindUnique(
     prisma: PrismaClient,

--- a/packages/shared/src/services/database/types.ts
+++ b/packages/shared/src/services/database/types.ts
@@ -41,18 +41,6 @@ export interface DatabaseTrackHistory {
   isPlaylist: boolean | null
 }
 
-export interface DatabaseCommandUsage {
-  id: string
-  userId: string | null
-  guildId: string | null
-  command: string
-  category: string
-  success: boolean
-  errorCode: string | null
-  duration: number | null
-  createdAt: Date
-}
-
 export interface DatabaseRateLimit {
   id: string
   key: string

--- a/packages/shared/src/types/prisma.d.ts
+++ b/packages/shared/src/types/prisma.d.ts
@@ -18,10 +18,6 @@ declare module '@prisma/client' {
             groupBy(args: unknown): Promise<unknown[]>
             deleteMany(args: unknown): Promise<{ count: number }>
         }
-        commandUsage: {
-            create(args: unknown): Promise<unknown>
-            deleteMany(args: unknown): Promise<{ count: number }>
-        }
         rateLimit: {
             findUnique(args: unknown): Promise<unknown | null>
             upsert(args: unknown): Promise<unknown>

--- a/prisma/migrations/20260612170000_drop_command_usage/migration.sql
+++ b/prisma/migrations/20260612170000_drop_command_usage/migration.sql
@@ -1,0 +1,3 @@
+-- CommandUsage was dead code: no production writer ever existed (issue #1341),
+-- so the table is empty in every environment. Drop it outright.
+DROP TABLE IF EXISTS "command_usage";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,6 @@ model User {
 
   // Relations
   preferences   UserPreferences?
-  commandUsage  CommandUsage[]
   trackFeedback UserTrackFeedback[]
 
   @@map("users")
@@ -66,7 +65,6 @@ model Guild {
   settings             GuildSettings?
   sessions             GuildSession[]
   trackHistory         TrackHistory[]
-  commandUsage         CommandUsage[]
   twitchNotifications  TwitchNotification[]
   featureToggles       GuildFeatureToggle[]
   namedQueues          NamedQueue[]
@@ -390,27 +388,6 @@ model TrackHistory {
   @@index([guildId, playedAt])
   @@index([trackId])
   @@map("track_history")
-}
-
-// Command Usage Analytics
-model CommandUsage {
-  id      String  @id @default(cuid())
-  userId  String?
-  guildId String?
-  user    User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
-  guild   Guild?  @relation(fields: [guildId], references: [discordId], onDelete: SetNull)
-
-  command   String
-  category  String
-  success   Boolean
-  errorCode String?
-  duration  Int? // Execution time in milliseconds
-
-  createdAt DateTime @default(now())
-
-  @@index([command, createdAt])
-  @@index([guildId, createdAt])
-  @@map("command_usage")
 }
 
 // Rate Limiting


### PR DESCRIPTION
## Summary

Removes the unused CommandUsage model and all associated code from the database layer.

- Deletes Prisma model definition and database migration (DROP TABLE command_usage)
- Removes TypeScript types: DatabaseCommandUsage interface, CommandUsageModel type
- Removes helper functions: toCommandUsage mapper, typedCommandUsageCreate
- Removes cleanupOldRecords function (dead code, zero callers)
- Updates cleanupOldData to remove commandUsage.deleteMany from aggregated cleanup
- Updates prisma.d.ts type stubs to remove commandUsage property
- Verification: 782 shared tests, 997 backend tests, 2483 bot tests all passing; zero CommandUsage references remain; ESLint passes with no new errors

Closes #1341

## Test plan

- All test suites pass (shared: 782, backend: 997, bot: 2483)
- Build and type checking pass (npm run build:shared && npm run type:check)
- ESLint passes with no new errors
- Final grep confirms zero CommandUsage references in codebase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead CommandUsage analytics from the codebase and schema. Adds the migration to drop the `command_usage` table (fulfills #1341).

- **Refactors**
  - Removed `CommandUsage` model and relations from `schema.prisma`; deleted related TS types, mappers, guards, empty constants, typed helpers, and the `recordCommandUsage` API.
  - Deleted `cleanupOldRecords`; updated `cleanupOldData` to only purge track history and rate limits.
  - Updated `prisma.d.ts` stubs to remove `commandUsage`.

- **Migration**
  - Added `prisma/migrations/20260612170000_drop_command_usage` to drop `command_usage`.
  - No data migration required.

<sup>Written for commit 27d7037e3b499f169a2cc7cffb2f24ff26168610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

