### PR TITLE
docs(adr): resolve criativaria tracking — keep instrumented, review 2026-07-14 (#1288)

### DIFF
--- a/decisions/2026-06-01-remove-criativaria-baseline.md
+++ b/decisions/2026-06-01-remove-criativaria-baseline.md
@@ -29,7 +29,7 @@ The bot's `/serversetup criativaria` command remains available and is tracked se
 
 ## Revisit
 
-Never; feature retired by decision.
+The dashboard "Criativaria Baseline" removal is final — never; that feature is retired by decision. This does **not** apply to the bot `/serversetup criativaria` command, which is kept and carries its own usage-review gate (2026-07-14) per the 2026-06-14 addendum below.
 
 ## Addendum 2026-06-14 — bot `/serversetup criativaria` tracking resolved (#1288)
 

--- a/decisions/2026-06-01-remove-criativaria-baseline.md
+++ b/decisions/2026-06-01-remove-criativaria-baseline.md
@@ -30,3 +30,9 @@ The bot's `/serversetup criativaria` command remains available and is tracked se
 ## Revisit
 
 Never; feature retired by decision.
+
+## Addendum 2026-06-14 — bot `/serversetup criativaria` tracking resolved (#1288)
+
+#1288 flagged that the bot command, kept per the original decision, was "tracked separately" with nothing actually tracking it. Resolved: the command IS instrumented at `packages/bot/src/functions/management/commands/serversetup.ts` — Prometheus counter `guildAutomationUsageTotal{operation="criativaria"}` (line 315) and a structured `serversetup: criativaria invoked` log carrying guildId/userId/mode (lines 307–314). The demand-measurement precondition is therefore satisfied.
+
+Decision: KEEP the command, instrumented. Defer removal until a usage review on 2026-07-14. If invocations are zero/negligible by then, run the standard feature-removal sweep (file + serversetup.ts choice/handler/imports + both spec files + this ADR). Tracking issue: #1288.


### PR DESCRIPTION
## Summary

Issue #1288 flagged that `/serversetup criativaria`, kept per the original ADR decision, had "tracking [that] was planned separately" but appeared to have no actual instrumentation. This addendum resolves that premise with verified telemetry.

## Resolution

The bot command IS instrumented at `packages/bot/src/functions/management/commands/serversetup.ts`:
- **Prometheus counter** (line 315): `guildAutomationUsageTotal.inc({ operation: 'criativaria' })`
- **Structured log** (lines 307–314): `infoLog({ message: 'serversetup: criativaria invoked', data: { guildId, userId, mode } })`

The demand-measurement precondition is satisfied.

## Decision: Keep + Review

- **KEEP** the command in production, instrumented.
- **Set usage-review gate** to 2026-07-14 (14 days).
- **On 2026-07-14:** Read `guildAutomationUsageTotal{operation="criativaria"}` + the structured logs; if invocations are zero/negligible across real guilds, run the standard feature-removal sweep (file `serversetupCriativaria.ts` + handler/choice/imports in `serversetup.ts` + both spec files + this ADR).

Closes #1288.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the ADR: the dashboard “Criativaria Baseline” remains retired with no revisit; the bot `/serversetup criativaria` command is kept and tracked per #1288. Telemetry is confirmed via `guildAutomationUsageTotal{operation="criativaria"}` and structured logs in `packages/bot/src/functions/management/commands/serversetup.ts`; ADR now scopes “Revisit” to the dashboard only and sets a 2026-07-14 usage review to remove if negligible.

<sup>Written for commit 5a1f5bab286ee799ed4cac72a1f6fbac28f29a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Architecture Decision Record to clarify instrumentation and tracking details for a server automation command. Previous removal timeline has been deferred pending a comprehensive usage review scheduled for July 14, 2026. Follow-up actions will be determined based on usage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->