### PR TITLE
fix(ci): grant review-tools caller the scopes its reusables require

### DIFF
--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -31,12 +31,18 @@ concurrency:
   group: review-tools-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# Minimum permissions for both reusable workflows:
-#   - claude-review.yml needs to read PR contents and post review comments
-#   - danger.yml needs to read PR diff and post a comment with findings
+# Minimum permissions for both reusable workflows. An explicit block sets
+# every unlisted scope to `none`, and a called reusable workflow cannot
+# request scopes the caller withheld — so the caller must grant the UNION of
+# what the reusables declare, or the run fails at startup (see #1423):
+#   - claude-review.yml needs contents:read, pull-requests:write,
+#     issues:write, and id-token:write (OIDC)
+#   - danger.yml needs contents:read, pull-requests:write, issues:write
 permissions:
   contents: read
   pull-requests: write
+  issues: write
+  id-token: write
 
 jobs:
   claude-review:


### PR DESCRIPTION
Closes #1423.

## Problem
`Review Tools` workflow `startup_failure`d on **100% of PRs** — the org-level Claude AI review + Danger reusable workflows have never run on a Lucky PR. Non-blocking (not a required check), so it went unnoticed.

## Root cause
`review-tools.yml` declared an explicit `permissions` block (`contents: read`, `pull-requests: write`). An explicit block sets every *unlisted* scope to `none`, and a called reusable workflow cannot request scopes the caller withheld. The reusables require more:
- `claude-review.yml@v1` → `issues: write` + `id-token: write` (OIDC)
- `danger.yml@v1` → `issues: write`

→ GitHub rejected the run before any job started.

## Fix
Grant the **union** of the reusables' declared scopes (2 added lines + a clarifying comment). Diagnosis in #1423.

## Confirmation
This PR modifies the `pull_request`-triggered workflow, so **its own `Review Tools` run is the live test** — it should now reach success/neutral instead of `startup_failure`, and Claude review + Danger comments should appear on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Review Tools workflow startup failures by granting the permissions required by its reusable workflows. Claude review and Danger now run on PRs.

- **Bug Fixes**
  - Root cause: `review-tools.yml` set explicit permissions (`contents: read`, `pull-requests: write`), making other scopes `none`.
  - Fix: added `issues: write` and `id-token: write` so the caller grants the union needed by `claude-review.yml@v1` and `danger.yml@v1`.
  - Result: the workflow starts and posts comments; this PR’s run is the live verification. Closes #1423.

<sup>Written for commit b810d4968b798980f325b0861b58c2719ea4171a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

