### PR TITLE
feat(observability): alert on redis control publish failures (#1401)

### DIFF
--- a/packages/shared/src/services/music/MusicControlService.ts
+++ b/packages/shared/src/services/music/MusicControlService.ts
@@ -2,6 +2,7 @@ import RedisClientClass, { type Redis } from 'ioredis'
 import { randomUUID } from 'crypto'
 import { createRedisConfig } from '../redis/config.js'
 import { debugLog, errorLog, infoLog } from '../../utils/general/log.js'
+import { captureMessageThrottled } from '../../utils/monitoring/sentry.js'
 import { assertDefined } from '../../utils/guards.js'
 import {
     CHANNEL_COMMAND,
@@ -86,15 +87,21 @@ export class MusicControlService {
             assertDefined(
                 this.publisher,
                 'publisher ready — guaranteed by isHealthy() guard',
-            ).publish(CHANNEL_COMMAND, JSON.stringify(cmd)).catch(
-                (err: unknown) => {
+            )
+                .publish(CHANNEL_COMMAND, JSON.stringify(cmd))
+                .catch((err: unknown) => {
                     this.pendingResults.delete(cmd.id)
                     clearTimeout(timeout)
                     const reason =
                         err instanceof Error ? err.message : String(err)
+                    captureMessageThrottled(
+                        'music:command:fail',
+                        'MusicControlService: command publish failed — bot did not receive the command',
+                        'warning',
+                        { reason },
+                    )
                     resolve(this.failResult(cmd, `Publish failed: ${reason}`))
-                },
-            )
+                })
         })
     }
 

--- a/packages/shared/src/services/twitch/TwitchControlService.ts
+++ b/packages/shared/src/services/twitch/TwitchControlService.ts
@@ -1,6 +1,7 @@
 import RedisClientClass, { type Redis } from 'ioredis'
 import { createRedisConfig } from '../redis/config.js'
 import { debugLog, errorLog, infoLog } from '../../utils/general/log.js'
+import { captureMessageThrottled } from '../../utils/monitoring/sentry.js'
 
 /** Redis pub/sub channel carrying "re-read your Twitch subscriptions" signals. */
 export const CHANNEL_TWITCH_REFRESH = 'twitch:refresh'
@@ -86,6 +87,11 @@ export class TwitchControlService {
                 message:
                     'TwitchControlService: skipping refresh publish (Redis not ready)',
             })
+            captureMessageThrottled(
+                'twitch:refresh:skip',
+                'TwitchControlService: refresh publish skipped — Redis not ready; bot sync delayed until reconnect/restart',
+                'warning',
+            )
             return
         }
         try {
@@ -95,6 +101,15 @@ export class TwitchControlService {
                 message: 'TwitchControlService: refresh publish failed',
                 error,
             })
+            captureMessageThrottled(
+                'twitch:refresh:fail',
+                'TwitchControlService: refresh publish failed',
+                'warning',
+                {
+                    reason:
+                        error instanceof Error ? error.message : String(error),
+                },
+            )
         }
     }
 

--- a/packages/shared/src/utils/monitoring/sentry.spec.ts
+++ b/packages/shared/src/utils/monitoring/sentry.spec.ts
@@ -354,10 +354,30 @@ describe('sentry monitoring', () => {
             expect(captureMessageMock).toHaveBeenCalledTimes(2)
         })
 
