### PR TITLE
fix(shared): log db error in feature-toggle override read (#1286)

### DIFF
--- a/packages/shared/src/services/FeatureToggleService.spec.ts
+++ b/packages/shared/src/services/FeatureToggleService.spec.ts
@@ -28,6 +28,12 @@ jest.mock('../config/featureToggles', () => ({
     }),
 }))
 
+const mockWarnLog = jest.fn()
+jest.mock('../utils/general/log', () => ({
+    ...jest.requireActual<object>('../utils/general/log'),
+    warnLog: (...args: unknown[]) => mockWarnLog(...args),
+}))
+
 describe('FeatureToggleService', () => {
     let service: InstanceType<
         (typeof import('./FeatureToggleService'))['featureToggleService'] extends infer S
@@ -43,6 +49,7 @@ describe('FeatureToggleService', () => {
         delete process.env.FLAGS
         mockFindUnique.mockReset()
         mockUpsert.mockReset()
+        mockWarnLog.mockReset()
 
         const mod = await import('./FeatureToggleService')
         service = mod.featureToggleService as unknown as typeof service
@@ -87,7 +94,7 @@ describe('FeatureToggleService', () => {
             expect(result).toBeNull()
         })
 
-        it('returns null when db throws', async () => {
+        it('returns null and logs a warning when db throws', async () => {
             mockFindUnique.mockRejectedValue(new Error('DB connection failed'))
             const result = await (
                 service as unknown as {
@@ -95,6 +102,14 @@ describe('FeatureToggleService', () => {
                 }
             ).getDbGlobalOverride('DOWNLOAD_AUDIO')
             expect(result).toBeNull()
+            // #1286 B3: the DB failure must be surfaced, not swallowed silently.
+            expect(mockWarnLog).toHaveBeenCalledTimes(1)
+            expect(mockWarnLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    error: expect.any(Error),
+                    data: { name: 'DOWNLOAD_AUDIO' },
+                }),
+            )
         })
     })
 

--- a/packages/shared/src/services/FeatureToggleService.ts
+++ b/packages/shared/src/services/FeatureToggleService.ts
@@ -5,6 +5,7 @@ import type {
 } from '../types/featureToggle'
 import { getFeatureToggleConfig } from '../config/featureToggles'
 import { getPrismaClient } from '../utils/database/prismaClient'
+import { warnLog } from '../utils/general/log'
 
 /** Manages feature toggles with multi-layer provider support (database, environment). */
 class FeatureToggleService {
@@ -39,7 +40,16 @@ class FeatureToggleService {
                 select: { enabled: true },
             })
             return row?.enabled ?? null
-        } catch {
+        } catch (error) {
+            // Fail open to the environment/config fallback, but surface the
+            // failure: a swallowed-to-null DB error here was indistinguishable
+            // from "no override set", hiding a persistent outage (#1286 B3).
+            warnLog({
+                message:
+                    'Failed to read global feature toggle override; falling back to config default',
+                error,
+                data: { name },
+            })
             return null
         }
     }


### PR DESCRIPTION
## What

First concrete delta for **#1286 Track B3** (silent-catch sweep on external/IO call paths): `FeatureToggleService.getDbGlobalOverride` no longer swallows DB errors to `null` without a trace.

```ts
} catch (error) {
    warnLog({
        message: 'Failed to read global feature toggle override; falling back to config default',
        error,
        data: { name },
    })
    return null
}
```

## Why

The previous `catch { return null }` made a **DB outage indistinguishable from "no override set"** — the caller (`getGlobalToggleStatus`) treats `null` as "fall back to the env/config default", so a persistent database failure silently degraded every global feature toggle to its config value with zero observability.

The fail-open-to-config behavior is **correct and intentionally preserved** — this only adds a `warnLog` so the failure is visible. `warn` (not `error`) because the path is gracefully handled.

## Scope note

This PR is the *only* genuine finding from a read-only sweep of the four external-API families called out in #1286's next-increment (Spotify, Last.fm, Discord, Prisma). The rest of those paths already log via `errorLog` / `warnLog` / `logAndSwallow` / `logAndWarn` before any swallow — the codebase's existing discipline (#1296/#1302/#1352/#1358) already covers them. The broader "promote empty-catch lint warn→error" item (~2026-06-26) and the Track C requestId issue remain as tracked in #1286.

## Verification

- `tsc --noEmit` clean; shared build clean.
- Extended the existing `FeatureToggleService.spec.ts` "db throws" test to assert the warning is emitted (`warnLog` called once with the error + `{ name }`).
- Shared suite green: **829/829** (61 suites).

Refs #1286.

@cubic-dev-ai please review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log database errors when reading global feature toggle overrides so outages are visible while still falling back to config defaults. Addresses #1286 (Track B3) by surfacing failures on an external/IO path.

- **Bug Fixes**
  - `FeatureToggleService.getDbGlobalOverride` now calls `warnLog({ message, error, data: { name } })` on DB errors, then returns `null`.
  - Extended unit test to assert the warning is emitted when the DB read throws.

<sup>Written for commit 3ffc0b4c5e7f1c69e65d8e0d2c195cd7c78b9bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

