### PR TITLE
chore(lint): keep no-unsafe at warn pending type-aware ci lint (#1378)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -132,13 +132,17 @@ export default [
             "no-unused-vars": "off",
             "no-empty": ["warn", { allowEmptyCatch: false }],
             "@typescript-eslint/no-non-null-assertion": "warn",
-            // Promoted to error: the no-unsafe-* inventory is cleaned (#1378),
-            // so these are now regression guards rather than ratchet warnings.
-            "@typescript-eslint/no-unsafe-assignment": "error",
-            "@typescript-eslint/no-unsafe-call": "error",
-            "@typescript-eslint/no-unsafe-member-access": "error",
-            "@typescript-eslint/no-unsafe-return": "error",
-            "@typescript-eslint/no-unsafe-argument": "error",
+            // NOTE: the no-unsafe-* inventory is cleaned to 0 (#1378), but these
+            // stay at `warn` until the CI `quality / Lint` job is type-aware.
+            // That job runs `eslint .` without `db:generate` / `build:shared`,
+            // so these type-aware rules report ~4200 phantom "type could not be
+            // resolved" errors there; promoting to `error` turns the job
+            // permanently red. Promotion is gated on #1386.
+            "@typescript-eslint/no-unsafe-assignment": "warn",
+            "@typescript-eslint/no-unsafe-call": "warn",
+            "@typescript-eslint/no-unsafe-member-access": "warn",
+            "@typescript-eslint/no-unsafe-return": "warn",
+            "@typescript-eslint/no-unsafe-argument": "warn",
             "@typescript-eslint/no-explicit-any": "warn",
             // Honor the same ^_ ignore convention as the per-package block
             // (line ~52): without these options the root-cwd lint flags

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -132,7 +132,7 @@ export default [
             "no-unused-vars": "off",
             "no-empty": ["warn", { allowEmptyCatch: false }],
             "@typescript-eslint/no-non-null-assertion": "warn",
-            // NOTE: the no-unsafe-* inventory is cleaned to 0 (#1378), but these
+            // NOTE: the no-unsafe-* inventory is cleaned to 0 (#1382/#1384/#1385), but these
             // stay at `warn` until the CI `quality / Lint` job is type-aware.
             // That job runs `eslint .` without `db:generate` / `build:shared`,
             // so these type-aware rules report ~4200 phantom "type could not be


### PR DESCRIPTION
Fast follow-up to #1385.

#1385 auto-merged on its **promotion** commit before the revert push landed, so `main` shipped the five `no-unsafe-*` rules at `error` in the bot/shared ratchet block. The CI **`quality / Lint`** job runs `eslint .` **without `db:generate` / `build:shared`**, so those **type-aware** rules emit ~4200 phantom *"type could not be resolved"* / *"error typed"* diagnostics across untouched files — making that (non-required) job permanently red.

This sets the five rules back to **`warn`**. The inventory is still 0 (the #1382/#1384/#1385 fixes stand); only the enforcement is deferred. Promotion is gated on **#1386** (make CI lint type-aware: run the Prisma/shared codegen before `eslint .`).

Note: `quality / Lint` is not a required check, so `main` still merges/deploys fine — this just restores a green lint signal. Syntactic rules (`import-x/no-duplicates`, etc.) are unaffected and remain at `error`.

## Validation
- root lint (typed env) exit 0
- only `eslint.config.js` changed (5 rules `error` → `warn`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the five `@typescript-eslint` `no-unsafe-*` rules back to `warn` in `eslint.config.js` to avoid false type errors when CI runs `eslint .` without codegen, keeping the `quality / Lint` job green until linting is type-aware. Also updated the inline comment to cite the actual cleanup PRs (#1382/#1384/#1385) and note that promotion to `error` is gated on #1386.

<sup>Written for commit a1e71a6b0c76f03684afb36cd359323942677cdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Adjusted linting configuration to downgrade specific TypeScript type-safety rule severities from errors to warnings. These remain as ratchet warnings pending alignment with CI lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->