### PR TITLE
chore(lint): clear no-unsafe in autoplay scoring/selection (#1378)

### DIFF
--- a/packages/bot/src/utils/general/responseEmbeds/buildTrackEmbed.ts
+++ b/packages/bot/src/utils/general/responseEmbeds/buildTrackEmbed.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder } from 'discord.js'
 import type { User } from 'discord.js'
 import type { Track } from 'discord-player'
 import { detectSource } from '../../music/nowPlayingEmbed'
+import { trackSource } from '../../music/trackFields'
 import { formatDurationClock } from '../formatDuration'
 
 export type TrackEmbedKind = 'queued' | 'playing' | 'recommended' | 'history'
@@ -78,6 +79,6 @@ export function trackToData(track: Track): TrackData {
         duration: track.durationMS
             ? formatDurationClock(Math.floor(track.durationMS / 1000))
             : undefined,
-        source: track.source ?? null,
+        source: trackSource(track) ?? null,
     }
 }

--- a/packages/bot/src/utils/music/autoplay/candidateScorer.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.ts
@@ -220,21 +220,21 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
         candidate,
         currentTrack,
         recentArtists,
-        likedWeights = new Map(),
+        likedWeights = new Map<string, number>(),
         preferredArtistKeys = new Set(),
         blockedArtistKeys = new Set(),
         autoplayMode = 'similar',
-        artistFrequency = new Map(),
+        artistFrequency = new Map<string, number>(),
         implicitDislikeKeys = new Set(),
         implicitLikeKeys = new Set(),
-        dislikedWeights = new Map(),
+        dislikedWeights = new Map<string, number>(),
         sessionMood = null,
         skipNoveltyBoost = false,
         seedDerived = false,
         genreContext = {},
         replayFrequentTrackIds = new Set(),
         replayFrequentArtists = new Set(),
-        recentArtistIndices = new Map(),
+        recentArtistIndices = new Map<string, number>(),
     } = ctx
     const candidateTags = genreContext.candidateTags ?? []
     const currentTrackTags = genreContext.currentTrackTags ?? []
