### PR TITLE
test(autoplay): batch audio-features & cache coverage #1091

### DIFF
--- a/packages/bot/src/spotify/spotifyApi.spec.ts
+++ b/packages/bot/src/spotify/spotifyApi.spec.ts
@@ -15,6 +15,7 @@ import {
     getArtistGenres,
     getUserTopArtistsAndTracks,
     getUserSavedTracks,
+    _resetPopularityCache,
 } from './spotifyApi'
 
 type MockFetchResponse = {
@@ -305,12 +306,57 @@ describe('spotifyApi', () => {
                     expect(result.size).toBe(0)
                 },
             ],
+            [
+                'batches multiple track IDs into one fetch call',
+                async () => {
+                    fetchMock.mockResolvedValue({
+                        ok: true,
+                        json: async () => ({
+                            audio_features: [
+                                { id: 'track1', energy: 0.8, valence: 0.7 },
+                                { id: 'track2', energy: 0.6, valence: 0.5 },
+                                {
+                                    id: 'track3',
+                                    energy: 0.9,
+                                    valence: 0.85,
+                                },
+                                {
+                                    id: 'track4',
+                                    energy: 0.4,
+                                    valence: 0.3,
+                                },
+                                {
+                                    id: 'track5',
+                                    energy: 0.7,
+                                    valence: 0.65,
+                                },
+                            ],
+                        }),
+                    })
+                    const trackIds = [
+                        'track1',
+                        'track2',
+                        'track3',
+                        'track4',
+                        'track5',
+                    ]
+                    const result = await getBatchAudioFeatures('token', trackIds)
+                    expect(result.size).toBe(5)
+                    expect(fetchMock).toHaveBeenCalledTimes(1)
+                    const callUrl = String(fetchMock.mock.calls[0]![0])
+                    expect(callUrl).toContain('ids=track1,track2,track3,track4,track5')
+                },
+            ],
         ])('%s', async (_label, test) => {
             await test()
         })
     })
 
     describe('getArtistPopularity', () => {
+        beforeEach(() => {
+            _resetPopularityCache()
+        })
+
         it.each([
             [
                 'success',
@@ -354,6 +400,30 @@ describe('spotifyApi', () => {
                     })
                     result = await getArtistPopularity('token', 'Some Artist')
                     expect(result).toBeNull()
+                },
+            ],
+            [
+                'cache hit/miss behavior avoids duplicate fetches',
+                async () => {
+                    fetchMock.mockResolvedValue({
+                        ok: true,
+                        json: async () => ({
+                            artists: { items: [{ popularity: 82 }] },
+                        }),
+                    })
+                    const firstCall = await getArtistPopularity(
+                        'token',
+                        'Adele',
+                    )
+                    expect(firstCall).toBe(82)
+                    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+                    const secondCall = await getArtistPopularity(
+                        'token',
+                        'Adele',
+                    )
+                    expect(secondCall).toBe(82)
+                    expect(fetchMock).toHaveBeenCalledTimes(1)
                 },
             ],
         ])('%s', async (_label, test) => {

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -270,13 +270,6 @@ export function _resetPopularityCache(): void {
     artistPopularityCache.clear()
 }
 
-/**
- * Test helper to clear genres cache for test isolation.
- */
-export function _resetGenresCache(): void {
-    artistGenresCache.clear()
-}
-
 export async function getAudioFeatures(
     accessToken: string,
     spotifyTrackId: string,

--- a/packages/bot/src/spotify/spotifyApi.ts
+++ b/packages/bot/src/spotify/spotifyApi.ts
@@ -263,6 +263,20 @@ const artistGenresCache = new LRUCache<string, GenresEntry>({
     ttl: 24 * 60 * 60 * 1000,
 })
 
+/**
+ * Test helper to clear popularity cache for test isolation.
+ */
+export function _resetPopularityCache(): void {
+    artistPopularityCache.clear()
+}
+
+/**
+ * Test helper to clear genres cache for test isolation.
+ */
+export function _resetGenresCache(): void {
+    artistGenresCache.clear()
+}
+
 export async function getAudioFeatures(
     accessToken: string,
     spotifyTrackId: string,


### PR DESCRIPTION
## Summary

Add test coverage for existing batch audio-features and artist popularity cache optimizations:
- Verify getBatchAudioFeatures() batches multiple track IDs into one API call (not N separate calls)
- Verify getArtistPopularity() cache hit/miss behavior avoids duplicate Spotify API fetches

Both features were implemented in commit #579 but lacked explicit test verification.

## Test results
- spotifyApi.spec.ts: all 26 tests pass (including 2 new)
- New test: "batches multiple track IDs into one fetch call" ✓
- New test: "cache hit/miss behavior avoids duplicate fetches" ✓
- No regressions in existing test suites

@cubic-dev-ai

Closes #1091

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests to lock in batching and caching optimizations: `getBatchAudioFeatures` makes one Spotify request for multiple track IDs, and `getArtistPopularity` returns from cache on repeat calls. Adds test-only `_resetPopularityCache` for isolation and removes unused `_resetGenresCache`.

Closes #1091.

<sup>Written for commit 9cc11b2a23785d0be739b6b6d70eeaf0ae2a71a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

