### PR TITLE
test(bot): integration coverage for blendAutoplayTracks (#1089)

### DIFF
--- a/packages/bot/src/utils/music/queueEditOps.spec.ts
+++ b/packages/bot/src/utils/music/queueEditOps.spec.ts
@@ -475,7 +475,11 @@ describe('blendAutoplayTracks', () => {
             }
             const queue = createQueue([auto1, auto2, auto3])
 
-            // Make node.remove fail on the second call
+            // Make node.remove fail on the second call, delegating successful
+            // calls to the stub's real implementation (mutates the live array)
+            const originalRemove = (
+                queue.node.remove as jest.Mock
+            ).getMockImplementation() as (track: Track) => void
             const removeCallCount = { count: 0 }
             ;(queue.node.remove as jest.Mock).mockImplementation(
                 (track: Track) => {
@@ -483,26 +487,17 @@ describe('blendAutoplayTracks', () => {
                     if (removeCallCount.count === 2) {
                         throw new Error('simulated removal failure')
                     }
-                    // Still remove from the internal array
-                    const idx = queue.tracks
-                        .toArray()
-                        .findIndex(
-                            (t) => t.url === track.url && t.title === track.title,
-                        )
-                    if (idx >= 0) {
-                        const tracks = queue.tracks.toArray()
-                        tracks.splice(idx, 1)
-                    }
+                    originalRemove(track)
                 },
             )
 
             // Should not throw despite the failure
             await blendAutoplayTracks(queue, seedTrack, 0.33)
 
-            // keepCount = ceil(3 * 0.33) = 1, so 2 tracks should be removed
-            // Second removal fails (mocked), so the queue still contains all 3
-            // (the implementation's try-catch prevents crashing)
-            expect(queue.tracks.size).toBe(3)
+            // keepCount = ceil(3 * 0.33) = 1, so 2 removals are attempted:
+            // the first succeeds (queue drops to 2), the second throws and is
+            // swallowed by the per-track try-catch — leaving 2 tracks
+            expect(queue.tracks.size).toBe(2)
             expect(replenishQueueMock).toHaveBeenCalledWith(queue)
         })
     })

--- a/packages/bot/src/utils/music/queueEditOps.spec.ts
+++ b/packages/bot/src/utils/music/queueEditOps.spec.ts
@@ -345,4 +345,165 @@ describe('blendAutoplayTracks', () => {
         expect(queue.node.remove).toHaveBeenCalledTimes(2)
         expect(replenishQueueMock).toHaveBeenCalledWith(queue)
     })
