### PR TITLE
refactor(shared): drop discord-player value import from config (#1322)

### DIFF
--- a/packages/shared/src/config/youtubeConfig.ts
+++ b/packages/shared/src/config/youtubeConfig.ts
@@ -1,5 +1,31 @@
-import { QueryType } from 'discord-player'
+import type { QueryType } from 'discord-player'
 import { ENVIRONMENT_CONFIG } from './config'
+
+// Search-engine identifiers as literal strings rather than `QueryType` enum
+// members. The enum is imported as a *type only* (erased at build), so this
+// config — loaded transitively by anything importing shared config — no longer
+// pulls the heavy `discord-player → discord-voip → @snazzah/davey` chain at
+// module load. That native chain registered a `CustomGC` handle that leaked
+// into jest workers and caused intermittent suite failures (#1322).
+//
+// `satisfies readonly \`${QueryType}\`[]` keeps these in lockstep with
+// discord-player's QueryType: if an upgrade renames a value, this stops
+// compiling. Verified against the installed package (e.g. SOUNDCLOUD_SEARCH ===
+// 'soundcloudSearch').
+const FALLBACK_ENGINES = [
+    'soundcloudSearch',
+    'spotifySong',
+    'appleMusicSong',
+    'auto',
+    'youtubeVideo',
+    'youtubeSearch',
+] as const satisfies readonly `${QueryType}`[]
+
+const YOUTUBE_ENGINES = [
+    'youtubeSearch',
+    'youtubeVideo',
+    'youtubePlaylist',
+] as const satisfies readonly `${QueryType}`[]
 
 /**
  * Configuration for YouTube.js error handling and fallback mechanisms
@@ -24,21 +50,10 @@ export const youtubeConfig = {
     },
 
     // Fallback search engines in order of preference
-    fallbackEngines: [
-        QueryType.SOUNDCLOUD_SEARCH,
-        QueryType.SPOTIFY_SONG,
-        QueryType.APPLE_MUSIC_SONG,
-        QueryType.AUTO,
-        QueryType.YOUTUBE_VIDEO,
-        QueryType.YOUTUBE_SEARCH,
-    ],
+    fallbackEngines: FALLBACK_ENGINES,
 
     // YouTube-specific search engines
-    youtubeEngines: [
-        QueryType.YOUTUBE_SEARCH,
-        QueryType.YOUTUBE_VIDEO,
-        QueryType.YOUTUBE_PLAYLIST,
-    ],
+    youtubeEngines: YOUTUBE_ENGINES,
 
     // Error messages for different types of YouTube errors
     errorMessages: {


### PR DESCRIPTION
## What

Source-level fix for the davey native-handle jest flake (#1322): `shared/src/config/youtubeConfig.ts` no longer eager-imports the `QueryType` **value** from `discord-player`.

- `import { QueryType }` → `import type { QueryType }` (erased at build).
- The two engine arrays are now string literals (`'soundcloudSearch'`, …) constrained by `as const satisfies readonly \`${QueryType}\`[]`, which keeps them in lockstep with discord-player's enum at compile time — an upstream rename stops compiling — without pulling the enum at runtime.

## Why

`QueryType` is a runtime enum, so importing it as a value loaded the whole native chain at module load:

```
discord-player → discord-voip → @snazzah/davey (registers a native CustomGC handle)
```

`youtubeConfig` is loaded transitively by anything importing shared config, so that handle leaked into jest workers. Under `maxWorkers: '50%'` jest force-exits the un-exitable worker and the in-flight test times out at 30s → the intermittent `1 failed, NNNN passed` flake (#1322). PRs #1408 (backend) and #1409 (bot) mock davey in test setup; **this removes the pull at the source** for all config consumers — runtime and tests alike.

## Verification

- `tsc --noEmit` clean; shared build clean.
- `youtubeConfig.d.ts` **byte-identical** before/after (literal tuple types unchanged).
- Built config loads **0** `discord-player` / `discord-voip` / `@snazzah/davey` modules (was pulling all three); engine values identical at runtime.
- Suites green: shared 829/829, bot 2545 passed, backend 1013/1013.

Closes #1322.

@cubic-dev-ai please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop importing the `discord-player` `QueryType` value in shared `youtubeConfig` to avoid eager native loads and fix the flaky Jest exit in #1322.

- **Refactors**
  - Switch to `import type { QueryType }` (type-only; erased at build).
  - Replace enum-based arrays with string literal constants (`FALLBACK_ENGINES`, `YOUTUBE_ENGINES`) constrained by `satisfies readonly \`${QueryType}\`[]`.
  - No runtime behavior change; engine values stay the same.

<sup>Written for commit 5bf147d14382a331ea40c5a27b9a99289fd9259a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

