### PR TITLE
docs(adr): hold autoplay mood clustering pending data spike (#1095)

### DIFF
--- a/decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md
+++ b/decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md
@@ -1,0 +1,101 @@
+# Autoplay mood clustering (#1095): hold and verify data first, don't override the Phase D gate
+
+- Status: accepted (defer with verification triggers)
+- Date: 2026-06-14
+
+## Context
+
+Issue #1095 proposes "audio-feature mood clustering": cluster autoplay candidates
+by (energy, valence, tempo) relative to the current track and prefer in-cluster
+candidates so the queue stays mood-coherent. It is labelled a "Phase D+ stretch."
+
+The question raised: **override the deferred Phase D gate and build #1095 now, or
+hold?**
+
+Evidence (verified against `main`):
+
+- **The Phase D gate is data-conditional.** `decisions/2026-05-21-autoplay-recommendation-roadmap.md`:
+  "Ship Phase D **only if** the baseline acceptance-rate delta is large enough to
+  justify the change. If Phase C shows the layered defense already produces **>85%
+  acceptance per source**, Phase D becomes optional and gets deferred." Plus: "Hold
+  Phase D for 7 days of production data minimum." #1095 is the roadmap's rejected
+  "Pair B / mood-vector v2" — "adds behavioural complexity before there is data to
+  tune."
+- **The data source is at risk.** Mood features come from `getTrackAudioFeatures`
+  → Spotify `GET /v1/audio-features` (`packages/bot/src/spotify/spotifyApi.ts`),
+  which Spotify **deprecated for non-grandfathered apps on 2024-11-27** (403 for
+  ineligible clients). Whether this app retains access is **unknown from code**.
+  The fetch is **user-token-gated** (`getValidAccessToken(userId)`) — null for any
+  user without a linked Spotify — and **logs-and-swallows to null** on any error,
+  with **no telemetry on its production success rate**. So the existing audio-
+  feature path may already be silently nulling for most tracks.
+- **Audio features are already used** — `enrichWithAudioFeatures` in
+  `candidateScorer.ts` applies energy/valence/tempo **delta penalties** to scores
+  today. #1095's clustering is a _second-order refinement_ on this existing
+  mechanism, not a greenfield capability.
+- **The Phase C acceptance baseline was not retrieved** (no prod DB access this
+  session), so the gate's own precondition is currently unevaluated.
+
+A `critic` review (Opus) of the build-vs-defer question returned the same verdict
+independently and did not flip it.
+
+## Decision
+
+**Do not override the gate. Hold #1095, gated on a cheap read-only verification
+spike** that must pass _before_ any build decision. The roadmap already says Phase D
+is conditional on Phase C data; #1095 (a Phase D+ stretch on a possibly-dead data
+source) inherits that condition and adds a data-source viability check on top.
+
+The spike (read-only, no code change) answers two facts and one analysis:
+
+1. **Spotify audio-features prod success rate** (query 7 days of logs/Sentry for
+   `getAudioFeatures` non-ok / 403 / null vs. success).
+2. **Phase C per-source acceptance baseline** (`getPerSourceAcceptance` / `getSummary`
+   over the last 7 days).
+3. **`enrichWithAudioFeatures` efficacy** — what share of live score variance the
+   existing energy/valence/tempo deltas already explain.
+
+## Alternatives considered
+
+- **Build now (override the gate).** Rejected. Risks spending effort on a feature
+  that (a) the roadmap's own >85%-acceptance gate may render optional, and (b) may
+  silently no-op because its Spotify data source is deprecated + user-token-gated.
+  Worse, with no Phase C baseline there is nothing to measure the improvement
+  against — unvalidatable by construction.
+- **Close #1095 as not-viable now.** Rejected _as premature_ — it becomes correct
+  only if the spike shows the audio-features source is effectively dead (<50%
+  success). We shouldn't close it before the cheap check, but this is a live
+  outcome of the spike, not a "never."
+- **Hold-and-verify-first (spike, then decide).** Chosen. An afternoon of read-only
+  telemetry resolves all three unknowns and routes to build / close / tune with
+  evidence instead of assumption.
+
+## Consequences
+
+- Positive: no speculative behavioural complexity added to a 60-day battle-tested
+  veto stack; the decision is routed to data; the spike also produces the Phase C
+  baseline the whole roadmap needs.
+- Negative: #1095 stays open and unshipped; the verification spike is itself a small
+  piece of (read-only) work that needs prod access an agent doesn't have.
+- Neutral: consistent with the telemetry-first autoplay roadmap and the
+  measure-demand-before-building posture.
+
+## Revisit when (concrete triggers — run the spike, then route)
+
+- **Spotify success ≥75% AND Phase C acceptance <85% per source** → #1095 is
+  justified; build behind a guild feature flag with an A/B gate (must beat the Phase
+  C baseline by **>2% acceptance** to ship).
+- **Spotify success <50%** → close #1095 as **not-viable** (data source degraded);
+  audio-feature scoring should itself be reconsidered.
+- **Phase C acceptance >85% per source** → close/defer #1095 as **optional** per the
+  roadmap gate (the layered defense already wins).
+- **`enrichWithAudioFeatures` already explains >40% of score variance** → #1095 is a
+  tuning task on the existing penalizer, not a new clustering layer — rescope.
+
+## References
+
+- Issue #1095 — `feat(autoplay): audio-feature mood clustering`
+- `decisions/2026-05-21-autoplay-recommendation-roadmap.md` (the Phase D data gate)
+- `packages/bot/src/utils/music/autoplay/audioFeatures.ts`, `candidateScorer.ts` (`enrichWithAudioFeatures`)
+- `packages/bot/src/spotify/spotifyApi.ts` (`getAudioFeatures` — deprecated endpoint, swallow-to-null)
+- `packages/shared/src/services/recommendationTelemetryReadService.ts` (baseline read)

