### PR TITLE
feat(backend): request-id correlation middleware for #1286

### DIFF
--- a/packages/backend/src/middleware/index.ts
+++ b/packages/backend/src/middleware/index.ts
@@ -5,6 +5,7 @@ import helmet from 'helmet'
 import { existsSync } from 'node:fs'
 import path from 'path'
 import { setupSessionMiddleware } from './session'
+import { requestId } from './requestId'
 import { requestLogger } from './requestLogger'
 import { metricsMiddleware } from './metrics'
 import { getFrontendOrigins } from '../utils/frontendOrigin'
@@ -119,6 +120,7 @@ export function setupMiddleware(app: Express): void {
         }),
     )
 
+    app.use(requestId)
     app.use(requestLogger)
     app.use(metricsMiddleware)
     app.use(express.json())

--- a/packages/backend/src/middleware/requestId.ts
+++ b/packages/backend/src/middleware/requestId.ts
@@ -1,0 +1,36 @@
+import type { Request, Response, NextFunction } from 'express'
+import { mintCorrelationId } from '@lucky/shared/utils/support'
+
+const REQUEST_ID_HEADER = 'x-request-id'
+const RESPONSE_HEADER = 'X-Request-Id'
+
+// An inbound id is attacker-controllable and gets logged, so it is only
+// honoured when it matches the same safe, bounded charset `mintCorrelationId`
+// produces ([A-Za-z0-9_-], 1-64 chars). Anything else (newlines for log
+// injection, oversized values) is dropped and a fresh id is minted. The
+// pattern is anchored with a single bounded quantifier — no ReDoS surface.
+const SAFE_INBOUND_ID = /^[A-Za-z0-9_-]{1,64}$/
+
+/**
+ * Assigns a correlation id to every request: honours a valid inbound
+ * `X-Request-Id` (so an upstream proxy / client trace id is preserved across
+ * the Cloudflare tunnel + nginx hop), otherwise mints a fresh one. Exposes it
+ * on `req.requestId` and echoes it back as the `X-Request-Id` response header
+ * for client-side correlation.
+ *
+ * Must be registered BEFORE `requestLogger` so the id is available to the
+ * request-summary log line.
+ */
+export function requestId(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+): void {
+    const inbound = req.get(REQUEST_ID_HEADER)
+    const id =
+        inbound && SAFE_INBOUND_ID.test(inbound) ? inbound : mintCorrelationId()
+
+    req.requestId = id
+    res.setHeader(RESPONSE_HEADER, id)
+    next()
+}