+
+    describe('integration: real queue.tracks mutation', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+            replenishQueueMock.mockResolvedValue(undefined)
+        })
+
+        it('removes autoplay tracks from queue.tracks, keeping correct count with ratio 0.5', async () => {
+            const seedTrack = createTrack('Seed', 'A', 'seed')
+            const auto1 = createTrack('Auto1', 'Bot', 'u1')
+            const auto2 = createTrack('Auto2', 'Bot', 'u2')
+            const auto3 = createTrack('Auto3', 'Bot', 'u3')
+            const auto4 = createTrack('Auto4', 'Bot', 'u4')
+            for (const t of [auto1, auto2, auto3, auto4]) {
+                ;(t as unknown as { metadata: Record<string, unknown> }).metadata =
+                    { isAutoplay: true }
+            }
+            const queue = createQueue([auto1, auto2, auto3, auto4])
+
+            expect(queue.tracks.size).toBe(4)
+
+            await blendAutoplayTracks(queue, seedTrack, 0.5)
+
+            // keepCount = ceil(4 * 0.5) = 2, so 2 tracks removed
+            expect(queue.tracks.size).toBe(2)
+            const remainingTracks = queue.tracks.toArray()
+            expect(remainingTracks).toHaveLength(2)
+            expect(remainingTracks[0]).toBe(auto1)
+            expect(remainingTracks[1]).toBe(auto2)
+        })
+
+        it('handles ratio 0 by removing all autoplay tracks', async () => {
+            const seedTrack = createTrack('Seed', 'A', 'seed')
+            const auto1 = createTrack('Auto1', 'Bot', 'u1')
+            const auto2 = createTrack('Auto2', 'Bot', 'u2')
+            for (const t of [auto1, auto2]) {
+                ;(t as unknown as { metadata: Record<string, unknown> }).metadata =
+                    { isAutoplay: true }
+            }
+            const queue = createQueue([auto1, auto2])
+
+            await blendAutoplayTracks(queue, seedTrack, 0)
+
+            // keepCount = ceil(2 * 0) = 0, so all 2 tracks removed
+            expect(queue.tracks.size).toBe(0)
+            expect(replenishQueueMock).toHaveBeenCalledWith(queue)
+        })
+
+        it('handles ratio 1 by keeping all autoplay tracks', async () => {
+            const seedTrack = createTrack('Seed', 'A', 'seed')
+            const auto1 = createTrack('Auto1', 'Bot', 'u1')
+            const auto2 = createTrack('Auto2', 'Bot', 'u2')
+            const auto3 = createTrack('Auto3', 'Bot', 'u3')
+            for (const t of [auto1, auto2, auto3]) {
+                ;(t as unknown as { metadata: Record<string, unknown> }).metadata =
+                    { isAutoplay: true }
+            }
+            const queue = createQueue([auto1, auto2, auto3])
+
+            await blendAutoplayTracks(queue, seedTrack, 1)
+
+            // keepCount = ceil(3 * 1) = 3, so 0 tracks removed
+            expect(queue.tracks.size).toBe(3)
+            expect(queue.tracks.toArray()).toEqual([auto1, auto2, auto3])
+            expect(replenishQueueMock).toHaveBeenCalledWith(queue)
+        })
+
+        it('leaves non-autoplay tracks untouched when blending', async () => {
+            const seedTrack = createTrack('Seed', 'A', 'seed')
+            const userTrack1 = createTrack('User1', 'Human', 'u1')
+            const auto1 = createTrack('Auto1', 'Bot', 'a1')
+            const auto2 = createTrack('Auto2', 'Bot', 'a2')
+            const userTrack2 = createTrack('User2', 'Human', 'u2')
+
+            ;(auto1 as unknown as { metadata: Record<string, unknown> }).metadata =
+                { isAutoplay: true }
+            ;(auto2 as unknown as { metadata: Record<string, unknown> }).metadata =
+                { isAutoplay: true }
+
+            const queue = createQueue([
+                userTrack1,
+                auto1,
+                auto2,
+                userTrack2,
+            ])
+
+            await blendAutoplayTracks(queue, seedTrack, 0.5)
+
+            // keepCount = ceil(2 * 0.5) = 1, so 1 autoplay track removed
+            expect(queue.tracks.size).toBe(3)
+            const remaining = queue.tracks.toArray()
+            expect(remaining).toContain(userTrack1)
+            expect(remaining).toContain(userTrack2)
+            // One of the two autoplay tracks should remain
+            const autoplayRemaining = remaining.filter((t) => {
+                const meta = (t as unknown as { metadata: Record<string, unknown> })
+                    .metadata
+                return (meta as { isAutoplay?: boolean }).isAutoplay === true
+            })
+            expect(autoplayRemaining).toHaveLength(1)
+        })
+
+        it('invokes replenishQueue with the queue after mutation', async () => {
+            const seedTrack = createTrack('Seed', 'A', 'seed')
+            const auto1 = createTrack('Auto1', 'Bot', 'u1')
+            const auto2 = createTrack('Auto2', 'Bot', 'u2')
+            for (const t of [auto1, auto2]) {
+                ;(t as unknown as { metadata: Record<string, unknown> }).metadata =
+                    { isAutoplay: true }
+            }
+            const queue = createQueue([auto1, auto2])
+
+            await blendAutoplayTracks(queue, seedTrack, 0.5)
+
+            // Verify replenishQueue was called with the queue
+            expect(replenishQueueMock).toHaveBeenCalledWith(queue)
+            expect(replenishQueueMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not crash on remove failures for individual tracks', async () => {
+            const seedTrack = createTrack('Seed', 'A', 'seed')
+            const auto1 = createTrack('Auto1', 'Bot', 'u1')
+            const auto2 = createTrack('Auto2', 'Bot', 'u2')
+            const auto3 = createTrack('Auto3', 'Bot', 'u3')
+            for (const t of [auto1, auto2, auto3]) {
+                ;(t as unknown as { metadata: Record<string, unknown> }).metadata =
+                    { isAutoplay: true }
+            }
+            const queue = createQueue([auto1, auto2, auto3])
+
+            // Make node.remove fail on the second call
+            const removeCallCount = { count: 0 }
+            ;(queue.node.remove as jest.Mock).mockImplementation(
+                (track: Track) => {
+                    removeCallCount.count++
+                    if (removeCallCount.count === 2) {
+                        throw new Error('simulated removal failure')
+                    }
+                    // Still remove from the internal array
+                    const idx = queue.tracks
+                        .toArray()
+                        .findIndex(
+                            (t) => t.url === track.url && t.title === track.title,
+                        )
+                    if (idx >= 0) {
+                        const tracks = queue.tracks.toArray()
+                        tracks.splice(idx, 1)
+                    }
+                },
+            )
+
+            // Should not throw despite the failure
+            await blendAutoplayTracks(queue, seedTrack, 0.33)
+
+            // keepCount = ceil(3 * 0.33) = 1, so 2 tracks should be removed
+            // Second removal fails (mocked), so the queue still contains all 3
+            // (the implementation's try-catch prevents crashing)
+            expect(queue.tracks.size).toBe(3)
+            expect(replenishQueueMock).toHaveBeenCalledWith(queue)
+        })
+    })
 })


### PR DESCRIPTION
## Summary
- Adds 6 new integration-level tests for `blendAutoplayTracks` function
- Exercises REAL implementation with actual queue.tracks mutations
- Verifies replenish queue invocation and error resilience

## Test Coverage
- **blendRatio 0.5:** Removes 50% of autoplay tracks (keepCount = ceil(4 * 0.5) = 2)
- **blendRatio 0:** Removes all autoplay tracks (empty autoplay pool)
- **blendRatio 1:** Keeps all autoplay tracks
- **Mixed queue:** Preserves user tracks while removing autoplay tracks
- **Replenish invocation:** Verifies replenishQueue called with correct queue
- **Error resilience:** Gracefully handles individual track removal failures

## Test Results
- **queueEditOps.spec.ts:** 28 passed
- **Full bot suite:** 2489 passed, 6 skipped

## Verification
```bash
cd packages/bot && npx jest src/utils/music/queueEditOps.spec.ts
# Result: Test Suites: 1 passed, Tests: 28 passed
```

Closes #1089

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 6 integration tests for `blendAutoplayTracks` to validate real queue.tracks mutations and replenish behavior. Covers ratios 0/0.5/1, preserves user tracks in mixed queues, invokes replenish with the queue, and includes a remove-failure case that mutates the live queue.

<sup>Written for commit 028332c8ace316ca00c62ec2e9d5829879bfa49b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

