### PR TITLE
fix(twitch): sync bot EventSub on web add/remove via Redis pub/sub (#870)

### DIFF
--- a/packages/backend/src/routes/twitch.ts
+++ b/packages/backend/src/routes/twitch.ts
@@ -4,7 +4,7 @@ import { validateBody, validateParams } from '../middleware/validate'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { managementSchemas as s } from '../schemas/management'
-import { twitchNotificationService } from '@lucky/shared/services'
+import { twitchNotificationService, twitchControlService } from '@lucky/shared/services'
 import { warnLog } from '@lucky/shared/utils'
 import { AppError } from '../errors/AppError'
 import { z } from 'zod'
@@ -117,6 +117,8 @@ async function lookupTwitchUser(
 }
 
 export function setupTwitchRoutes(app: Express): void {
+    void twitchControlService.connect()
+
     app.get(
         '/api/twitch/status',
         asyncHandler(async (_req: Request, res: Response) => {
@@ -189,6 +191,9 @@ export function setupTwitchRoutes(app: Express): void {
                 twitchUserId,
                 twitchLogin,
             )
+            if (success) {
+                twitchControlService.publishRefresh()
+            }
             res.json({ success })
         }),
     )
@@ -206,6 +211,9 @@ export function setupTwitchRoutes(app: Express): void {
                 guildId,
                 twitchUserId,
             )
+            if (success) {
+                twitchControlService.publishRefresh()
+            }
             res.json({ success })
         }),
     )

--- a/packages/backend/src/routes/twitch.ts
+++ b/packages/backend/src/routes/twitch.ts
@@ -4,7 +4,10 @@ import { validateBody, validateParams } from '../middleware/validate'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { managementSchemas as s } from '../schemas/management'
-import { twitchNotificationService, twitchControlService } from '@lucky/shared/services'
+import {
+    twitchNotificationService,
+    twitchControlService,
+} from '@lucky/shared/services'
 import { warnLog } from '@lucky/shared/utils'
 import { AppError } from '../errors/AppError'
 import { z } from 'zod'
