### PR TITLE
fix(spotify): log oauth token-exchange failures (#1286 track b)

### DIFF
--- a/packages/backend/src/services/SpotifyAuthService.ts
+++ b/packages/backend/src/services/SpotifyAuthService.ts
@@ -1,3 +1,5 @@
+import { errorLog } from '@lucky/shared/utils'
+
 export type SpotifyTokenResponse = {
     accessToken: string
     refreshToken: string
@@ -78,7 +80,11 @@ export async function exchangeCodeForToken(
             spotifyId: userData.id,
             spotifyUsername: userData.display_name ?? userData.id,
         }
-    } catch {
+    } catch (error) {
+        errorLog({
+            message: 'Spotify authorization-code token exchange failed',
+            error,
+        })
         return null
     }
 }
@@ -112,7 +118,11 @@ export async function getSpotifyClientToken(): Promise<string | null> {
             expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000 - 30_000,
         }
         return cachedClientToken.token
-    } catch {
+    } catch (error) {
+        errorLog({
+            message: 'Spotify client-credentials token request failed',
+            error,
+        })
         return null
     }
 }


### PR DESCRIPTION
Part of **#1286** Track B (B3 silent-catch sweep), phase-1 external-API boundaries.

## Problem
`SpotifyAuthService` has two outer `try/catch` blocks that swallowed errors with a bare `catch { return null }`:
- `exchangeCodeForToken` (`:81`) — OAuth authorization-code exchange.
- `getSpotifyClientToken` (`:115`) — client-credentials token request.

`fetchJson` returns `null` on a non-ok response, but the outer catches caught **network errors and the 10s `AbortSignal.timeout`** — those vanished with no log, so a failing Spotify token flow produced **zero operational signal**.

## Fix
Add `errorLog({ message, error })` at both boundaries before returning `null`. Behaviour (return `null` on failure) is unchanged. Secrets are not logged — only a message + the error object (the `code` and the `Basic auth` header are never passed to the logger).

## Scope note
The B3 phase-1 inventory surfaced 6 candidate sites; the other 4 were left intentionally and are **not** swallow-without-log bugs: `spotify.ts` state-decode + URL-parse are security/config reject paths (logging the user-controlled value would risk CodeQL log-injection), and the two autoplay catches (`replenisher.ts`, `lastFmSeeder.ts`) are documented graceful-degradation / try-next-engine fallbacks.

## Verify
- backend `tsc --noEmit` clean
- backend spotify suites: 27 passed

@cubic-dev-ai please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add error logs for Spotify OAuth token exchange and client-credentials requests so network/timeout failures are visible. Part of #1286 Track B (silent-catch sweep); runtime behavior is unchanged.

- **Bug Fixes**
  - Log errors at external API boundaries in `SpotifyAuthService` (`exchangeCodeForToken`, `getSpotifyClientToken`) via `errorLog` from `@lucky/shared/utils`.
  - Avoid logging secrets; only a message and the error object are recorded.

<sup>Written for commit 2a68038030365c455f96b934a1bcd3f05c003244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

