### PR TITLE
refactor(backend): top.gg vote tracking Redis → Postgres (#1111)

### DIFF
--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -1,12 +1,10 @@
 import type { Express, Request, Response } from 'express'
 import { timingSafeEqual } from 'node:crypto'
-import Redis from 'ioredis'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { AppError } from '../errors/AppError'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
-import { debugLog, errorLog } from '@lucky/shared/utils'
-import { parseIntEnv } from '@lucky/shared/utils/env'
+import { debugLog, errorLog, getPrismaClient } from '@lucky/shared/utils'
 import {
     TOP_GG_VOTE_TIERS,
     TOP_GG_VOTE_URL,
@@ -14,48 +12,11 @@ import {
 } from '@lucky/shared/constants'
 
 // Vote window: top.gg allows one upvote every 12 hours.
-const VOTE_TTL_SECONDS = 60 * 60 * 12
+const VOTE_TTL_MILLISECONDS = 60 * 60 * 12 * 1000
 
 // Streak window: 36h gives 12h grace around the 24h cycle so a daily voter
 // doesn't lose their streak due to timezone or minor scheduling drift.
-const STREAK_TTL_SECONDS = 60 * 60 * 36
-
-const RECORD_VOTE_SCRIPT = `
-if redis.call('EXISTS', KEYS[1]) == 1 then
-  return 0
-end
-redis.call('INCR', KEYS[2])
-redis.call('EXPIRE', KEYS[2], tonumber(ARGV[3]))
-redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
-return 1
-`
-
-let redisClient: Redis | null = null
-
-function getRedis(): Redis {
-    if (redisClient) return redisClient
-    const host = process.env.REDIS_HOST
-    if (!host) {
-        throw AppError.serviceUnavailable('REDIS_HOST is not configured')
-    }
-    redisClient = new Redis({
-        host,
-        port: parseIntEnv('REDIS_PORT', 6379),
-        password: process.env.REDIS_PASSWORD || undefined,
-        lazyConnect: true,
-        maxRetriesPerRequest: 1,
-    })
-    // ioredis raises uncaughtException if no 'error' listener is attached
-    // while the connection is retrying. Log and swallow — calls will error
-    // per-request via maxRetriesPerRequest, so we don't need to crash.
-    redisClient.on('error', (err) => {
-        errorLog({
-            message: 'webhooks redis error',
-            data: { error: String(err) },
-        })
-    })
-    return redisClient
-}
+const STREAK_TTL_MILLISECONDS = 60 * 60 * 36 * 1000
 
 function safeEqualString(a: string, b: string): boolean {
     const ab = Buffer.from(a)
@@ -96,66 +57,80 @@ function verifyInternalKey(req: Request): void {
 }
 
 async function readVoteState(
-    redis: Redis,
     userId: string,
 ): Promise<{ hasVoted: boolean; streak: number; nextVoteInSeconds: number }> {
-    const voteKey = `votes:${userId}`
-    const streakKey = `votes:streak:${userId}`
-    const replies = (await redis
-        .pipeline()
-        .get(voteKey)
-        .get(streakKey)
-        .ttl(voteKey)
-        .exec()) as
-        | [
-              [Error | null, string | null],
-              [Error | null, string | null],
-              [Error | null, number],
-          ]
-        | null
+    const prisma = getPrismaClient()
+    const vote = await prisma.topggVote.findUnique({
+        where: { userId },
+    })
 
-    if (!replies) {
-        throw new AppError(500, 'failed to read vote state')
+    if (!vote) {
+        return {
+            hasVoted: false,
+            streak: 0,
+            nextVoteInSeconds: 0,
+        }
     }
 
-    const [voteResult, streakResult, ttlResult] = replies
-    const commandError =
-        voteResult[0] ?? streakResult[0] ?? ttlResult[0] ?? null
-    if (commandError) {
-        errorLog({
-            message: 'vote state redis read failed',
-            data: { voteKey, streakKey, error: String(commandError) },
-        })
-        throw new AppError(500, 'failed to read vote state')
-    }
+    const now = Date.now()
+    const timeSinceVote = now - vote.lastVoteAt.getTime()
+    const nextVoteInMilliseconds = Math.max(
+        0,
+        VOTE_TTL_MILLISECONDS - timeSinceVote,
+    )
 
-    const voteTs = voteResult[1]
-    const streakRaw = streakResult[1]
-    const ttl = ttlResult[1]
     return {
-        hasVoted: voteTs !== null,
-        streak: streakRaw ? Number(streakRaw) : 0,
-        nextVoteInSeconds: ttl > 0 ? ttl : 0,
+        hasVoted: timeSinceVote < VOTE_TTL_MILLISECONDS,
+        streak: vote.streak,
+        nextVoteInSeconds: Math.ceil(nextVoteInMilliseconds / 1000),
     }
 }
 
-async function recordVote(
-    redis: Redis,
-    voteKey: string,
-    streakKey: string,
-): Promise<'recorded' | 'duplicate'> {
-    const result = await redis.eval(
-        RECORD_VOTE_SCRIPT,
-        2,
-        voteKey,
-        streakKey,
-        Date.now().toString(),
-        String(VOTE_TTL_SECONDS),
-        String(STREAK_TTL_SECONDS),
-    )
-    if (result === 1 || result === '1') return 'recorded'
-    if (result === 0 || result === '0') return 'duplicate'
-    throw new AppError(500, 'unexpected vote record result')
+async function recordVote(userId: string): Promise<'recorded' | 'duplicate'> {
+    const prisma = getPrismaClient()
+    const now = new Date()
+    const nowMs = now.getTime()
+
+    return await prisma.$transaction(async (tx) => {
+        // Check for existing vote record
+        const existing = await tx.topggVote.findUnique({
+            where: { userId },
+        })
+
+        // Duplicate check: vote exists and is within 12h TTL
+        if (existing) {
+            const timeSinceVote = nowMs - existing.lastVoteAt.getTime()
+            if (timeSinceVote < VOTE_TTL_MILLISECONDS) {
+                return 'duplicate'
+            }
+        }
+
+        // Accept: compute new streak
+        let newStreak = 1
+        if (existing) {
+            const timeSinceVote = nowMs - existing.lastVoteAt.getTime()
+            // Preserve streak if within 36h, otherwise reset to 1
+            newStreak = timeSinceVote <= STREAK_TTL_MILLISECONDS
+                ? existing.streak + 1
+                : 1
+        }
+
+        // Upsert: create or update vote record
+        await tx.topggVote.upsert({
+            where: { userId },
+            create: {
+                userId,
+                lastVoteAt: now,
+                streak: newStreak,
+            },
+            update: {
+                lastVoteAt: now,
+                streak: newStreak,
+            },
+        })
+
+        return 'recorded'
+    })
 }
 
 function validateVoteUserId(userId: unknown): string {
@@ -178,7 +153,7 @@ export function setupWebhookApiRoutes(app: Express): void {
         asyncHandler(async (req: Request, res: Response) => {
             verifyInternalKey(req)
             const userId = validateRouteUserId(req.params.userId)
-            const state = await readVoteState(getRedis(), userId)
+            const state = await readVoteState(userId)
             res.status(200).json(state)
         }),
     )
@@ -191,7 +166,7 @@ export function setupWebhookApiRoutes(app: Express): void {
             if (!userId) {
                 throw AppError.unauthorized('not authenticated')
             }
-            const state = await readVoteState(getRedis(), userId)
+            const state = await readVoteState(userId)
             const tier = tierForVoteStreak(state.streak)
             const nextTier = [...TOP_GG_VOTE_TIERS]
                 .reverse()
@@ -234,12 +209,8 @@ export function setupWebhookPublicRoutes(app: Express): void {
 
             const userId = validateVoteUserId(payload.user)
 
-            const redis = getRedis()
-            const voteKey = `votes:${userId}`
-            const streakKey = `votes:streak:${userId}`
-
             try {
-                const recordResult = await recordVote(redis, voteKey, streakKey)
+                const recordResult = await recordVote(userId)
 
                 if (recordResult === 'duplicate') {
                     debugLog({

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -79,9 +79,12 @@ async function readVoteState(
         VOTE_TTL_MILLISECONDS - timeSinceVote,
     )
 
+    // Streak expires after 36h with no vote, matching the original Redis EXPIRE behavior
+    const expiredStreak = timeSinceVote > STREAK_TTL_MILLISECONDS ? 0 : vote.streak
+
     return {
         hasVoted: timeSinceVote < VOTE_TTL_MILLISECONDS,
-        streak: vote.streak,
+        streak: expiredStreak,
         nextVoteInSeconds: Math.ceil(nextVoteInMilliseconds / 1000),
     }
 }

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -38,7 +38,6 @@ jest.mock('../../../src/middleware/auth', () => ({
 // Mock Prisma client via getPrismaClient so the route never opens a real database connection.
 // This must be done before importing the route module.
 const mockFindUnique = jest.fn()
-const mockUpsert = jest.fn()
 const mockTransaction = jest.fn()
 
 jest.mock('@lucky/shared/utils', () => {
@@ -48,7 +47,6 @@ jest.mock('@lucky/shared/utils', () => {
         getPrismaClient: jest.fn(() => ({
             topggVote: {
                 findUnique: mockFindUnique,
-                upsert: mockUpsert,
             },
             $transaction: mockTransaction,
         })),
@@ -81,7 +79,6 @@ beforeEach(() => {
     process.env.TOPGG_AUTH_TOKEN = 'valid-token'
     process.env.LUCKY_NOTIFY_API_KEY = 'internal-key'
     mockFindUnique.mockClear()
-    mockUpsert.mockClear()
     mockTransaction.mockClear()
 })
 
@@ -213,6 +210,25 @@ describe('GET /api/internal/votes/:userId', () => {
             nextVoteInSeconds: 0,
         })
     })
+
+    it('returns streak=0 when streak has expired (>36h stale)', async () => {
+        const now = Date.now()
+        const lastVoteTime = new Date(now - 129600001) // 36h + 1ms ago
+        mockFindUnique.mockResolvedValueOnce({
+            userId: '123456789012345678',
+            lastVoteAt: lastVoteTime,
+            streak: 7,
+        })
+        const res = await request(buildApp())
+            .get('/api/internal/votes/123456789012345678')
+            .set('x-notify-key', 'internal-key')
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({
+            hasVoted: false,
+            streak: 0,
+            nextVoteInSeconds: 0,
+        })
+    })
 })
 
 describe('GET /api/me/vote-status', () => {
@@ -276,16 +292,20 @@ describe('GET /api/me/vote-status', () => {
 describe('POST /webhooks/topgg-votes persistence', () => {
     it('records a valid upvote with Prisma transaction', async () => {
         // Mock the transaction callback to simulate recording a new vote
+        const txUpsertCalls: unknown[] = []
         mockTransaction.mockImplementation(async (callback: Function) => {
             // The callback receives a tx object with topggVote operations
             const txMock = {
                 topggVote: {
                     findUnique: jest.fn().mockResolvedValue(null), // No existing vote
-                    upsert: jest.fn().mockResolvedValue({
-                        id: 'vote-id',
-                        userId: '123456789012345678',
-                        lastVoteAt: new Date(),
-                        streak: 1,
+                    upsert: jest.fn(async (arg) => {
+                        txUpsertCalls.push(arg)
+                        return {
+                            id: 'vote-id',
+                            userId: '123456789012345678',
+                            lastVoteAt: new Date(),
+                            streak: 1,
+                        }
                     }),
                 },
             }
@@ -304,11 +324,25 @@ describe('POST /webhooks/topgg-votes persistence', () => {
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ ok: true })
         expect(mockTransaction).toHaveBeenCalled()
+        expect(txUpsertCalls).toHaveLength(1)
+        expect(txUpsertCalls[0]).toEqual(
+            expect.objectContaining({
+                where: { userId: '123456789012345678' },
+                create: expect.objectContaining({
+                    userId: '123456789012345678',
+                    streak: 1,
+                }),
+                update: expect.objectContaining({
+                    streak: 1,
+                }),
+            }),
+        )
     })
 
     it('returns duplicate=true on duplicate vote within 12h', async () => {
         const now = Date.now()
         const lastVoteTime = new Date(now - 3600000) // 1 hour ago, within 12h window
+        const txUpsertCalls: unknown[] = []
         mockTransaction.mockImplementation(async (callback: Function) => {
             const txMock = {
                 topggVote: {
@@ -317,7 +351,10 @@ describe('POST /webhooks/topgg-votes persistence', () => {
                         lastVoteAt: lastVoteTime,
                         streak: 5,
                     }),
-                    upsert: jest.fn(),
+                    upsert: jest.fn(async (arg) => {
+                        txUpsertCalls.push(arg)
+                        throw new Error('upsert should not be called on duplicate')
+                    }),
                 },
             }
             const result = await callback(txMock)
@@ -335,12 +372,19 @@ describe('POST /webhooks/topgg-votes persistence', () => {
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ ok: true, duplicate: true })
         expect(mockTransaction).toHaveBeenCalled()
+        expect(txUpsertCalls).toHaveLength(0)
     })
 
     it('increments streak when vote recorded after 12h but within 36h', async () => {
         const now = Date.now()
         const lastVoteTime = new Date(now - 86400000) // 24 hours ago, within 36h window
+        let txMockUpsert: jest.Mock
         mockTransaction.mockImplementation(async (callback: Function) => {
+            txMockUpsert = jest.fn().mockResolvedValue({
+                userId: '123456789012345678',
+                lastVoteAt: new Date(),
+                streak: 6,
+            })
             const txMock = {
                 topggVote: {
                     findUnique: jest.fn().mockResolvedValue({
@@ -348,11 +392,7 @@ describe('POST /webhooks/topgg-votes persistence', () => {
                         lastVoteAt: lastVoteTime,
                         streak: 5,
                     }),
-                    upsert: jest.fn().mockResolvedValue({
-                        userId: '123456789012345678',
-                        lastVoteAt: new Date(),
-                        streak: 6,
-                    }),
+                    upsert: txMockUpsert,
                 },
             }
             const result = await callback(txMock)
@@ -370,12 +410,31 @@ describe('POST /webhooks/topgg-votes persistence', () => {
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ ok: true })
         expect(mockTransaction).toHaveBeenCalled()
+        expect(txMockUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { userId: '123456789012345678' },
+                update: expect.objectContaining({
+                    streak: 6,
+                }),
+            }),
+        )
     })
 
-    it('resets streak when vote recorded after 36h', async () => {
-        const now = Date.now()
-        const lastVoteTime = new Date(now - 129600000) // 36 hours ago, beyond streak window
+    it('preserves streak at exactly 36h boundary', async () => {
+        // Use fake timers to control time precisely
+        const STREAK_TTL = 129600000 // 36 hours in milliseconds
+        const baseTime = 1000000000 // arbitrary fixed time
+        jest.useFakeTimers()
+        jest.setSystemTime(baseTime)
+
+        const lastVoteTime = new Date(baseTime - STREAK_TTL) // exactly 36h ago
+        let txMockUpsert: jest.Mock
         mockTransaction.mockImplementation(async (callback: Function) => {
+            txMockUpsert = jest.fn().mockResolvedValue({
+                userId: '123456789012345678',
+                lastVoteAt: new Date(),
+                streak: 11,
+            })
             const txMock = {
                 topggVote: {
                     findUnique: jest.fn().mockResolvedValue({
@@ -383,11 +442,7 @@ describe('POST /webhooks/topgg-votes persistence', () => {
                         lastVoteAt: lastVoteTime,
                         streak: 10,
                     }),
-                    upsert: jest.fn().mockResolvedValue({
-                        userId: '123456789012345678',
-                        lastVoteAt: new Date(),
-                        streak: 1,
-                    }),
+                    upsert: txMockUpsert,
                 },
             }
             const result = await callback(txMock)
@@ -405,6 +460,68 @@ describe('POST /webhooks/topgg-votes persistence', () => {
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ ok: true })
         expect(mockTransaction).toHaveBeenCalled()
+        expect(txMockUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { userId: '123456789012345678' },
+                update: expect.objectContaining({
+                    streak: 11,
+                }),
+            }),
+        )
+
+        jest.useRealTimers()
+    })
+
+    it('resets streak when vote recorded after 36h', async () => {
+        // Use fake timers to control time precisely
+        const STREAK_TTL = 129600000 // 36 hours in milliseconds
+        const baseTime = 1000000000 // arbitrary fixed time
+        jest.useFakeTimers()
+        jest.setSystemTime(baseTime)
+
+        const lastVoteTime = new Date(baseTime - STREAK_TTL - 1) // 36h + 1ms ago, beyond window
+        let txMockUpsert: jest.Mock
+        mockTransaction.mockImplementation(async (callback: Function) => {
+            txMockUpsert = jest.fn().mockResolvedValue({
+                userId: '123456789012345678',
+                lastVoteAt: new Date(),
+                streak: 1,
+            })
+            const txMock = {
+                topggVote: {
+                    findUnique: jest.fn().mockResolvedValue({
+                        userId: '123456789012345678',
+                        lastVoteAt: lastVoteTime,
+                        streak: 10,
+                    }),
+                    upsert: txMockUpsert,
+                },
+            }
+            const result = await callback(txMock)
+            return result
+        })
+
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({
+                user: '123456789012345678',
+                type: 'upvote',
+                bot: '962198089161134131',
+            })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true })
+        expect(mockTransaction).toHaveBeenCalled()
+        expect(txMockUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { userId: '123456789012345678' },
+                update: expect.objectContaining({
+                    streak: 1,
+                }),
+            }),
+        )
+
+        jest.useRealTimers()
     })
 
     it('rejects unsafe non-snowflake user ids before writing to database', async () => {

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -9,26 +9,14 @@ import {
 import express from 'express'
 import request from 'supertest'
 
-// Mock ioredis so the route never opens a real connection.
-const pipelineExec = jest.fn<() => Promise<unknown>>().mockResolvedValue([])
-const pipelineMock = {
-    set: jest.fn().mockReturnThis(),
-    incr: jest.fn().mockReturnThis(),
-    expire: jest.fn().mockReturnThis(),
-    get: jest.fn().mockReturnThis(),
-    ttl: jest.fn().mockReturnThis(),
-    exec: pipelineExec,
-}
-const redisEval = jest.fn<() => Promise<unknown>>().mockResolvedValue(1)
-const redisOn = jest.fn()
-
-jest.mock('ioredis', () => {
-    return jest.fn().mockImplementation(() => ({
-        pipeline: () => pipelineMock,
-        eval: redisEval,
-        on: redisOn,
-    }))
-})
+// Mock chalk to avoid "color is not a function" in LogService
+jest.mock('chalk', () => ({
+    red: (str: string) => str,
+    yellow: (str: string) => str,
+    blue: (str: string) => str,
+    green: (str: string) => str,
+    gray: (str: string) => str,
+}))
 
 // Mock auth middleware to inject a configurable user. The actual middleware
 // reads from session; for unit tests we short-circuit with a header.
@@ -46,6 +34,26 @@ jest.mock('../../../src/middleware/auth', () => ({
         next()
     },
 }))
+
+// Mock Prisma client via getPrismaClient so the route never opens a real database connection.
+// This must be done before importing the route module.
+const mockFindUnique = jest.fn()
+const mockUpsert = jest.fn()
+const mockTransaction = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => {
+    const actual = jest.requireActual('@lucky/shared/utils')
+    return {
+        ...actual,
+        getPrismaClient: jest.fn(() => ({
+            topggVote: {
+                findUnique: mockFindUnique,
+                upsert: mockUpsert,
+            },
+            $transaction: mockTransaction,
+        })),
+    }
+}, { virtual: true })
 
 import { setupWebhookRoutes } from '../../../src/routes/webhooks'
 
@@ -72,23 +80,14 @@ function buildApp(): express.Express {
 beforeEach(() => {
     process.env.TOPGG_AUTH_TOKEN = 'valid-token'
     process.env.LUCKY_NOTIFY_API_KEY = 'internal-key'
-    process.env.REDIS_HOST = 'localhost'
-    process.env.REDIS_PORT = '6379'
-    pipelineExec.mockClear().mockResolvedValue([])
-    pipelineMock.set.mockClear()
-    pipelineMock.incr.mockClear()
-    pipelineMock.expire.mockClear()
-    pipelineMock.get.mockClear()
-    pipelineMock.ttl.mockClear()
-    redisEval.mockClear().mockResolvedValue(1)
-    redisOn.mockClear()
+    mockFindUnique.mockClear()
+    mockUpsert.mockClear()
+    mockTransaction.mockClear()
 })
 
 afterEach(() => {
     delete process.env.TOPGG_AUTH_TOKEN
     delete process.env.LUCKY_NOTIFY_API_KEY
-    delete process.env.REDIS_HOST
-    delete process.env.REDIS_PORT
 })
 
 describe('POST /webhooks/topgg-votes', () => {
@@ -131,7 +130,7 @@ describe('POST /webhooks/topgg-votes', () => {
             .send({ type: 'test' })
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ ok: true, test: true })
-        expect(pipelineExec).not.toHaveBeenCalled()
+        expect(mockTransaction).not.toHaveBeenCalled()
     })
 
     it('rejects when user id is missing', async () => {
@@ -148,17 +147,19 @@ describe('POST /webhooks/topgg-votes', () => {
             .set('authorization', 'valid-token')
             .send({ user: '1', type: 'downvote' })
         expect(res.status).toBe(400)
-        expect(redisEval).not.toHaveBeenCalled()
+        expect(mockTransaction).not.toHaveBeenCalled()
     })
 })
 
 describe('GET /api/internal/votes/:userId', () => {
     it('responds to GET /api/internal/votes/:userId with current state', async () => {
-        pipelineExec.mockResolvedValueOnce([
-            [null, '1700000000000'],
-            [null, '7'],
-            [null, 3600],
-        ])
+        const now = Date.now()
+        const lastVoteTime = new Date(now - 7200000) // 2 hours ago
+        mockFindUnique.mockResolvedValueOnce({
+            userId: '123456789012345678',
+            lastVoteAt: lastVoteTime,
+            streak: 7,
+        })
         const res = await request(buildApp())
             .get('/api/internal/votes/123456789012345678')
             .set('x-notify-key', 'internal-key')
@@ -166,8 +167,10 @@ describe('GET /api/internal/votes/:userId', () => {
         expect(res.body).toEqual({
             hasVoted: true,
             streak: 7,
-            nextVoteInSeconds: 3600,
+            nextVoteInSeconds: expect.any(Number),
         })
+        expect(res.body.nextVoteInSeconds).toBeGreaterThan(0)
+        expect(res.body.nextVoteInSeconds).toBeLessThanOrEqual(43200) // 12h in seconds
     })
 
     it('rejects GET with wrong internal key', async () => {
@@ -198,16 +201,17 @@ describe('GET /api/internal/votes/:userId', () => {
         expect(res.status).toBe(400)
     })
 
-    it('returns 500 when a Redis read command fails', async () => {
-        pipelineExec.mockResolvedValueOnce([
-            [new Error('get failed'), null],
-            [null, null],
-            [null, -2],
-        ])
+    it('returns state with no votes when user not found', async () => {
+        mockFindUnique.mockResolvedValueOnce(null)
         const res = await request(buildApp())
             .get('/api/internal/votes/123456789012345678')
             .set('x-notify-key', 'internal-key')
-        expect(res.status).toBe(500)
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({
+            hasVoted: false,
+            streak: 0,
+            nextVoteInSeconds: 0,
+        })
     })
 })
 
@@ -218,31 +222,26 @@ describe('GET /api/me/vote-status', () => {
     })
 
     it('returns state + tier + nextTier + voteUrl for a streak-14 voter', async () => {
-        pipelineExec.mockResolvedValueOnce([
-            [null, '1700000000000'],
-            [null, '14'],
-            [null, 7200],
-        ])
+        const now = Date.now()
+        const lastVoteTime = new Date(now - 7200000) // 2 hours ago
+        mockFindUnique.mockResolvedValueOnce({
+            userId: '555',
+            lastVoteAt: lastVoteTime,
+            streak: 14,
+        })
         const res = await request(buildApp())
             .get('/api/me/vote-status')
             .set('x-test-user', '555')
         expect(res.status).toBe(200)
-        expect(res.body).toEqual({
-            hasVoted: true,
-            streak: 14,
-            nextVoteInSeconds: 7200,
-            tier: { label: 'Lucky Regular', threshold: 14 },
-            nextTier: { label: 'Lucky Legend', threshold: 30 },
-            voteUrl: 'https://top.gg/bot/962198089161134131/vote',
-        })
+        expect(res.body.hasVoted).toBe(true)
+        expect(res.body.streak).toBe(14)
+        expect(res.body.tier).toEqual({ label: 'Lucky Regular', threshold: 14 })
+        expect(res.body.nextTier).toEqual({ label: 'Lucky Legend', threshold: 30 })
+        expect(res.body.voteUrl).toBe('https://top.gg/bot/962198089161134131/vote')
     })
 
     it('returns tier=null for a 0-streak user', async () => {
-        pipelineExec.mockResolvedValueOnce([
-            [null, null],
-            [null, null],
-            [null, -2],
-        ])
+        mockFindUnique.mockResolvedValueOnce(null)
         const res = await request(buildApp())
             .get('/api/me/vote-status')
             .set('x-test-user', '777')
@@ -257,22 +256,43 @@ describe('GET /api/me/vote-status', () => {
     })
 
     it('returns nextTier=null when user is at max tier (30+)', async () => {
-        pipelineExec.mockResolvedValueOnce([
-            [null, '1700000000000'],
-            [null, '45'],
-            [null, 100],
-        ])
+        const now = Date.now()
+        const lastVoteTime = new Date(now - 36000000) // 10 hours ago
+        mockFindUnique.mockResolvedValueOnce({
+            userId: '999',
+            lastVoteAt: lastVoteTime,
+            streak: 45,
+        })
         const res = await request(buildApp())
             .get('/api/me/vote-status')
             .set('x-test-user', '999')
         expect(res.status).toBe(200)
         expect(res.body.tier.label).toBe('Lucky Legend')
         expect(res.body.nextTier).toBeNull()
+        expect(res.body.streak).toBe(45)
     })
 })
 
 describe('POST /webhooks/topgg-votes persistence', () => {
-    it('records a valid upvote with one atomic Redis script', async () => {
+    it('records a valid upvote with Prisma transaction', async () => {
+        // Mock the transaction callback to simulate recording a new vote
+        mockTransaction.mockImplementation(async (callback: Function) => {
+            // The callback receives a tx object with topggVote operations
+            const txMock = {
+                topggVote: {
+                    findUnique: jest.fn().mockResolvedValue(null), // No existing vote
+                    upsert: jest.fn().mockResolvedValue({
+                        id: 'vote-id',
+                        userId: '123456789012345678',
+                        lastVoteAt: new Date(),
+                        streak: 1,
+                    }),
+                },
+            }
+            const result = await callback(txMock)
+            return result
+        })
+
         const res = await request(buildApp())
             .post('/webhooks/topgg-votes')
             .set('authorization', 'valid-token')
@@ -283,25 +303,116 @@ describe('POST /webhooks/topgg-votes persistence', () => {
             })
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ ok: true })
-        expect(redisEval).toHaveBeenCalledWith(
-            expect.stringContaining("redis.call('INCR', KEYS[2])"),
-            2,
-            'votes:123456789012345678',
-            'votes:streak:123456789012345678',
-            expect.any(String),
-            String(60 * 60 * 12),
-            String(60 * 60 * 36),
-        )
-        expect(pipelineMock.incr).not.toHaveBeenCalled()
-        expect(pipelineMock.expire).not.toHaveBeenCalled()
+        expect(mockTransaction).toHaveBeenCalled()
     })
 
-    it('rejects unsafe non-snowflake user ids before writing to Redis', async () => {
+    it('returns duplicate=true on duplicate vote within 12h', async () => {
+        const now = Date.now()
+        const lastVoteTime = new Date(now - 3600000) // 1 hour ago, within 12h window
+        mockTransaction.mockImplementation(async (callback: Function) => {
+            const txMock = {
+                topggVote: {
+                    findUnique: jest.fn().mockResolvedValue({
+                        userId: '123456789012345678',
+                        lastVoteAt: lastVoteTime,
+                        streak: 5,
+                    }),
+                    upsert: jest.fn(),
+                },
+            }
+            const result = await callback(txMock)
+            return result
+        })
+
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({
+                user: '123456789012345678',
+                type: 'upvote',
+                bot: '962198089161134131',
+            })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true, duplicate: true })
+        expect(mockTransaction).toHaveBeenCalled()
+    })
+
+    it('increments streak when vote recorded after 12h but within 36h', async () => {
+        const now = Date.now()
+        const lastVoteTime = new Date(now - 86400000) // 24 hours ago, within 36h window
+        mockTransaction.mockImplementation(async (callback: Function) => {
+            const txMock = {
+                topggVote: {
+                    findUnique: jest.fn().mockResolvedValue({
+                        userId: '123456789012345678',
+                        lastVoteAt: lastVoteTime,
+                        streak: 5,
+                    }),
+                    upsert: jest.fn().mockResolvedValue({
+                        userId: '123456789012345678',
+                        lastVoteAt: new Date(),
+                        streak: 6,
+                    }),
+                },
+            }
+            const result = await callback(txMock)
+            return result
+        })
+
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({
+                user: '123456789012345678',
+                type: 'upvote',
+                bot: '962198089161134131',
+            })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true })
+        expect(mockTransaction).toHaveBeenCalled()
+    })
+
+    it('resets streak when vote recorded after 36h', async () => {
+        const now = Date.now()
+        const lastVoteTime = new Date(now - 129600000) // 36 hours ago, beyond streak window
+        mockTransaction.mockImplementation(async (callback: Function) => {
+            const txMock = {
+                topggVote: {
+                    findUnique: jest.fn().mockResolvedValue({
+                        userId: '123456789012345678',
+                        lastVoteAt: lastVoteTime,
+                        streak: 10,
+                    }),
+                    upsert: jest.fn().mockResolvedValue({
+                        userId: '123456789012345678',
+                        lastVoteAt: new Date(),
+                        streak: 1,
+                    }),
+                },
+            }
+            const result = await callback(txMock)
+            return result
+        })
+
+        const res = await request(buildApp())
+            .post('/webhooks/topgg-votes')
+            .set('authorization', 'valid-token')
+            .send({
+                user: '123456789012345678',
+                type: 'upvote',
+                bot: '962198089161134131',
+            })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true })
+        expect(mockTransaction).toHaveBeenCalled()
+    })
+
+    it('rejects unsafe non-snowflake user ids before writing to database', async () => {
         const res = await request(buildApp())
             .post('/webhooks/topgg-votes')
             .set('authorization', 'valid-token')
             .send({ user: 'streak:123', type: 'upvote' })
         expect(res.status).toBe(400)
-        expect(redisEval).not.toHaveBeenCalled()
+        expect(mockTransaction).not.toHaveBeenCalled()
     })
 })

--- a/prisma/migrations/20260613000000_add_topgg_votes/migration.sql
+++ b/prisma/migrations/20260613000000_add_topgg_votes/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable "topgg_votes"
+CREATE TABLE "topgg_votes" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "lastVoteAt" TIMESTAMP(3) NOT NULL,
+    "streak" INTEGER NOT NULL DEFAULT 1,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "topgg_votes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "topgg_votes_userId_key" ON "topgg_votes"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -974,3 +974,15 @@ model SupportReport {
   // allowed values) are enforced in the migration — Prisma cannot model them.
   @@map("support_reports")
 }
+
+// Top.gg vote tracking: dedup (12h TTL) + streak counter (36h reset).
+// One row per Discord user who has ever voted; no FK to users table.
+model TopggVote {
+  id        String   @id @default(cuid())
+  userId    String   @unique // Discord user snowflake
+  lastVoteAt DateTime
+  streak    Int      @default(1)
+  updatedAt DateTime @updatedAt
+
+  @@map("topgg_votes")
+}


### PR DESCRIPTION
## Summary
Migrates top.gg vote tracking from Redis to Postgres using Prisma with ACID-safe transactions. Implements vote deduplication (12h TTL) and streak preservation (36h window) with proper idempotency semantics.

## Changes
- Add `topggVote` table with userId, lastVoteAt, streak
- Rewrite `readVoteState()` to query Prisma
- Rewrite `recordVote()` to use atomic `$transaction` for upsert logic
- Remove Redis client and Lua script
- Update webhook tests to mock Prisma instead of Redis
- Fix LogService chalk mocking in tests

## Test coverage
- All 22 webhook tests pass (vote persistence, dedup, streak logic, auth, tier calculation)
- Full backend suite: 1,002 tests pass
- Typecheck: No errors
- Lint: No errors

## Verification
- [x] jest: 68 test suites, 1,002 tests all passing
- [x] typecheck: No TypeScript errors
- [x] lint: ESLint clean
- [x] Migration: Schema updated, migration file added

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates top.gg vote tracking from Redis to Postgres using `Prisma` transactions for ACID-safe, idempotent writes. Implements 12h vote dedup and a 36h streak window with expiry on reads, aligning with Linear #1111 and removing the Redis dependency.

- **Refactors**
  - Added `TopggVote` table (`topgg_votes`) with `userId` (unique), `lastVoteAt`, `streak`, `updatedAt`.
  - Rewrote `readVoteState()` and `recordVote()` to use `Prisma` queries and atomic `$transaction` upserts; added streak expiry on read and verified the 36h boundary in tests.
  - Removed Redis client/Lua script; updated webhook tests to mock `Prisma` and fixed `chalk` mocks.

- **Migration**
  - Run database migration to create `topgg_votes` with a unique index on `userId`.
  - Redis vote config is no longer needed; no API changes required.

<sup>Written for commit a3cca5dabf58a630621dc6e03a9d27d7b48d5732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Part of #1111 (final store migration; express-session decision remains open there).
