### PR TITLE
feat(autoplay): add implicit-dislike-penalty signal

### DIFF
--- a/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
@@ -675,7 +675,7 @@ describe('candidateScorer', () => {
             expect(() => result).not.toThrow()
         })
 
-        it('emits implicit-dislike-penalty signal when candidate is in implicit dislike keys', () => {
+        it('emits implicit dislike signal when candidate is in implicit dislike keys', () => {
             const baselineResult = calculateRecommendationScore({
                 candidate: createTrack({
                     title: 'Skipped Song',
@@ -693,11 +693,11 @@ describe('candidateScorer', () => {
                 recentArtists: new Set(),
                 implicitDislikeKeys: new Set(['skippedsong::testartist']),
             })
-            expect(withDislikeResult.signals).toContain('implicit-dislike-penalty')
+            expect(withDislikeResult.signals).toContain('implicit dislike')
             expect(withDislikeResult.score).toBeLessThan(baselineResult.score)
         })
 
-        it('emits implicit-dislike-penalty signal when candidate artist matches current without deep-dive', () => {
+        it('does not emit implicit dislike signal for the same-artist penalty', () => {
             const result = calculateRecommendationScore({
                 candidate: createTrack({
                     title: 'Similar Track',
@@ -713,10 +713,10 @@ describe('candidateScorer', () => {
                     restless: false,
                 },
             })
-            expect(result.signals).toContain('implicit-dislike-penalty')
+            expect(result.signals).not.toContain('implicit dislike')
         })
 
-        it('does not emit implicit-dislike-penalty for same artist during deep-dive', () => {
+        it('does not emit implicit dislike for same artist during deep-dive', () => {
             const deepDiveArtist = 'Deep Dive Artist'
             const result = calculateRecommendationScore({
                 candidate: createTrack({
@@ -733,10 +733,10 @@ describe('candidateScorer', () => {
                     restless: false,
                 },
             })
-            expect(result.signals).not.toContain('implicit-dislike-penalty')
+            expect(result.signals).not.toContain('implicit dislike')
         })
 
-        it('does not emit implicit-dislike-penalty when implicit dislike keys do not match', () => {
+        it('does not emit implicit dislike when implicit dislike keys do not match', () => {
             const result = calculateRecommendationScore({
                 candidate: createTrack({
                     title: 'Other Song',
@@ -746,7 +746,7 @@ describe('candidateScorer', () => {
                 recentArtists: new Set(),
                 implicitDislikeKeys: new Set(['skippedsong::testartist']),
             })
-            expect(result.signals).not.toContain('implicit-dislike-penalty')
+            expect(result.signals).not.toContain('implicit dislike')
         })
     })
 })

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.spec.ts
@@ -674,5 +674,79 @@ describe('candidateScorer', () => {
             expect(result.signals).toBeDefined()
             expect(() => result).not.toThrow()
         })
+
+        it('emits implicit-dislike-penalty signal when candidate is in implicit dislike keys', () => {
+            const baselineResult = calculateRecommendationScore({
+                candidate: createTrack({
+                    title: 'Skipped Song',
+                    author: 'Test Artist',
+                }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+            })
+            const withDislikeResult = calculateRecommendationScore({
+                candidate: createTrack({
+                    title: 'Skipped Song',
+                    author: 'Test Artist',
+                }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                implicitDislikeKeys: new Set(['skippedsong::testartist']),
+            })
+            expect(withDislikeResult.signals).toContain('implicit-dislike-penalty')
+            expect(withDislikeResult.score).toBeLessThan(baselineResult.score)
+        })
+
+        it('emits implicit-dislike-penalty signal when candidate artist matches current without deep-dive', () => {
+            const result = calculateRecommendationScore({
+                candidate: createTrack({
+                    title: 'Similar Track',
+                    author: 'Current Artist',
+                }),
+                currentTrack: createTrack({ author: 'Current Artist' }),
+                recentArtists: new Set(),
+                sessionMood: {
+                    dominantLocale: null,
+                    deepDiveArtist: null,
+                    preferLong: false,
+                    preferShort: false,
+                    restless: false,
+                },
+            })
+            expect(result.signals).toContain('implicit-dislike-penalty')
+        })
+
+        it('does not emit implicit-dislike-penalty for same artist during deep-dive', () => {
+            const deepDiveArtist = 'Deep Dive Artist'
+            const result = calculateRecommendationScore({
+                candidate: createTrack({
+                    title: 'Similar Track',
+                    author: deepDiveArtist,
+                }),
+                currentTrack: createTrack({ author: deepDiveArtist }),
+                recentArtists: new Set(),
+                sessionMood: {
+                    dominantLocale: null,
+                    deepDiveArtist: deepDiveArtist,
+                    preferLong: false,
+                    preferShort: false,
+                    restless: false,
+                },
+            })
+            expect(result.signals).not.toContain('implicit-dislike-penalty')
+        })
+
+        it('does not emit implicit-dislike-penalty when implicit dislike keys do not match', () => {
+            const result = calculateRecommendationScore({
+                candidate: createTrack({
+                    title: 'Other Song',
+                    author: 'Other Artist',
+                }),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                implicitDislikeKeys: new Set(['skippedsong::testartist']),
+            })
+            expect(result.signals).not.toContain('implicit-dislike-penalty')
+        })
     })
 })

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.ts
@@ -367,7 +367,7 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
 
     if (implicitDislikeKeys.has(candidateKey)) {
         score += SCORE_IMPLICIT_DISLIKE
-        signals.push('implicit-dislike-penalty')
+        signals.push('implicit dislike')
     }
     if (implicitLikeKeys.has(candidateKey)) {
         score += SCORE_IMPLICIT_LIKE
@@ -381,8 +381,10 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
         deepDiveArtist !== null && candidateArtist === deepDiveArtist
     if (candidateArtist === currentArtist) {
         if (!isDeepDive) {
+            // Same-artist penalty reuses the implicit-dislike weight but is a
+            // distinct heuristic — do NOT emit the 'implicit dislike' signal
+            // here or Phase D telemetry would conflate the two.
             score += SCORE_IMPLICIT_DISLIKE
-            signals.push('implicit-dislike-penalty')
         }
         const titleSim = sharedTitleTokenScore(
             candidate.title ?? '',

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.ts
@@ -367,7 +367,7 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
 
     if (implicitDislikeKeys.has(candidateKey)) {
         score += SCORE_IMPLICIT_DISLIKE
-        signals.push('skipped before')
+        signals.push('implicit-dislike-penalty')
     }
     if (implicitLikeKeys.has(candidateKey)) {
         score += SCORE_IMPLICIT_LIKE
@@ -382,6 +382,7 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
     if (candidateArtist === currentArtist) {
         if (!isDeepDive) {
             score += SCORE_IMPLICIT_DISLIKE
+            signals.push('implicit-dislike-penalty')
         }
         const titleSim = sharedTitleTokenScore(
             candidate.title ?? '',

--- a/packages/bot/src/utils/music/autoplay/recommendationBasis.ts
+++ b/packages/bot/src/utils/music/autoplay/recommendationBasis.ts
@@ -22,6 +22,7 @@ export type RecommendationSignal =
     | 'old dislike'
     | 'skipped before'
     | 'completed before'
+    | 'implicit-dislike-penalty'
     | 'album match'
     | 'deep-dive artist'
     | 'session novelty'

--- a/packages/bot/src/utils/music/autoplay/recommendationBasis.ts
+++ b/packages/bot/src/utils/music/autoplay/recommendationBasis.ts
@@ -22,7 +22,7 @@ export type RecommendationSignal =
     | 'old dislike'
     | 'skipped before'
     | 'completed before'
-    | 'implicit-dislike-penalty'
+    | 'implicit dislike'
     | 'album match'
     | 'deep-dive artist'
     | 'session novelty'


### PR DESCRIPTION
## Summary
Serialize the implicit-dislike penalty as a recommendation signal to support Phase D baseline telemetry. Signal is emitted when an implicit dislike is applied—either matching the skip history or the same-artist penalty outside deep-dive mode.

## Changes
- Add 'implicit-dislike-penalty' to RecommendationSignal union type in recommendationBasis.ts
- Update candidateScorer.ts to emit signal at both penalty application sites (line 370, line 384)
- Add unit tests covering signal emission for implicit dislike keys and same-artist penalty cases
- Verification: bot tests pass (2500 passed, 6 skipped); lint clean

## Test plan
- [x] Unit tests for signal emission: 44 tests pass
- [x] Full bot test suite: 2500 tests pass, 6 skipped (expected)
- [x] Lint: no new warnings or errors
- [x] Manual: reviewed signal name aligns with existing RecommendationSignal naming convention

Closes #1094

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `implicit dislike` recommendation signal for Phase D telemetry, per #1094. The signal emits only for skip-history matches; the same-artist penalty reuses the weight but does not emit this signal.

- **New Features**
  - Add `implicit dislike` to `RecommendationSignal` and emit in `candidateScorer` when `implicitDislikeKeys` contains the candidate.
  - Add unit tests for emission and non-emission cases.

- **Bug Fixes**
  - Scope signal emission to skip-history matches; do not emit for same-artist penalty (including deep-dive).

<sup>Written for commit 58e6d1a512564badff33f27beaac1a6f3408ea81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

