### PR TITLE
fix(auth): log session lookup failures in optional auth (#1286)

### DIFF
--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
 import { sessionService } from '../services/SessionService'
-import { errorLog } from '@lucky/shared/utils'
+import { errorLog, warnLog } from '@lucky/shared/utils'
 
 export interface AuthenticatedRequest extends Request {
     sessionId?: string
@@ -88,7 +88,15 @@ export function optionalAuth(
 
             next()
         })
-        .catch(() => {
+        .catch((error) => {
+            // Optional auth: proceed unauthenticated, but a session-store
+            // failure (DB/Redis) would otherwise be invisible — surface it so a
+            // store outage degrading every request to anonymous is observable.
+            warnLog({
+                message:
+                    'optionalAuth: session lookup failed; proceeding unauthenticated',
+                error,
+            })
             next()
         })
 }


### PR DESCRIPTION
Part of **#1286** Track B (B3 silent-catch sweep), **phase-2** (broader swallow-without-log class, beyond external APIs).

## Problem
`optionalAuth` in `packages/backend/src/middleware/auth.ts` looked up the session and, on rejection, did `.catch(() => next())` — proceeding unauthenticated with **no log**. A session-store outage (Postgres/Redis) that silently degrades **every** optional-auth request to anonymous was therefore invisible to operators.

## Fix
`warnLog` the failure before `next()`. Behaviour is unchanged — optional auth still proceeds without a user on failure (that's the point of *optional*); the degradation is now observable.

## Sweep note
A deterministic scan of all 441 catch blocks in bot+backend surfaced ~108 raw candidates, but verification against source showed the codebase is already well-disciplined: the vast majority **log**, **rethrow/propagate** (e.g. `callback(error)`, `next(error)`), or are **documented-intentional** degradation / try-next-fallback / security-reject paths. This `optionalAuth` catch was the one genuinely meaningful silent swallow. The empty-`catch {}` subset is separately handled by the lint `warn→error` promotion (~2026-06-26). #1286 stays open as the umbrella tracker.

## Verify
- backend `tsc --noEmit` clean · auth suites: 95 passed.

@cubic-dev-ai please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log session lookup failures in `optionalAuth` so session-store outages are visible while requests still proceed unauthenticated. Addresses #1286.

<sup>Written for commit 3d1d6faae903e7d1b7989c7af9b744b652d367f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced error visibility for authentication failures—session lookup errors are now properly logged, improving system reliability diagnostics during service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->