### PR TITLE
fix(web): report swallowed member-context fetch error to Sentry (#1286 B3)

### DIFF
--- a/packages/frontend/src/stores/guildStore.ts
+++ b/packages/frontend/src/stores/guildStore.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/types'
 import { api } from '@/services/api'
 import { ApiError } from '@/services/ApiError'
+import { captureFrontendException } from '@/lib/sentry'
 
 export type GuildLoadErrorKind =
     | 'auth'
@@ -184,7 +185,13 @@ export const useGuildStore = create<GuildState>((set, get) => ({
                       }
                     : {},
             )
-        } catch {
+        } catch (error) {
+            // The UI already degrades (context cleared below); report to Sentry
+            // so the failure isn't silently swallowed (#1286 Track B3).
+            captureFrontendException(error, {
+                message: 'Failed to fetch guild member context',
+                guildId,
+            })
             set((state) =>
                 state.selectedGuildId === guildId
                     ? {


### PR DESCRIPTION
## What

`guildStore.fetchMemberContext` swallowed a failed `api.guilds.getMe(guildId)` in a bare `catch {}` — the UI degraded (member context cleared) but nothing was logged or sent to Sentry, so the failure was invisible to operators.

Now the catch reports via `captureFrontendException` (whose docstring is exactly this case — "use from catch blocks where the existing UI already shows an error state") while preserving the existing degrade-to-null UX.

## Why

Last remaining real silent-swallow from a read-only Track B3 sweep (#1286) of non-external-API catches. The sweep otherwise confirmed the codebase already logs-before-swallow nearly everywhere (40+ benign fallbacks; one flagged catch — `replenisher.ts:110` — was a false positive: its error already propagates to `trackHandlers` which `errorLog`s it). With this fix, the B3 silent-catch sweep is effectively complete.

## Verify

ESLint clean, `tsc` clean, `Sidebar.test.tsx` (exercises `fetchMemberContext`) 21/21 green. Behavior-preserving — only adds a Sentry report on the error path.

Refs #1286

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report failed member-context fetches to Sentry in `guildStore.fetchMemberContext` instead of silently swallowing, while keeping the degrade-to-null UI. Completes the Track B3 silent-catch sweep in #1286.

- **Bug Fixes**
  - Replace bare `catch {}` with `captureFrontendException(error, { message: 'Failed to fetch guild member context', guildId })`.
  - Keep existing UX: context clears on error; this adds telemetry only.

<sup>Written for commit 10578fbbab55054ef98fd6fa8b9d3ea30e7b02be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error tracking and diagnostics for guild operations to improve issue identification and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->