### PR TITLE
chore(lint): clear no-unsafe in shared services and similarity (#1378)

### DIFF
--- a/packages/shared/src/services/LyricsService.ts
+++ b/packages/shared/src/services/LyricsService.ts
@@ -81,7 +81,7 @@ export class LyricsService {
         const url = `https://api.lyrics.ovh/v1/${encodeURIComponent(artist)}/${encodeURIComponent(title)}`
 
         try {
-            const response = await axios.get(url, {
+            const response = await axios.get<{ lyrics?: string }>(url, {
                 timeout: LyricsService.TIMEOUT,
                 headers: {
                     'User-Agent': 'Lucky/1.0',

--- a/packages/shared/src/services/music/MusicControlService.ts
+++ b/packages/shared/src/services/music/MusicControlService.ts
@@ -83,12 +83,12 @@ export class MusicControlService {
             this.pendingResults.set(cmd.id, { resolve, timeout })
 
             this.publisher!.publish(CHANNEL_COMMAND, JSON.stringify(cmd)).catch(
-                (err) => {
+                (err: unknown) => {
                     this.pendingResults.delete(cmd.id)
                     clearTimeout(timeout)
-                    resolve(
-                        this.failResult(cmd, `Publish failed: ${err.message}`),
-                    )
+                    const reason =
+                        err instanceof Error ? err.message : String(err)
+                    resolve(this.failResult(cmd, `Publish failed: ${reason}`))
                 },
             )
         })

--- a/packages/shared/src/utils/similarity.ts
+++ b/packages/shared/src/utils/similarity.ts
@@ -31,7 +31,7 @@ export function levenshteinDistance(str1: string, str2: string): number {
     if (m === 0) return n
 
     let prev: number[] = Array.from({ length: m + 1 }, (_, i) => i)
-    let curr: number[] = new Array(m + 1)
+    let curr: number[] = new Array<number>(m + 1)
 
     for (let j = 1; j <= n; j++) {
         curr[0] = j


### PR DESCRIPTION
Part of #1378 (ratchet tail). Clears the remaining **6 `no-unsafe-*`** warnings in `packages/shared`, taking the shared package to **0**. Typing-only, no behavior change.

## Fixes
- **LyricsService** — `axios.get` returns `AxiosResponse<any>`; typed it `axios.get<{ lyrics?: string }>(…)` so `response.data.lyrics` / `.trim()` are no longer `any`.
- **MusicControlService** — typed the publish-`catch` param `unknown` and narrowed with `instanceof Error` before reading `.message`.
- **similarity** — `new Array(m + 1)` inferred `any[]`; annotated `new Array<number>(m + 1)`.

## Sequencing
Rules stay `warn`. The whole `no-unsafe-*` family hits 0 — and gets promoted to `error` — in the next slice (bot handlers: memberHandler + giveaway). Remaining `no-unsafe-*`: bot only (memberHandler 14, giveaway 2).

While clearing giveaway I found its end/reroll path is dead — filed #1383 (separate; the typing fix lands with the bot-handler slice).

## Validation
- shared tsc clean; 4-workspace tsc clean (pre-commit)
- full shared suite green (818 passed)
- shared `no-unsafe-*`: **6 → 0**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the last 6 no-unsafe-* lint warnings in `packages/shared` by tightening types. Typing-only; no behavior changes.

- **Refactors**
  - `LyricsService`: typed `axios.get<{ lyrics?: string }>` for safe `lyrics` access.
  - `MusicControlService`: catch param as `unknown`; narrow with `instanceof Error` before using `.message`.
  - `utils/similarity`: annotate `new Array<number>(m + 1)` as `number[]`.

<sup>Written for commit d471fe627b29bd1ef5448b4937b5d84eb5f626fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

