### PR TITLE
feat(security): collect CSP violations via report-uri sink (#1283)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -53,7 +53,7 @@ server {
         add_header X-Frame-Options DENY always;
         add_header X-Content-Type-Options nosniff always;
         add_header Referrer-Policy strict-origin-when-cross-origin always;
-        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://cdn.discordapp.com https://cdn.discord.com; connect-src 'self' https://lucky-api.lucassantana.tech https://api.luk-homeserver.com.br https://*.sentry.io; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://cdn.discordapp.com https://cdn.discord.com; connect-src 'self' https://lucky-api.lucassantana.tech https://api.luk-homeserver.com.br https://*.sentry.io; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; report-uri /api/security/csp-report" always;
 
         set $frontend_upstream http://frontend:8080;
         proxy_pass $frontend_upstream;

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -31,6 +31,7 @@ import { setupMetricsRoute } from './metrics'
 import { setupStatsRoutes } from './stats'
 import { setupInviteRoute } from './invite'
 import { setupSupportRoutes } from './support'
+import { setupSecurityRoutes } from './security'
 
 type GuildGuardConfig = {
     path: string
@@ -94,6 +95,9 @@ export function setupRoutes(app: Express): void {
     setupStatsRoutes(app)
     setupInternalNotifyRoutes(app)
     setupWebhookPublicRoutes(app)
+    // Public, unauthenticated CSP report sink — registered before the shared
+    // /api limiter/guards so it uses its own strict limiter (#1283).
+    setupSecurityRoutes(app)
     app.use('/api/', apiLimiter)
     app.use('/api/admin', requireAuth, requireAdmin)
     app.use('/api/toggles/global', requireAuth, requireAdmin, writeLimiter)

--- a/packages/backend/src/routes/security.ts
+++ b/packages/backend/src/routes/security.ts
@@ -1,4 +1,9 @@
-import express, { type Express, type Request, type Response } from 'express'
+import express, {
+    type Express,
+    type NextFunction,
+    type Request,
+    type Response,
+} from 'express'
 import rateLimit from 'express-rate-limit'
 import { warnLog } from '@lucky/shared/utils'
 import { captureMessageThrottled } from '@lucky/shared/utils/monitoring'
@@ -121,6 +126,13 @@ export function setupSecurityRoutes(app: Express): void {
             } catch {
                 // A malformed report must never surface an error to the browser.
             }
+            res.status(204).end()
+        },
+        // Route-scoped error handler: cspBodyParser throws a SyntaxError on
+        // malformed JSON *before* the handler runs, which would otherwise reach
+        // the global error handler and 500. Swallow it — a public report sink
+        // must stay quiet (204) under malformed traffic.
+        (_err: unknown, _req: Request, res: Response, _next: NextFunction) => {
             res.status(204).end()
         },
     )

--- a/packages/backend/src/routes/security.ts
+++ b/packages/backend/src/routes/security.ts
@@ -1,0 +1,115 @@
+import express, { type Express, type Request, type Response } from 'express'
+import rateLimit from 'express-rate-limit'
+import { warnLog } from '@lucky/shared/utils'
+import { captureMessageThrottled } from '@lucky/shared/utils/monitoring'
+
+/**
+ * Same-origin sink for CSP violation reports (#1283).
+ *
+ * The CSP `report-uri` directive (set in nginx.conf and vercel.json while the
+ * policy is in Report-Only mode) points browsers here so violations are
+ * collected centrally instead of only surfacing in each user's console. Reports
+ * are logged (greppable `csp-violation`) and forwarded to Sentry — the ADR's
+ * intended destination — without committing the Sentry DSN to nginx/vercel.json.
+ *
+ * Security posture for an unauthenticated public endpoint: a dedicated strict
+ * rate limit, a small body cap, and a field allowlist (never log/forward
+ * arbitrary attacker-supplied JSON).
+ */
+
+// CSP reports are low-volume on legitimate page loads; cap hard to keep an
+// open endpoint from flooding logs or Sentry.
+const cspReportLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+})
+
+// Browsers POST violations as `application/csp-report` (legacy report-uri) or
+// `application/reports+json` (Reporting API). The global express.json() only
+// parses application/json and leaves these untouched, so re-parse here.
+const cspBodyParser = express.json({
+    type: [
+        'application/csp-report',
+        'application/reports+json',
+        'application/json',
+    ],
+    limit: '16kb',
+})
+
+const MAX_FIELD_LENGTH = 512
+
+const str = (value: unknown): string | undefined =>
+    typeof value === 'string' ? value.slice(0, MAX_FIELD_LENGTH) : undefined
+
+/**
+ * Extract the report payload(s). Legacy report-uri sends `{ "csp-report": {…} }`;
+ * the Reporting API sends an array of `{ type, body: {…} }`.
+ */
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+    value && typeof value === 'object'
+        ? (value as Record<string, unknown>)
+        : undefined
+
+const extractReports = (body: unknown): Array<Record<string, unknown>> => {
+    if (Array.isArray(body)) {
+        return (body as unknown[])
+            .map((entry) => {
+                const record = asRecord(entry)
+                return record && 'body' in record
+                    ? asRecord(record.body)
+                    : record
+            })
+            .filter((entry): entry is Record<string, unknown> => !!entry)
+    }
+    const record = asRecord(body)
+    if (record) {
+        const wrapped = asRecord(record['csp-report'])
+        return wrapped ? [wrapped] : [record]
+    }
+    return []
+}
+
+// Allowlist the fields we record, accepting both the kebab-case (report-uri)
+// and camelCase (Reporting API) spellings.
+const pickReportFields = (report: Record<string, unknown>) => ({
+    documentUri: str(report['document-uri'] ?? report['documentURL']),
+    violatedDirective: str(
+        report['violated-directive'] ??
+            report['effective-directive'] ??
+            report['effectiveDirective'],
+    ),
+    blockedUri: str(report['blocked-uri'] ?? report['blockedURL']),
+    disposition: str(report['disposition']),
+})
+
+export function setupSecurityRoutes(app: Express): void {
+    app.post(
+        '/api/security/csp-report',
+        cspReportLimiter,
+        cspBodyParser,
+        (req: Request, res: Response) => {
+            try {
+                for (const raw of extractReports(req.body)) {
+                    const fields = pickReportFields(raw)
+                    // Ignore empty/garbage payloads — only act on a real violation.
+                    if (!fields.violatedDirective && !fields.blockedUri) continue
+
+                    warnLog({ message: 'csp-violation', data: fields })
+                    captureMessageThrottled(
+                        `csp:${fields.violatedDirective ?? 'unknown'}`,
+                        `CSP violation: ${
+                            fields.violatedDirective ?? 'unknown'
+                        } blocked ${fields.blockedUri ?? 'unknown'}`,
+                        'warning',
+                        fields,
+                    )
+                }
+            } catch {
+                // A malformed report must never surface an error to the browser.
+            }
+            res.status(204).end()
+        },
+    )
+}

