### PR TITLE
test(backend): fix intermittent jest flake from @snazzah/davey native handle (#1322)

### DIFF
--- a/packages/backend/tests/setup.ts
+++ b/packages/backend/tests/setup.ts
@@ -202,6 +202,16 @@ jest.mock('express-session', () => {
     return sessionFactory
 })
 
+// Neutralize the @snazzah/davey native addon (Discord DAVE E2E encryption).
+// It is pulled in transitively (config → youtubeConfig imports `QueryType` from
+// discord-player → discord-voip → @snazzah/davey) and registers a native
+// `CustomGC` handle that keeps the jest worker alive. Under maxWorkers > 1 jest
+// force-exits the un-exitable worker, and whatever test is in-flight there times
+// out at 30s — an intermittent, victim-varies failure that vanishes on rerun
+// (#1322). discord-voip wraps the require in try/catch (DAVE is optional), and
+// backend route tests never exercise it, so an empty module is safe.
+jest.mock('@snazzah/davey', () => ({}))
+
 jest.mock('chalk', () => ({
     default: {
         red: jest.fn((str: string) => str),


### PR DESCRIPTION
Fixes #1322.

## Root cause (finally reproduced + identified)

#1322 was the week-old "backend jest suite fails once with `1 failed, NNNN passed`, no test-level output, vanishes on rerun" flake (~3/9 runs). Reproduced it **3 of 6 runs** with full output captured, which prior investigations never managed:

- The failing test **varies** each run (snowflakeValidation / trackHistory / twitch) — so it's not a buggy test.
- Failing suites timed out at **exactly 30s** (`testTimeout`), and jest printed: *"A worker process has failed to exit gracefully and has been force exited… Active timers can also cause this, ensure that `.unref()` was called."*

`jest --detectOpenHandles --runInBand` named the single leak:

```
●  CustomGC  (native handle)
  @snazzah/davey  ← discord-voip  ← discord-player (StreamDispatcher)
  ← shared/config/youtubeConfig.ts (imports `QueryType` from discord-player)
  ← shared/config → redis/config → MusicControlService → @lucky/shared/services
  ← backend src/routes/recommendations.ts
```

`youtubeConfig.ts` imports `QueryType` (an enum **value**) from `discord-player`, which drags the whole native chain — including `@snazzah/davey` (Discord DAVE E2E encryption) — into any backend module that loads config. The native addon registers a `CustomGC` handle that keeps the jest worker alive.

**Mechanism of the intermittency:** with `maxWorkers: '50%'`, file→worker assignment shuffles each run. The worker that loaded davey can't exit gracefully, so jest **force-exits** it — and whatever test was in-flight in that worker is reported failed/timed-out. Different worker layout each run → different victim, ~50% hit rate, and always green under `--runInBand` (single worker, no force-exit race). That exactly matches every observation in the issue thread.

## Fix

Mock `@snazzah/davey` in `packages/backend/tests/setup.ts` so the native addon never loads. Production-zero-risk:
- `discord-voip` already wraps `require('@snazzah/davey')` in try/catch (DAVE is optional).
- Backend route tests never exercise DAVE.
- Only `tests/setup.ts` changes — no src.

## Verification

| | before fix | after fix |
|---|---|---|
| full-suite runs | 6 | 8 |
| failed | **3** (`1 failed, 1012 passed`) | **0** (1013/1013 every run) |
| "failed to exit gracefully" warnings | present on failures | **0** |

8 clean runs after the fix vs a ~50% pre-fix failure rate (≈0.4% chance of 8 clean by luck if still flaky).

@cubic-dev-ai please review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent backend Jest flake by mocking the `@snazzah/davey` native addon so workers exit cleanly. Eliminates 30s timeouts and “failed to exit gracefully” warnings seen in #1322.

- **Bug Fixes**
  - Mocked `@snazzah/davey` in `packages/backend/tests/setup.ts` to avoid the native `CustomGC` handle that kept Jest workers alive (transitively loaded via `discord-player` → `discord-voip`).
  - Safe change: `discord-voip` treats it as optional and backend tests don’t use it; 8/8 green runs after the change vs ~50% flake before.

<sup>Written for commit 8cb62423ae1b96cfc6cb5d42ec8bdc877f78fd1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed intermittent test failures in end-to-end test suite by mocking an internal dependency during test execution. This improves test stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->