@@ -153,7 +156,10 @@ export function setupTwitchRoutes(app: Express): void {
                     displayName: user.display_name,
                 })
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'TimeoutError') {
+                if (
+                    error instanceof DOMException &&
+                    error.name === 'TimeoutError'
+                ) {
                     throw AppError.gatewayTimeout(
                         'Twitch API request timed out, please try again',
                     )

--- a/packages/backend/tests/integration/routes/twitch.test.ts
+++ b/packages/backend/tests/integration/routes/twitch.test.ts
@@ -16,12 +16,17 @@ jest.mock('../../../src/services/SessionService', () => ({
 const mockListByGuild = jest.fn<any>()
 const mockAdd = jest.fn<any>()
 const mockRemove = jest.fn<any>()
+const mockPublishRefresh = jest.fn<any>()
 
 jest.mock('@lucky/shared/services', () => ({
     twitchNotificationService: {
         listByGuild: (...args: any[]) => mockListByGuild(...args),
         add: (...args: any[]) => mockAdd(...args),
         remove: (...args: any[]) => mockRemove(...args),
+    },
+    twitchControlService: {
+        connect: jest.fn(),
+        publishRefresh: (...args: any[]) => mockPublishRefresh(...args),
     },
 }))
 

--- a/packages/backend/tests/unit/routes/twitch.test.ts
+++ b/packages/backend/tests/unit/routes/twitch.test.ts
@@ -15,6 +15,10 @@ jest.mock('@lucky/shared/services', () => ({
         add: jest.fn(),
         remove: jest.fn(),
     },
+    twitchControlService: {
+        connect: jest.fn(),
+        publishRefresh: jest.fn(),
+    },
 }))
 
 // Mock auth middleware

--- a/packages/bot/src/twitch/index.ts
+++ b/packages/bot/src/twitch/index.ts
@@ -1,6 +1,9 @@
 import type { Client } from 'discord.js'
 import { infoLog } from '@lucky/shared/utils'
-import { featureToggleService, twitchControlService } from '@lucky/shared/services'
+import {
+    featureToggleService,
+    twitchControlService,
+} from '@lucky/shared/services'
 import { isTwitchConfigured } from './token'
 import { twitchEventSubClient } from './eventsubClient'
 

--- a/packages/bot/src/twitch/index.ts
+++ b/packages/bot/src/twitch/index.ts
@@ -1,6 +1,6 @@
 import type { Client } from 'discord.js'
 import { infoLog } from '@lucky/shared/utils'
-import { featureToggleService } from '@lucky/shared/services'
+import { featureToggleService, twitchControlService } from '@lucky/shared/services'
 import { isTwitchConfigured } from './token'
 import { twitchEventSubClient } from './eventsubClient'
 
@@ -12,6 +12,11 @@ export async function startTwitchService(client: Client): Promise<void> {
     try {
         await twitchEventSubClient.start(client)
         infoLog({ message: 'Twitch EventSub service started' })
+
+        await twitchControlService.connect()
+        await twitchControlService.onRefresh(() => {
+            void refreshTwitchSubscriptions()
+        })
     } catch (err) {
         infoLog({
             message: 'Twitch EventSub service failed to start (non-fatal)',

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -30,6 +30,11 @@ export {
     validateEmbedData,
 } from './embedValidation.js'
 export { twitchNotificationService } from './TwitchNotificationService'
+export {
+	TwitchControlService,
+	twitchControlService,
+	CHANNEL_TWITCH_REFRESH,
+} from './twitch/TwitchControlService.js'
 export { lastFmLinkService, type LastFmLinkRow } from './LastFmLinkService'
 export { spotifyLinkService, type SpotifyLinkRow } from './SpotifyLinkService'
 export {

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -31,9 +31,9 @@ export {
 } from './embedValidation.js'
 export { twitchNotificationService } from './TwitchNotificationService'
 export {
-	TwitchControlService,
-	twitchControlService,
-	CHANNEL_TWITCH_REFRESH,
+    TwitchControlService,
+    twitchControlService,
+    CHANNEL_TWITCH_REFRESH,
 } from './twitch/TwitchControlService.js'
 export { lastFmLinkService, type LastFmLinkRow } from './LastFmLinkService'
 export { spotifyLinkService, type SpotifyLinkRow } from './SpotifyLinkService'

--- a/packages/shared/src/services/twitch/TwitchControlService.spec.ts
+++ b/packages/shared/src/services/twitch/TwitchControlService.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, jest } from '@jest/globals'
+
+jest.mock('../../utils/general/log.js', () => ({
+    debugLog: jest.fn(),
+    errorLog: jest.fn(),
+    infoLog: jest.fn(),
+}))
+
+jest.mock('ioredis', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}))
+
+import {
+    TwitchControlService,
+    CHANNEL_TWITCH_REFRESH,
+} from './TwitchControlService.js'
+
+type PublishFn = (channel: string, message: string) => Promise<number>
+type SubscribeFn = (channel: string) => Promise<unknown>
+type MessageListener = (channel: string, message: string) => void
+type OnFn = (event: string, listener: MessageListener) => void
+
+type PublisherMock = { status: string; publish: jest.Mock<PublishFn> }
+type SubscriberMock = {
+    status: string
+    subscribe: jest.Mock<SubscribeFn>
+    on: jest.Mock<OnFn>
+}
+type WithClients = {
+    publisher: PublisherMock | null
+    subscriber: SubscriberMock | null
+}
+
+function makePublisher(): PublisherMock {
+    return { status: 'ready', publish: jest.fn<PublishFn>() }
+}
+
+function makeSubscriber(): SubscriberMock {
+    return {
+        status: 'ready',
+        subscribe: jest.fn<SubscribeFn>(() => Promise.resolve()),
+        on: jest.fn<OnFn>(),
+    }
+}
+
+describe('TwitchControlService health', () => {
+    it('is unhealthy before connect()', () => {
+        expect(new TwitchControlService().isHealthy()).toBe(false)
+    })
+
+    it('is healthy only when both clients are ready', () => {
+        const service = new TwitchControlService()
+        const internals = service as unknown as WithClients
+
+        const publisher = makePublisher()
+        const subscriber = makeSubscriber()
+        subscriber.status = 'reconnecting'
+        internals.publisher = publisher
+        internals.subscriber = subscriber
+        expect(service.isHealthy()).toBe(false)
+
+        subscriber.status = 'ready'
+        expect(service.isHealthy()).toBe(true)
+    })
+})
+
+describe('TwitchControlService.publishRefresh', () => {
+    it('does nothing and does not throw when not connected', () => {
+        const service = new TwitchControlService()
+        expect(() => service.publishRefresh()).not.toThrow()
+    })
+
+    it('publishes a refresh message to the twitch channel', () => {
+        const service = new TwitchControlService()
+        const internals = service as unknown as WithClients
+        const publisher = makePublisher()
+        publisher.publish.mockResolvedValue(1)
+        internals.publisher = publisher
+
+        service.publishRefresh()
+
+        expect(publisher.publish).toHaveBeenCalledWith(
+            CHANNEL_TWITCH_REFRESH,
+            'refresh',
+        )
+    })
+
+    it('swallows publish rejection (fire-and-forget)', () => {
+        const service = new TwitchControlService()
+        const internals = service as unknown as WithClients
+        const publisher = makePublisher()
+        publisher.publish.mockRejectedValue(new Error('redis down'))
+        internals.publisher = publisher
+
+        expect(() => service.publishRefresh()).not.toThrow()
+    })
+})
+
+describe('TwitchControlService.onRefresh', () => {
+    it('does nothing when not connected', async () => {
+        const service = new TwitchControlService()
+        const cb = jest.fn()
+        await service.onRefresh(cb)
+        expect(cb).not.toHaveBeenCalled()
+    })
+
+    it('subscribes to the twitch channel and invokes cb on a matching message', async () => {
+        const service = new TwitchControlService()
+        const internals = service as unknown as WithClients
+        const subscriber = makeSubscriber()
+        let handler: MessageListener | undefined
+        subscriber.on.mockImplementation((_event, listener) => {
+            handler = listener
+        })
+        internals.subscriber = subscriber
+        const cb = jest.fn()
+
+        await service.onRefresh(cb)
+
+        expect(subscriber.subscribe).toHaveBeenCalledWith(CHANNEL_TWITCH_REFRESH)
+        handler?.(CHANNEL_TWITCH_REFRESH, 'refresh')
+        expect(cb).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores messages on other channels', async () => {
+        const service = new TwitchControlService()
+        const internals = service as unknown as WithClients
+        const subscriber = makeSubscriber()
+        let handler: MessageListener | undefined
+        subscriber.on.mockImplementation((_event, listener) => {
+            handler = listener
+        })
+        internals.subscriber = subscriber
+        const cb = jest.fn()
+
+        await service.onRefresh(cb)
+        handler?.('some:other:channel', 'refresh')
+
+        expect(cb).not.toHaveBeenCalled()
+    })
+})

--- a/packages/shared/src/services/twitch/TwitchControlService.ts
+++ b/packages/shared/src/services/twitch/TwitchControlService.ts
@@ -5,72 +5,74 @@ import { errorLog, infoLog } from '../../utils/general/log.js'
 export const CHANNEL_TWITCH_REFRESH = 'twitch:refresh'
 
 export class TwitchControlService {
-	private publisher: Redis | null = null
-	private subscriber: Redis | null = null
+    private publisher: Redis | null = null
+    private subscriber: Redis | null = null
 
-	async connect(): Promise<void> {
-		try {
-			const config = createRedisConfig()
-			this.publisher = new RedisClientClass(config) as Redis
-			this.subscriber = new RedisClientClass(config) as Redis
-			await Promise.all([
-				this.publisher.connect(),
-				this.subscriber.connect(),
-			])
-			infoLog({ message: 'TwitchControlService connected to Redis' })
-		} catch (error) {
-			errorLog({
-				message: 'TwitchControlService failed to connect:',
-				error,
-			})
-		}
-	}
+    async connect(): Promise<void> {
+        try {
+            const config = createRedisConfig()
+            this.publisher = new RedisClientClass(config) as Redis
+            this.subscriber = new RedisClientClass(config) as Redis
+            await Promise.all([
+                this.publisher.connect(),
+                this.subscriber.connect(),
+            ])
+            infoLog({ message: 'TwitchControlService connected to Redis' })
+        } catch (error) {
+            errorLog({
+                message: 'TwitchControlService failed to connect:',
+                error,
+            })
+        }
+    }
 
-	async disconnect(): Promise<void> {
-		try {
-			if (this.subscriber) {
-				await this.subscriber.unsubscribe()
-				await this.subscriber.disconnect()
-			}
-			if (this.publisher) await this.publisher.disconnect()
-		} catch (error) {
-			errorLog({
-				message: 'TwitchControlService disconnect error:',
-				error,
-			})
-		}
-	}
+    async disconnect(): Promise<void> {
+        try {
+            if (this.subscriber) {
+                await this.subscriber.unsubscribe()
+                await this.subscriber.disconnect()
+            }
+            if (this.publisher) await this.publisher.disconnect()
+        } catch (error) {
+            errorLog({
+                message: 'TwitchControlService disconnect error:',
+                error,
+            })
+        }
+    }
 
-	isHealthy(): boolean {
-		return (
-			this.publisher?.status === 'ready' &&
-			this.subscriber?.status === 'ready'
-		)
-	}
+    isHealthy(): boolean {
+        return (
+            this.publisher?.status === 'ready' &&
+            this.subscriber?.status === 'ready'
+        )
+    }
 
-	publishRefresh(): void {
-		if (!this.publisher) return
-		this.publisher.publish(CHANNEL_TWITCH_REFRESH, 'refresh').catch((err: unknown) => {
-			errorLog({
-				message: 'Error publishing twitch refresh:',
-				error: err,
-			})
-		})
-	}
+    publishRefresh(): void {
+        if (!this.publisher) return
+        this.publisher
+            .publish(CHANNEL_TWITCH_REFRESH, 'refresh')
+            .catch((err: unknown) => {
+                errorLog({
+                    message: 'Error publishing twitch refresh:',
+                    error: err,
+                })
+            })
+    }
 
-	async onRefresh(cb: () => void): Promise<void> {
-		if (!this.subscriber) return
-		await this.subscriber.subscribe(CHANNEL_TWITCH_REFRESH)
-		this.subscriber.on('message', (ch: string, _msg: string) => {
-			if (ch !== CHANNEL_TWITCH_REFRESH) return
-			try {
-				cb()
-			} catch (error) {
-				errorLog({ message: 'Error handling twitch refresh:', error })
-			}
-		})
-		infoLog({ message: 'Subscribed to twitch refresh notifications' })
-	}
+    async onRefresh(cb: () => void): Promise<void> {
+        if (!this.subscriber) return
+        await this.subscriber.subscribe(CHANNEL_TWITCH_REFRESH)
+        this.subscriber.on('message', (ch: string, _msg: string) => {
+            if (ch !== CHANNEL_TWITCH_REFRESH) return
+            try {
+                cb()
+            } catch (error) {
+                errorLog({ message: 'Error handling twitch refresh:', error })
+            }
+        })
+        infoLog({ message: 'Subscribed to twitch refresh notifications' })
+    }
 }
 
 export const twitchControlService = new TwitchControlService()

--- a/packages/shared/src/services/twitch/TwitchControlService.ts
+++ b/packages/shared/src/services/twitch/TwitchControlService.ts
@@ -1,0 +1,76 @@
+import RedisClientClass, { type Redis } from 'ioredis'
+import { createRedisConfig } from '../redis/config.js'
+import { errorLog, infoLog } from '../../utils/general/log.js'
+
+export const CHANNEL_TWITCH_REFRESH = 'twitch:refresh'
+
+export class TwitchControlService {
+	private publisher: Redis | null = null
+	private subscriber: Redis | null = null
+
+	async connect(): Promise<void> {
+		try {
+			const config = createRedisConfig()
+			this.publisher = new RedisClientClass(config) as Redis
+			this.subscriber = new RedisClientClass(config) as Redis
+			await Promise.all([
+				this.publisher.connect(),
+				this.subscriber.connect(),
+			])
+			infoLog({ message: 'TwitchControlService connected to Redis' })
+		} catch (error) {
+			errorLog({
+				message: 'TwitchControlService failed to connect:',
+				error,
+			})
+		}
+	}
+
+	async disconnect(): Promise<void> {
+		try {
+			if (this.subscriber) {
+				await this.subscriber.unsubscribe()
+				await this.subscriber.disconnect()
+			}
+			if (this.publisher) await this.publisher.disconnect()
+		} catch (error) {
+			errorLog({
+				message: 'TwitchControlService disconnect error:',
+				error,
+			})
+		}
+	}
+
+	isHealthy(): boolean {
+		return (
+			this.publisher?.status === 'ready' &&
+			this.subscriber?.status === 'ready'
+		)
+	}
+
+	publishRefresh(): void {
+		if (!this.publisher) return
+		this.publisher.publish(CHANNEL_TWITCH_REFRESH, 'refresh').catch((err: unknown) => {
+			errorLog({
+				message: 'Error publishing twitch refresh:',
+				error: err,
+			})
+		})
+	}
+
+	async onRefresh(cb: () => void): Promise<void> {
+		if (!this.subscriber) return
+		await this.subscriber.subscribe(CHANNEL_TWITCH_REFRESH)
+		this.subscriber.on('message', (ch: string, _msg: string) => {
+			if (ch !== CHANNEL_TWITCH_REFRESH) return
+			try {
+				cb()
+			} catch (error) {
+				errorLog({ message: 'Error handling twitch refresh:', error })
+			}
+		})
+		infoLog({ message: 'Subscribed to twitch refresh notifications' })
+	}
+}
+
+export const twitchControlService = new TwitchControlService()


### PR DESCRIPTION
Fixes #870 (fix #1 — the actual "not working" cause).

## Problem
Adding/removing a Twitch streamer via the **web dashboard** (backend `POST/DELETE /api/twitch/...`) wrote to Postgres but never told the running bot, so the bot's EventSub session never subscribed → no live notification until a bot restart. The Discord-command path already refreshed via `refreshTwitchSubscriptions()`; this gives the web path parity.

## Fix (no Prisma migration)
New `TwitchControlService` (shared) mirroring the existing `MusicControlService` Redis pub/sub on a `twitch:refresh` channel:
- **Backend** (`routes/twitch.ts`): `twitchControlService.connect()` once in `setupTwitchRoutes`; `publishRefresh()` after a successful add/remove (fire-and-forget, never blocks the response).
- **Bot** (`twitch/index.ts` `startTwitchService`): `connect()` + `onRefresh(() => refreshTwitchSubscriptions())` (idempotent re-fetch; within the existing try/catch so Redis-down stays non-fatal).
- Graceful degradation: publisher `.catch`-logs; subscriber no-ops if Redis unavailable.

## Tests
- shared: `TwitchControlService.spec.ts` — 8 tests (health, publishRefresh fire-and-forget incl. rejection swallow, onRefresh subscribe/dispatch/channel-guard).
- backend: unit + integration twitch route tests updated to mock `twitchControlService`.

## Verification (local)
- `build:shared` clean; prettier + eslint clean on changed files.
- **shared 826, backend 1003, bot 2537 — all pass.**

## Scope / follow-ups (separate issues, in #870)
- Fix #2: notification dedup (`notifiedAt` field — needs a migration).
- Fix #4: EventSub subscription-create retry on 429/5xx.

@cubic-dev-ai @coderabbitai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the bot’s Twitch EventSub when streamers are added/removed via the web dashboard by introducing a Redis pub/sub `TwitchControlService`, so live notifications work without a bot restart. Addresses #870 by giving the web path parity with the Discord command flow.

- **Bug Fixes**
  - Backend: after successful add/remove, publish `twitch:refresh` and connect once during route setup; fire-and-forget so responses aren’t blocked.
  - Bot: subscribe to `twitch:refresh` and trigger `refreshTwitchSubscriptions()`; degrades gracefully if Redis is unavailable.
  - Shared: new `TwitchControlService` exported from `@lucky/shared/services` with `connect`, `publishRefresh`, and `onRefresh`.

<sup>Written for commit 855967f236217297e863b34fc0b574483a1c6529. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic refresh mechanism for Twitch notification configurations and active subscriptions to keep services synchronized
  * Refresh is triggered automatically when Twitch notification settings are modified

* **Tests**
  * Added comprehensive test coverage for new Twitch synchronization functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->