### PR TITLE
fix(bot): thread real Client into endGiveaway (#1383)

### DIFF
--- a/packages/bot/src/functions/general/commands/giveaway.ts
+++ b/packages/bot/src/functions/general/commands/giveaway.ts
@@ -61,17 +61,6 @@ async function endGiveaway(
 
     if (!giveaway) return
 
-    if (!client) {
-        try {
-            // NOTE: this fallback path is currently broken — `../../../client`
-            // resolves to a non-existent module, so the require throws and the
-            // catch returns. Tracked in #1383. Cast keeps the type honest.
-            client = (require('../../../client') as { default: Client }).default
-        } catch {
-            return
-        }
-    }
-
     if (!client) return
     const guild = client.guilds.cache.get(giveaway.guildId)
     if (!guild) return
@@ -270,7 +259,7 @@ export default new Command({
                     endTime,
                     entries: new Set(),
                     timeoutId: setTimeout(() => {
-                        endGiveaway(message.id)
+                        endGiveaway(message.id, false, interaction.client)
                     }, durationMs),
                 }
 
@@ -310,7 +299,7 @@ export default new Command({
                     return
                 }
 
-                await endGiveaway(messageId)
+                await endGiveaway(messageId, false, interaction.client)
 
                 await interactionReply({
                     interaction,
@@ -346,7 +335,7 @@ export default new Command({
                     return
                 }
 
-                await endGiveaway(messageId, true)
+                await endGiveaway(messageId, true, interaction.client)
 
                 await interactionReply({
                     interaction,


### PR DESCRIPTION
## Root Cause
`endGiveaway` in `packages/bot/src/functions/general/commands/giveaway.ts` had a broken fallback path that attempted to require a non-existent client module at `../../../client` when no client argument was provided. The require would throw, the surrounding try/catch would suppress the error, and the function would return early without processing giveaway completion or rerolls.

All three call sites omitted the client argument, so winner selection and announcement never ran.

## Fix
Thread the real `Client` instance from each call site to `endGiveaway`:
- **Line 273 (setTimeout completion):** Pass `interaction.client` from the surrounding command handler
- **Line 313 (manual end):** Pass `interaction.client` from the 'end' subcommand handler
- **Line 349 (reroll):** Pass `interaction.client` from the 'reroll' subcommand handler

Removed the broken fallback require entirely since all call sites now supply a client.

## Verification
- ✅ `npm run build --workspace=packages/bot` — compiles successfully
- ✅ `npm run lint --workspace=packages/bot` — no unsafe/require warnings on giveaway.ts; only pre-existing complexity warning remains
- ✅ No breaking changes; purely fixes silent failure mode

Closes #1383

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes giveaways not completing or rerolling by passing the real Discord `Client` into `endGiveaway`. Removes a broken fallback that suppressed errors and returned early.

- **Bug Fixes**
  - Pass `interaction.client` to `endGiveaway` for timeout completion, manual end, and reroll.
  - Remove the `require('../../../client')` fallback since all call sites now supply a client.

<sup>Written for commit 25bcf630469232a5f0afcf2b376b165d7a93e956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

