### PR TITLE
ci(deploy): gate production deploy to release publication, not every main push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,14 +137,14 @@ jobs:
                   detect_interval=5
                   run_info=""
                   while [ $detect_elapsed -lt $detect_max ]; do
-                    run_info=$(gh run list \
-                      --repo "${{ github.repository }}" \
-                      --workflow=docker-publish.yml \
-                      --json headSha,status,conclusion,databaseId \
-                      --limit 10 \
-                      | jq -r --arg sha "$commit_sha" \
-                        '.[] | select(.headSha == $sha) | "\(.databaseId) \(.status) \(.conclusion)"' \
-                      | head -1)
+                    # Look the build up by exact head_sha, not from the N most
+                    # recent runs: a release can be published for an older tag
+                    # whose docker-publish run has since fallen out of the recent
+                    # window, which a capped `gh run list` would miss (#1398).
+                    run_info=$(gh api \
+                      "repos/${{ github.repository }}/actions/workflows/docker-publish.yml/runs?head_sha=${commit_sha}&per_page=1" \
+                      --jq '.workflow_runs[0] | select(. != null) | "\(.id) \(.status) \(.conclusion)"' \
+                      2>/dev/null || true)
                     [ -n "$run_info" ] && break
                     echo "  No docker-publish run yet, waiting ${detect_interval}s... (${detect_elapsed}s elapsed)"
                     sleep $detect_interval

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,8 @@ on:
                 required: false
                 default: ''
                 type: string
-    workflow_run:
-        workflows: ["Build & Push Docker Images"]
-        types: [completed]
-        branches: [main]
+    release:
+        types: [published]
 
 permissions:
     contents: read
@@ -36,7 +34,7 @@ jobs:
             contents: read
         if: |
             github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+            github.event_name == 'release'
 
         env:
             # Build/CI secret — when unset, all Sentry release steps below are skipped.
@@ -60,6 +58,51 @@ jobs:
                     exit 1
                   fi
 
+            - id: resolve_sha
+              name: Resolve deploy SHA
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_PAGER: cat
+                  ROLLBACK_SHA: ${{ inputs.rollback_sha }}
+                  EVENT_NAME: ${{ github.event_name }}
+                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+                  PUSH_SHA: ${{ github.sha }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+                  # Single source of truth for the commit SHA this deploy ships.
+                  # Every downstream step (image wait, webhook, Sentry release,
+                  # validation) reads steps.resolve_sha.outputs.sha, so the Sentry
+                  # release, the deployed :<sha> image, and the validated status
+                  # can never disagree.
+                  if [ -n "$ROLLBACK_SHA" ]; then
+                    # Manual rollback to an explicit prior commit.
+                    deploy_sha="$ROLLBACK_SHA"
+                  elif [ "$EVENT_NAME" = "release" ]; then
+                    # Production deploys are gated to GitHub Release publication.
+                    # Resolve the release tag to its commit SHA; github.sha is not
+                    # reliable on release events, and our tags are annotated, so
+                    # dereference the tag object to reach the underlying commit.
+                    ref_obj=$(gh api "repos/${REPO}/git/ref/tags/${RELEASE_TAG}" \
+                      --jq '{type: .object.type, sha: .object.sha}')
+                    obj_type=$(echo "$ref_obj" | jq -r '.type')
+                    deploy_sha=$(echo "$ref_obj" | jq -r '.sha')
+                    if [ "$obj_type" = "tag" ]; then
+                      deploy_sha=$(gh api "repos/${REPO}/git/tags/${deploy_sha}" \
+                        --jq '.object.sha')
+                    fi
+                  else
+                    # workflow_dispatch: deploy the commit the workflow ran on.
+                    deploy_sha="$PUSH_SHA"
+                  fi
+
+                  if [ -z "$deploy_sha" ] || [ "$deploy_sha" = "null" ]; then
+                    echo "::error::Could not resolve a deploy SHA (event=$EVENT_NAME tag=${RELEASE_TAG:-none})"
+                    exit 1
+                  fi
+                  echo "==> Deploy SHA resolved: $deploy_sha (event=$EVENT_NAME)"
+                  echo "sha=$deploy_sha" >> "$GITHUB_OUTPUT"
+
             - id: docker_wait
               name: Wait for Docker images
               env:
@@ -75,11 +118,7 @@ jobs:
                     echo "docker_rebuilt=false" >> "$GITHUB_OUTPUT"
                     exit 0
                   fi
-                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
-                    commit_sha="${{ github.event.workflow_run.head_sha }}"
-                  else
-                    commit_sha="${{ github.sha }}"
-                  fi
+                  commit_sha="${{ steps.resolve_sha.outputs.sha }}"
                   max_wait=600
                   interval=15
                   elapsed=0
@@ -191,22 +230,11 @@ jobs:
             - name: Sentry release — create
               if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
               continue-on-error: true
-              env:
-                  ROLLBACK_SHA: ${{ inputs.rollback_sha }}
-                  WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-                  PUSH_SHA: ${{ github.sha }}
-                  EVENT_NAME: ${{ github.event_name }}
               run: |
                   set -euo pipefail
-                  # Attribute the Sentry release to the SHA actually deployed
-                  # (the rollback target on a rollback) for runtime traceability.
-                  if [ -n "$ROLLBACK_SHA" ]; then
-                    release="$ROLLBACK_SHA"
-                  elif [ "$EVENT_NAME" = "workflow_run" ]; then
-                    release="$WORKFLOW_RUN_SHA"
-                  else
-                    release="$PUSH_SHA"
-                  fi
+                  # Attribute the Sentry release to the exact SHA being deployed
+                  # (resolved once above) for runtime traceability.
+                  release="${{ steps.resolve_sha.outputs.sha }}"
                   echo "==> Creating Sentry release $release"
                   npx --yes @sentry/cli@3.5.0 releases new "$release"
                   npx --yes @sentry/cli@3.5.0 releases set-commits "$release" --local --ignore-missing || true
@@ -215,27 +243,14 @@ jobs:
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
                   WEBHOOK_SECRET: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}
