### PR TITLE
test(shared): cover DatabaseService error and edge paths

### DIFF
--- a/packages/shared/src/services/database/DatabaseService.spec.ts
+++ b/packages/shared/src/services/database/DatabaseService.spec.ts
@@ -1,81 +1,802 @@
-import { describe, it, expect } from '@jest/globals'
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+
+const mockConnect = jest.fn<() => Promise<void>>()
+const mockDisconnect = jest.fn<() => Promise<void>>()
+const mockQueryRaw = jest.fn<() => Promise<unknown>>()
+const mockUserUpsert = jest.fn<() => Promise<any>>()
+const mockUserFindUnique = jest.fn<() => Promise<any>>()
+const mockGuildUpsert = jest.fn<() => Promise<any>>()
+const mockGuildFindUnique = jest.fn<() => Promise<any>>()
+const mockTrackHistoryCreate = jest.fn<() => Promise<any>>()
+const mockTrackHistoryFindMany = jest.fn<() => Promise<any>>()
+const mockTrackHistoryGroupBy = jest.fn<() => Promise<any>>()
+const mockTrackHistoryDeleteMany = jest.fn<() => Promise<any>>()
+const mockRateLimitFindUnique = jest.fn<() => Promise<any>>()
+const mockRateLimitUpsert = jest.fn<() => Promise<any>>()
+const mockRateLimitUpdate = jest.fn<() => Promise<any>>()
+const mockRateLimitDeleteMany = jest.fn<() => Promise<any>>()
+const mockGetPrismaClient = jest.fn<() => any>()
+
+jest.mock('../../utils/database/prismaClient', () => ({
+    getPrismaClient: mockGetPrismaClient,
+}))
+
+jest.mock('../../utils/general/log', () => ({
+    infoLog: jest.fn(),
+    errorLog: jest.fn(),
+}))
+
+import { DatabaseService } from './DatabaseService'
+
+const TEST_CONFIG = {
+    url: 'postgresql://user:pass@localhost:5432/test',
+    ttl: 3600,
+    maxConnections: 10,
+    connectionTimeout: 5000,
+}
 
 describe('DatabaseService', () => {
-  describe('Configuration validation', () => {
-    it('should validate database URL format', () => {
-      const validUrl = 'postgresql://user:pass@localhost:5432/db'
-      const invalidUrl = 'invalid-url'
+    let service: DatabaseService
 
-      expect(validUrl).toMatch(/^postgresql:\/\//)
-      expect(invalidUrl).not.toMatch(/^postgresql:\/\//)
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockGetPrismaClient.mockReturnValue({
+            $connect: mockConnect,
+            $disconnect: mockDisconnect,
+            $queryRaw: mockQueryRaw,
+            user: {
+                upsert: mockUserUpsert,
+                findUnique: mockUserFindUnique,
+            },
+            guild: {
+                upsert: mockGuildUpsert,
+                findUnique: mockGuildFindUnique,
+            },
+            trackHistory: {
+                create: mockTrackHistoryCreate,
+                findMany: mockTrackHistoryFindMany,
+                groupBy: mockTrackHistoryGroupBy,
+                deleteMany: mockTrackHistoryDeleteMany,
+            },
+            rateLimit: {
+                findUnique: mockRateLimitFindUnique,
+                upsert: mockRateLimitUpsert,
+                update: mockRateLimitUpdate,
+                deleteMany: mockRateLimitDeleteMany,
+            },
+        })
+        service = new DatabaseService(TEST_CONFIG)
     })
 
-    it('should validate TTL values', () => {
-      const validTtl = 3600
-      const invalidTtl = -1
+    describe('connect', () => {
+        it('establishes connection and returns success', async () => {
+            mockConnect.mockResolvedValue(undefined)
 
-      expect(validTtl).toBeGreaterThan(0)
-      expect(invalidTtl).toBeLessThan(0)
+            const result = await service.connect()
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(true)
+            expect(mockConnect).toHaveBeenCalledTimes(1)
+        })
+
+        it('returns true if already connected (skips $connect)', async () => {
+            mockConnect.mockResolvedValue(undefined)
+
+            const result1 = await service.connect()
+            expect(result1.isSuccess()).toBe(true)
+
+            const result2 = await service.connect()
+            expect(result2.isSuccess()).toBe(true)
+            expect(mockConnect).toHaveBeenCalledTimes(1)
+        })
+
+        it('returns failure on connection error', async () => {
+            const connError = new Error('Connection failed')
+            mockConnect.mockRejectedValue(connError)
+
+            const result = await service.connect()
+
+            expect(result.isFailure()).toBe(true)
+            expect(result.getError()).toBeDefined()
+        })
+
+        it('converts non-Error exceptions to Error on connect failure', async () => {
+            mockConnect.mockRejectedValue('string error')
+
+            const result = await service.connect()
+
+            expect(result.isFailure()).toBe(true)
+            expect(result.getError()).toBeInstanceOf(Error)
+        })
     })
 
-    it('should validate connection parameters', () => {
-      const validMaxConnections = 10
-      const invalidMaxConnections = 0
+    describe('disconnect', () => {
+        it('closes connection and returns success', async () => {
+            mockConnect.mockResolvedValue(undefined)
+            mockDisconnect.mockResolvedValue(undefined)
 
-      expect(validMaxConnections).toBeGreaterThan(0)
-      expect(invalidMaxConnections).toBeLessThanOrEqual(0)
+            await service.connect()
+            const result = await service.disconnect()
+
+            expect(result.isSuccess()).toBe(true)
+            expect(mockDisconnect).toHaveBeenCalledTimes(1)
+        })
+
+        it('skips $disconnect if not connected', async () => {
+            const result = await service.disconnect()
+
+            expect(result.isSuccess()).toBe(true)
+            expect(mockDisconnect).not.toHaveBeenCalled()
+        })
+
+        it('returns failure on disconnect error', async () => {
+            mockConnect.mockResolvedValue(undefined)
+            mockDisconnect.mockRejectedValue(new Error('Disconnect failed'))
+
+            await service.connect()
+            const result = await service.disconnect()
+
+            expect(result.isFailure()).toBe(true)
+        })
     })
-  })
 
-  describe('Data validation', () => {
-    it('should validate guild ID format', () => {
-      const validGuildId = '123456789012345678'
-      const invalidGuildId = 'invalid'
+    describe('isHealthy', () => {
+        it('returns true when database responds to health check', async () => {
+            mockConnect.mockResolvedValue(undefined)
+            mockQueryRaw.mockResolvedValue([{ '1': 1 }])
 
-      expect(validGuildId).toMatch(/^\d{17,19}$/)
-      expect(invalidGuildId).not.toMatch(/^\d{17,19}$/)
+            await service.connect()
+            const result = await service.isHealthy()
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(true)
+        })
+
+        it('returns false when not connected', async () => {
+            const result = await service.isHealthy()
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(false)
+        })
+
+        it('returns failure when query execution fails', async () => {
+            mockConnect.mockResolvedValue(undefined)
+            mockQueryRaw.mockRejectedValue(new Error('Query failed'))
+
+            await service.connect()
+            const result = await service.isHealthy()
+
+            expect(result.isFailure()).toBe(true)
+        })
     })
 
-    it('should validate user ID format', () => {
-      const validUserId = '123456789012345678'
-      const invalidUserId = 'invalid'
+    describe('createUser', () => {
+        it('creates new user and returns mapped result', async () => {
+            const now = new Date()
+            mockUserUpsert.mockResolvedValue({
+                id: 'user-1',
+                discordId: '123456789',
+                username: 'testuser',
+                avatar: 'http://example.com/avatar.png',
+                createdAt: now,
+                updatedAt: now,
+            })
 
-      expect(validUserId).toMatch(/^\d{17,19}$/)
-      expect(invalidUserId).not.toMatch(/^\d{17,19}$/)
+            const result = await service.createUser(
+                '123456789',
+                'testuser',
+                'http://example.com/avatar.png',
+            )
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()?.discordId).toBe('123456789')
+            expect(result.getData()?.username).toBe('testuser')
+            expect(result.getData()?.avatar).toBe('http://example.com/avatar.png')
+        })
+
+        it('creates user without avatar', async () => {
+            const now = new Date()
+            mockUserUpsert.mockResolvedValue({
+                id: 'user-2',
+                discordId: '987654321',
+                username: 'noavatar',
+                avatar: null,
+                createdAt: now,
+                updatedAt: now,
+            })
+
+            const result = await service.createUser('987654321', 'noavatar')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()?.avatar).toBeUndefined()
+        })
+
+        it('handles upsert error gracefully', async () => {
+            mockUserUpsert.mockRejectedValue(
+                new Error('Unique constraint violation'),
+            )
+
+            const result = await service.createUser('123456789', 'testuser')
+
+            expect(result.isFailure()).toBe(true)
+        })
+
+        it('returns fallback value on failure', async () => {
+            mockUserUpsert.mockRejectedValue(new Error('DB error'))
+
+            const result = await service.createUser('123456789', 'testuser')
+
+            expect(result.isFailure()).toBe(true)
+            expect(result.getError()).toBeDefined()
+        })
     })
 
-    it('should validate track data structure', () => {
-      const validTrackData = {
-        guildId: '123456789012345678',
-        trackId: 'track123',
-        title: 'Test Track',
-        author: 'Test Artist',
-        duration: '3:30',
-        url: 'https://youtube.com/watch?v=test',
-        source: 'youtube'
-      }
+    describe('getUser', () => {
+        it('retrieves user by discord id', async () => {
+            const now = new Date()
+            mockUserFindUnique.mockResolvedValue({
+                id: 'user-1',
+                discordId: '123456789',
+                username: 'testuser',
+                avatar: 'avatar.png',
+                createdAt: now,
+                updatedAt: now,
+            })
 
-      expect(validTrackData.guildId).toMatch(/^\d{17,19}$/)
-      expect(validTrackData.trackId).toBeTruthy()
-      expect(validTrackData.title).toBeTruthy()
-      expect(validTrackData.author).toBeTruthy()
-      expect(validTrackData.duration).toBeTruthy()
-      expect(validTrackData.url).toMatch(/^https?:\/\//)
-      expect(validTrackData.source).toBeTruthy()
+            const result = await service.getUser('123456789')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()?.username).toBe('testuser')
+        })
+
+        it('returns null when user not found', async () => {
+            mockUserFindUnique.mockResolvedValue(null)
+
+            const result = await service.getUser('999999999')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBeNull()
+        })
+
+        it('returns failure on query error', async () => {
+            mockUserFindUnique.mockRejectedValue(new Error('DB connection lost'))
+
+            const result = await service.getUser('123456789')
+
+            expect(result.isFailure()).toBe(true)
+        })
     })
-  })
 
-  describe('Rate limiting', () => {
-    it('should validate rate limit parameters', () => {
-      const validKey = 'user:123'
-      const validLimit = 10
-      const validWindowMs = 60000
+    describe('createGuild', () => {
+        it('creates new guild and returns mapped result', async () => {
+            const now = new Date()
+            mockGuildUpsert.mockResolvedValue({
+                id: 'guild-1',
+                discordId: '111222333',
+                name: 'Test Guild',
+                icon: 'guild.png',
+                ownerId: 'owner-123',
+                createdAt: now,
+                updatedAt: now,
+            })
 
-      expect(typeof validKey).toBe('string')
-      expect(typeof validLimit).toBe('number')
-      expect(typeof validWindowMs).toBe('number')
-      expect(validLimit).toBeGreaterThan(0)
-      expect(validWindowMs).toBeGreaterThan(0)
+            const result = await service.createGuild(
+                '111222333',
+                'Test Guild',
+                'owner-123',
+                'guild.png',
+            )
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()?.name).toBe('Test Guild')
+            expect(result.getData()?.ownerId).toBe('owner-123')
+        })
+
+        it('creates guild without icon', async () => {
+            const now = new Date()
+            mockGuildUpsert.mockResolvedValue({
+                id: 'guild-2',
+                discordId: '222333444',
+                name: 'No Icon Guild',
+                icon: null,
+                ownerId: 'owner-456',
+                createdAt: now,
+                updatedAt: now,
+            })
+
+            const result = await service.createGuild(
+                '222333444',
+                'No Icon Guild',
+                'owner-456',
+            )
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()?.icon).toBeUndefined()
+        })
+
+        it('handles upsert error for guild creation', async () => {
+            mockGuildUpsert.mockRejectedValue(new Error('FK constraint failed'))
+
+            const result = await service.createGuild(
+                '111222333',
+                'Test Guild',
+                'owner-123',
+            )
+
+            expect(result.isFailure()).toBe(true)
+        })
     })
-  })
+
+    describe('getGuild', () => {
+        it('retrieves guild by discord id', async () => {
+            const now = new Date()
+            mockGuildFindUnique.mockResolvedValue({
+                id: 'guild-1',
+                discordId: '111222333',
+                name: 'Test Guild',
+                icon: 'guild.png',
+                ownerId: 'owner-123',
+                createdAt: now,
+                updatedAt: now,
+            })
+
+            const result = await service.getGuild('111222333')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()?.name).toBe('Test Guild')
+        })
+
+        it('returns null when guild not found', async () => {
+            mockGuildFindUnique.mockResolvedValue(null)
+
+            const result = await service.getGuild('999999999')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBeNull()
+        })
+
+        it('returns failure on query error', async () => {
+            mockGuildFindUnique.mockRejectedValue(
+                new Error('Connection timeout'),
+            )
+
+            const result = await service.getGuild('111222333')
+
+            expect(result.isFailure()).toBe(true)
+        })
+    })
+
+    describe('addTrackToHistory', () => {
+        it('adds track to history and returns mapped result', async () => {
+            const now = new Date()
+            mockTrackHistoryCreate.mockResolvedValue({
+                id: 'track-1',
+                guildId: 'guild-1',
+                trackId: 'yt-123',
+                title: 'Test Song',
+                author: 'Test Artist',
+                duration: '3:45',
+                url: 'https://youtube.com/watch?v=test',
+                thumbnail: 'thumb.jpg',
+                source: 'youtube',
+                playedAt: now,
+                createdAt: now,
+                playedBy: 'user-1',
+                isAutoplay: false,
+                playlistName: null,
+                playDuration: null,
+                skipped: null,
+                isPlaylist: null,
+            })
+
+            const result = await service.addTrackToHistory({
+                guildId: 'guild-1',
+                trackId: 'yt-123',
+                title: 'Test Song',
+                author: 'Test Artist',
+                duration: '3:45',
+                url: 'https://youtube.com/watch?v=test',
+                thumbnail: 'thumb.jpg',
+                source: 'youtube',
+                playedBy: 'user-1',
+                isAutoplay: false,
+            })
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()?.title).toBe('Test Song')
+            expect(result.getData()?.isAutoplay).toBe(false)
+        })
+
+        it('defaults isAutoplay to false when not provided', async () => {
+            const now = new Date()
+            mockTrackHistoryCreate.mockResolvedValue({
+                id: 'track-2',
+                guildId: 'guild-1',
+                trackId: 'yt-456',
+                title: 'Another Song',
+                author: 'Another Artist',
+                duration: '4:00',
+                url: 'https://youtube.com/watch?v=test2',
+                thumbnail: null,
+                source: 'spotify',
+                playedAt: now,
+                createdAt: now,
+                playedBy: null,
+                isAutoplay: false,
+                playlistName: null,
+                playDuration: null,
+                skipped: null,
+                isPlaylist: null,
+            })
+
+            const result = await service.addTrackToHistory({
+                guildId: 'guild-1',
+                trackId: 'yt-456',
+                title: 'Another Song',
+                author: 'Another Artist',
+                duration: '4:00',
+                url: 'https://youtube.com/watch?v=test2',
+                source: 'spotify',
+            })
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()?.isAutoplay).toBe(false)
+        })
+
+        it('handles create error for track history', async () => {
+            mockTrackHistoryCreate.mockRejectedValue(
+                new Error('FK: guild not found'),
+            )
+
+            const result = await service.addTrackToHistory({
+                guildId: 'nonexistent-guild',
+                trackId: 'yt-123',
+                title: 'Test Song',
+                author: 'Test Artist',
+                duration: '3:45',
+                url: 'https://youtube.com/watch?v=test',
+                source: 'youtube',
+            })
+
+            expect(result.isFailure()).toBe(true)
+        })
+    })
+
+    describe('getTrackHistory', () => {
+        it('retrieves track history for a guild with default limit', async () => {
+            const now = new Date()
+            const track = {
+                id: 'track-1',
+                guildId: 'guild-1',
+                trackId: 'yt-123',
+                title: 'Test Song',
+                author: 'Test Artist',
+                duration: '3:45',
+                url: 'https://youtube.com/watch?v=test',
+                thumbnail: null,
+                source: 'youtube',
+                playedAt: now,
+                createdAt: now,
+                playedBy: null,
+                isAutoplay: false,
+                playlistName: null,
+                playDuration: null,
+                skipped: null,
+                isPlaylist: null,
+            }
+            mockTrackHistoryFindMany.mockResolvedValue([track])
+
+            const result = await service.getTrackHistory('guild-1')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toHaveLength(1)
+            expect(result.getData()?.[0].title).toBe('Test Song')
+        })
+
+        it('respects custom limit parameter', async () => {
+            mockTrackHistoryFindMany.mockResolvedValue([])
+
+            await service.getTrackHistory('guild-1', 50)
+
+            expect(mockTrackHistoryFindMany).toHaveBeenCalled()
+        })
+
+        it('returns empty array when no tracks found', async () => {
+            mockTrackHistoryFindMany.mockResolvedValue([])
+
+            const result = await service.getTrackHistory('guild-1')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toEqual([])
+        })
+
+        it('returns failure on query error', async () => {
+            mockTrackHistoryFindMany.mockRejectedValue(
+                new Error('DB connection lost'),
+            )
+
+            const result = await service.getTrackHistory('guild-1')
+
+            expect(result.isFailure()).toBe(true)
+        })
+    })
+
+    describe('checkRateLimit', () => {
+        it('allows request when under limit and no existing entry', async () => {
+            mockRateLimitFindUnique.mockResolvedValue(null)
+            mockRateLimitUpsert.mockResolvedValue({
+                key: 'user-123',
+                count: 1,
+                resetAt: new Date(Date.now() + 60000),
+            })
+
+            const result = await service.checkRateLimit('user-123', 10, 60000)
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(true)
+            expect(mockRateLimitUpsert).toHaveBeenCalled()
+        })
+
+        it('allows request when under limit', async () => {
+            const resetAt = new Date(Date.now() + 30000)
+            mockRateLimitFindUnique.mockResolvedValue({
+                resetAt,
+                count: 5,
+            })
+            mockRateLimitUpdate.mockResolvedValue({
+                key: 'user-123',
+                count: 6,
+                resetAt,
+            })
+
+            const result = await service.checkRateLimit('user-123', 10, 60000)
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(true)
+            expect(mockRateLimitUpdate).toHaveBeenCalled()
+        })
+
+        it('denies request when at or over limit', async () => {
+            const resetAt = new Date(Date.now() + 30000)
+            mockRateLimitFindUnique.mockResolvedValue({
+                resetAt,
+                count: 10,
+            })
+
+            const result = await service.checkRateLimit('user-123', 10, 60000)
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(false)
+            expect(mockRateLimitUpdate).not.toHaveBeenCalled()
+        })
+
+        it('resets counter when window has expired', async () => {
+            const expiredResetAt = new Date(Date.now() - 10000)
+            mockRateLimitFindUnique.mockResolvedValue({
+                resetAt: expiredResetAt,
+                count: 10,
+            })
+            mockRateLimitUpsert.mockResolvedValue({
+                key: 'user-123',
+                count: 1,
+                resetAt: new Date(Date.now() + 60000),
+            })
+
+            const result = await service.checkRateLimit('user-123', 10, 60000)
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(true)
+            expect(mockRateLimitUpsert).toHaveBeenCalled()
+        })
+
+        it('returns failure on database error', async () => {
+            mockRateLimitFindUnique.mockRejectedValue(
+                new Error('DB connection failed'),
+            )
+
+            const result = await service.checkRateLimit('user-123', 10, 60000)
+
+            expect(result.isFailure()).toBe(true)
+        })
+    })
+
+    describe('getTopTracks', () => {
+        it('returns top tracks grouped by track id, title, author', async () => {
+            mockTrackHistoryGroupBy.mockResolvedValue([
+                {
+                    trackId: 'yt-1',
+                    title: 'Top Song',
+                    author: 'Top Artist',
+                    _count: { trackId: 15 },
+                },
+                {
+                    trackId: 'yt-2',
+                    title: 'Second Song',
+                    author: 'Second Artist',
+                    _count: { trackId: 8 },
+                },
+            ])
+
+            const result = await service.getTopTracks('guild-1')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toHaveLength(2)
+            expect(result.getData()?.[0].playCount).toBe(15)
+            expect(result.getData()?.[1].playCount).toBe(8)
+        })
+
+        it('respects custom limit parameter', async () => {
+            mockTrackHistoryGroupBy.mockResolvedValue([])
+
+            await service.getTopTracks('guild-1', 50)
+
+            expect(mockTrackHistoryGroupBy).toHaveBeenCalled()
+        })
+
+        it('returns empty array when no tracks exist', async () => {
+            mockTrackHistoryGroupBy.mockResolvedValue([])
+
+            const result = await service.getTopTracks('guild-1')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toEqual([])
+        })
+
+        it('returns failure on query error', async () => {
+            mockTrackHistoryGroupBy.mockRejectedValue(
+                new Error('Query execution failed'),
+            )
+
+            const result = await service.getTopTracks('guild-1')
+
+            expect(result.isFailure()).toBe(true)
+        })
+
+        it('filters out invalid track objects', async () => {
+            mockTrackHistoryGroupBy.mockResolvedValue([
+                {
+                    trackId: 'yt-1',
+                    title: 'Valid Song',
+                    author: 'Valid Artist',
+                    _count: { trackId: 5 },
+                },
+                null,
+                { incomplete: 'object' },
+                {
+                    trackId: 'yt-2',
+                    title: 'Another Song',
+                    author: 'Another Artist',
+                    _count: { trackId: 3 },
+                },
+            ])
+
+            const result = await service.getTopTracks('guild-1')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toHaveLength(2)
+        })
+    })
+
+    describe('getTopArtists', () => {
+        it('returns top artists grouped by author', async () => {
+            mockTrackHistoryGroupBy.mockResolvedValue([
+                {
+                    author: 'Top Artist',
+                    _count: { author: 25 },
+                },
+                {
+                    author: 'Second Artist',
+                    _count: { author: 12 },
+                },
+            ])
+
+            const result = await service.getTopArtists('guild-1')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toHaveLength(2)
+            expect(result.getData()?.[0].playCount).toBe(25)
+        })
+
+        it('respects custom limit parameter', async () => {
+            mockTrackHistoryGroupBy.mockResolvedValue([])
+
+            await service.getTopArtists('guild-1', 25)
+
+            expect(mockTrackHistoryGroupBy).toHaveBeenCalled()
+        })
+
+        it('returns empty array when no artists exist', async () => {
+            mockTrackHistoryGroupBy.mockResolvedValue([])
+
+            const result = await service.getTopArtists('guild-1')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toEqual([])
+        })
+
+        it('returns failure on query error', async () => {
+            mockTrackHistoryGroupBy.mockRejectedValue(
+                new Error('GroupBy failed'),
+            )
+
+            const result = await service.getTopArtists('guild-1')
+
+            expect(result.isFailure()).toBe(true)
+        })
+
+        it('filters out invalid artist objects', async () => {
+            mockTrackHistoryGroupBy.mockResolvedValue([
+                {
+                    author: 'Valid Artist',
+                    _count: { author: 10 },
+                },
+                null,
+                { invalid: true },
+                {
+                    author: 'Another Artist',
+                    _count: { author: 7 },
+                },
+            ])
+
+            const result = await service.getTopArtists('guild-1')
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toHaveLength(2)
+        })
+    })
+
+    describe('cleanupOldData', () => {
+        it('deletes old tracks and rate limits, returns total count', async () => {
+            mockTrackHistoryDeleteMany.mockResolvedValue({ count: 50 })
+            mockRateLimitDeleteMany.mockResolvedValue({ count: 30 })
+
+            const result = await service.cleanupOldData()
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(80)
+            expect(mockTrackHistoryDeleteMany).toHaveBeenCalled()
+            expect(mockRateLimitDeleteMany).toHaveBeenCalled()
+        })
+
+        it('handles zero deletions', async () => {
+            mockTrackHistoryDeleteMany.mockResolvedValue({ count: 0 })
+            mockRateLimitDeleteMany.mockResolvedValue({ count: 0 })
+
+            const result = await service.cleanupOldData()
+
+            expect(result.isSuccess()).toBe(true)
+            expect(result.getData()).toBe(0)
+        })
+
+        it('returns failure on track deletion error', async () => {
+            mockTrackHistoryDeleteMany.mockRejectedValue(
+                new Error('Deletion failed'),
+            )
+
+            const result = await service.cleanupOldData()
+
+            expect(result.isFailure()).toBe(true)
+        })
+
+        it('returns failure on rate limit deletion error', async () => {
+            mockTrackHistoryDeleteMany.mockResolvedValue({ count: 10 })
+            mockRateLimitDeleteMany.mockRejectedValue(
+                new Error('Rate limit deletion failed'),
+            )
+
+            const result = await service.cleanupOldData()
+
+            expect(result.isFailure()).toBe(true)
+        })
+    })
+
+    describe('getClient', () => {
+        it('returns the underlying prisma client', () => {
+            const client = service.getClient()
+
+            expect(client).toBeDefined()
+            expect(client.$connect).toBeDefined()
+            expect(client.$disconnect).toBeDefined()
+        })
+    })
 })

--- a/packages/shared/src/services/database/DatabaseService.spec.ts
+++ b/packages/shared/src/services/database/DatabaseService.spec.ts
@@ -8,8 +8,8 @@ const mockUserFindUnique = jest.fn<() => Promise<any>>()
 const mockGuildUpsert = jest.fn<() => Promise<any>>()
 const mockGuildFindUnique = jest.fn<() => Promise<any>>()
 const mockTrackHistoryCreate = jest.fn<() => Promise<any>>()
-const mockTrackHistoryFindMany = jest.fn<() => Promise<any>>()
-const mockTrackHistoryGroupBy = jest.fn<() => Promise<any>>()
+const mockTrackHistoryFindMany = jest.fn<(args?: any) => Promise<any>>()
+const mockTrackHistoryGroupBy = jest.fn<(args?: any) => Promise<any>>()
 const mockTrackHistoryDeleteMany = jest.fn<() => Promise<any>>()
 const mockRateLimitFindUnique = jest.fn<() => Promise<any>>()
 const mockRateLimitUpsert = jest.fn<() => Promise<any>>()
@@ -191,7 +191,9 @@ describe('DatabaseService', () => {
             expect(result.isSuccess()).toBe(true)
             expect(result.getData()?.discordId).toBe('123456789')
             expect(result.getData()?.username).toBe('testuser')
-            expect(result.getData()?.avatar).toBe('http://example.com/avatar.png')
+            expect(result.getData()?.avatar).toBe(
+                'http://example.com/avatar.png',
+            )
         })
 
         it('creates user without avatar', async () => {
@@ -259,7 +261,9 @@ describe('DatabaseService', () => {
         })
 
         it('returns failure on query error', async () => {
-            mockUserFindUnique.mockRejectedValue(new Error('DB connection lost'))
+            mockUserFindUnique.mockRejectedValue(
+                new Error('DB connection lost'),
+            )
 
             const result = await service.getUser('123456789')
 
@@ -498,7 +502,9 @@ describe('DatabaseService', () => {
 
             await service.getTrackHistory('guild-1', 50)
 
-            expect(mockTrackHistoryFindMany).toHaveBeenCalled()
+            expect(mockTrackHistoryFindMany).toHaveBeenCalledWith(
+                expect.objectContaining({ take: 50 }),
+            )
         })
 
         it('returns empty array when no tracks found', async () => {
@@ -630,7 +636,9 @@ describe('DatabaseService', () => {
 
             await service.getTopTracks('guild-1', 50)
 
-            expect(mockTrackHistoryGroupBy).toHaveBeenCalled()
+            expect(mockTrackHistoryGroupBy).toHaveBeenCalledWith(
+                expect.objectContaining({ take: 50 }),
+            )
         })
 
         it('returns empty array when no tracks exist', async () => {
@@ -702,7 +710,9 @@ describe('DatabaseService', () => {
 
             await service.getTopArtists('guild-1', 25)
 
-            expect(mockTrackHistoryGroupBy).toHaveBeenCalled()
+            expect(mockTrackHistoryGroupBy).toHaveBeenCalledWith(
+                expect.objectContaining({ take: 25 }),
+            )
         })
 
         it('returns empty array when no artists exist', async () => {


### PR DESCRIPTION
Closes #1419.

`DatabaseService` (a core shared data-layer service used by both bot and backend) was severely under-tested (~754 src lines vs ~81 test lines). Added comprehensive unit tests prioritizing **error and edge paths** over happy-path.

## Coverage: 7 → 50 tests
Public methods now covered, each with failure modes:
- **Connection lifecycle** — `connect()` (success, idempotency, error, non-Error coercion), `disconnect()` (success, already-disconnected, error), `isHealthy()` (healthy, not-connected, query failure)
- **User / Guild ops** — `createUser`/`getUser`, `createGuild`/`getGuild` — happy path, optional fields, upsert/FK errors, null-on-miss, query errors
- **Track history** — `addTrackToHistory` (default isAutoplay, FK error), `getTrackHistory` (custom limit, empty, error)
- **Rate limiting** — `checkRateLimit` (under/at/over limit, window-expiry reset, error)
- **Analytics** — `getTopTracks`/`getTopArtists` (grouping, custom limit, empty, invalid-object filtering)
- **Cleanup** — `cleanupOldData` (both tables, zero deletions, per-table error paths)
- **Utility** — `getClient`

Tests follow the existing shared convention exactly: `@jest/globals`, factory-mocked `prismaClient`, `beforeEach` cleanup, one-behavior-per-test, `Result<T>` success+failure both asserted.

## Verification (main checkout, real deps — not the worktree)
- DatabaseService spec: **50/50 pass**
- Full shared suite: **61 suites / 872 tests pass** (829 baseline + 43 new)
- `type:check` clean · lint **0 errors**

> Note: writing was done by a subagent in a worktree; results were independently re-run on the main checkout before this PR (the worktree showed 9 unrelated suites failing on a stale-type artifact — those pass cleanly on the main checkout, confirmed not caused by this change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded `DatabaseService` unit tests from 7 to 50, covering error and edge paths across all public methods. Closes #1419 and hardens the shared data layer; also asserts limit forwarding to Prisma to address P3 notes from #1422.

- **Test Coverage**
  - Connection: `connect`, `disconnect`, `isHealthy` (idempotency, non-Error coercion, query failures)
  - Users/Guilds: `create*`, `get*` (null-on-miss, optional fields, upsert/FK errors)
  - Track history: `addTrackToHistory`, `getTrackHistory` (default `isAutoplay`, custom limits, empty results; assert `findMany({ take })` forwarded)
  - Rate limiting: `checkRateLimit` (under/at/over limit, window reset, DB errors)
  - Analytics/Cleanup: `getTopTracks`, `getTopArtists` (filter invalid objects; assert `groupBy({ take })` forwarded), `cleanupOldData` (per-table error paths)
  - Test harness: `@jest/globals`, factory-mocked `prismaClient` (mocks accept params), one-behavior-per-test pattern

<sup>Written for commit a125cd21aca231a71a838b25b4590770a63f0146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