--- a/decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md
+++ b/decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md
@@ -53,7 +53,11 @@ The spike (read-only, no code change) answers two facts and one analysis:
 2. **Phase C per-source acceptance baseline** (`getPerSourceAcceptance` / `getSummary`
    over the last 7 days).
 3. **`enrichWithAudioFeatures` efficacy** — what share of live score variance the
-   existing energy/valence/tempo deltas already explain.
+   existing audio-feature adjustments already explain. Scope this to the helper's
+   _full_ contribution, not just the mood-clustering signal: besides the
+   energy/valence/tempo deltas, `enrichWithAudioFeatures` also applies an
+   acousticness adjustment and a duration-match bonus (`candidateScorer.ts`), so a
+   model limited to the three mood terms would undercount its real effect.
 
 ## Alternatives considered
 


### PR DESCRIPTION
## Decision

**Hold #1095 (autoplay audio-feature mood clustering) — do NOT override the deferred Phase D gate.** Build only after a cheap read-only verification spike.

ADR: `decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md`

### Why hold (two independent reasons)

1. **The gate is data-conditional and unmet/unmeasured.** The roadmap ADR (`2026-05-21-autoplay-recommendation-roadmap.md`) ships Phase D "only if … >85% acceptance per source is not met; hold 7 days of production data." The Phase C baseline was never retrieved (no prod DB this session).
2. **The data source is at risk.** `getAudioFeatures` → Spotify `/v1/audio-features` is **deprecated for non-grandfathered apps (2024-11-27)**, **user-token-gated**, and **swallows errors to null** with no prod success-rate telemetry — it may already be silently nulling. `enrichWithAudioFeatures` (`candidateScorer.ts`) **already** applies energy/valence/tempo delta penalties, so #1095 is a 2nd-order refinement on an existing, unverified mechanism.

A `critic` (Opus) review independently reached the same verdict and did not flip it.

### Triggers (run the spike, then route)

- Spotify success ≥75% AND Phase C acceptance <85%/source → **build** (guild flag, A/B must beat baseline >2%).
- Spotify success <50% → **close not-viable**.
- Phase C acceptance >85%/source → **close/defer optional**.
- `enrichWithAudioFeatures` explains >40% of variance → **rescope as tuning**.

Docs-only — no code changes.

@cubic-dev-ai please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hold autoplay mood clustering (#1095) and do not bypass the Phase D gate; proceed only after a read‑only data spike. The ADR sets build/close/rescope triggers from Spotify audio‑features success, Phase C per‑source acceptance, and the full `enrichWithAudioFeatures` effect (mood deltas, acousticness, duration); docs‑only.

<sup>Written for commit c142a0dd1afb0a16e56c45df43f5c68bd6ddea63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a decision record documenting considerations and verification requirements for a pending feature, including data reliability assessment criteria and conditions for future development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->