--- a/packages/backend/src/routes/security.ts
+++ b/packages/backend/src/routes/security.ts
@@ -39,9 +39,20 @@ const cspBodyParser = express.json({
 })
 
 const MAX_FIELD_LENGTH = 512
+// Real browsers send one (or a tiny batch of) report(s) per POST. Cap hard so a
+// crafted multi-report payload that fits under the body limit can't fan out into
+// hundreds of log/Sentry writes in a single request.
+const MAX_REPORTS_PER_REQUEST = 20
 
 const str = (value: unknown): string | undefined =>
     typeof value === 'string' ? value.slice(0, MAX_FIELD_LENGTH) : undefined
+
+// document-uri carries the full page URL; its query string can hold tokens/PII.
+// Keep only the path-and-origin so secrets don't land in logs or Sentry.
+const strNoQuery = (value: unknown): string | undefined =>
+    typeof value === 'string'
+        ? value.split('?')[0].slice(0, MAX_FIELD_LENGTH)
+        : undefined
 
 /**
  * Extract the report payload(s). Legacy report-uri sends `{ "csp-report": {…} }`;
@@ -62,6 +73,7 @@ const extractReports = (body: unknown): Array<Record<string, unknown>> => {
                     : record
             })
             .filter((entry): entry is Record<string, unknown> => !!entry)
+            .slice(0, MAX_REPORTS_PER_REQUEST)
     }
     const record = asRecord(body)
     if (record) {
@@ -74,7 +86,7 @@ const extractReports = (body: unknown): Array<Record<string, unknown>> => {
 // Allowlist the fields we record, accepting both the kebab-case (report-uri)
 // and camelCase (Reporting API) spellings.
 const pickReportFields = (report: Record<string, unknown>) => ({
-    documentUri: str(report['document-uri'] ?? report['documentURL']),
+    documentUri: strNoQuery(report['document-uri'] ?? report['documentURL']),
     violatedDirective: str(
         report['violated-directive'] ??
             report['effective-directive'] ??

--- a/packages/backend/tests/integration/routes/cspReport.test.ts
+++ b/packages/backend/tests/integration/routes/cspReport.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import request from 'supertest'
+import express from 'express'
+
+jest.mock('@lucky/shared/utils', () => ({
+    warnLog: jest.fn(),
+    infoLog: jest.fn(),
+    errorLog: jest.fn(),
+    debugLog: jest.fn(),
+}))
+jest.mock('@lucky/shared/utils/monitoring', () => ({
+    captureMessageThrottled: jest.fn(),
+}))
+
+import { warnLog } from '@lucky/shared/utils'
+import { captureMessageThrottled } from '@lucky/shared/utils/monitoring'
+import { setupSecurityRoutes } from '../../../src/routes/security'
+
+const warnLogMock = warnLog as jest.MockedFunction<typeof warnLog>
+const captureMock = captureMessageThrottled as jest.MockedFunction<
+    typeof captureMessageThrottled
+>
+
+describe('POST /api/security/csp-report (#1283)', () => {
+    let app: express.Express
+
+    beforeEach(() => {
+        app = express()
+        // The global express.json() runs in the real middleware stack; the
+        // route carries its own parser for the CSP content types, so none here.
+        setupSecurityRoutes(app)
+        jest.clearAllMocks()
+    })
+
+    test('records a legacy report-uri violation and returns 204', async () => {
+        const response = await request(app)
+            .post('/api/security/csp-report')
+            .set('Content-Type', 'application/csp-report')
+            .send(
+                JSON.stringify({
+                    'csp-report': {
+                        'document-uri': 'https://app.example/dashboard',
+                        'violated-directive': 'script-src',
+                        'blocked-uri': 'https://evil.example/x.js',
+                        disposition: 'report',
+                    },
+                }),
+            )
+
+        expect(response.status).toBe(204)
+        expect(warnLogMock).toHaveBeenCalledTimes(1)
+        expect(warnLogMock).toHaveBeenCalledWith({
+            message: 'csp-violation',
+            data: expect.objectContaining({
+                violatedDirective: 'script-src',
+                blockedUri: 'https://evil.example/x.js',
+            }),
+        })
+        expect(captureMock).toHaveBeenCalledTimes(1)
+    })
+
+    test('records a Reporting-API (report-to) violation and returns 204', async () => {
+        const response = await request(app)
+            .post('/api/security/csp-report')
+            .set('Content-Type', 'application/reports+json')
+            .send(
+                JSON.stringify([
+                    {
+                        type: 'csp-violation',
+                        body: {
+                            documentURL: 'https://app.example/',
+                            effectiveDirective: 'img-src',
+                            blockedURL: 'https://evil.example/p.png',
+                        },
+                    },
+                ]),
+            )
+
+        expect(response.status).toBe(204)
+        expect(warnLogMock).toHaveBeenCalledWith({
+            message: 'csp-violation',
+            data: expect.objectContaining({
+                violatedDirective: 'img-src',
+                blockedUri: 'https://evil.example/p.png',
+            }),
+        })
+    })
+
+    test('ignores an empty/garbage payload without logging and returns 204', async () => {
+        const response = await request(app)
+            .post('/api/security/csp-report')
+            .set('Content-Type', 'application/csp-report')
+            .send(JSON.stringify({ 'csp-report': { foo: 'bar' } }))
+
+        expect(response.status).toBe(204)
+        expect(warnLogMock).not.toHaveBeenCalled()
+        expect(captureMock).not.toHaveBeenCalled()
+    })
+})

--- a/packages/backend/tests/integration/routes/cspReport.test.ts
+++ b/packages/backend/tests/integration/routes/cspReport.test.ts
@@ -84,6 +84,18 @@ describe('POST /api/security/csp-report (#1283)', () => {
                 blockedUri: 'https://evil.example/p.png',
             }),
         })
+        expect(captureMock).toHaveBeenCalledTimes(1)
+    })
+
+    test('returns 204 (not 500) on malformed JSON without logging', async () => {
+        const response = await request(app)
+            .post('/api/security/csp-report')
+            .set('Content-Type', 'application/csp-report')
+            .send('{ this is not valid json')
+
+        expect(response.status).toBe(204)
+        expect(warnLogMock).not.toHaveBeenCalled()
+        expect(captureMock).not.toHaveBeenCalled()
     })
 
     test('strips the query string from document-uri before recording', async () => {

--- a/packages/backend/tests/integration/routes/cspReport.test.ts
+++ b/packages/backend/tests/integration/routes/cspReport.test.ts
@@ -86,6 +86,48 @@ describe('POST /api/security/csp-report (#1283)', () => {
         })
     })
 
+    test('strips the query string from document-uri before recording', async () => {
+        await request(app)
+            .post('/api/security/csp-report')
+            .set('Content-Type', 'application/csp-report')
+            .send(
+                JSON.stringify({
+                    'csp-report': {
+                        'document-uri':
+                            'https://app.example/dashboard?token=secret123',
+                        'violated-directive': 'script-src',
+                        'blocked-uri': 'https://evil.example/x.js',
+                    },
+                }),
+            )
+            .expect(204)
+
+        expect(warnLogMock).toHaveBeenCalledWith({
+            message: 'csp-violation',
+            data: expect.objectContaining({
+                documentUri: 'https://app.example/dashboard',
+            }),
+        })
+    })
+
+    test('caps the number of reports processed per request', async () => {
+        const reports = Array.from({ length: 50 }, () => ({
+            type: 'csp-violation',
+            body: {
+                effectiveDirective: 'img-src',
+                blockedURL: 'https://evil.example/p.png',
+            },
+        }))
+
+        await request(app)
+            .post('/api/security/csp-report')
+            .set('Content-Type', 'application/reports+json')
+            .send(JSON.stringify(reports))
+            .expect(204)
+
+        expect(warnLogMock.mock.calls.length).toBeLessThanOrEqual(20)
+    })
+
     test('ignores an empty/garbage payload without logging and returns 204', async () => {
         const response = await request(app)
             .post('/api/security/csp-report')

--- a/packages/backend/tests/unit/routes/index.test.ts
+++ b/packages/backend/tests/unit/routes/index.test.ts
@@ -23,6 +23,7 @@ const setupMusicRoutes = jest.fn()
 const setupSpotifyRoutes = jest.fn()
 const setupArtistsRoutes = jest.fn()
 const setupSupportRoutes = jest.fn()
+const setupSecurityRoutes = jest.fn()
 const setupInternalNotifyRoutes = jest.fn()
 const setupWebhookApiRoutes = jest.fn()
 const setupWebhookPublicRoutes = jest.fn()
@@ -127,6 +128,10 @@ jest.mock('../../../src/routes/internalNotify', () => ({
     setupInternalNotifyRoutes,
 }))
 
+jest.mock('../../../src/routes/security', () => ({
+    setupSecurityRoutes,
+}))
+
 jest.mock('../../../src/routes/webhooks', () => ({
     setupWebhookApiRoutes,
     setupWebhookPublicRoutes,
@@ -183,6 +188,7 @@ describe('setupRoutes', () => {
         expect(setupInviteRoute).toHaveBeenCalledWith(app)
         expect(setupInternalNotifyRoutes).toHaveBeenCalledWith(app)
         expect(setupWebhookPublicRoutes).toHaveBeenCalledWith(app)
+        expect(setupSecurityRoutes).toHaveBeenCalledWith(app)
         expect(app.use).toHaveBeenCalledWith('/api/', apiLimiter)
         expect(app.use).toHaveBeenCalledWith(
             '/api/admin',

--- a/vercel.json
+++ b/vercel.json
@@ -15,7 +15,7 @@
                 },
                 {
                     "key": "Content-Security-Policy-Report-Only",
-                    "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://cdn.discordapp.com https://cdn.discord.com; connect-src 'self' https://lucky-api.lucassantana.tech https://api.luk-homeserver.com.br https://*.sentry.io; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+                    "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://cdn.discordapp.com https://cdn.discord.com; connect-src 'self' https://lucky-api.lucassantana.tech https://api.luk-homeserver.com.br https://*.sentry.io; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; report-uri /api/security/csp-report"
                 }
             ]
         }


### PR DESCRIPTION
## What

Adds central collection of CSP violations while the policy is in **Report-Only** mode (#1283), so the 2026-06-25 enforce decision has real data instead of only per-user browser-console output.

- **`report-uri /api/security/csp-report`** appended to the Report-Only CSP at **both** origins (`nginx/nginx.conf`, `vercel.json`) — kept in sync per the ADR.
- **`POST /api/security/csp-report`** — a same-origin sink that parses the report (legacy `report-uri` and Reporting-API `report-to` shapes), logs allowlisted fields as `csp-violation`, and forwards to Sentry via `captureMessageThrottled`.

## Why a same-origin sink (not Sentry directly)

The frontend Sentry DSN is env-only (`VITE_SENTRY_DSN`, not committed) and `nginx.conf` is copied statically (no envsubst), so a Sentry `report-uri` would require hardcoding the DSN into `vercel.json`. The backend already holds the DSN at runtime, so routing through `/api` reaches Sentry with nothing secret in the repo, and works for both the Vercel- and homelab-served SPA.

## Scope / non-goals

- **Does NOT enforce CSP** — stays `Content-Security-Policy-Report-Only`. The Report-Only→enforce flip is the separate second PR that closes #1283 (gated on the measurement window, review 2026-06-25). **Part of #1283**, does not close it.

## Security posture (unauthenticated public endpoint)

Independently security-reviewed (PASS). Hardening: dedicated strict limiter (30/min/IP, separate from the global `/api` limiter, registered before auth guards); 16 KB body cap + **≤20 reports/request**; field allowlist (4 known fields, truncated) — `warnLog` serializes `data` as JSON so no log forging; **`document-uri` query string stripped** to avoid token/PII leakage; all error paths return `204`.

## Tests

5 integration tests (`tests/integration/routes/cspReport.test.ts`): legacy + Reporting-API shapes, query-strip, per-request cap, garbage payload — green locally. ESLint clean; tsc clean on changed files.

Refs #1283

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a same‑origin CSP report sink and wire it into the Report‑Only policy to centrally collect violations. This feeds #1283 with real data ahead of the 2026‑06‑25 enforce decision; no enforcement here.

- **New Features**
  - Append `report-uri /api/security/csp-report` to the Report‑Only CSP at both origins (`nginx/nginx.conf`, `vercel.json`).
  - Add `POST /api/security/csp-report`: accepts legacy and Reporting‑API payloads, allowlists/truncates fields, strips `document-uri` query, logs `csp-violation`, forwards to Sentry; strict limiter (30/min/IP), 16 KB body cap, ≤20 reports/request, always 204.

- **Bug Fixes**
  - Swallow malformed‑JSON body‑parser errors with a route‑scoped handler to ensure 204 responses instead of 500s.

<sup>Written for commit 84cc51c3d8d526a652b987a915487b36fc863166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

