### PR TITLE
refactor(web): use shared api client in autoplay genres component

### DIFF
--- a/packages/frontend/src/components/Music/AutoplayGenres.test.tsx
+++ b/packages/frontend/src/components/Music/AutoplayGenres.test.tsx
@@ -6,12 +6,10 @@ import { toast } from 'sonner'
 let mockGet: any
 let mockPut: any
 
-vi.mock('axios', () => ({
+vi.mock('@/services/api', () => ({
     default: {
-        create: vi.fn(() => ({
-            get: (...args: any[]) => mockGet(...args),
-            put: (...args: any[]) => mockPut(...args),
-        })),
+        get: (...args: any[]) => mockGet(...args),
+        put: (...args: any[]) => mockPut(...args),
     },
 }))
 
@@ -40,7 +38,9 @@ describe('AutoplayGenres', () => {
 
         render(<AutoplayGenres guildId={mockGuildId} />)
 
-        expect(screen.getByText('Autoplay Genre Preferences')).toBeInTheDocument()
+        expect(
+            screen.getByText('Autoplay Genre Preferences'),
+        ).toBeInTheDocument()
     })
 
     test('loads genres on mount', async () => {
@@ -84,9 +84,9 @@ describe('AutoplayGenres', () => {
             expect(mockGet).toHaveBeenCalled()
         })
 
-        const rockButton = screen.getAllByRole('button').find(
-            (btn) => btn.textContent === 'rock'
-        )
+        const rockButton = screen
+            .getAllByRole('button')
+            .find((btn) => btn.textContent === 'rock')
         await user.click(rockButton!)
 
         const input = screen.getByPlaceholderText(/e.g., rock, pop, jazz/)
@@ -135,7 +135,9 @@ describe('AutoplayGenres', () => {
         const input = screen.getByPlaceholderText(/e.g., rock, pop, jazz/)
         await user.type(input, 'jazz')
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         await waitFor(() => {
@@ -155,7 +157,9 @@ describe('AutoplayGenres', () => {
             expect(mockGet).toHaveBeenCalled()
         })
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         expect(mockPut).not.toHaveBeenCalled()
@@ -176,7 +180,9 @@ describe('AutoplayGenres', () => {
         const input = screen.getByPlaceholderText(/e.g., rock, pop, jazz/)
         await user.type(input, 'rock')
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         expect(toast.error).toHaveBeenCalledWith('Genre already added')
@@ -229,7 +235,7 @@ describe('AutoplayGenres', () => {
 
         await waitFor(() => {
             expect(
-                screen.getByText('Failed to load autoplay genres')
+                screen.getByText('Failed to load autoplay genres'),
             ).toBeInTheDocument()
         })
     })
@@ -250,12 +256,14 @@ describe('AutoplayGenres', () => {
         const input = screen.getByPlaceholderText(/e.g., rock, pop, jazz/)
         await user.type(input, 'rock')
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         await waitFor(() => {
             expect(
-                screen.getByText('Failed to update autoplay genres')
+                screen.getByText('Failed to update autoplay genres'),
             ).toBeInTheDocument()
         })
     })
@@ -276,11 +284,13 @@ describe('AutoplayGenres', () => {
         })
 
         const input = screen.getByPlaceholderText(
-            /e.g., rock, pop, jazz/
+            /e.g., rock, pop, jazz/,
         ) as HTMLInputElement
         await user.type(input, 'rock')
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         await waitFor(() => {
@@ -297,11 +307,10 @@ describe('AutoplayGenres', () => {
             () =>
                 new Promise((resolve) =>
                     setTimeout(
-                        () =>
-                            resolve({ data: { genres: ['rock'] } }),
-                        50
-                    )
-                )
+                        () => resolve({ data: { genres: ['rock'] } }),
+                        50,
+                    ),
+                ),
         )
 
         render(<AutoplayGenres guildId={mockGuildId} />)
@@ -313,7 +322,9 @@ describe('AutoplayGenres', () => {
         const input = screen.getByPlaceholderText(/e.g., rock, pop, jazz/)
         await user.type(input, 'rock')
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         expect(input).toBeDisabled()
@@ -353,7 +364,9 @@ describe('AutoplayGenres', () => {
         const input = screen.getByPlaceholderText(/e.g., rock, pop, jazz/)
         await user.type(input, 'ROCK')
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         await waitFor(() => {
@@ -379,11 +392,15 @@ describe('AutoplayGenres', () => {
         const input = screen.getByPlaceholderText(/e.g., rock, pop, jazz/)
         await user.type(input, 'rock')
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         await waitFor(() => {
-            expect(toast.success).toHaveBeenCalledWith('Autoplay genres updated')
+            expect(toast.success).toHaveBeenCalledWith(
+                'Autoplay genres updated',
+            )
         })
     })
 
@@ -403,11 +420,15 @@ describe('AutoplayGenres', () => {
         const input = screen.getByPlaceholderText(/e.g., rock, pop, jazz/)
         await user.type(input, 'rock')
 
-        const addButtons = screen.getAllByRole('button').filter(btn => btn.textContent?.includes('Add'))
+        const addButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent?.includes('Add'))
         await user.click(addButtons[addButtons.length - 1])
 
         await waitFor(() => {
-            expect(toast.error).toHaveBeenCalledWith('Failed to update autoplay genres')
+            expect(toast.error).toHaveBeenCalledWith(
+                'Failed to update autoplay genres',
+            )
         })
     })
 
@@ -419,7 +440,9 @@ describe('AutoplayGenres', () => {
         render(<AutoplayGenres guildId={mockGuildId} />)
 
         await waitFor(() => {
-            expect(screen.getByText(/Selected Genres \(3\/5\)/)).toBeInTheDocument()
+            expect(
+                screen.getByText(/Selected Genres \(3\/5\)/),
+            ).toBeInTheDocument()
         })
     })
 
@@ -434,7 +457,9 @@ describe('AutoplayGenres', () => {
             expect(screen.getByText('rock')).toBeInTheDocument()
         })
 
-        const rockButtons = screen.getAllByRole('button').filter(btn => btn.textContent === 'rock')
+        const rockButtons = screen
+            .getAllByRole('button')
+            .filter((btn) => btn.textContent === 'rock')
         expect(rockButtons.length).toBe(1)
     })
 })

--- a/packages/frontend/src/components/Music/AutoplayGenres.tsx
+++ b/packages/frontend/src/components/Music/AutoplayGenres.tsx
@@ -6,20 +6,7 @@ import Button from '@/components/ui/Button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { toast } from 'sonner'
-import axios from 'axios'
-import { inferApiBase } from '@/services/apiBase'
-
-const API_BASE = inferApiBase(
-    import.meta.env.VITE_API_BASE_URL,
-    typeof globalThis !== 'undefined' && 'window' in globalThis
-        ? globalThis.window.location
-        : undefined,
-)
-
-const apiClient = axios.create({
-    baseURL: API_BASE,
-    withCredentials: true,
-})
+import apiClient from '@/services/api'
 
 interface AutoplayGenresProps {
     guildId: string


### PR DESCRIPTION
Closes #1420.

`AutoplayGenres.tsx` created its own `axios.create()` instead of the shared `services/api.ts` client every other frontend module uses — bypassing its interceptors + centralized error handling.

## Change
- Replaced the local `axios.create({ baseURL: API_BASE, withCredentials: true })` with the shared default client (`import apiClient from '@/services/api'`). Behavior preserved: the shared client resolves baseURL via the **same** `inferApiBase` (normalized) and keeps `withCredentials: true`; it additionally carries the standard timeout + interceptors.
- Removed the now-orphaned `axios` / `inferApiBase` imports and the `API_BASE` const.
- **Test:** updated the mock from `vi.mock('axios')` to `vi.mock('@/services/api')` — the shared client registers a response interceptor that the bare-axios mock didn't model (it threw at import). The 20 existing assertions (mockGet/mockPut) are unchanged and still pass.

## Verification (local)
- `AutoplayGenres` vitest: **20/20 pass**
- Frontend `type:check`: clean · lint: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes `AutoplayGenres` to use the shared API client for consistent interceptors, timeouts, and error handling. Addresses #1420 by removing the local `axios` instance and aligning tests with `@/services/api`.

- **Refactors**
  - Replaced local `axios.create(...)` with `apiClient` from `@/services/api` (preserves baseURL and `withCredentials`; adds standard timeout/interceptors).
  - Removed unused `axios`, `inferApiBase`, and `API_BASE` code.
  - Updated tests to mock `@/services/api` instead of `axios`; all existing assertions still pass.

<sup>Written for commit a7cde3985714894f1adf6cf4f1b0532809669bda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated music component to utilize a consolidated API client for improved consistency across the application.

* **Tests**
  * Enhanced test suite with improved selector patterns and assertion structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->