### PR TITLE
chore(lint): assertDefined non-null cleanup — music commands + shared services (#1378)

### DIFF
--- a/packages/bot/src/functions/music/commands/album.ts
+++ b/packages/bot/src/functions/music/commands/album.ts
@@ -17,6 +17,7 @@ import {
 import { interactionReply } from '../../../utils/general/interactionReply'
 import { errorLog } from '@lucky/shared/utils'
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
+import { assertDefined } from '@lucky/shared/utils/guards'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 import { featureToggleService } from '@lucky/shared/services'
 import { isUnknownInteractionError } from './play/queryUtils'
@@ -92,7 +93,7 @@ export default new Command({
         if (!(await requireVoiceChannel(interaction))) return
         if (!(await requireDJRole(interaction, interaction.guildId))) return
 
-        const voiceChannel = member.voice.channel!
+        const voiceChannel = assertDefined(member.voice.channel, 'voice channel present after requireVoiceChannel guard')
         const query = interaction.options.getString('query', true)
         const artistFilter = interaction.options.getString('artist')
 

--- a/packages/bot/src/functions/music/commands/artist.ts
+++ b/packages/bot/src/functions/music/commands/artist.ts
@@ -17,6 +17,7 @@ import {
 import { interactionReply } from '../../../utils/general/interactionReply'
 import { errorLog } from '@lucky/shared/utils'
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
+import { assertDefined } from '@lucky/shared/utils/guards'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 import { featureToggleService } from '@lucky/shared/services'
 import { isUnknownInteractionError } from './play/queryUtils'
@@ -88,7 +89,7 @@ export default new Command({
         if (!(await requireVoiceChannel(interaction))) return
         if (!(await requireDJRole(interaction, interaction.guildId))) return
 
-        const voiceChannel = member.voice.channel!
+        const voiceChannel = assertDefined(member.voice.channel, 'voice channel present after requireVoiceChannel guard')
         const artistName = interaction.options.getString('name', true)
         const limit = interaction.options.getInteger('limit') ?? DEFAULT_LIMIT
 

--- a/packages/bot/src/functions/music/commands/effects.ts
+++ b/packages/bot/src/functions/music/commands/effects.ts
@@ -128,11 +128,11 @@ export default new Command({
 
         if (subcommand === 'bassboost') {
             const level = interaction.options.getInteger('level', true)
-            await handleBassBoost(queue!, level, interaction)
+            await handleBassBoost(assertDefined(queue, 'queue present after requireQueue guard'), level, interaction)
         } else if (subcommand === 'nightcore') {
-            await handleNightcore(queue!, interaction)
+            await handleNightcore(assertDefined(queue, 'queue present after requireQueue guard'), interaction)
         } else if (subcommand === 'reset') {
-            await handleReset(queue!, interaction)
+            await handleReset(assertDefined(queue, 'queue present after requireQueue guard'), interaction)
         }
     },
 })

--- a/packages/bot/src/functions/music/commands/leavecleanup.ts
+++ b/packages/bot/src/functions/music/commands/leavecleanup.ts
@@ -77,6 +77,6 @@ export default new Command({
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
         if (!(await requireQueue(queue, interaction))) return
 
-        await cleanupTracksFromLeftMembers(queue!, interaction)
+        await cleanupTracksFromLeftMembers(assertDefined(queue, 'queue present after requireQueue guard'), interaction)
     },
 })

--- a/packages/bot/src/functions/music/commands/play/index.ts
+++ b/packages/bot/src/functions/music/commands/play/index.ts
@@ -6,6 +6,7 @@ import {
 import type { CommandExecuteParams } from '../../../../types/CommandData'
 import Command from '../../../../models/Command'
 import { executePlayHandler } from './handlers/playHandler'
+import { assertDefined } from '@lucky/shared/utils/guards'
 
 export default new Command({
     data: new SlashCommandBuilder()
@@ -60,7 +61,7 @@ export default new Command({
         if (
             !(await requireDJRole(
                 params.interaction,
-                params.interaction.guildId!,
+                assertDefined(params.interaction.guildId, 'guildId guaranteed by preceding guard'),
             ))
         )
             return

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -16,6 +16,7 @@ import { interactionReply } from '../../../../utils/general/interactionReply'
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
 import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
 import { withTimeout } from '@lucky/shared/utils/async'
+import { assertDefined } from '@lucky/shared/utils/guards'
 
 export const DISCORD_UNKNOWN_INTERACTION_CODE = 10062
 
@@ -176,7 +177,7 @@ export async function executePlayAtTop({
     if (!(await requireVoiceChannel(interaction))) return
     if (!(await requireDJRole(interaction, interaction.guildId))) return
 
-    const voiceChannel = member.voice.channel!
+    const voiceChannel = assertDefined(member.voice.channel, 'voice channel present after requireVoiceChannel guard')
 
     try {
         await interaction.deferReply()

--- a/packages/bot/src/functions/music/commands/shuffle.ts
+++ b/packages/bot/src/functions/music/commands/shuffle.ts
@@ -12,6 +12,7 @@ import type { CommandExecuteParams } from '../../../types/CommandData'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 import { smartShuffle } from '../../../utils/music/queue/smartShuffle'
 import { parseIntEnv } from '@lucky/shared/utils/env'
+import { assertDefined } from '@lucky/shared/utils/guards'
 
 const STREAK_LIMIT = parseIntEnv('SMART_SHUFFLE_STREAK_LIMIT', 2)
 
@@ -58,11 +59,11 @@ export default new Command({
         const subcommand = interaction.options.getSubcommand(false) ?? 'random'
 
         if (subcommand === 'smart') {
-            const tracks = queue!.tracks.toArray()
+            const tracks = assertDefined(queue, 'queue present after requireQueue guard').tracks.toArray()
             const shuffled = smartShuffle(tracks, { streakLimit: STREAK_LIMIT })
-            queue!.tracks.clear()
+            assertDefined(queue, 'queue present after requireQueue guard').tracks.clear()
             for (const track of shuffled) {
-                queue!.tracks.add(track)
+                assertDefined(queue, 'queue present after requireQueue guard').tracks.add(track)
             }
             await interactionReply({
                 interaction,

--- a/packages/bot/src/functions/music/commands/skip.ts
+++ b/packages/bot/src/functions/music/commands/skip.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import { debugLog, errorLog } from '@lucky/shared/utils'
+import { assertDefined } from '@lucky/shared/utils/guards'
 import Command from '../../../models/Command'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import {
@@ -116,7 +117,7 @@ export default new Command({
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
         if (!(await requireGuild(interaction))) return
-        if (!(await requireDJRole(interaction, interaction.guildId!))) return
+        if (!(await requireDJRole(interaction, assertDefined(interaction.guildId, 'guildId guaranteed by requireGuild guard')))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 

--- a/packages/bot/src/functions/music/commands/skipto.ts
+++ b/packages/bot/src/functions/music/commands/skipto.ts
@@ -3,10 +3,12 @@ import Command from '../../../models/Command'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import type { CommandExecuteParams } from '../../../types/CommandData'
 import {
+    requireGuild,
     requireQueue,
     requireVoiceChannel,
     requireDJRole,
 } from '../../../utils/command/commandValidations'
+import { assertDefined } from '@lucky/shared/utils/guards'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
 import {
     createSuccessEmbed,
@@ -27,8 +29,9 @@ export default new Command({
         ),
     category: 'music',
     execute: async ({ client, interaction }: CommandExecuteParams) => {
+        if (!(await requireGuild(interaction))) return
         if (!(await requireVoiceChannel(interaction))) return
-        if (!(await requireDJRole(interaction, interaction.guildId!))) return
+        if (!(await requireDJRole(interaction, assertDefined(interaction.guildId, 'guildId guaranteed by requireGuild guard')))) return
 
         const { queue } = resolveGuildQueue(client, interaction.guildId ?? '')
 

--- a/packages/bot/src/functions/music/commands/songinfo.ts
+++ b/packages/bot/src/functions/music/commands/songinfo.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import Command from '../../../models/Command'
+import { assertDefined } from '@lucky/shared/utils/guards'
 import { interactionReply } from "../../../utils/general/interactionReply"
 import { buildTrackEmbed, trackToData } from '../../../utils/general/responseEmbeds'
 import type { CommandExecuteParams } from "../../../types/CommandData"
@@ -23,7 +24,7 @@ export default new Command({
         if (!(await requireQueue(queue, interaction))) return
         if (!(await requireCurrentTrack(queue, interaction))) return
 
-        const trackData = trackToData(track!)
+        const trackData = trackToData(assertDefined(track, 'track present after requireCurrentTrack guard'))
         const embed = buildTrackEmbed(trackData, 'playing', {
             tag: interaction.user.username,
             displayAvatarURL: interaction.user.displayAvatarURL,

--- a/packages/bot/src/handlers/musicButtonHandler.ts
+++ b/packages/bot/src/handlers/musicButtonHandler.ts
@@ -45,7 +45,7 @@ export async function handleMusicButtonInteraction(
 
         const { queue, source, diagnostics } = resolveGuildQueue(
             interaction.client as unknown as Pick<CustomClient, 'player'>,
-            interaction.guildId!,
+            interaction.guildId ?? '',
         )
         if (!queue) {
             debugLog({

--- a/packages/bot/src/services/musicRecommendation/feedbackService.ts
+++ b/packages/bot/src/services/musicRecommendation/feedbackService.ts
@@ -1,5 +1,6 @@
 import { errorLog, getPrismaClient } from '@lucky/shared/utils'
 import { parseIntEnv } from '@lucky/shared/utils/env'
+import { assertDefined } from '@lucky/shared/utils/guards'
 import { cleanAuthor } from '../../utils/music/searchQueryCleaner'
 
 export type RecommendationFeedback = 'like' | 'dislike'
@@ -421,7 +422,7 @@ export class RecommendationFeedbackService {
         if (!this.implicitFeedbackCache.has(userId)) {
             this.implicitFeedbackCache.set(userId, {})
         }
-        return this.implicitFeedbackCache.get(userId)!
+        return assertDefined(this.implicitFeedbackCache.get(userId), 'Map entry present after .has() and .set() guards')
     }
 
     async recordImplicitFeedback(

--- a/packages/bot/src/utils/music/candidateFallback.ts
+++ b/packages/bot/src/utils/music/candidateFallback.ts
@@ -1,6 +1,7 @@
 import { QueryType, type Track, type GuildQueue } from 'discord-player'
 import type { User } from 'discord.js'
 import { logAndSwallow } from '@lucky/shared/utils/error'
+import { assertDefined } from '@lucky/shared/utils/guards'
 import {
     getBatchAudioFeatures,
     getArtistGenres,
@@ -318,7 +319,7 @@ export function interleaveByArtist(tracks: ScoredTrack[]): ScoredTrack[] {
         added = false
         for (const group of groups.values()) {
             if (round < group.length) {
-                result.push(group[round]!)
+                result.push(assertDefined(group[round], 'element present after length check'))
                 added = true
             }
         }

--- a/packages/bot/src/utils/music/voteSkipStore.ts
+++ b/packages/bot/src/utils/music/voteSkipStore.ts
@@ -1,10 +1,12 @@
+import { assertDefined } from '@lucky/shared/utils/guards'
+
 const activeVotes = new Map<string, Set<string>>()
 
 export function addVote(guildId: string, userId: string): Set<string> {
     if (!activeVotes.has(guildId)) {
         activeVotes.set(guildId, new Set())
     }
-    const votes = activeVotes.get(guildId)!
+    const votes = assertDefined(activeVotes.get(guildId), 'Set present after .has() and .set() guards')
     votes.add(userId)
     return votes
 }

--- a/packages/shared/src/config/environment.ts
+++ b/packages/shared/src/config/environment.ts
@@ -2,6 +2,7 @@ import { config } from 'dotenv'
 import { setLogLevel, debugLog } from '../utils/general/log'
 import { setEnvironmentLoaded } from './config'
 import { parseIntEnv } from '../utils/env'
+import { assertDefined } from '../utils/guards.js'
 import path from 'path'
 import fs from 'fs'
 
@@ -226,11 +227,11 @@ async function loadInfisicalSecrets(): Promise<void> {
         const siteUrl = process.env.INFISICAL_SITE_URL
         const client = new InfisicalSDK(siteUrl ? { siteUrl } : undefined)
         await client.auth().universalAuth.login({
-            clientId: process.env.INFISICAL_CLIENT_ID!,
-            clientSecret: process.env.INFISICAL_CLIENT_SECRET!,
+            clientId: assertDefined(process.env.INFISICAL_CLIENT_ID, 'INFISICAL_CLIENT_ID required when isInfisicalConfigured'),
+            clientSecret: assertDefined(process.env.INFISICAL_CLIENT_SECRET, 'INFISICAL_CLIENT_SECRET required when isInfisicalConfigured'),
         })
-        const projectId = process.env.INFISICAL_PROJECT_ID!
-        const environment = process.env.INFISICAL_ENV!
+        const projectId = assertDefined(process.env.INFISICAL_PROJECT_ID, 'INFISICAL_PROJECT_ID required when isInfisicalConfigured')
+        const environment = assertDefined(process.env.INFISICAL_ENV, 'INFISICAL_ENV required when isInfisicalConfigured')
         const secretPath = process.env.INFISICAL_SECRET_PATH ?? '/'
         const response = (await client.secrets().listSecrets({
             projectId,

--- a/packages/shared/src/services/AutoMessageService.ts
+++ b/packages/shared/src/services/AutoMessageService.ts
@@ -1,6 +1,7 @@
 import { getPrismaClient } from '../utils/database/prismaClient.js'
 import { Prisma } from '../generated/prisma/client.js'
 import type { EmbedData } from './embedValidation.js'
+import { assertDefined } from '../utils/guards.js'
 
 const prisma = getPrismaClient()
 
@@ -208,17 +209,17 @@ export class AutoMessageService {
         if (data.guild || data.server) {
             const guildData = data.guild || data.server
             result = result
-                .replace(/{guild}/g, guildData!.name)
-                .replace(/{guild\.name}/g, guildData!.name)
+                .replace(/{guild}/g, assertDefined(guildData, 'guildData present after guard').name)
+                .replace(/{guild\.name}/g, assertDefined(guildData, 'guildData present after guard').name)
                 .replace(
                     /{guild\.memberCount}/g,
-                    String(guildData!.memberCount),
+                    String(assertDefined(guildData, 'guildData present after guard').memberCount),
                 )
-                .replace(/{server}/g, guildData!.name)
-                .replace(/{server\.name}/g, guildData!.name)
+                .replace(/{server}/g, assertDefined(guildData, 'guildData present after guard').name)
+                .replace(/{server\.name}/g, assertDefined(guildData, 'guildData present after guard').name)
                 .replace(
                     /{server\.memberCount}/g,
-                    String(guildData!.memberCount),
+                    String(assertDefined(guildData, 'guildData present after guard').memberCount),
                 )
         }
 

--- a/packages/shared/src/services/music/MusicControlService.ts
+++ b/packages/shared/src/services/music/MusicControlService.ts
@@ -2,6 +2,7 @@ import RedisClientClass, { type Redis } from 'ioredis'
 import { randomUUID } from 'crypto'
 import { createRedisConfig } from '../redis/config.js'
 import { debugLog, errorLog, infoLog } from '../../utils/general/log.js'
+import { assertDefined } from '../../utils/guards.js'
 import {
     CHANNEL_COMMAND,
     CHANNEL_STATE,
@@ -82,7 +83,10 @@ export class MusicControlService {
 
             this.pendingResults.set(cmd.id, { resolve, timeout })
 
-            this.publisher!.publish(CHANNEL_COMMAND, JSON.stringify(cmd)).catch(
+            assertDefined(
+                this.publisher,
+                'publisher ready — guaranteed by isHealthy() guard',
+            ).publish(CHANNEL_COMMAND, JSON.stringify(cmd)).catch(
                 (err: unknown) => {
                     this.pendingResults.delete(cmd.id)
                     clearTimeout(timeout)


### PR DESCRIPTION
Part of #1378 (follow-up to #1391). Clears the remaining **29** `@typescript-eslint/no-non-null-assertion` sites across bot + shared → **0 repo-wide**.

## Changes
Each `expr!` replaced with `assertDefined(expr, '<reason> — guaranteed by <guard>')` from `@lucky/shared/utils/guards` (submodule path; barrel untouched), where a preceding guard already guarantees non-nullness:
- **Music commands:** album, artist, effects, leavecleanup, play/index, play/queryUtils, shuffle, skip, songinfo (behind `requireQueue` / `requireVoiceChannel` / `requireCurrentTrack` / explicit guards).
- **Bot utils/services:** candidateFallback, voteSkipStore, feedbackService (Map `.get()` after `.has()`).
- **Shared:** `AutoMessageService` (×6), `environment.ts` Infisical block (×4, behind the `isInfisicalConfigured()` early-return that verifies all 4 vars), `MusicControlService` publisher (behind `isHealthy()`).

### 2 latent-bug guard hardenings (same class CodeRabbit flagged on stop.ts in #1391)
- **`skipto.ts`** — was an **unguarded** `interaction.guildId!` (would throw in a non-guild context). Added `requireGuild` precondition before `requireDJRole`, then `assertDefined` — matches the merged skip.ts/stop.ts pattern.
- **`musicButtonHandler.ts`** — `interaction.guildId!` → `interaction.guildId ?? ''` (voice-channel check guarantees guild; matches the `resolveGuildQueue` call convention with its graceful no-queue path).

## Verification (local, post-rebase onto #1392)
- eslint `no-non-null-assertion`: **0** across `packages/bot/src` + `packages/shared/src`
- `build:shared`: clean
- **shared 818/818**, **bot 2537 passed** (6 skipped) — no failures, no import.meta/barrel regressions

Follow-up (separate PR): promote `no-unsafe-* warn → error` now that #1392 gives CI lint type info and these warnings are cleared.

@cubic-dev-ai @coderabbitai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all remaining non‑null assertions with `assertDefined` to satisfy `@typescript-eslint/no-non-null-assertion` and improve guard-based safety. Also tightened guild checks to prevent edge-case crashes; completes the cleanup tracked in #1378.

- **Refactors**
  - Replaced `x!` with `assertDefined(x, 'reason')` from `@lucky/shared/utils/guards` where prior guards ensure non-null (queues, voice channels, tracks, Map/Set entries).
  - Touched music commands (`album`, `artist`, `play`, `effects`, `shuffle`, `skip`, `songinfo`, `leavecleanup`), utils/services (`candidateFallback`, `voteSkipStore`, `feedbackService`), and shared (`environment` Infisical block, `AutoMessageService`, `MusicControlService` publisher).

- **Bug Fixes**
  - `skipto`: add `requireGuild` before `requireDJRole`; assert `interaction.guildId`.
  - `musicButtonHandler`: use `interaction.guildId ?? ''` when calling `resolveGuildQueue` for a graceful no-queue path.

<sup>Written for commit f7dd0ea27dd801dc70b6147ccca3619929ca0c25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

