### PR TITLE
chore(lint): promote empty-catch rule warn→error (#1412)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,7 +77,7 @@ export default [
             "no-alert": "error",
             "no-debugger": "error",
             "no-console": "warn",
-            "no-empty": ["warn", { allowEmptyCatch: false }],
+            "no-empty": ["error", { allowEmptyCatch: false }],
             "complexity": ["warn", 15],
             "max-depth": ["warn", 6],
             "max-params": ["warn", 6],
@@ -130,7 +130,7 @@ export default [
             // (files: ["src/**/*.ts"]) doesn't match from the root, so without
             // these the @eslint/js recommended core rules fire as errors (#1364)
             "no-unused-vars": "off",
-            "no-empty": ["warn", { allowEmptyCatch: false }],
+            "no-empty": ["error", { allowEmptyCatch: false }],
             "@typescript-eslint/no-non-null-assertion": "warn",
             // NOTE: the no-unsafe-* inventory is cleaned to 0 (#1382/#1384/#1385), but these
             // stay at `warn` until the CI `quality / Lint` job is type-aware.

--- a/packages/bot/src/functions/general/commands/version.ts
+++ b/packages/bot/src/functions/general/commands/version.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
 import { MessageFlags } from 'discord.js'
+import { debugLog } from '@lucky/shared/utils'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -17,7 +18,11 @@ function resolveVersion(): string {
             version?: string
         }
         if (packageJson.version) return `v${packageJson.version}`
-    } catch {
+    } catch (error) {
+        debugLog({
+            message: 'version: failed to read package.json, using fallback',
+            data: { error: String(error) },
+        })
     }
 
     const sha = process.env.COMMIT_SHA


### PR DESCRIPTION
## Summary

Promotes `no-empty` rule with `allowEmptyCatch:false` from warn to error across the codebase (Track B3 of logging-hardening ADR).

Fixed the lone surviving empty catch block in `packages/bot/src/functions/general/commands/version.ts` (line 20-21) by capturing and logging the swallowed error with debugLog.

## Verification

Bot linting (0 errors):
```
✖ 250 problems (0 errors, 250 warnings)
EXIT=0
```

Backend linting (no no-empty errors, pre-existing type-safety errors):
```
✖ 126 problems (125 errors, 1 warning)
EXIT=1
```
No `no-empty` errors in either package.

## Changes

- Updated `eslint.config.js` lines 80 and 133: `"no-empty": ["warn", ...]` → `["error", ...]`
- Added `debugLog` import and logging call to version.ts catch block

Closes #1412

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes ESLint `no-empty` with `allowEmptyCatch:false` from warn to error, and replaces the last empty catch by logging the error in the bot’s version command. This surfaces hidden exceptions and completes the lint upgrade in #1412.

Closes #1412.

<sup>Written for commit a169224619e2539c388cb5c374a4b303a737b49a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

