### PR TITLE
chore(lint): clear no-explicit-any in bot+shared (#1378)

### DIFF
--- a/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
@@ -1,4 +1,5 @@
 import type { GuildMember } from 'discord.js'
+import type { PlayerNodeInitializationResult } from 'discord-player'
 import type { CommandExecuteParams } from '../../../../../types/CommandData'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
@@ -119,7 +120,7 @@ export async function executePlayHandler({
             searchEngine,
         }
 
-        let result: any
+        let result: PlayerNodeInitializationResult<unknown>
         let resolutionTelemetry
         try {
             const resolution = await resolveQueryWithFallbacks(
@@ -149,9 +150,9 @@ export async function executePlayHandler({
             throw error
         }
 
-        const track = (result as any).track
+        const track = result.track
 
-        const isPlaylist = !!(result as any).searchResult.playlist
+        const isPlaylist = !!result.searchResult.playlist
         if (!isPlaylist && !track.title) {
             throw new Error('YouTube: track metadata unavailable')
         }
@@ -172,15 +173,15 @@ export async function executePlayHandler({
                     : queuedTracks.length
                 : 0
 
-        const embed = (result as any).searchResult.playlist
+        const embed = result.searchResult.playlist
             ? buildPlayResponseEmbed({
                   kind: 'playlistQueued',
                   track,
                   requestedBy: interaction.user,
                   playlist: {
-                      title: (result as any).searchResult.playlist.title,
-                      trackCount: (result as any).searchResult.tracks.length,
-                      url: (result as any).searchResult.playlist.url,
+                      title: result.searchResult.playlist.title,
+                      trackCount: result.searchResult.tracks.length,
+                      url: result.searchResult.playlist.url,
                   },
               })
             : buildPlayResponseEmbed({

--- a/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.ts
@@ -1,4 +1,9 @@
 import { QueryType } from 'discord-player'
+import type {
+    Player,
+    PlayerNodeInitializerOptions,
+    PlayerNodeInitializationResult,
+} from 'discord-player'
 import type { VoiceBasedChannel } from 'discord.js'
 import { warnLog } from '@lucky/shared/utils'
 import { addBreadcrumb } from '@lucky/shared/utils/monitoring'
@@ -21,13 +26,16 @@ interface ResolutionTelemetry {
  * Emits telemetry breadcrumbs for observability.
  */
 export async function resolveQueryWithFallbacks(
-    player: any,
+    player: Player,
     voiceChannel: VoiceBasedChannel,
     query: string,
     requestedProvider: string,
     searchEngine: QueryType,
-    playOptions: any,
-): Promise<{ result: any; telemetry: ResolutionTelemetry }> {
+    playOptions: PlayerNodeInitializerOptions<unknown>,
+): Promise<{
+    result: PlayerNodeInitializationResult<unknown>
+    telemetry: ResolutionTelemetry
+}> {
     const startTime = Date.now()
     const telemetry: ResolutionTelemetry = {
         resolvedVia: 'primary',
@@ -56,7 +64,7 @@ export async function resolveQueryWithFallbacks(
             try {
                 // Attempt YouTube fallback
                 const result = await player.play(voiceChannel, query, {
-                    ...(playOptions as Record<string, unknown>),
+                    ...playOptions,
                     searchEngine: QueryType.YOUTUBE_SEARCH,
                 })
                 telemetry.latencyMs = Date.now() - startTime
@@ -72,7 +80,7 @@ export async function resolveQueryWithFallbacks(
                 try {
                     // Attempt SoundCloud fallback
                     const result = await player.play(voiceChannel, query, {
-                        ...(playOptions as Record<string, unknown>),
+                        ...playOptions,
                         searchEngine: QueryType.SOUNDCLOUD_SEARCH,
                     })
                     telemetry.latencyMs = Date.now() - startTime

--- a/packages/shared/src/services/ModerationService.ts
+++ b/packages/shared/src/services/ModerationService.ts
@@ -81,7 +81,7 @@ export class ModerationService {
 
         for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
             try {
-                return await prisma.$transaction(async (tx: any) => {
+                return await prisma.$transaction(async (tx) => {
                     const lastCase = await tx.moderationCase.findFirst({
                         where: { guildId: input.guildId },
                         orderBy: { caseNumber: 'desc' },

--- a/packages/shared/src/services/ServerLogService.ts
+++ b/packages/shared/src/services/ServerLogService.ts
@@ -11,7 +11,7 @@ export type ServerLog = {
     userId: string | null
     channelId: string | null
     moderatorId: string | null
-    details: any
+    details: unknown
     createdAt: Date
 }
 
@@ -35,7 +35,7 @@ export type LogType =
 
 /** Arbitrary key-value payload attached to a log entry. */
 export interface LogDetails {
-    [key: string]: any
+    [key: string]: unknown
 }
 
 /** Service for creating and querying server audit logs persisted in the database. */

--- a/packages/shared/src/services/SupportReportService.ts
+++ b/packages/shared/src/services/SupportReportService.ts
@@ -85,7 +85,11 @@ export class SupportReportService {
             const report = await prisma.supportReport.create({
                 data: {
                     context: input.context,
-                    image: (input.image ?? null) as any,
+                    // Prisma's Bytes input is typed Uint8Array<ArrayBuffer>;
+                    // Buffer is Uint8Array<ArrayBufferLike> at compile time but
+                    // a valid Bytes value at runtime — narrow the generic here.
+                    image: (input.image ??
+                        null) as Uint8Array<ArrayBuffer> | null,
                     imageMimeType: input.imageMimeType || null,
                     correlationId: input.correlationId || null,
                     guildId: input.guildId || null,

--- a/packages/shared/src/services/recommendationTelemetryReadService.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.ts
@@ -160,7 +160,7 @@ export async function getSummary(
     const prisma = getPrismaClient()
     const createdAtGte = getCreatedAtCutoff(days)
 
-    const getCountValue = (result: any): number =>
+    const getCountValue = (result: number | { count: number }): number =>
         typeof result === 'number' ? result : result.count
 
     const totalPicks = getCountValue(
@@ -250,7 +250,7 @@ export async function getAutoplaySkipRateForGuild(
     const prisma = getPrismaClient()
     const createdAtGte = new Date(Date.now() - 24 * 60 * 60 * 1000) // 24 hours
 
-    const getCountValue = (result: any): number =>
+    const getCountValue = (result: number | { count: number }): number =>
         typeof result === 'number' ? result : result.count
 
     const acceptedCount = getCountValue(


### PR DESCRIPTION
Part of the #1378 ratchet cleanup — clears `@typescript-eslint/no-explicit-any` in `packages/bot` + `packages/shared` (16 → 0) with **real types**, not `unknown`-blanket suppressions.

## Changes
- **play handlers** (`resolveProvider.ts`, `playHandler.ts`): typed the discord-player resolution flow with `Player`, `PlayerNodeInitializerOptions<unknown>`, and `PlayerNodeInitializationResult<unknown>`. This also let the seven `(result as any)` casts and a redundant `as Record<string, unknown>` spread cast drop out — `result.track` / `result.searchResult.playlist` are now properly typed.
- **recommendationTelemetryReadService**: `(result: any)` → `number | { count: number }` (the function already branches on `typeof result`).
- **ModerationService**: dropped the `(tx: any)` annotation so the `$transaction` callback infers its Prisma transaction client.
- **ServerLogService**: `details` / `LogDetails` index signature → `unknown` (no typed consumers — all writes).
- **SupportReportService**: replaced `as any` on the Prisma `Bytes` field with a documented `Uint8Array<ArrayBuffer>` cast (Buffer is `ArrayBufferLike` at compile time; valid Bytes at runtime).

## Verification (first-hand on this branch)
- `@typescript-eslint/no-explicit-any` in bot+shared: **0**, zero new lint errors
- `tsc --noEmit`: clean (shared + bot)
- Tests: shared **818 passed**, bot **2530 passed**
- All four workspaces lint exit 0

@cubic-dev-ai please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes all explicit `any` in `packages/bot` and `packages/shared` (16 → 0) by adding concrete types. Improves type safety in the music play flow and shared services; part of #1378 cleanup.

- **Refactors**
  - Typed music play resolution with `discord-player` (`Player`, `PlayerNodeInitializerOptions<unknown>`, `PlayerNodeInitializationResult<unknown>`); removed `(result as any)` and redundant `Record` cast.
  - `resolveQueryWithFallbacks` now uses `Player` types for inputs/return and spreads `playOptions` without casting.
  - `recommendationTelemetryReadService`: helpers accept `number | { count: number }`.
  - `ModerationService`: let Prisma `$transaction` infer `tx`.
  - `ServerLogService`: `details` and `LogDetails` use `unknown`.
  - `SupportReportService`: replace `any` cast for Bytes with `Uint8Array<ArrayBuffer> | null`.

<sup>Written for commit 2a8aebcbb7b040c42d26ee69986410f877038d0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Strengthened type safety throughout the music playback system, moderation service, logging, and recommendation features by replacing loose type casting with explicit type definitions
* Improved code reliability through consistent type narrowing across internal services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->