### PR TITLE
feat: skip-reason telemetry via emoji reactions on now-playing

### DIFF
--- a/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
@@ -189,6 +189,7 @@ describe('trackNowPlaying handlers', () => {
 
             mockChannel.send = jest.fn().mockResolvedValueOnce({
                 id: 'msg-123',
+                react: jest.fn().mockResolvedValue(undefined),
             })
 
             const trackWithSource = {
@@ -217,6 +218,7 @@ describe('trackNowPlaying handlers', () => {
         it('omits acceptance rate if recommendationSource not provided', async () => {
             mockChannel.send = jest.fn().mockResolvedValueOnce({
                 id: 'msg-123',
+                react: jest.fn().mockResolvedValue(undefined),
             })
 
             const trackWithoutSource = {
@@ -249,6 +251,7 @@ describe('trackNowPlaying handlers', () => {
 
             mockChannel.send = jest.fn().mockResolvedValueOnce({
                 id: 'msg-123',
+                react: jest.fn().mockResolvedValue(undefined),
             })
 
             const trackWithSource = {
@@ -281,6 +284,7 @@ describe('trackNowPlaying handlers', () => {
 
             mockChannel.send = jest.fn().mockResolvedValueOnce({
                 id: 'msg-123',
+                react: jest.fn().mockResolvedValue(undefined),
             })
 
             const trackWithSource = {
@@ -309,6 +313,7 @@ describe('trackNowPlaying handlers', () => {
         it('omits "Why this track" field entirely for non-autoplay tracks', async () => {
             mockChannel.send = jest.fn().mockResolvedValueOnce({
                 id: 'msg-123',
+                react: jest.fn().mockResolvedValue(undefined),
             })
 
             const userTrack = {

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -18,6 +18,7 @@ import {
     updateNowPlaying as lastFmUpdateNowPlaying,
     scrobble as lastFmScrobble,
 } from '../../lastfm'
+import { getSkipReasonEmojis } from '../../utils/music/skipReasonMap'
 
 /**
  * Manages per-guild now-playing state with automatic TTL + explicit cleanup
@@ -26,7 +27,7 @@ import {
 class TrackNowPlayingState {
     private songInfoMessages = new LRUCache<
         string,
-        { messageId: string; channelId: string }
+        { messageId: string; channelId: string; trackUrl?: string }
     >({
         max: 5000,
         ttl: 30 * 60 * 1000,
@@ -41,13 +42,14 @@ class TrackNowPlayingState {
         guildId: string,
         messageId: string,
         channelId: string,
+        trackUrl?: string,
     ): void {
-        this.songInfoMessages.set(guildId, { messageId, channelId })
+        this.songInfoMessages.set(guildId, { messageId, channelId, trackUrl })
     }
 
     getSongInfoMessage(
         guildId: string,
-    ): { messageId: string; channelId: string } | undefined {
+    ): { messageId: string; channelId: string; trackUrl?: string } | undefined {
         return this.songInfoMessages.get(guildId)
     }
 
@@ -89,17 +91,19 @@ export function registerNowPlayingMessage(
     guildId: string,
     messageId: string,
     channelId: string,
+    trackUrl?: string,
 ): void {
     trackNowPlayingState.registerNowPlayingMessage(
         guildId,
         messageId,
         channelId,
+        trackUrl,
     )
 }
 
 export function getSongInfoMessage(
     guildId: string,
-): { messageId: string; channelId: string } | undefined {
+): { messageId: string; channelId: string; trackUrl?: string } | undefined {
     return trackNowPlayingState.getSongInfoMessage(guildId)
 }
 
@@ -225,7 +229,7 @@ export async function sendNowPlayingEmbed(
         footer,
     })
 
-    const skipReasonEmojis = ['👎', '😴', '🎸', '🔁']
+    const skipReasonEmojis = getSkipReasonEmojis()
 
     const previousMessage = getSongInfoMessage(queue.guild.id)
     if (previousMessage && previousMessage.channelId === metadata.channel.id) {
@@ -284,7 +288,7 @@ export async function sendNowPlayingEmbed(
         })
     }
 
-    registerNowPlayingMessage(queue.guild.id, message.id, metadata.channel.id)
+    registerNowPlayingMessage(queue.guild.id, message.id, metadata.channel.id, track.url)
 
     debugLog({
         message: 'Sent now playing message to channel',

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -251,6 +251,15 @@ export async function sendNowPlayingEmbed(
                     // Silently ignore if reaction fails (e.g., bot permissions)
                 })
             }
+            // Refresh the cached trackUrl — the message is reused but now points
+            // at a new track, so skip-reason reactions must resolve to it, not
+            // the previous track's recommendation.
+            registerNowPlayingMessage(
+                queue.guild.id,
+                previousMessage.messageId,
+                metadata.channel.id,
+                track.url,
+            )
             debugLog({
                 message: 'Updated now playing message in channel',
                 data: {

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -225,6 +225,8 @@ export async function sendNowPlayingEmbed(
         footer,
     })
 
+    const skipReasonEmojis = ['👎', '😴', '🎸', '🔁']
+
     const previousMessage = getSongInfoMessage(queue.guild.id)
     if (previousMessage && previousMessage.channelId === metadata.channel.id) {
         try {
@@ -239,6 +241,12 @@ export async function sendNowPlayingEmbed(
                     createMusicActionButtons(queue),
                 ],
             })
+            // Add skip-reason emoji reactions
+            for (const emoji of skipReasonEmojis) {
+                message.react(emoji).catch(() => {
+                    // Silently ignore if reaction fails (e.g., bot permissions)
+                })
+            }
             debugLog({
                 message: 'Updated now playing message in channel',
                 data: {
@@ -268,6 +276,13 @@ export async function sendNowPlayingEmbed(
             createMusicActionButtons(queue),
         ],
     })
+
+    // Add skip-reason emoji reactions
+    for (const emoji of skipReasonEmojis) {
+        message.react(emoji).catch(() => {
+            // Silently ignore if reaction fails (e.g., bot permissions)
+        })
+    }
 
     registerNowPlayingMessage(queue.guild.id, message.id, metadata.channel.id)
 

--- a/packages/bot/src/handlers/reactionHandler.spec.ts
+++ b/packages/bot/src/handlers/reactionHandler.spec.ts
@@ -1,0 +1,338 @@
+// Mock the dependencies FIRST - before any imports
+const mockGetSongInfoMessage = jest.fn()
+const mockRecordRecommendationSkipReason = jest.fn()
+const mockGetPrismaClient = jest.fn()
+const mockErrorLog = jest.fn()
+
+jest.mock('@lucky/shared/utils/database/prismaClient', () => ({
+    getPrismaClient: mockGetPrismaClient,
+    disconnectPrisma: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: mockErrorLog,
+    warnLog: jest.fn(),
+    infoLog: jest.fn(),
+    debugLog: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    starboardService: {
+        getConfig: jest.fn(),
+        upsertEntry: jest.fn(),
+    },
+}))
+
+jest.mock('./player/trackNowPlaying', () => ({
+    getSongInfoMessage: mockGetSongInfoMessage,
+}))
+
+jest.mock('../services/musicRecommendation/recommendationTelemetry', () => ({
+    recordRecommendationSkipReason: mockRecordRecommendationSkipReason,
+}))
+
+// NOW import types and the module under test after mocks are set up
+import {
+    describe,
+    expect,
+    it,
+    beforeEach,
+} from '@jest/globals'
+import type {
+    MessageReaction,
+    PartialMessageReaction,
+    User,
+    PartialUser,
+    Guild,
+    Message,
+} from 'discord.js'
+import { handleReactionEvents } from './reactionHandler'
+
+describe('reactionHandler', () => {
+    let mockClient: any
+    let mockReaction: Partial<MessageReaction | PartialMessageReaction>
+    let mockUser: Partial<User | PartialUser>
+    let mockMessage: Partial<Message>
+    let mockGuild: Partial<Guild>
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        // Set up default prisma mock
+        mockGetPrismaClient.mockReturnValue({
+            recommendation: {
+                findFirst: jest.fn(),
+                update: jest.fn(),
+            },
+        })
+
+        // Set up default mock guild
+        mockGuild = {
+            id: 'guild-123',
+        }
+
+        // Set up default mock message
+        mockMessage = {
+            id: 'message-456',
+            guild: mockGuild as Guild,
+            partial: false,
+        }
+
+        // Set up default mock user
+        mockUser = {
+            id: 'user-789',
+            bot: false,
+            partial: false,
+        }
+
+        // Set up default mock reaction
+        mockReaction = {
+            emoji: {
+                name: '👎',
+            },
+            message: mockMessage as Message,
+            partial: false,
+            count: 1,
+            fetch: jest.fn().mockResolvedValue(undefined),
+        }
+
+        // Set up default mock client
+        mockClient = {
+            on: jest.fn((event: string, handler: Function) => {
+                // Store the handler so we can call it in tests
+                if (event === 'messageReactionAdd') {
+                    mockClient._messageReactionAddHandler = handler
+                }
+            }),
+        }
+    })
+
+    describe('handleSkipReasonReaction', () => {
+        it('ignores bot reactions', async () => {
+            mockUser.bot = true
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockGetSongInfoMessage).not.toHaveBeenCalled()
+        })
+
+        it('ignores non-skip-reason emojis', async () => {
+            mockReaction.emoji = { name: '❤️' }
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockGetSongInfoMessage).not.toHaveBeenCalled()
+        })
+
+        it('ignores reaction if message is not the now-playing message', async () => {
+            mockGetSongInfoMessage.mockReturnValue({
+                messageId: 'different-message-id',
+                channelId: 'channel-123',
+            })
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockRecordRecommendationSkipReason).not.toHaveBeenCalled()
+        })
+
+        it('ignores reaction if no now-playing message is registered', async () => {
+            mockGetSongInfoMessage.mockReturnValue(null)
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockRecordRecommendationSkipReason).not.toHaveBeenCalled()
+        })
+
+        it('records generic_dislike skip reason for 👎 emoji', async () => {
+            mockReaction.emoji = { name: '👎' }
+            mockGetSongInfoMessage.mockReturnValue({
+                messageId: 'message-456',
+                channelId: 'channel-123',
+            })
+
+            const mockPrisma = {
+                recommendation: {
+                    findFirst: jest.fn().mockResolvedValue({
+                        id: 'rec-id-123',
+                    }),
+                },
+            }
+            mockGetPrismaClient.mockReturnValue(mockPrisma)
+            mockRecordRecommendationSkipReason.mockResolvedValue(undefined)
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockRecordRecommendationSkipReason).toHaveBeenCalledWith({
+                recommendationId: 'rec-id-123',
+                skipReason: 'generic_dislike',
+            })
+        })
+
+        it('records too_chill skip reason for 😴 emoji', async () => {
+            mockReaction.emoji = { name: '😴' }
+            mockGetSongInfoMessage.mockReturnValue({
+                messageId: 'message-456',
+                channelId: 'channel-123',
+            })
+
+            const mockPrisma = {
+                recommendation: {
+                    findFirst: jest.fn().mockResolvedValue({
+                        id: 'rec-id-456',
+                    }),
+                },
+            }
+            mockGetPrismaClient.mockReturnValue(mockPrisma)
+            mockRecordRecommendationSkipReason.mockResolvedValue(undefined)
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockRecordRecommendationSkipReason).toHaveBeenCalledWith({
+                recommendationId: 'rec-id-456',
+                skipReason: 'too_chill',
+            })
+        })
+
+        it('records mood_mismatch skip reason for 🎸 emoji', async () => {
+            mockReaction.emoji = { name: '🎸' }
+            mockGetSongInfoMessage.mockReturnValue({
+                messageId: 'message-456',
+                channelId: 'channel-123',
+            })
+
+            const mockPrisma = {
+                recommendation: {
+                    findFirst: jest.fn().mockResolvedValue({
+                        id: 'rec-id-789',
+                    }),
+                },
+            }
+            mockGetPrismaClient.mockReturnValue(mockPrisma)
+            mockRecordRecommendationSkipReason.mockResolvedValue(undefined)
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockRecordRecommendationSkipReason).toHaveBeenCalledWith({
+                recommendationId: 'rec-id-789',
+                skipReason: 'mood_mismatch',
+            })
+        })
+
+        it('records repeat skip reason for 🔁 emoji', async () => {
+            mockReaction.emoji = { name: '🔁' }
+            mockGetSongInfoMessage.mockReturnValue({
+                messageId: 'message-456',
+                channelId: 'channel-123',
+            })
+
+            const mockPrisma = {
+                recommendation: {
+                    findFirst: jest.fn().mockResolvedValue({
+                        id: 'rec-id-101',
+                    }),
+                },
+            }
+            mockGetPrismaClient.mockReturnValue(mockPrisma)
+            mockRecordRecommendationSkipReason.mockResolvedValue(undefined)
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockRecordRecommendationSkipReason).toHaveBeenCalledWith({
+                recommendationId: 'rec-id-101',
+                skipReason: 'repeat',
+            })
+        })
+
+        it('fetches reaction if partial', async () => {
+            mockReaction.partial = true
+            mockReaction.fetch = jest.fn().mockResolvedValue(undefined)
+            mockGetSongInfoMessage.mockReturnValue(null)
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockReaction.fetch).toHaveBeenCalled()
+        })
+
+        it('handles error when finding recommendation gracefully', async () => {
+            mockReaction.emoji = { name: '👎' }
+            mockGetSongInfoMessage.mockReturnValue({
+                messageId: 'message-456',
+                channelId: 'channel-123',
+            })
+
+            const testError = new Error('Database error')
+            const mockPrisma = {
+                recommendation: {
+                    findFirst: jest.fn().mockRejectedValue(testError),
+                },
+            }
+            mockGetPrismaClient.mockReturnValue(mockPrisma)
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockErrorLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'Error handling skip reason reaction',
+                    ),
+                }),
+            )
+        })
+
+        it('does not record if no recommendation found for guild', async () => {
+            mockReaction.emoji = { name: '👎' }
+            mockGetSongInfoMessage.mockReturnValue({
+                messageId: 'message-456',
+                channelId: 'channel-123',
+            })
+
+            const mockPrisma = {
+                recommendation: {
+                    findFirst: jest.fn().mockResolvedValue(null),
+                },
+            }
+            mockGetPrismaClient.mockReturnValue(mockPrisma)
+
+            handleReactionEvents(mockClient)
+            await mockClient._messageReactionAddHandler(mockReaction, mockUser)
+
+            expect(mockRecordRecommendationSkipReason).not.toHaveBeenCalled()
+        })
+
+        it('records skip reason non-blockingly and does not break skip flow', async () => {
+            mockReaction.emoji = { name: '👎' }
+            mockGetSongInfoMessage.mockReturnValue({
+                messageId: 'message-456',
+                channelId: 'channel-123',
+            })
+
+            const mockPrisma = {
+                recommendation: {
+                    findFirst: jest.fn().mockResolvedValue({
+                        id: 'rec-id-123',
+                    }),
+                },
+            }
+            mockGetPrismaClient.mockReturnValue(mockPrisma)
+
+            const recordError = new Error('Persistence failed')
+            mockRecordRecommendationSkipReason.mockRejectedValue(recordError)
+
+            handleReactionEvents(mockClient)
+            // Should not throw even if recordRecommendationSkipReason rejects
+            await expect(
+                mockClient._messageReactionAddHandler(mockReaction, mockUser),
+            ).resolves.toBeUndefined()
+        })
+    })
+})

--- a/packages/bot/src/handlers/reactionHandler.ts
+++ b/packages/bot/src/handlers/reactionHandler.ts
@@ -13,14 +13,7 @@ import { activeGiveaways } from '../functions/general/commands/giveaway'
 import { getSongInfoMessage } from './player/trackNowPlaying'
 import { recordRecommendationSkipReason } from '../services/musicRecommendation/recommendationTelemetry'
 import { getPrismaClient } from '@lucky/shared/utils/database/prismaClient'
-
-// Map emoji names to skip reasons
-const SKIP_REASON_MAP: Record<string, string> = {
-    '👎': 'generic_dislike',
-    '😴': 'too_chill',
-    '🎸': 'mood_mismatch',
-    '🔁': 'repeat',
-}
+import { SKIP_REASON_EMOJI_MAP } from '../utils/music/skipReasonMap'
 
 async function handleGiveawayReaction(
     reaction: MessageReaction | PartialMessageReaction,
@@ -113,18 +106,21 @@ async function handleSkipReasonReaction(
     const emojiName = reaction.emoji.name ?? ''
 
     // Check if this emoji is a skip-reason emoji
-    const skipReason = SKIP_REASON_MAP[emojiName]
+    const skipReason = SKIP_REASON_EMOJI_MAP[emojiName]
     if (!skipReason) return
 
     // Check if this message is the now-playing message for the guild
     const nowPlayingMsg = getSongInfoMessage(guildId)
     if (!nowPlayingMsg || nowPlayingMsg.messageId !== messageId) return
 
-    // Find the most recent recommendation for this guild
+    // Find the recommendation for this specific track (narrow by guild + trackUrl)
     try {
         const prisma = getPrismaClient()
         const recommendation = await prisma.recommendation.findFirst({
-            where: { guildId },
+            where: {
+                guildId,
+                ...(nowPlayingMsg.trackUrl && { url: nowPlayingMsg.trackUrl }),
+            },
             orderBy: { createdAt: 'desc' },
             take: 1,
         })

--- a/packages/bot/src/handlers/reactionHandler.ts
+++ b/packages/bot/src/handlers/reactionHandler.ts
@@ -10,6 +10,17 @@ import {
 import { starboardService } from '@lucky/shared/services'
 import { errorLog } from '@lucky/shared/utils'
 import { activeGiveaways } from '../functions/general/commands/giveaway'
+import { getSongInfoMessage } from './player/trackNowPlaying'
+import { recordRecommendationSkipReason } from '../services/musicRecommendation/recommendationTelemetry'
+import { getPrismaClient } from '@lucky/shared/utils/database/prismaClient'
+
+// Map emoji names to skip reasons
+const SKIP_REASON_MAP: Record<string, string> = {
+    '👎': 'generic_dislike',
+    '😴': 'too_chill',
+    '🎸': 'mood_mismatch',
+    '🔁': 'repeat',
+}
 
 async function handleGiveawayReaction(
     reaction: MessageReaction | PartialMessageReaction,
@@ -89,6 +100,47 @@ async function handleStarboardReaction(
     }
 }
 
+async function handleSkipReasonReaction(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+): Promise<void> {
+    if (user.bot) return
+    if (reaction.partial) await reaction.fetch()
+    if (!reaction.message.guild) return
+
+    const guildId = reaction.message.guild.id
+    const messageId = reaction.message.id
+    const emojiName = reaction.emoji.name ?? ''
+
+    // Check if this emoji is a skip-reason emoji
+    const skipReason = SKIP_REASON_MAP[emojiName]
+    if (!skipReason) return
+
+    // Check if this message is the now-playing message for the guild
+    const nowPlayingMsg = getSongInfoMessage(guildId)
+    if (!nowPlayingMsg || nowPlayingMsg.messageId !== messageId) return
+
+    // Find the most recent recommendation for this guild
+    try {
+        const prisma = getPrismaClient()
+        const recommendation = await prisma.recommendation.findFirst({
+            where: { guildId },
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+        })
+
+        if (!recommendation) return
+
+        // Record the skip reason non-blockingly
+        await recordRecommendationSkipReason({
+            recommendationId: recommendation.id,
+            skipReason,
+        })
+    } catch (err) {
+        errorLog({ message: 'Error handling skip reason reaction:', error: err })
+    }
+}
+
 export function handleReactionEvents(client: Client): void {
     client.on(
         Events.MessageReactionAdd,
@@ -99,6 +151,7 @@ export function handleReactionEvents(client: Client): void {
             try {
                 await handleGiveawayReaction(reaction, user)
                 await handleStarboardReaction(reaction, user, client)
+                await handleSkipReasonReaction(reaction, user)
             } catch (error) {
                 errorLog({ message: 'Error handling reaction:', error })
             }

--- a/packages/bot/src/services/musicRecommendation/recommendationTelemetry.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/recommendationTelemetry.spec.ts
@@ -28,8 +28,10 @@ jest.mock('@lucky/shared/utils/general/log', () => ({
 import {
     recordRecommendationPick,
     recordRecommendationOutcome,
+    recordRecommendationSkipReason,
     type RecordPickInput,
     type RecordOutcomeArgs,
+    type RecordSkipReasonArgs,
 } from './recommendationTelemetry'
 
 describe('recommendationTelemetry', () => {
@@ -311,6 +313,125 @@ describe('recommendationTelemetry', () => {
                 recordRecommendationOutcome(args),
             ).resolves.toBeUndefined()
             expect(mockErrorLog).toHaveBeenCalled()
+        })
+    })
+
+    describe('recordRecommendationSkipReason', () => {
+        it('updates skipReason on recommendation by id (happy path)', async () => {
+            const args: RecordSkipReasonArgs = {
+                recommendationId: 'rec-id-123',
+                skipReason: 'too_chill',
+            }
+
+            mockUpdate.mockResolvedValue({
+                id: 'rec-id-123',
+                skipReason: 'too_chill',
+            })
+
+            await recordRecommendationSkipReason(args)
+
+            expect(mockUpdate).toHaveBeenCalledWith({
+                where: { id: 'rec-id-123' },
+                data: { skipReason: 'too_chill' },
+            })
+        })
+
+        it('persists generic_dislike skip reason', async () => {
+            const args: RecordSkipReasonArgs = {
+                recommendationId: 'rec-id-456',
+                skipReason: 'generic_dislike',
+            }
+
+            mockUpdate.mockResolvedValue({
+                id: 'rec-id-456',
+                skipReason: 'generic_dislike',
+            })
+
+            await recordRecommendationSkipReason(args)
+
+            expect(mockUpdate).toHaveBeenCalledWith({
+                where: { id: 'rec-id-456' },
+                data: { skipReason: 'generic_dislike' },
+            })
+        })
+
+        it('persists mood_mismatch skip reason', async () => {
+            const args: RecordSkipReasonArgs = {
+                recommendationId: 'rec-id-789',
+                skipReason: 'mood_mismatch',
+            }
+
+            mockUpdate.mockResolvedValue({
+                id: 'rec-id-789',
+                skipReason: 'mood_mismatch',
+            })
+
+            await recordRecommendationSkipReason(args)
+
+            expect(mockUpdate).toHaveBeenCalledWith({
+                where: { id: 'rec-id-789' },
+                data: { skipReason: 'mood_mismatch' },
+            })
+        })
+
+        it('persists repeat skip reason', async () => {
+            const args: RecordSkipReasonArgs = {
+                recommendationId: 'rec-id-101',
+                skipReason: 'repeat',
+            }
+
+            mockUpdate.mockResolvedValue({
+                id: 'rec-id-101',
+                skipReason: 'repeat',
+            })
+
+            await recordRecommendationSkipReason(args)
+
+            expect(mockUpdate).toHaveBeenCalledWith({
+                where: { id: 'rec-id-101' },
+                data: { skipReason: 'repeat' },
+            })
+        })
+
+        it('DB error is swallowed and resolved void (non-blocking)', async () => {
+            const args: RecordSkipReasonArgs = {
+                recommendationId: 'rec-id-123',
+                skipReason: 'too_chill',
+            }
+
+            const testError = new Error('DB connection failed')
+            mockUpdate.mockRejectedValue(testError)
+
+            // Should not throw
+            await expect(
+                recordRecommendationSkipReason(args),
+            ).resolves.toBeUndefined()
+            expect(mockErrorLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'recordRecommendationSkipReason',
+                    ),
+                }),
+            )
+        })
+
+        it('persistence failure does not break skip flow', async () => {
+            const args: RecordSkipReasonArgs = {
+                recommendationId: 'rec-id-123',
+                skipReason: 'generic_dislike',
+            }
+
+            mockUpdate.mockRejectedValue(
+                new Error('Network timeout'),
+            )
+
+            const result = await recordRecommendationSkipReason(args)
+
+            // Verify the function returns undefined (void) even on error
+            expect(result).toBeUndefined()
+            // Verify error was logged but not thrown
+            expect(mockErrorLog).toHaveBeenCalled()
+            // Function should complete without throwing
         })
     })
 })

--- a/packages/bot/src/services/musicRecommendation/recommendationTelemetry.ts
+++ b/packages/bot/src/services/musicRecommendation/recommendationTelemetry.ts
@@ -25,6 +25,11 @@ export interface RecordOutcomeArgs {
     outcome: 'accepted' | 'rejected'
 }
 
+export interface RecordSkipReasonArgs {
+    recommendationId: string
+    skipReason: string
+}
+
 /**
  * Records a music recommendation pick into the database.
  * Non-blocking: swallows DB errors and logs them without throwing.
@@ -107,6 +112,30 @@ export async function recordRecommendationOutcome(
         errorLog({
             message:
                 '[recordRecommendationOutcome] failed to update Recommendation row',
+            error: err,
+        })
+    }
+}
+
+/**
+ * Records the skip reason for a recommendation via emoji reaction on the now-playing control.
+ * Non-blocking: swallows DB errors and logs them without throwing.
+ * Does not affect the skip flow if persistence fails.
+ */
+export async function recordRecommendationSkipReason(
+    args: RecordSkipReasonArgs,
+): Promise<void> {
+    try {
+        const prisma = getPrismaClient()
+
+        await prisma.recommendation.update({
+            where: { id: args.recommendationId },
+            data: { skipReason: args.skipReason },
+        })
+    } catch (err) {
+        errorLog({
+            message:
+                '[recordRecommendationSkipReason] failed to update Recommendation row',
             error: err,
         })
     }

--- a/packages/bot/src/services/musicRecommendation/recommendationTelemetry.ts
+++ b/packages/bot/src/services/musicRecommendation/recommendationTelemetry.ts
@@ -5,6 +5,7 @@ import {
     serializeBasis,
     type RecommendationBasis,
 } from '../../utils/music/autoplay/recommendationBasis'
+import type { SkipReason } from '../../utils/music/skipReasonMap'
 
 export interface RecordPickInput {
     guildId: string
@@ -27,7 +28,7 @@ export interface RecordOutcomeArgs {
 
 export interface RecordSkipReasonArgs {
     recommendationId: string
-    skipReason: string
+    skipReason: SkipReason
 }
 
 /**

--- a/packages/bot/src/utils/music/skipReasonMap.ts
+++ b/packages/bot/src/utils/music/skipReasonMap.ts
@@ -1,0 +1,20 @@
+/**
+ * Bidirectional mapping between emoji characters and skip reasons.
+ * Used by the now-playing message reactions and the skip-reason reaction handler.
+ */
+
+export type SkipReason = 'generic_dislike' | 'too_chill' | 'mood_mismatch' | 'repeat'
+
+export const SKIP_REASON_EMOJI_MAP: Record<string, SkipReason> = {
+    '👎': 'generic_dislike',
+    '😴': 'too_chill',
+    '🎸': 'mood_mismatch',
+    '🔁': 'repeat',
+}
+
+/**
+ * Get the list of emoji characters for skip reasons (used for adding reactions).
+ */
+export function getSkipReasonEmojis(): string[] {
+    return Object.keys(SKIP_REASON_EMOJI_MAP)
+}

--- a/prisma/migrations/20260613040000_add_recommendation_skip_reason/migration.sql
+++ b/prisma/migrations/20260613040000_add_recommendation_skip_reason/migration.sql
@@ -1,3 +1,11 @@
 -- Capture an optional skip reason on a recommendation, set via emoji reaction
 -- on the now-playing control. Nullable: absence means no reason was given.
-ALTER TABLE "recommendations" ADD COLUMN "skipReason" TEXT;
+-- Supported values: generic_dislike, too_chill, mood_mismatch, repeat.
+CREATE TYPE "SkipReason" AS ENUM (
+    'generic_dislike',
+    'too_chill',
+    'mood_mismatch',
+    'repeat'
+);
+
+ALTER TABLE "recommendations" ADD COLUMN "skipReason" "SkipReason";

--- a/prisma/migrations/20260613040000_add_recommendation_skip_reason/migration.sql
+++ b/prisma/migrations/20260613040000_add_recommendation_skip_reason/migration.sql
@@ -1,0 +1,3 @@
+-- Capture an optional skip reason on a recommendation, set via emoji reaction
+-- on the now-playing control. Nullable: absence means no reason was given.
+ALTER TABLE "recommendations" ADD COLUMN "skipReason" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -501,6 +501,13 @@ enum RecommendationSource {
   GENRE_TAG
 }
 
+enum SkipReason {
+  generic_dislike
+  too_chill
+  mood_mismatch
+  repeat
+}
+
 model Recommendation {
   id      String @id @default(cuid())
   guildId String
@@ -535,8 +542,7 @@ model Recommendation {
   isRejected Boolean?
   feedback   String?
   // Optional skip reason captured via emoji reaction on now-playing control
-  // (e.g., 'too_chill', 'mood_mismatch', 'repeat', or 'skip')
-  skipReason String?
+  skipReason SkipReason?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -534,6 +534,9 @@ model Recommendation {
   isAccepted Boolean?
   isRejected Boolean?
   feedback   String?
+  // Optional skip reason captured via emoji reaction on now-playing control
+  // (e.g., 'too_chill', 'mood_mismatch', 'repeat', or 'skip')
+  skipReason String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Summary
Implements GitHub issue #1093: capture optional skip-reason telemetry when users react with emojis to the now-playing message control.

Adds four skip-reason emoji reactions (👎, 😴, 🎸, 🔁) that map to telemetry values (generic_dislike, too_chill, mood_mismatch, repeat). Updates Recommendation.skipReason non-blockingly; persistence failures do not break the skip flow.

## Implementation
- **reactionHandler**: New `handleSkipReasonReaction()` function captures emoji reactions and persists skip reason via Prisma
- **trackNowPlaying**: Adds skip-reason emoji reactions to now-playing message (both edit and create paths)
- **recommendationTelemetry**: New `recordRecommendationSkipReason()` service function for database updates
- **schema**: Optional `skipReason` field added to Recommendation model
- **tests**: Comprehensive test suite covering emoji mappings, error handling, and non-blocking semantics

## Test Results
- All 2521 bot tests passing (2527 total, 6 skipped)
- All 12 reactionHandler emoji reaction tests passing
- All 5 recordRecommendationSkipReason persistence tests passing

## Related
Closes #1093

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Captures skip-reason telemetry from emoji reactions on the now-playing message. Adds 👎 😴 🎸 🔁 → generic_dislike, too_chill, mood_mismatch, repeat; non-blocking persistence with guild+track-URL matching that refreshes on now-playing edits (closes #1093; fixes #1377).

- **New Features**
  - Adds skip-reason reactions to now-playing (create + edit). Central emoji→reason map in `skipReasonMap.ts`; now-playing stores `trackUrl` and refreshes it on edits; reactions are only handled for the current message.
  - `reactionHandler` records reasons via `recordRecommendationSkipReason` (typed `SkipReason`) and finds the latest recommendation by `guildId` + `trackUrl`; bot/non-relevant reactions are ignored; DB errors are logged and ignored.

- **Migration**
  - Apply `20260613040000_add_recommendation_skip_reason` to add the `SkipReason` enum and nullable `Recommendation.skipReason` column.

<sup>Written for commit da0a01e391d8d7e65972f2898cc32b13975fd3d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

