### PR TITLE
feat(bot): instrument serversetup criativaria invocations (#1288)

### DIFF
--- a/packages/bot/src/functions/management/commands/serversetup.spec.ts
+++ b/packages/bot/src/functions/management/commands/serversetup.spec.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import serversetupCommand from './serversetup'
 import { interactionReply } from '../../../utils/general/interactionReply'
+import { infoLog } from '@lucky/shared/utils'
+import { guildAutomationUsageTotal } from '../../../utils/monitoring/prometheus'
 import {
     formatCriativariaSummary,
     resolveSetupMode,
@@ -117,6 +119,22 @@ describe('serversetup command', () => {
         expect(formatCriativariaSummary).toHaveBeenCalled()
         expect(interaction.editReply).toHaveBeenCalledWith('summary output')
         expect(interactionReply).not.toHaveBeenCalled()
+
+        // Guards the demand-measurement telemetry (#1288): if the instrumentation
+        // is removed, these assertions fail rather than passing silently.
+        expect(guildAutomationUsageTotal.inc).toHaveBeenCalledWith({
+            operation: 'criativaria',
+        })
+        expect(infoLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'serversetup: criativaria invoked',
+                data: expect.objectContaining({
+                    guildId: '895505900016631839',
+                    userId: '123456789',
+                    mode: 'dry-run',
+                }),
+            }),
+        )
     })
 
     it('returns terminal error reply when criativaria setup fails after defer', async () => {

--- a/packages/bot/src/functions/management/commands/serversetup.spec.ts
+++ b/packages/bot/src/functions/management/commands/serversetup.spec.ts
@@ -16,6 +16,12 @@ jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
 }))
 
+jest.mock('../../../utils/monitoring/prometheus', () => ({
+    guildAutomationUsageTotal: {
+        inc: jest.fn(),
+    },
+}))
+
 jest.mock('./helpers/serversetupCriativaria', () => ({
     resolveSetupMode: jest.fn(),
     runCriativariaSetup: jest.fn(),
@@ -35,6 +41,9 @@ function createInteraction(options: {
                       id: '895505900016631839',
                       name: 'Criativaria',
                   },
+        user: {
+            id: '123456789',
+        },
         options: {
             getString: jest.fn((name: string, required?: boolean) => {
                 if (name === 'template') {

--- a/packages/bot/src/functions/management/commands/serversetup.ts
+++ b/packages/bot/src/functions/management/commands/serversetup.ts
@@ -14,6 +14,7 @@ import {
 import Command from '../../../models/Command.js'
 import { infoLog, errorLog } from '@lucky/shared/utils'
 import { interactionReply } from '../../../utils/general/interactionReply.js'
+import { guildAutomationUsageTotal } from '../../../utils/monitoring/prometheus.js'
 import {
     formatCriativariaSummary,
     resolveSetupMode,
@@ -302,6 +303,17 @@ export default new Command({
         const mode = resolveSetupMode(interaction.options.getString('mode'))
 
         if (template === 'criativaria') {
+            // Telemetry: track invocation of criativaria command for demand measurement
+            infoLog({
+                message: 'serversetup: criativaria invoked',
+                data: {
+                    guildId: interaction.guild.id,
+                    userId: interaction.user.id,
+                    mode,
+                },
+            })
+            guildAutomationUsageTotal.inc({ operation: 'criativaria' })
+
             await interaction.deferReply({ flags: MessageFlags.Ephemeral })
             try {
                 const result = await runCriativariaSetup(


### PR DESCRIPTION
## Summary

Add lightweight invocation telemetry for the deprecated `/serversetup criativaria` command to satisfy the demand-measurement rule (see ADR 2026-06-01-remove-criativaria-baseline and issue #1288).

## Implementation

- **Prometheus counter:** increments `lucky_guild_automation_usage_total` with label `operation="criativaria"` at invocation time
- **Structured log:** emits `infoLog()` with `message='serversetup: criativaria invoked'` and contextual data (`guildId`, `userId`, `mode`)
- **Location:** `packages/bot/src/functions/management/commands/serversetup.ts:304–315` (immediately after the `criativaria` template branch is selected)
- **Tests:** updated `serversetup.spec.ts` to mock the counter and user object; all tests pass

## Acceptance criteria (this PR)

- [x] Usage measured via invocation signal (telemetry + logs for `/serversetup criativaria` calls)
- [x] No behavior changes to the 907-LOC helper; deletion decision explicitly deferred
- [x] Surgical changes only; no refactoring of `serversetupCriativaria.ts`
- [x] Build, lint, and test suite pass
- [x] Conventional commit; no AI attribution

## Next steps

This instruments invocation count only. The remove-vs-keep decision on #1288 is deferred until usage data accrues over time. 

Refs #1288

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add lightweight telemetry for the deprecated `/serversetup criativaria` command to measure demand and inform #1288. No behavior changes.

- **New Features**
  - Increment Prometheus counter `lucky_guild_automation_usage_total` via `guildAutomationUsageTotal.inc({ operation: 'criativaria' })`.
  - Emit `infoLog` from `@lucky/shared/utils` with message `serversetup: criativaria invoked` and data `guildId`, `userId`, and `mode`.
  - Tests mock `guildAutomationUsageTotal` and `infoLog` and assert both signals on invocation.

<sup>Written for commit a05e01579e26ba0713f1368f0ffe3380b4a57b6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced server setup test isolation with improved mocking and consistent test data structures to ensure reliable test execution.

* **Chores**
  * Added monitoring and logging to track template configuration usage, providing better insights into feature adoption patterns and usage analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->