-        it('does not reach sentry when disabled', () => {
+        it('does not reach sentry and returns false when disabled', () => {
             process.env.SENTRY_ENABLED = 'false'
-            captureMessageThrottled('test:disabled', 'x', 'warning')
+            const captured = captureMessageThrottled(
+                'test:disabled',
+                'x',
+                'warning',
+            )
+            expect(captured).toBe(false)
             expect(captureMessageMock).not.toHaveBeenCalled()
+        })
+
+        it('does not pollute the throttle window while disabled', () => {
+            // Disabled call must not consume the window: once re-enabled, the
+            // first real capture for the same key must still go through.
+            process.env.SENTRY_ENABLED = 'false'
+            captureMessageThrottled('test:reenable', 'skipped', 'warning')
+            process.env.SENTRY_ENABLED = 'true'
+            const captured = captureMessageThrottled(
+                'test:reenable',
+                'real',
+                'warning',
+            )
+            expect(captured).toBe(true)
+            expect(captureMessageMock).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/packages/shared/src/utils/monitoring/sentry.spec.ts
+++ b/packages/shared/src/utils/monitoring/sentry.spec.ts
@@ -23,6 +23,7 @@ jest.mock('../general/log', () => ({
 import {
     captureException,
     captureMessage,
+    captureMessageThrottled,
     flushSentry,
     initializeSentry,
     isSentryEnabled,
@@ -321,6 +322,42 @@ describe('sentry monitoring', () => {
             process.env.SENTRY_ENABLED = 'false'
             monitorInteractionHandling('button', 'user-1')
             expect(setContextMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('captureMessageThrottled', () => {
+        it('captures the first message for a key', () => {
+            const captured = captureMessageThrottled(
+                'test:first',
+                'first',
+                'warning',
+            )
+            expect(captured).toBe(true)
+            expect(captureMessageMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('throttles repeats within the window for the same key', () => {
+            captureMessageThrottled('test:repeat', 'a', 'warning')
+            const second = captureMessageThrottled(
+                'test:repeat',
+                'b',
+                'warning',
+            )
+            expect(second).toBe(false)
+            // only the first call reached sentry
+            expect(captureMessageMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('captures independently for distinct keys', () => {
+            captureMessageThrottled('test:k1', 'a', 'warning')
+            captureMessageThrottled('test:k2', 'b', 'warning')
+            expect(captureMessageMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('does not reach sentry when disabled', () => {
+            process.env.SENTRY_ENABLED = 'false'
+            captureMessageThrottled('test:disabled', 'x', 'warning')
+            expect(captureMessageMock).not.toHaveBeenCalled()
         })
     })
 })

--- a/packages/shared/src/utils/monitoring/sentry.ts
+++ b/packages/shared/src/utils/monitoring/sentry.ts
@@ -162,6 +162,13 @@ export function captureMessageThrottled(
     extras?: Record<string, unknown>,
     windowMs = 60_000,
 ): boolean {
+    // Check enablement first: a disabled call must not touch the throttle map,
+    // otherwise it pollutes the window and could suppress the first real capture
+    // if Sentry is re-enabled before the window elapses. Also keeps the return
+    // contract honest (true only when actually captured).
+    if (!isSentryEnabled()) {
+        return false
+    }
     const now = Date.now()
     const last = lastThrottledCaptureAt.get(key)
     if (last !== undefined && now - last < windowMs) {

--- a/packages/shared/src/utils/monitoring/sentry.ts
+++ b/packages/shared/src/utils/monitoring/sentry.ts
@@ -143,6 +143,35 @@ export function captureMessage(
     })
 }
 
+const lastThrottledCaptureAt = new Map<string, number>()
+
+/**
+ * Capture a message in Sentry at most once per `windowMs` for a given `key`,
+ * so a sustained failure (e.g. a Redis outage hit on every request) raises one
+ * alert instead of flooding Sentry. Returns true when the message was captured.
+ * @param key Throttle bucket — repeats within the window for the same key are dropped
+ * @param message The message to capture
+ * @param level The severity level
+ * @param extras Additional data to include (sanitized before send)
+ * @param windowMs Minimum gap between captures for this key (default 60s)
+ */
+export function captureMessageThrottled(
+    key: string,
+    message: string,
+    level: Sentry.SeverityLevel = 'warning',
+    extras?: Record<string, unknown>,
+    windowMs = 60_000,
+): boolean {
+    const now = Date.now()
+    const last = lastThrottledCaptureAt.get(key)
+    if (last !== undefined && now - last < windowMs) {
+        return false
+    }
+    lastThrottledCaptureAt.set(key, now)
+    captureMessage(message, level, extras)
+    return true
+}
+
 /**
  * Initialize Sentry monitoring with appropriate configuration
  */


### PR DESCRIPTION
Closes **#1401** (filed from the no-broker ADR #1400 + its critic review).

## Problem
The two Redis pub/sub control services degrade **best-effort** when Redis is down (intentional — Postgres is the SoT, the bot reconciles on restart). But that degradation was **log-only**, so a Redis blip silently delayed bot sync with no alert — users noticed before operators did.

## Change
- New `captureMessageThrottled(key, message, level, extras, windowMs=60s)` in `utils/monitoring/sentry.ts` — wraps `captureMessage` but fires at most once per window per key, so a sustained outage raises **one** alert instead of flooding Sentry. Respects `isSentryEnabled()` (no-op in dev/when disabled) and the existing PII sanitizer.
- Wired into the publish-failure paths:
  - `TwitchControlService.publishRefresh` — skipped-when-not-ready **and** publish throw.
  - `MusicControlService.sendCommand` — publish rejection (bot never received the command).

Delivery semantics are **unchanged** (still best-effort, no broker — see ADR `2026-06-13-message-broker-rabbitmq-kafka.md`); this only makes the existing degradation observable.

## Verify
- shared: sentry + Twitch/Music control specs — **42 passed** (incl. 4 new throttle tests: first-capture, same-key throttle, distinct-key independence, disabled-no-op).
- all 4 `tsc --noEmit` clean.

@cubic-dev-ai please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add throttled Sentry alerts for Redis control publish failures so operators get notified when Twitch refreshes or music commands aren’t published. Addresses #1401; delivery semantics remain best-effort and unchanged.

- **New Features**
  - Added `captureMessageThrottled(key, message, level, extras, windowMs=60_000)` to send at most one alert per key per window; keeps PII sanitization.
  - Instrumented `TwitchControlService.publishRefresh` for skipped (Redis not ready) and failed publishes, and `MusicControlService.sendCommand` for publish rejections; sends `warning` with reason.

- **Bug Fixes**
  - Throttle now checks `isSentryEnabled()` before touching state; disabled calls return false and don’t pollute the window. Added a re-enable-within-window regression test.

<sup>Written for commit a32e780bab67f99e59c9a097918bd4cdf80f2ad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

