### PR TITLE
test(bot): fix same @snazzah/davey native handle leak in bot suite (#1322)

### DIFF
--- a/packages/bot/jest.config.cjs
+++ b/packages/bot/jest.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
     testEnvironment: 'node',
     roots: ['<rootDir>/src', '<rootDir>/tests'],
     testMatch: ['**/*.test.ts', '**/*.spec.ts'],
+    setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
     collectCoverageFrom: [
         'src/**/*.ts',
         '!src/**/*.d.ts',

--- a/packages/bot/tests/setup.ts
+++ b/packages/bot/tests/setup.ts
@@ -1,0 +1,11 @@
+import { jest } from '@jest/globals'
+
+// Neutralize the @snazzah/davey native addon (Discord DAVE E2E encryption).
+// It is pulled in transitively (discord-player → discord-voip → @snazzah/davey)
+// and registers a native `CustomGC` handle that keeps the jest worker alive.
+// Under multi-worker runs jest force-exits the un-exitable worker, and whatever
+// test is in-flight there times out — an intermittent, victim-varies failure
+// that vanishes on rerun (the backend hit the same leak: #1322). discord-voip
+// wraps the require in try/catch (DAVE is optional) and bot specs never exercise
+// it, so an empty module is safe.
+jest.mock('@snazzah/davey', () => ({}))


### PR DESCRIPTION
Follow-up to #1408 (which fixed the same leak in the **backend** suite, #1322).

## Why

While fixing #1322 I checked whether the bot suite has the same latent leak. It does:

```
jest --config packages/bot/jest.config.cjs --detectOpenHandles --runInBand
→ Jest has detected the following 1 open handle:
  ●  CustomGC   (native)
      at requireNative (node_modules/@snazzah/davey/index.js:200)
      ... entry via src/handlers/player/errorHandlers.spec.ts
```

The bot imports `discord-player` legitimately and mocks it **per-spec-file**, but it has **no global jest setup** — so specs that transitively load the real `discord-player → discord-voip → @snazzah/davey` chain register the native `CustomGC` handle. That handle keeps the jest worker alive; under multi-worker runs jest force-exits the un-exitable worker and an in-flight test can time out — the same intermittent, victim-varies flake that hit the backend (#1322). 2551 tests makes the bot suite the bigger exposure.

## Fix

Add a global `packages/bot/tests/setup.ts` that mocks `@snazzah/davey`, wired via `setupFilesAfterEnv`. The bot config previously had no global setup. Production-zero-risk: DAVE E2E is optional (`discord-voip` try/catches the require) and bot specs never exercise it.

## Verification

`--detectOpenHandles --runInBand` after the fix:

| | before | after |
|---|---|---|
| open-handle report | 1 (`CustomGC` / davey) | **0** |
| force-exit warnings | — | **0** |
| tests | 2545 passed, 6 skipped | **2545 passed, 6 skipped** (no regression) |

Mirrors the backend fix in #1408 (merged). With this, both jest suites that transitively load discord-player are leak-free.

A deeper one-shot fix (making `shared/src/config/youtubeConfig.ts` not eager-import discord-player's `QueryType`) would unblock the native chain for all consumers at once — noted for later; it's shared-touching and out of scope here.

@cubic-dev-ai please review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mocked `@snazzah/davey` in the bot Jest setup to stop the native `CustomGC` handle leak that caused intermittent timeouts. Removes open-handle and force-exit warnings and addresses #1322 for the bot suite.

- **Bug Fixes**
  - Added `tests/setup.ts` and wired it via `setupFilesAfterEnv` to mock `@snazzah/davey`.
  - `--detectOpenHandles` now reports 0; no force-exit warnings; test counts unchanged.

<sup>Written for commit 9e40d9f13f2bedbe4617ffd8cd6eebd8a9260731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Jest configuration to initialize test setup files before running tests.
  * Resolved intermittent timeout issues that occurred during parallel test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->