-                  ROLLBACK_SHA: ${{ inputs.rollback_sha }}
-                  WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-                  PUSH_SHA: ${{ github.sha }}
-                  EVENT_NAME: ${{ github.event_name }}
+                  DEPLOY_SHA: ${{ steps.resolve_sha.outputs.sha }}
               run: |
                   set -euo pipefail
                   echo "==> Triggering deploy webhook..."
 
-                  # Resolve the image SHA to deploy: an explicit rollback target
-                  # when given, else the commit that triggered this run. Sent to
-                  # the homelab so it deploys that exact :<sha> image tag.
-                  # All SHA sources are read from env (never inlined) to avoid
-                  # shell injection from the user-supplied rollback input.
-                  if [ -n "$ROLLBACK_SHA" ]; then
-                    DEPLOY_SHA="$ROLLBACK_SHA"
-                    echo "==> Manual rollback to $DEPLOY_SHA"
-                  elif [ "$EVENT_NAME" = "workflow_run" ]; then
-                    DEPLOY_SHA="$WORKFLOW_RUN_SHA"
-                  else
-                    DEPLOY_SHA="$PUSH_SHA"
-                  fi
+                  # Deploy the exact :<sha> image tag resolved above. Read from
+                  # env (never inlined) to keep the curl headers injection-safe.
+                  echo "==> Deploying SHA $DEPLOY_SHA"
 
                   call_webhook() {
                     local url="$1"
@@ -333,24 +348,14 @@ jobs:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
                   DOCKER_REBUILT: ${{ steps.docker_wait.outputs.docker_rebuilt }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  ROLLBACK_SHA: ${{ inputs.rollback_sha }}
-                  WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-                  PUSH_SHA: ${{ github.sha }}
-                  EVENT_NAME: ${{ github.event_name }}
+                  EXPECTED_SHA: ${{ steps.resolve_sha.outputs.sha }}
               run: |
                   set -euo pipefail
                   base_url=$(node -e 'const u = new URL(process.env.WEBHOOK_URL); console.log(`${u.protocol}//${u.host}`)')
-                  # Validate the SHA actually deployed. On a rollback this is the
-                  # rollback target, so we verify the homelab posted a successful
-                  # deploy status for it (deploy.sh posts success only after the
-                  # rollback passes health checks).
-                  if [ -n "$ROLLBACK_SHA" ]; then
-                    expected="$ROLLBACK_SHA"
-                  elif [ "$EVENT_NAME" = "workflow_run" ]; then
-                    expected="$WORKFLOW_RUN_SHA"
-                  else
-                    expected="$PUSH_SHA"
-                  fi
+                  # Validate the exact SHA deployed (resolved once above): verify
+                  # the homelab posted a successful deploy status for it (deploy.sh
+                  # posts success only after the rollout passes health checks).
+                  expected="$EXPECTED_SHA"
 
                   if [ "${DOCKER_REBUILT:-false}" != "true" ]; then
                     health_url="${base_url}/api/health"
@@ -435,11 +440,7 @@ jobs:
               continue-on-error: true
               run: |
                   set -euo pipefail
-                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
-                    release="${{ github.event.workflow_run.head_sha }}"
-                  else
-                    release="${{ github.sha }}"
-                  fi
+                  release="${{ steps.resolve_sha.outputs.sha }}"
                   echo "==> Finalizing Sentry release $release"
                   npx --yes @sentry/cli@3.5.0 releases finalize "$release"
 
@@ -681,11 +682,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   set -euo pipefail
-                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
-                    expected="${{ github.event.workflow_run.head_sha }}"
-                  else
-                    expected="${{ github.sha }}"
-                  fi
+                  expected="${{ steps.resolve_sha.outputs.sha }}"
 
                   echo "==> Waiting for homelab deploy to complete (SHA: $expected)..."
                   status_was_seen=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,12 +96,17 @@ jobs:
                     deploy_sha="$PUSH_SHA"
                   fi
 
-                  if [ -z "$deploy_sha" ] || [ "$deploy_sha" = "null" ]; then
-                    echo "::error::Could not resolve a deploy SHA (event=$EVENT_NAME tag=${RELEASE_TAG:-none})"
+                  deploy_sha="$(printf '%s' "${deploy_sha:-}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+                  # Reject anything that isn't a hex commit SHA before exporting:
+                  # rollback_sha is user-supplied on workflow_dispatch, and this
+                  # value flows into downstream shell + curl headers. 7-40 chars
+                  # covers a short rollback SHA through a full 40-char commit SHA.
+                  if ! printf '%s' "$deploy_sha" | grep -Eq '^[0-9a-f]{7,40}$'; then
+                    echo "::error::Could not resolve a valid hex deploy SHA (event=$EVENT_NAME tag=${RELEASE_TAG:-none})"
                     exit 1
                   fi
                   echo "==> Deploy SHA resolved: $deploy_sha (event=$EVENT_NAME)"
-                  echo "sha=$deploy_sha" >> "$GITHUB_OUTPUT"
+                  printf 'sha=%s\n' "$deploy_sha" >> "$GITHUB_OUTPUT"
 
             - id: docker_wait
               name: Wait for Docker images
@@ -109,6 +114,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   GH_PAGER: cat
                   ROLLBACK_SHA: ${{ inputs.rollback_sha }}
+                  RESOLVED_SHA: ${{ steps.resolve_sha.outputs.sha }}
               run: |
                   set -euo pipefail
                   # Rollback deploys an already-published prior image; its build
@@ -118,7 +124,7 @@ jobs:
                     echo "docker_rebuilt=false" >> "$GITHUB_OUTPUT"
                     exit 0
                   fi
-                  commit_sha="${{ steps.resolve_sha.outputs.sha }}"
+                  commit_sha="$RESOLVED_SHA"
                   max_wait=600
                   interval=15
                   elapsed=0
@@ -230,11 +236,13 @@ jobs:
             - name: Sentry release — create
               if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
               continue-on-error: true
+              env:
+                  RESOLVED_SHA: ${{ steps.resolve_sha.outputs.sha }}
               run: |
                   set -euo pipefail
                   # Attribute the Sentry release to the exact SHA being deployed
                   # (resolved once above) for runtime traceability.
-                  release="${{ steps.resolve_sha.outputs.sha }}"
+                  release="$RESOLVED_SHA"
                   echo "==> Creating Sentry release $release"
                   npx --yes @sentry/cli@3.5.0 releases new "$release"
                   npx --yes @sentry/cli@3.5.0 releases set-commits "$release" --local --ignore-missing || true
@@ -438,9 +446,11 @@ jobs:
             - name: Sentry release — finalize
               if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
               continue-on-error: true
+              env:
+                  RESOLVED_SHA: ${{ steps.resolve_sha.outputs.sha }}
               run: |
                   set -euo pipefail
-                  release="${{ steps.resolve_sha.outputs.sha }}"
+                  release="$RESOLVED_SHA"
                   echo "==> Finalizing Sentry release $release"
                   npx --yes @sentry/cli@3.5.0 releases finalize "$release"
 
@@ -680,9 +690,10 @@ jobs:
               if: steps.docker_wait.outputs.docker_rebuilt == 'true'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  EXPECTED_SHA: ${{ steps.resolve_sha.outputs.sha }}
               run: |
                   set -euo pipefail
-                  expected="${{ steps.resolve_sha.outputs.sha }}"
+                  expected="$EXPECTED_SHA"
 
                   echo "==> Waiting for homelab deploy to complete (SHA: $expected)..."
                   status_was_seen=false


### PR DESCRIPTION
Production currently ships on **every push to `main`** — `docker-publish` builds images on each main commit and **Deploy to Homelab** chains off it via `workflow_run`, so every merge auto-deploys to prod (and they race — see #1397). This makes shipping accidental rather than deliberate.

## Change
Gate production deploys to **GitHub Release publication**:

- **Trigger:** swap `workflow_run` (Build & Push Docker Images / main) → `release: types: [published]`. `workflow_dispatch` (manual deploy + rollback) is unchanged.
- **SHA resolution:** add one `resolve_sha` step as the single source of truth for the shipped commit. On a release it dereferences the **annotated** tag to its commit SHA (`github.sha` is unreliable on release events). Rollback and `workflow_dispatch` paths are preserved.
- **Consistency:** every downstream step (image wait, webhook, Sentry create/finalize, version validation, homelab wait) now reads that one resolved SHA, so the Sentry release, the deployed `:<sha>` image, and the validated commit status can never disagree (they were independently re-derived in 6 places before).

## What does NOT change
- `docker-publish.yml` still builds `:<sha>` + `:latest` on every main push, so the image for a release commit already exists when the release is cut. **Building artifacts is decoupled from shipping them.**
- The `Production` environment protection (wait timer) still applies — now on release deploys.
- Rollback via `workflow_dispatch` `rollback_sha` is untouched.

## Shipping flow after this
`merge to main` → images built (no deploy) → cut release `vX` (push annotated tag → `Release` workflow publishes it) → **Deploy to Homelab fires for the tagged commit**.

## Known limitation
If a release tag points at a commit that never built a `:<sha>` image (e.g. a docs-only HEAD that `docker-publish` path-filtered out), the deploy falls to the existing `:latest` path. In practice release tags sit on code/`package.json` commits that always build. Flagging for review rather than over-engineering.

## Verification
- `actionlint`: 0 new findings vs `main` baseline (7 pre-existing `SC2016` info notes on intentional single-quoted `jq`/`node -e`, identical on both).
- YAML parses; no `workflow_run` / stray `github.sha` references remain outside the intended `workflow_dispatch` path.
- Pre-commit type-check (shared/bot/backend/frontend) passed.

@cubic-dev-ai please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate production deploys to GitHub Release publication instead of every push to `main`. Adds SHA validation and env-based propagation to prevent injection, keeping Sentry, image tags, and commit status in sync, and improves Docker build lookup for older tags.

- **Refactors**
  - Trigger changed: `workflow_run` → `release: [published]`; `workflow_dispatch` (manual/rollback) stays.
  - Added `resolve_sha` to pick the shipped commit once; on release, dereferences the annotated tag to its commit SHA.
  - Validates the resolved SHA (7–40 lowercase hex) and passes it via env; all steps read it to prevent template-injection via `rollback_sha`.
  - Docker wait now finds the build by exact `head_sha` via the Actions API (not a recent window), so releases for older tags don’t fail lookup.
  - Downstream steps (image wait, webhook, Sentry create/finalize, version validation, homelab wait) use the one SHA.
  - `docker-publish.yml` still builds `:<sha>` and `:latest` on `main`; building artifacts is decoupled from shipping them.

<sup>Written for commit 0b4902a2712a99fa4edfd5aef51f9f8a9b97cdc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to trigger on release publication instead of Docker build completion.
  * Improved deployment SHA resolution for better consistency across rollbacks, releases, and manual deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->