--- a/packages/backend/src/middleware/requestLogger.ts
+++ b/packages/backend/src/middleware/requestLogger.ts
@@ -16,6 +16,7 @@ export function requestLogger(
 
         const logParams = {
             message: `${method} ${url} ${status} ${duration}ms`,
+            correlationId: req.requestId,
         }
 
         if (status >= 500) {

--- a/packages/backend/src/types/express.d.ts
+++ b/packages/backend/src/types/express.d.ts
@@ -1,0 +1,16 @@
+import 'express'
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Express {
+        interface Request {
+            /**
+             * Per-request correlation id, assigned by the `requestId`
+             * middleware (honours a sane inbound `X-Request-Id`, else minted).
+             * Threaded into request logs so a single request can be traced
+             * across log lines. See decisions/2026-06-01-logging-observability-hardening.md (Track C7).
+             */
+            requestId?: string
+        }
+    }
+}

--- a/packages/backend/tests/unit/middleware/requestId.test.ts
+++ b/packages/backend/tests/unit/middleware/requestId.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect, jest } from '@jest/globals'
+import type { Request, Response } from 'express'
+import { requestId } from '../../../src/middleware/requestId'
+
+function createReq(headerValue?: string): Request {
+    return {
+        get: (name: string) =>
+            name.toLowerCase() === 'x-request-id' ? headerValue : undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+}
+
+function createRes(): Response & { headers: Record<string, string> } {
+    const headers: Record<string, string> = {}
+    return {
+        headers,
+        setHeader: (name: string, value: string) => {
+            headers[name] = value
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+}
+
+describe('requestId middleware', () => {
+    test('mints an id when no inbound header is present', () => {
+        const req = createReq()
+        const res = createRes()
+        const next = jest.fn()
+
+        requestId(req, res, next)
+
+        expect(req.requestId).toMatch(/^[A-Za-z0-9_-]{8}$/)
+        expect(res.headers['X-Request-Id']).toBe(req.requestId)
+        expect(next).toHaveBeenCalledTimes(1)
+    })
+
+    test('honours a valid inbound X-Request-Id', () => {
+        const req = createReq('abc-DEF_123')
+        const res = createRes()
+        const next = jest.fn()
+
+        requestId(req, res, next)
+
+        expect(req.requestId).toBe('abc-DEF_123')
+        expect(res.headers['X-Request-Id']).toBe('abc-DEF_123')
+    })
+
+    test('mints a fresh id when the inbound header has unsafe characters', () => {
+        // A newline would let an attacker inject forged log lines.
+        const req = createReq('evil\ninjected')
+        const res = createRes()
+        const next = jest.fn()
+
+        requestId(req, res, next)
+
+        expect(req.requestId).not.toBe('evil\ninjected')
+        expect(req.requestId).toMatch(/^[A-Za-z0-9_-]{8}$/)
+    })
+
+    test('mints a fresh id when the inbound header is over 64 chars', () => {
+        const req = createReq('a'.repeat(65))
+        const res = createRes()
+        const next = jest.fn()
+
+        requestId(req, res, next)
+
+        expect(req.requestId).toMatch(/^[A-Za-z0-9_-]{8}$/)
+    })
+
+    test('mints a fresh id when the inbound header is empty', () => {
+        const req = createReq('')
+        const res = createRes()
+        const next = jest.fn()
+
+        requestId(req, res, next)
+
+        expect(req.requestId).toMatch(/^[A-Za-z0-9_-]{8}$/)
+    })
+})

--- a/packages/backend/tests/unit/middleware/requestId.test.ts
+++ b/packages/backend/tests/unit/middleware/requestId.test.ts
@@ -55,6 +55,7 @@ describe('requestId middleware', () => {
 
         expect(req.requestId).not.toBe('evil\ninjected')
         expect(req.requestId).toMatch(/^[A-Za-z0-9_-]{8}$/)
+        expect(res.headers['X-Request-Id']).toBe(req.requestId)
     })
 
     test('mints a fresh id when the inbound header is over 64 chars', () => {
@@ -65,6 +66,7 @@ describe('requestId middleware', () => {
         requestId(req, res, next)
 
         expect(req.requestId).toMatch(/^[A-Za-z0-9_-]{8}$/)
+        expect(res.headers['X-Request-Id']).toBe(req.requestId)
     })
 
     test('mints a fresh id when the inbound header is empty', () => {
@@ -75,5 +77,6 @@ describe('requestId middleware', () => {
         requestId(req, res, next)
 
         expect(req.requestId).toMatch(/^[A-Za-z0-9_-]{8}$/)
+        expect(res.headers['X-Request-Id']).toBe(req.requestId)
     })
 })


### PR DESCRIPTION
## What

Track **C7** of the logging-hardening umbrella (#1286) — a lightweight **requestId correlation middleware** for the backend.

- New `requestId` middleware: honours a valid inbound `X-Request-Id` (preserving an upstream proxy / client trace id across the Cloudflare tunnel + nginx hop), otherwise mints a fresh short id via the existing `mintCorrelationId` util.
- Exposes it on `req.requestId` (new global `Express.Request` augmentation in `src/types/express.d.ts`) and echoes it back as the `X-Request-Id` response header for client-side correlation.
- Registered **before** `requestLogger`, which now threads it as `correlationId` — so every request-summary log line is prefixed `[id]` (the log service already supports `correlationId`, `enableCorrelationId: true` by default).

## Security

Inbound ids are validated against the same safe, bounded charset `mintCorrelationId` produces — `^[A-Za-z0-9_-]{1,64}$` — **before** use. A non-matching value (newline log-injection attempt, oversized header) is dropped and a fresh id minted. The pattern is anchored with a single bounded quantifier (no ReDoS surface).

## Scope / ADR alignment

Per `decisions/2026-06-01-logging-observability-hardening.md`, C7 is the **lightweight manual-threading** step. Pino + `AsyncLocalStorage` auto-propagation is the deferred escalation, only if manual adoption stalls — **not** in this PR. This wires the foundation + the request-summary log site; deeper per-service threading follows incrementally.

## Tests

- New `tests/unit/middleware/requestId.test.ts` (5 cases): mints when absent, honours valid inbound, rejects newline-injection → mints, rejects >64 chars → mints, rejects empty → mints; asserts `X-Request-Id` response header + `next()`.
- Full backend suite green locally: **1024/1024**. Typecheck + lint clean (only the pre-existing `artistSuggestion` complexity warning).

Part of #1286 — does not complete the umbrella (C7 is the last track; this is its first incremental unit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add request ID middleware that preserves or generates `X-Request-Id` and threads it into request logs for traceability. Implements Track C7 of #1286.

- **New Features**
  - Honors a valid inbound `X-Request-Id`; otherwise mints one via `mintCorrelationId` from `@lucky/shared/utils/support` (only `^[A-Za-z0-9_-]{1,64}$` allowed).
  - Sets `req.requestId` and echoes `X-Request-Id` on responses; tests assert the header mirrors minted IDs when inbound is invalid.
  - Runs before `requestLogger`, which now sends `correlationId` on each request log line.

<sup>Written for commit c0853ffa37d2b6650322b159c9ecfc5ccc05917b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

