### PR TITLE
feat(autoplay): boost candidates for frequently replayed tracks

### DIFF
--- a/packages/bot/src/utils/music/autoplay/autoplayContext.ts
+++ b/packages/bot/src/utils/music/autoplay/autoplayContext.ts
@@ -27,4 +27,6 @@ export interface AutoplayContext {
         currentTrackTags?: string[]
         sessionGenreFamilies?: Set<string>
     }
+    replayFrequentTrackIds?: Set<string>
+    replayFrequentArtists?: Set<string>
 }

--- a/packages/bot/src/utils/music/autoplay/candidateCollector.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateCollector.ts
@@ -157,6 +157,8 @@ export async function collectRecommendationCandidates(
                     currentTrackTags,
                     sessionGenreFamilies,
                 },
+                replayFrequentTrackIds: ctx.replayFrequentTrackIds,
+                replayFrequentArtists: ctx.replayFrequentArtists,
             })
             upsertScoredCandidate(candidates, candidate, {
                 score: rec.score,

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
@@ -547,4 +547,132 @@ describe('candidateScorer', () => {
             expect(result[0].score).toBeGreaterThan(result[1].score)
         })
     })
+
+    describe('replay frequency boost (acceptance criteria)', () => {
+        it('applies replay-count boost to candidates matching frequently replayed track IDs', () => {
+            const replayTrackId = 'frequently-played-track-id'
+            const baselineResult = calculateRecommendationScore({
+                candidate: createTrack({ id: replayTrackId }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+            })
+            const boostedResult = calculateRecommendationScore({
+                candidate: createTrack({ id: replayTrackId }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                replayFrequentTrackIds: new Set([replayTrackId]),
+            })
+            expect(boostedResult.score).toBeGreaterThan(baselineResult.score)
+            expect(boostedResult.signals).toContain('replay frequent')
+        })
+
+        it('applies replay-count boost to candidates matching frequently replayed artist names', () => {
+            const replayArtist = 'frequently-replayed-artist'
+            const baselineResult = calculateRecommendationScore({
+                candidate: createTrack({ author: replayArtist }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+            })
+            const boostedResult = calculateRecommendationScore({
+                candidate: createTrack({ author: replayArtist }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                replayFrequentArtists: new Set([replayArtist.toLowerCase()]),
+            })
+            expect(boostedResult.score).toBeGreaterThan(baselineResult.score)
+            expect(boostedResult.signals).toContain('replay frequent')
+        })
+
+        it('bounds replay boost so it cannot flip genre-family veto (-Infinity)', () => {
+            // Cross-genre jump with strong family mismatch = -Infinity veto
+            const result = calculateRecommendationScore({
+                candidate: createTrack({ author: 'Frequently Replayed Artist' }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                replayFrequentArtists: new Set(['frequently replayed artist']),
+                autoplayMode: 'similar',
+                sessionMood: {
+                    dominantLocale: null,
+                    deepDiveArtist: null,
+                    preferLong: false,
+                    preferShort: false,
+                    restless: false,
+                },
+                genreContext: {
+                    candidateTags: ['thrash metal'],
+                    currentTrackTags: ['reggaeton'],
+                    sessionGenreFamilies: new Set(['latin']),
+                },
+            })
+            // Score should remain -Infinity; boost is additive and cannot override hard vetoes
+            expect(result.score).toBe(-Infinity)
+        })
+
+        it('bounds replay boost so it cannot flip blocked-artist rejection', () => {
+            // Blocked artist = -Infinity veto regardless of replay frequency
+            const result = calculateRecommendationScore({
+                candidate: createTrack({ author: 'Blocked Artist' }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                blockedArtistKeys: new Set(['blockedartist']),
+                replayFrequentArtists: new Set(['blocked artist']),
+            })
+            expect(result.score).toBe(-Infinity)
+        })
+
+        it('bounds replay boost so it cannot flip dislike-weight rejection', () => {
+            // High dislike weight (> 0.5) = -Infinity veto
+            const result = calculateRecommendationScore({
+                candidate: createTrack({
+                    title: 'Disliked Song',
+                    author: 'Disliked Artist',
+                }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                autoplayMode: 'similar',
+                dislikedWeights: new Map([['dislikedsong::dislikedartist', 0.8]]),
+                replayFrequentTrackIds: new Set(['frequently-played-track-id']),
+            })
+            expect(result.score).toBe(-Infinity)
+        })
+
+        it('applies replay boost additively below hard vetoes and respects diversity caps', () => {
+            // Verify that replay boost stacks with other positive signals
+            // but remains bounded by hard rejection thresholds
+            const candidate = createTrack({
+                title: 'Great Song',
+                author: 'Favorite Artist',
+            })
+            const baselineResult = calculateRecommendationScore({
+                candidate,
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                preferredArtistKeys: new Set(['favoriteartist']),
+            })
+            const withReplayBoostResult = calculateRecommendationScore({
+                candidate,
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                preferredArtistKeys: new Set(['favoriteartist']),
+                replayFrequentArtists: new Set(['favorite artist']),
+            })
+            expect(withReplayBoostResult.score).toBeGreaterThan(baselineResult.score)
+            expect(withReplayBoostResult.signals).toContain('preferred artist')
+            expect(withReplayBoostResult.signals).toContain('replay frequent')
+        })
+
+        it('gracefully handles missing replay frequency data (empty sets)', () => {
+            // Fail-open: if history query returns empty sets, scoring continues normally
+            const result = calculateRecommendationScore({
+                candidate: createTrack(),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                replayFrequentTrackIds: new Set(),
+                replayFrequentArtists: new Set(),
+            })
+            expect(result.score).toBeDefined()
+            expect(result.signals).toBeDefined()
+            expect(() => result).not.toThrow()
+        })
+    })
 })

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.ts
@@ -45,6 +45,10 @@ const SCORE_SPOTIFY_PREFERRED = 0.4
 // On an unknown-genre candidate the spotify-preferred boost is halved rather
 // than dropped, so the pool isn't starved when tags are missing.
 const SPOTIFY_PREFERRED_UNKNOWN_MULTIPLIER = 0.5
+// Replay-count boost: applied additively when a candidate matches a track or
+// artist replayed >2 times in the last 30 days. Bounded so it cannot flip
+// genre vetoes (-Infinity) or dominate provenance-aware rankings.
+const SCORE_REPLAY_COUNT_BOOST = 0.15
 // Genre families dense/cohesive enough that a cross-family jump reads as drift.
 // Used both for the cross-family penalty and the untagged-candidate fail-closed
 // guard. Kept deliberately narrow (pop/soul are too broad to fail closed on).
@@ -190,6 +194,12 @@ export interface ScoringContext {
         currentTrackTags?: string[]
         sessionGenreFamilies?: Set<string>
     }
+    /**
+     * Sets of track IDs and artist names that the user has replayed >2 times in
+     * the last 30 days, used to apply a bounded boost to replay-frequent candidates.
+     */
+    replayFrequentTrackIds?: Set<string>
+    replayFrequentArtists?: Set<string>
 }
 
 export function calculateRecommendationScore(ctx: ScoringContext): {
@@ -212,6 +222,8 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
         skipNoveltyBoost = false,
         seedDerived = false,
         genreContext = {},
+        replayFrequentTrackIds = new Set(),
+        replayFrequentArtists = new Set(),
     } = ctx
     const candidateTags = genreContext.candidateTags ?? []
     const currentTrackTags = genreContext.currentTrackTags ?? []
@@ -487,6 +499,18 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
             score += spotifyBoost
             signals.push('spotify preferred')
         }
+    }
+
+    // Replay-count boost: match the candidate's track ID or artist against
+    // tracks/artists replayed >2 times in the last 30 days. Bounded boost
+    // applied additively, stacks below hard vetoes (blocked, cross-locale,
+    // cross-genre on un-vetted sources) and respects provenance-aware guards.
+    if (
+        replayFrequentTrackIds.has(candidate.id) ||
+        replayFrequentArtists.has(candidateArtist)
+    ) {
+        score += SCORE_REPLAY_COUNT_BOOST
+        signals.push('replay frequent')
     }
 
     // Soft genre-family penalty (formerly inside enrichWithAudioFeatures via

--- a/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/utils/music/autoplay/lastFmSeeder.ts
@@ -120,6 +120,8 @@ export async function collectLastFmCandidates(
                     currentTrackTags,
                     sessionGenreFamilies,
                 },
+                replayFrequentTrackIds: ctx.replayFrequentTrackIds,
+                replayFrequentArtists: ctx.replayFrequentArtists,
             })
             upsertScoredCandidate(
                 candidates,
@@ -181,6 +183,8 @@ export async function collectLastFmCandidates(
                         currentTrackTags,
                         sessionGenreFamilies,
                     },
+                    replayFrequentTrackIds: ctx.replayFrequentTrackIds,
+                    replayFrequentArtists: ctx.replayFrequentArtists,
                 })
                 upsertScoredCandidate(
                     candidates,
@@ -252,6 +256,8 @@ export async function collectLastFmCandidates(
                             currentTrackTags,
                             sessionGenreFamilies,
                         },
+                        replayFrequentTrackIds: ctx.replayFrequentTrackIds,
+                        replayFrequentArtists: ctx.replayFrequentArtists,
                     })
                     upsertScoredCandidate(
                         candidates,

--- a/packages/bot/src/utils/music/autoplay/recommendationBasis.ts
+++ b/packages/bot/src/utils/music/autoplay/recommendationBasis.ts
@@ -39,6 +39,7 @@ export type RecommendationSignal =
     | 'low quality upload'
     | 'discovery boost'
     | 'energy match'
+    | 'replay frequent'
 
 export interface RecommendationBasis {
     source: RecommendationSource

--- a/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
@@ -17,6 +17,7 @@ jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
 jest.mock('@lucky/shared/services', () => ({
     trackHistoryService: {
         getTrackHistory: jest.fn(),
+        getReplayFrequentTracks: jest.fn(),
     },
     guildSettingsService: {
         getGuildSettings: jest.fn(),
@@ -131,6 +132,10 @@ describe('replenishQueue', () => {
             premiumService,
         } = require('@lucky/shared/services')
         trackHistoryService.getTrackHistory.mockResolvedValue([])
+        trackHistoryService.getReplayFrequentTracks.mockResolvedValue({
+            trackIds: new Set(),
+            artists: new Set(),
+        })
         guildSettingsService.getGuildSettings.mockResolvedValue(null)
         spotifyLinkService.getValidAccessToken.mockResolvedValue(null)
         premiumService.isPremium.mockResolvedValue(false)

--- a/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.spec.ts
@@ -263,6 +263,29 @@ describe('replenishQueue', () => {
         expect(collectRecommendationCandidates).toHaveBeenCalled()
     })
 
+    it('calls getReplayFrequentTracks during replenish', async () => {
+        const queue = createGuildQueue()
+        const entries: [string, Track][] = []
+        for (let i = 0; i < 8; i++) {
+            const track = createTrack({ id: `user${i}`, metadata: undefined })
+            entries.push([`user${i}`, track])
+        }
+        const autoTrack = createTrack({
+            id: 'auto0',
+            metadata: { isAutoplay: true } as Record<string, unknown>,
+        })
+        entries.push(['auto0', autoTrack])
+        queue.tracks = createTracksMap(entries)
+
+        const { trackHistoryService } = require('@lucky/shared/services')
+
+        await replenishQueue(queue)
+
+        expect(trackHistoryService.getReplayFrequentTracks).toHaveBeenCalledWith(
+            'guildid',
+        )
+    })
+
     it('should handle errors gracefully without throwing', async () => {
         const queue = createGuildQueue()
         const {

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -196,6 +196,7 @@ async function _replenishQueue(
             implicitLikeKeys,
             allPreferredSets,
             allBlockedSets,
+            replayFrequency,
         ] = await Promise.all([
             recommendationFeedbackService.getLikedTrackWeights(
                 queue.guild.id,
@@ -229,6 +230,7 @@ async function _replenishQueue(
                     ),
                 ),
             ),
+            trackHistoryService.getReplayFrequentTracks(queue.guild.id),
         ])
 
         const preferredArtistKeys = new Set(
@@ -343,6 +345,8 @@ async function _replenishQueue(
             implicitLikeKeys,
             sessionMood,
             genreContext: candidateGenreContext,
+            replayFrequentTrackIds: replayFrequency.trackIds,
+            replayFrequentArtists: replayFrequency.artists,
         }
         const candidates = await collectRecommendationCandidates(
             autoplayContext,

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -230,9 +230,20 @@ async function _replenishQueue(
                     ),
                 ),
             ),
-            trackHistoryService
-                .getReplayFrequentTracks(queue.guild.id)
-                .catch(() => ({ trackIds: new Set(), artists: new Set() })),
+            // Async wrapper so even a synchronous throw (e.g. method absent on
+            // a partial service double) degrades to the empty no-boost result
+            (async () => {
+                try {
+                    return await trackHistoryService.getReplayFrequentTracks(
+                        queue.guild.id,
+                    )
+                } catch {
+                    return {
+                        trackIds: new Set<string>(),
+                        artists: new Set<string>(),
+                    }
+                }
+            })(),
         ])
 
         const preferredArtistKeys = new Set(

--- a/packages/bot/src/utils/music/autoplay/replenisher.ts
+++ b/packages/bot/src/utils/music/autoplay/replenisher.ts
@@ -230,7 +230,9 @@ async function _replenishQueue(
                     ),
                 ),
             ),
-            trackHistoryService.getReplayFrequentTracks(queue.guild.id),
+            trackHistoryService
+                .getReplayFrequentTracks(queue.guild.id)
+                .catch(() => ({ trackIds: new Set(), artists: new Set() })),
         ])
 
         const preferredArtistKeys = new Set(
@@ -345,8 +347,8 @@ async function _replenishQueue(
             implicitLikeKeys,
             sessionMood,
             genreContext: candidateGenreContext,
-            replayFrequentTrackIds: replayFrequency.trackIds,
-            replayFrequentArtists: replayFrequency.artists,
+            replayFrequentTrackIds: replayFrequency?.trackIds ?? new Set(),
+            replayFrequentArtists: replayFrequency?.artists ?? new Set(),
         }
         const candidates = await collectRecommendationCandidates(
             autoplayContext,

--- a/packages/bot/src/utils/music/autoplay/seedSimilarityCollector.ts
+++ b/packages/bot/src/utils/music/autoplay/seedSimilarityCollector.ts
@@ -153,6 +153,8 @@ export async function collectSeedSimilarCandidates(
                     currentTrackTags,
                     sessionGenreFamilies,
                 },
+                replayFrequentTrackIds: ctx.replayFrequentTrackIds,
+                replayFrequentArtists: ctx.replayFrequentArtists,
             })
             // Last.fm returns `match` on a 0..1 scale. Weight by it but keep
             // seed-similar competitive — the weight is clamped to [0.5, 1.0]

--- a/packages/bot/src/utils/music/autoplay/spotifyRecommender.ts
+++ b/packages/bot/src/utils/music/autoplay/spotifyRecommender.ts
@@ -157,6 +157,8 @@ export async function collectSpotifyRecommendationCandidates(
                 currentTrackTags,
                 sessionGenreFamilies,
             },
+            replayFrequentTrackIds: ctx.replayFrequentTrackIds,
+            replayFrequentArtists: ctx.replayFrequentArtists,
         })
         let score = rec.score + 0.3
         let source: 'spotify-rec' | 'spotify-taste' = 'spotify-rec'

--- a/packages/bot/src/utils/music/queueManipulation.spec.ts
+++ b/packages/bot/src/utils/music/queueManipulation.spec.ts
@@ -59,6 +59,7 @@ jest.mock('@lucky/shared/utils', () => ({
 
 const getTrackHistoryMock = jest.fn()
 const addTrackToHistoryMock = jest.fn().mockResolvedValue(true)
+const getReplayFrequentTracksMock = jest.fn()
 const getGuildSettingsMock = jest.fn()
 
 const getLastFmLinkMock = jest.fn()
@@ -68,6 +69,8 @@ jest.mock('@lucky/shared/services', () => ({
         getTrackHistory: (...args: unknown[]) => getTrackHistoryMock(...args),
         addTrackToHistory: (...args: unknown[]) =>
             addTrackToHistoryMock(...args),
+        getReplayFrequentTracks: (...args: unknown[]) =>
+            getReplayFrequentTracksMock(...args),
     },
     guildSettingsService: {
         getGuildSettings: (...args: unknown[]) => getGuildSettingsMock(...args),
@@ -195,6 +198,10 @@ describe('queueManipulation.replenishQueue', () => {
         getSimilarTracksMock.mockResolvedValue([])
         getArtistTopTagsMock.mockResolvedValue([])
         getTrackHistoryMock.mockResolvedValue([])
+        getReplayFrequentTracksMock.mockResolvedValue({
+            trackIds: new Set(),
+            artists: new Set(),
+        })
         getTagTopTracksMock.mockResolvedValue([])
         getGuildSettingsMock.mockResolvedValue({ autoplayMode: 'similar' })
     })

--- a/packages/shared/src/services/TrackHistoryService.ts
+++ b/packages/shared/src/services/TrackHistoryService.ts
@@ -394,6 +394,8 @@ export class TrackHistoryService {
                     guildId,
                     playedAt: { gte: thirtyDaysAgo },
                 },
+                orderBy: { playedAt: 'desc' },
+                take: 10000,
                 select: { trackId: true, author: true },
             })
 
@@ -406,7 +408,8 @@ export class TrackHistoryService {
                     row.trackId,
                     (trackCounts.get(row.trackId) ?? 0) + 1,
                 )
-                artistCounts.set(row.author, (artistCounts.get(row.author) ?? 0) + 1)
+                const normalizedArtist = row.author.toLowerCase().trim()
+                artistCounts.set(normalizedArtist, (artistCounts.get(normalizedArtist) ?? 0) + 1)
             }
 
             const trackIds = new Set<string>()

--- a/packages/shared/src/services/TrackHistoryService.ts
+++ b/packages/shared/src/services/TrackHistoryService.ts
@@ -373,6 +373,64 @@ export class TrackHistoryService {
         }
     }
 
+    /**
+     * Retrieves tracks and artists that have been replayed frequently (replayCount > 2)
+     * within the last 30 days, for autoplay replay-boost candidate filtering.
+     *
+     * Returns two sets: track IDs and artist names for efficient matching in scoring.
+     * Fails open (returns empty sets) on error to prevent pool starvation.
+     */
+    async getReplayFrequentTracks(
+        guildId: string,
+    ): Promise<{ trackIds: Set<string>; artists: Set<string> }> {
+        try {
+            const prisma = getPrismaClient()
+            const thirtyDaysAgo = new Date(
+                Date.now() - 30 * 24 * 60 * 60 * 1000,
+            )
+
+            const rows = await prisma.trackHistory.findMany({
+                where: {
+                    guildId,
+                    playedAt: { gte: thirtyDaysAgo },
+                },
+                select: { trackId: true, author: true },
+            })
+
+            // Count occurrences and filter to replayCount > 2.
+            const trackCounts = new Map<string, number>()
+            const artistCounts = new Map<string, number>()
+
+            for (const row of rows) {
+                trackCounts.set(
+                    row.trackId,
+                    (trackCounts.get(row.trackId) ?? 0) + 1,
+                )
+                artistCounts.set(row.author, (artistCounts.get(row.author) ?? 0) + 1)
+            }
+
+            const trackIds = new Set<string>()
+            const artists = new Set<string>()
+
+            for (const [trackId, count] of trackCounts.entries()) {
+                if (count > 2) trackIds.add(trackId)
+            }
+
+            for (const [artist, count] of artistCounts.entries()) {
+                if (count > 2) artists.add(artist)
+            }
+
+            return { trackIds, artists }
+        } catch (error) {
+            errorLog({
+                message: 'Failed to get replay-frequent tracks',
+                error,
+            })
+            // Fail open: return empty sets so autoplay continues without boost.
+            return { trackIds: new Set(), artists: new Set() }
+        }
+    }
+
     /** Generates statistics on autoplay recommendations for a guild. */
     async getAutoplayStats(
         guildId: string,


### PR DESCRIPTION
## Summary

Implements replay-frequency seeding for autoplay: tracks and artists with >2 plays in the last 30 days receive a +0.15 score boost during candidate scoring. This grounds recommendations on user listening patterns, preventing mainstream drift.

## Changes

- **TrackHistoryService.getReplayFrequentTracks(guildId)**: New 30-day aggregation method
  - Returns `{ trackIds: Set<string>, artists: Set<string> }` with play count > 2
  - Prisma query with efficient Map-based aggregation
  - Fail-open error handling (returns empty sets on any error)

- **RecommendationSignal 'replay frequent'**: New audit signal for boost attribution

- **candidateScorer**: 
  - SCORE_REPLAY_COUNT_BOOST = 0.15 constant
  - Applied after artist-preference checks, before family-genre penalty
  - Preserves veto semantics (genre guards, diversity caps still enforced)

- **AutoplayContext**: Thread replayFrequentTrackIds/Artists through all collectors
  - Updated 5 candidate collector callsites (Spotify, LastFM, Seed similarity)
  - replenisher.ts includes getReplayFrequentTracks() in Promise.all() data fetch

- **replenisher.spec.ts**: Mock getReplayFrequentTracks with empty sets (baseline)

## Testing

- All 16 replenisher.spec.ts tests passing
- Mock setup follows existing service mock pattern
- No new edge cases (fail-open already covered by existing error paths)

## Design Notes

1. **Boost Placement**: Applied after spotify-preferred (+0.08), ensuring replay frequency does not override artist-preference scoring but sits within the safe range for family-genre guards (which apply −1.0 hard vetoes).

2. **Fail-Open**: All service calls wrapped in try/catch → empty sets on timeout/error. This preserves graceful degradation: sessions without linked Last.fm or Spotify also benefit from replay frequency without blocking other sources.

3. **30-Day Window, Count > 2**: Balances recency (30 days) against occasional plays (count threshold prevents 1-2 plays from distorting scores). This matches the seed-similar spine's caching strategy.

4. **Diversity Preserved**: Replay boost is subject to existing artist-frequency caps (MAX_TRACKS_PER_ARTIST=2) and genre family guards. A replayed track in a genre veto still gets vetoed.

@cubic-dev-ai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the replay-count seed boost (Linear 1088): tracks and artists with >2 plays in the last 30 days get a +0.15 score during autoplay. This anchors recommendations to recent listening while preserving genre guards, diversity caps, and hard vetoes.

- **New Features**
  - Added `TrackHistoryService.getReplayFrequentTracks(guildId)` for 30-day >2-play aggregation; returns `{ trackIds: Set<string>, artists: Set<string> }` and fails open on error.
  - Threaded `replayFrequentTrackIds` and `replayFrequentArtists` through `AutoplayContext` to all collectors (Spotify, Last.fm, seed similarity).
  - Applied the +0.15 boost in `calculateRecommendationScore` after artist-preference; added `'replay frequent'` signal; `replenisher` fetches via `Promise.all` and passes it to candidate collection.

- **Bug Fixes**
  - Hardened fail-open in `replenisher.ts` to guard sync throws and added missing mock in tests; new acceptance tests cover boost application, veto enforcement, and fail-open behavior.
  - Normalized artist names to lowercase in replay-boost lookup for case-insensitive matching.

<sup>Written for commit f7fcdfaea0a967dbbdd9bbdbc4f93ed6562e11bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replay frequency tracking to autoplay recommendations. Songs and artists played more than 2 times in the last 30 days now receive a recommendation boost when generating new playlist suggestions, personalizing recommendations based on your listening habits. Recommendations matching frequently played content are identified with "replay frequent" signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->