### PR TITLE
chore(docker): bump base image to Node 24 LTS (#847)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,14 @@
 # Multi-stage Dockerfile for Lucky services
 # Usage: docker compose --env-file .env.production up -d --build
 
-ARG NODE_VERSION=22-alpine
+# Node 24 = Active LTS (since Oct 2025). @discordjs/opus ships no prebuilt for
+# this ABI, so it source-compiles via the toolchain the build/deps stages carry
+# (build-base python3-dev opus-dev). Verified on linux/amd64 — the arch CI builds
+# and the homelab runs. NOTE: opus 0.10.0's bundled NEON code fails to compile on
+# linux/arm64 (musl) regardless of Node version (already broken on Node 22) — see
+# issue #1406; Apple-Silicon local dev should run the bot natively rather than
+# via the Docker dev stage.
+ARG NODE_VERSION=24-alpine
 # Lockfile-hash cache key — auto-busts npm BuildKit caches when package-lock.json
 # changes. Passed as a build-arg from the workflow: hashFiles('package-lock.json').
 # Bump the default (v3 → v4) only if you need a forced one-off cache wipe.


### PR DESCRIPTION
Closes #847.

## What

Bump the Docker base image `ARG NODE_VERSION` from `22-alpine` to **`24-alpine`** (Node 24 Active LTS since Oct 2025). Single-line default change — `package.json` engines already allows `>=22 <27`, and CI's `docker-publish.yml` doesn't override the arg, so this default drives all built images.

## Why #847's blocker no longer applies

#847 stayed open waiting for `@discordjs/opus` to ship Node 24/26 **prebuilts**. That premise is obsolete: the Dockerfile was since restructured so every stage that builds opus (`build`, `deps-production`) carries the C toolchain (`build-base python3-dev opus-dev`), and since #1309 opus already **source-compiles** on every build because the musl prebuilt 404'd. So opus prebuilts are irrelevant — Node version is decoupled from them.

Upstream re-checked: `@discordjs/opus` latest is still `0.10.0` (2025-01-25), no new prebuilts — confirming the source-compile path is the right call rather than waiting.

## Verification (local — no PR docker gate exists; `docker-publish.yml` runs only on main push)

Built on **`linux/amd64`** (the arch CI builds and the homelab runs):

- ✅ `--target build` (Node 24, amd64) — opus source-compiles, 0 errors.
- ✅ `--target production-bot` (Node 24, amd64) — full ship image builds end-to-end.
- ✅ Runtime: image reports `v24.16.0`; `require('@discordjs/opus')` loads the compiled binary (`opus loads OK`).

## Known limitation (pre-existing, tracked separately)

opus 0.10.0's bundled NEON code fails to source-compile on **`linux/arm64` (musl)** — `celt_neon_intr.c: implicit declaration of 'celt_inner_prod_neon'`. This is **already broken on `main`** (Node 22 arm64 fails identically), so this PR regresses nothing. It only affects building the Docker dev stage on Apple Silicon; filed as **#1406**. Apple-Silicon local dev should run the bot natively (`npm run dev`). A code comment by the `ARG` documents this.

## Out of scope

CI `setup-node` stays at `'22'` (separate dev/test runtime, not the deploy image). Bumping it is a follow-up if desired.

@cubic-dev-ai please review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump Docker base image to Node 24 LTS (`24-alpine`) so all built images use Node 24. Validated on linux/amd64; closes #847.

- **Dependencies**
  - Default `ARG NODE_VERSION` updated from `22-alpine` to `24-alpine` (used by all stages; CI does not override).
  - `@discordjs/opus` continues to source-compile in build/deps stages; prebuilts not needed (blocker in #847 no longer applies).
  - Known: linux/arm64 (musl) build still fails with `@discordjs/opus` 0.10.0 NEON; tracked in #1406 (pre-existing, no regression).

<sup>Written for commit b21c75fcc12fa18d307cf63f4a29cf3da7b5442b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