@@ -662,7 +662,7 @@ export async function enrichWithAudioFeatures(
     if (spotifyIds.length === 0) return tracks
 
     const features = await getBatchAudioFeatures(token, spotifyIds).catch(
-        () => new Map(),
+        () => new Map<string, SpotifyAudioFeatures>(),
     )
 
     // Genre-family scoring moved to in-pass `calculateRecommendationScore`

--- a/packages/bot/src/utils/music/autoplay/diversitySelector.ts
+++ b/packages/bot/src/utils/music/autoplay/diversitySelector.ts
@@ -5,6 +5,7 @@ import { extractSongCore, cleanTitle, cleanAuthor } from '../searchQueryCleaner'
 import { calculateStringSimilarity } from '../duplicateDetection/similarityChecker'
 import { markAndRecordAutoplayTrack } from './queueMarkers'
 import { extractYouTubeVideoId } from './scoringUtils'
+import { trackSource, trackAlbumName } from '../trackFields'
 import type { RecommendationBasis } from './recommendationBasis.js'
 
 interface ScoredTrack {
@@ -266,9 +267,11 @@ export function selectDiverseCandidates(
 
     for (const candidate of sortedCandidates) {
         const artistKey = candidate.track.author.toLowerCase()
-        const sourceKey = (candidate.track.source ?? 'unknown').toLowerCase()
+        const sourceKey = (
+            trackSource(candidate.track) ?? 'unknown'
+        ).toLowerCase()
         const titleKey = normalizeTitleOnly(candidate.track.title)
-        const albumName = candidate.track.raw?.album?.name?.toLowerCase() ?? ''
+        const albumName = trackAlbumName(candidate.track)?.toLowerCase() ?? ''
         const core = extractSongCore(
             candidate.track.title ?? '',
             candidate.track.author,

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -249,7 +249,7 @@ export async function enrichWithAudioFeatures(
     if (spotifyIds.length === 0) return tracks
 
     const features = await getBatchAudioFeatures(token, spotifyIds).catch(
-        () => new Map(),
+        () => new Map<string, SpotifyAudioFeatures>(),
     )
 
     let currentGenres: string[] = []

--- a/packages/bot/src/utils/music/sessionSnapshots.ts
+++ b/packages/bot/src/utils/music/sessionSnapshots.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto'
 import { getPrismaClient, debugLog, errorLog } from '@lucky/shared/utils'
 import type { Prisma } from '@lucky/shared/utils'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
+import { trackSource } from './trackFields'
 
 /**
  * Extracts the structured Prisma error fields (`code` + `meta`) for logging.
@@ -83,7 +84,7 @@ export function toSnapshotTrack(track: Track): SnapshotTrack {
         author: track.author,
         url: track.url,
         duration: toDurationString(track.duration),
-        source: track.source ?? 'unknown',
+        source: trackSource(track) ?? 'unknown',
         recommendationReason: metadata.recommendationReason,
         isAutoplay: metadata.isAutoplay,
         requestedById: metadata.requestedById,

--- a/packages/bot/src/utils/music/trackFields.spec.ts
+++ b/packages/bot/src/utils/music/trackFields.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from '@jest/globals'
+import type { Track } from 'discord-player'
+import { trackSource, trackAlbumName } from './trackFields'
+
+// discord-player's `Track` is large and built by extractors at runtime; these
+// helpers only read two loosely-typed fields, so a minimal cast is enough.
+const asTrack = (partial: Partial<Track>): Track => partial as Track
+
+describe('trackSource', () => {
+    it('returns the source value', () => {
+        expect(trackSource(asTrack({ source: 'spotify' }))).toBe('spotify')
+    })
+
+    it('returns undefined when source is absent', () => {
+        expect(trackSource(asTrack({}))).toBeUndefined()
+    })
+})
+
+describe('trackAlbumName', () => {
+    it('reads album.name from the raw payload', () => {
+        const track = asTrack({ raw: { album: { name: 'Discovery' } } })
+        expect(trackAlbumName(track)).toBe('Discovery')
+    })
+
+    it('returns undefined when raw, album, or name is missing', () => {
+        expect(trackAlbumName(asTrack({}))).toBeUndefined()
+        expect(trackAlbumName(asTrack({ raw: {} }))).toBeUndefined()
+        expect(trackAlbumName(asTrack({ raw: { album: {} } }))).toBeUndefined()
+    })
+
+    it('returns undefined when name is not a string', () => {
+        const track = asTrack({ raw: { album: { name: 42 as never } } })
+        expect(trackAlbumName(track)).toBeUndefined()
+    })
+})

--- a/packages/bot/src/utils/music/trackFields.spec.ts
+++ b/packages/bot/src/utils/music/trackFields.spec.ts
@@ -14,6 +14,11 @@ describe('trackSource', () => {
     it('returns undefined when source is absent', () => {
         expect(trackSource(asTrack({}))).toBeUndefined()
     })
+
+    it('returns undefined when source is null or not a string', () => {
+        expect(trackSource(asTrack({ source: null as never }))).toBeUndefined()
+        expect(trackSource(asTrack({ source: 7 as never }))).toBeUndefined()
+    })
 })
 
 describe('trackAlbumName', () => {

--- a/packages/bot/src/utils/music/trackFields.ts
+++ b/packages/bot/src/utils/music/trackFields.ts
@@ -17,7 +17,8 @@ import type { Track, TrackSource } from 'discord-player'
  * runtime so callers keep their existing fallbacks.
  */
 export function trackSource(track: Track): TrackSource | undefined {
-    return track.source as TrackSource | undefined
+    const source: unknown = track.source
+    return typeof source === 'string' ? (source as TrackSource) : undefined
 }
 
 /**

--- a/packages/bot/src/utils/music/trackFields.ts
+++ b/packages/bot/src/utils/music/trackFields.ts
@@ -1,0 +1,33 @@
+import type { Track, TrackSource } from 'discord-player'
+
+/**
+ * Typed accessors for discord-player {@link Track} fields the library leaves
+ * loosely typed (`Track.source`'s getter and `Track.raw` are both `any`).
+ *
+ * Narrowing those `any` values here, at a single boundary, keeps every call
+ * site type-safe instead of scattering casts — and gives one place to adjust
+ * if the underlying extractor payloads change.
+ */
+
+/**
+ * The track's playback source (youtube/spotify/soundcloud/…).
+ *
+ * `Track.source` is typed `any` by discord-player; assert it back to the real
+ * {@link TrackSource} union. Returns `undefined` when the source is absent at
+ * runtime so callers keep their existing fallbacks.
+ */
+export function trackSource(track: Track): TrackSource | undefined {
+    return track.source as TrackSource | undefined
+}
+
+/**
+ * The album name from the extractor's raw payload, when present.
+ *
+ * `Track.raw` is `any` and its shape varies by extractor; read `album.name`
+ * defensively and hand callers a plain `string | undefined`.
+ */
+export function trackAlbumName(track: Track): string | undefined {
+    const raw = track.raw as { album?: { name?: string } } | undefined
+    const name = raw?.album?.name
+    return typeof name === 'string' ? name : undefined
+}


### PR DESCRIPTION
Part of #1378 (ratchet tail). Clears **28 of the 50** remaining `no-unsafe-*` warnings in the bot+shared ESLint ratchet — all in the autoplay candidate pipeline. **Typing-only, no behavior change.**

## Root causes & fixes
- **candidateScorer / candidateFallback** — `new Map()` destructuring defaults and `.catch(() => new Map())` fallbacks inferred `Map<any, any>`, overriding the declared `Map<string, number>` / batch-audio-features types, so `.get()` and the for-of iteration leaked `any`. Annotated the defaults with explicit type args.
- **diversitySelector / buildTrackEmbed / sessionSnapshots** — discord-player types `Track.source` (getter) and `Track.raw` as `any`. Added a small typed-accessor util (`trackFields.ts`: `trackSource`, `trackAlbumName`) that narrows those at a single boundary, with unit tests, instead of scattering casts.

## Scope / sequencing
Rules stay at `warn`. Promotion to `error` lands once the whole `no-unsafe-*` family reaches 0 (Phase 3 of `.claude/plans/2026-06-13-1378-typing-tail.md`). Remaining 22: memberHandler (14), LyricsService (4), giveaway (2), MusicControlService (1), similarity (1).

## Validation
- bot tsc clean (local TS 6.0); 4-workspace tsc clean (pre-commit)
- bot + shared lint exit 0
- full bot suite green (2535 passed, +5 new trackFields specs)
- `no-unsafe-*` count: **50 → 22**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts `no-unsafe-*` ESLint warnings in the autoplay pipeline by tightening types, centralizing safe `Track` field access, and validating `Track.source` at runtime. Clears 28 warnings (50 → 22) with no expected behavior changes. Progress on #1378.

- **Refactors**
  - Added `trackFields.ts` with `trackSource` and `trackAlbumName` to safely read `discord-player` `Track.source`/`Track.raw`; updated callers in diversity selection, embed building, and session snapshots.
  - Annotated `new Map<...>()` defaults and `.catch(() => new Map<...>())` fallbacks in autoplay scoring and fallback to prevent `Map<any, any>` inference.

- **Bug Fixes**
  - Hardened `trackSource` to return `undefined` for null/non-string values; added tests for these cases.

<sup>Written for commit 68fab6df9f134b81005b62e3f4a89a57438669c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

