### PR TITLE
fix(twitch): re-subscribe to EventSub after unexpected reconnect (#870)

### DIFF
--- a/packages/bot/src/twitch/eventsubClient.spec.ts
+++ b/packages/bot/src/twitch/eventsubClient.spec.ts
@@ -15,7 +15,24 @@ const infoLogMock = jest.fn()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
 
-jest.mock('ws')
+const mockWsHandlers: Record<string, (...args: unknown[]) => void> = {}
+const mockWsInstance = {
+    on: jest.fn(),
+    close: jest.fn(),
+    pong: jest.fn(),
+    readyState: 1,
+}
+
+jest.mock('ws', () => {
+    // Plain function (not jest.fn) so the bot suite's resetMocks/restoreMocks
+    // can't strip the constructor's return value between tests.
+    function MockWebSocket(): typeof mockWsInstance {
+        return mockWsInstance
+    }
+    // The client reads WebSocket.OPEN to gate the keepalive close.
+    ;(MockWebSocket as unknown as { OPEN: number }).OPEN = 1
+    return { __esModule: true, default: MockWebSocket }
+})
 
 jest.mock('./token', () => ({
     getTwitchUserAccessToken: getTwitchUserAccessTokenMock,
@@ -40,6 +57,15 @@ describe('TwitchEventSubClient', () => {
 
     beforeEach(() => {
         jest.clearAllMocks()
+        // resetMocks wipes implementations each test, so (re)install the handler
+        // capture and reset the shared ws instance state.
+        for (const key of Object.keys(mockWsHandlers))
+            delete mockWsHandlers[key]
+        mockWsInstance.readyState = 1
+        mockWsInstance.on.mockImplementation((...args: unknown[]) => {
+            const [event, cb] = args as [string, (...a: unknown[]) => void]
+            mockWsHandlers[event] = cb
+        })
         client = new TwitchEventSubClient()
         mockDiscordClient = {}
         process.env.TWITCH_CLIENT_ID = 'test-client-id'
@@ -108,6 +134,59 @@ describe('TwitchEventSubClient', () => {
             // Should call subscribe to refresh (may be called or not depending on session state)
             // Just verify it doesn't throw
             expect(client).toBeDefined()
+        })
+    })
+
+    describe('reconnect resubscription', () => {
+        const fireWelcome = (sessionId: string): void => {
+            mockWsHandlers.message?.(
+                Buffer.from(
+                    JSON.stringify({
+                        metadata: { message_type: 'session_welcome' },
+                        payload: {
+                            session: {
+                                id: sessionId,
+                                status: 'connected',
+                                keepalive_timeout_seconds: 600,
+                                reconnect_url: null,
+                            },
+                        },
+                    }),
+                ),
+            )
+        }
+
+        it('clears the dedupe set on unexpected close so the new session re-subscribes from empty', async () => {
+            jest.useFakeTimers()
+            // Simulate the real subscribe: record the set size seen on each call,
+            // then mark the broadcaster as subscribed (as the real impl does).
+            const setSizesAtCall: number[] = []
+            subscribeToStreamOnlineMock.mockImplementation(
+                (_sessionId: string, _clientId: string, set: Set<string>) => {
+                    setSizesAtCall.push(set.size)
+                    set.add('broadcaster-1')
+                    return Promise.resolve()
+                },
+            )
+            getTwitchUserAccessTokenMock.mockResolvedValue('valid-token')
+
+            const startPromise = client.start(mockDiscordClient as Client)
+            await Promise.resolve()
+            fireWelcome('session-1')
+            await startPromise
+
+            // Unexpected close (non-1000) -> schedules reconnect after 5s.
+            mockWsHandlers.close?.(4005, Buffer.from('keepalive timeout'))
+            await jest.advanceTimersByTimeAsync(5000)
+            fireWelcome('session-2')
+            await Promise.resolve()
+
+            // Both subscribe calls must see an EMPTY set: the first on the fresh
+            // session, the second because the close handler cleared the stale ids.
+            // Before the fix the second call saw size 1 and skipped every id.
+            expect(setSizesAtCall).toEqual([0, 0])
+
+            jest.useRealTimers()
         })
     })
 })

--- a/packages/bot/src/twitch/eventsubClient.ts
+++ b/packages/bot/src/twitch/eventsubClient.ts
@@ -80,8 +80,16 @@ export class TwitchEventSubClient {
                 this.clearKeepalive()
                 this.ws = null
                 this.sessionId = null
-                if (code !== 1000 && this.client)
+                if (code !== 1000 && this.client) {
+                    // Unexpected close: the old session and its subscriptions are
+                    // gone, so the reconnect gets a brand-new session. Clear the
+                    // dedupe set or subscribeToStreamOnline would skip every id and
+                    // register zero subscriptions, silently killing notifications.
+                    // (session_reconnect migration closes with code 1000 and keeps
+                    // its subscriptions, so it intentionally bypasses this reset.)
+                    this.subscribedUserIds.clear()
                     setTimeout(() => this.connect(EVENTSUB_WS_URL), 5000)
+                }
             })
             this.ws.on('error', (err) =>
                 errorLog({
@@ -102,10 +110,16 @@ export class TwitchEventSubClient {
                 this.scheduleKeepalive(
                     p.session.keepalive_timeout_seconds * 1000,
                 )
-                subscribeToStreamOnline(
+                void subscribeToStreamOnline(
                     this.sessionId,
                     this.clientId,
                     this.subscribedUserIds,
+                ).catch((error) =>
+                    errorLog({
+                        message:
+                            'Twitch EventSub: subscribe on session_welcome failed',
+                        error,
+                    }),
                 )
                 break
             }


### PR DESCRIPTION
## Problem

Found while statically verifying the Twitch notification path for #870.

On an **unexpected** WebSocket close (`code !== 1000`), `TwitchEventSubClient` reconnects (`eventsubClient.ts:83`) but never cleared `subscribedUserIds`. The brand-new session then calls `subscribeToStreamOnline` with the **stale** dedupe set, which skips every id (`eventsubSubscriptions.ts:38`) and registers **zero** subscriptions on the new session.

**Impact:** after any network blip / keepalive timeout, live notifications silently stop until the bot is fully restarted. No error is logged.

## Fix

- Clear `subscribedUserIds` on the non-1000 close path before reconnecting, so the fresh session re-subscribes all broadcasters.
- The `session_reconnect` migration path closes with code `1000` and is intentionally **excluded** — Twitch preserves subscriptions across that handoff, so re-POSTing would be redundant.
- Hardened the fire-and-forget `subscribeToStreamOnline` call on `session_welcome` against unhandled promise rejection (Prisma/token errors would otherwise escape as an `unhandledRejection`).

## Test

Added a regression test (`eventsubClient.spec.ts`) that drives `session_welcome → non-1000 close → reconnect → session_welcome` and asserts the new session re-subscribes from an **empty** set. Verified it **fails without the fix** (`[0, 1]`) and passes with it (`[0, 0]`).

Full Twitch suite: **52/52 green**. Bot/shared/backend/frontend type:check green (pre-commit).

## Scope note

This fixes one concrete defect on the path. The full end-to-end runtime verification in #870 (live stream → Discord post with real creds) still needs the operator; remaining audit notes are posted on #870.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Twitch EventSub reconnection so the bot re-subscribes after unexpected WebSocket closes, preventing silent loss of live notifications. Addresses a reliability gap found while verifying the Twitch notification path for #870.

- **Bug Fixes**
  - Clear `subscribedUserIds` on non-1000 close before reconnect, so the new session re-subscribes all broadcasters.
  - Keep code 1000 (`session_reconnect`) unchanged since Twitch preserves subscriptions.
  - Make `subscribeToStreamOnline` on `session_welcome` fire-and-forget with error logging to prevent unhandled rejections; added a regression test that confirms re-subscribe after unexpected reconnect.

<sup>Written for commit 2521701f133eabf194a0644b49a6e90535e6a267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

