### PR TITLE
test(shared): ratchet coverage floor up to measured coverage

### DIFF
--- a/packages/shared/jest.config.cjs
+++ b/packages/shared/jest.config.cjs
@@ -24,16 +24,19 @@ module.exports = {
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov'],
-  // Honest gate (#1277): set just below coverage measured on 2026-06-09
-  // (47.08/41.83/38.82/46.76). The previous 89/89/90/89 was never enforced —
-  // no CI job ran shared tests — and had drifted far from reality. Ratchet
-  // these up as coverage improves; never raise above measured coverage.
+  // Honest gate (#1277, ratcheted up #1426): set just below coverage measured
+  // on 2026-06-14 (57.07/52.63/49.66/56.94). Coverage climbed ~10pp since the
+  // floor was last set (2026-06-09 @ 47%) — e.g. DatabaseService 7→50 tests
+  // (#1419) — but the floor wasn't ratcheted, leaving a silent-decay window on
+  // the most-depended-upon package. The original 89/89/90/89 was never enforced
+  // (no CI job ran shared tests, pre-#1277). Ratchet these up as coverage
+  // improves; never raise above measured coverage.
   coverageThreshold: {
     global: {
-      statements: 46,
-      branches: 41,
-      functions: 38,
-      lines: 46
+      statements: 56,
+      branches: 52,
+      functions: 49,
+      lines: 56
     }
   },
   testTimeout: 30000,


### PR DESCRIPTION
**#1426 Phase 1** (honest test safety net) — first unit.

## What
Raised the `shared` package's Jest coverage floor from **46/41/38/46** to **56/52/49/56** (statements/branches/functions/lines).

## Why
The floor was set on 2026-06-09 just below the 47% measured then (#1277's honest-floor design). Coverage has since climbed to **57.07/52.63/49.66/56.94** (e.g. DatabaseService 7→50 tests in #1419) but the floor was never ratcheted — leaving a **~10pp silent-decay window** on the package every other workspace depends on. The existing gate comment explicitly prescribes "ratchet these up as coverage improves"; this does that.

## Verification correction (worth flagging)
The XP assessment that spawned #1426 claimed shared tests "likely don't run in CI" and the gate was "46%, down from 89%". **Both were wrong** — `ci.yml` has a `test-shared` job running with `--coverage`, actual coverage is 57% (not 89%), and the 46% floor was a *deliberate honest floor*, just stale. So this PR is a **ratchet**, not a fix for a broken gate. (Other Phase-1 items the assessment proposed — SonarCloud `continue-on-error`, bot ratchet — also turned out to be non-issues on verification; see PR discussion.)

## Tests
Shared suite **872/872** green; new floor passes with ~0.6–1pp headroom. Floor never set above measured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ratcheted the `shared` package `jest` coverage floor from 46/41/38/46 to 56/52/49/56 to match current measured coverage (~57/53/50/57) with a small headroom. Addresses #1426 Phase 1 (honest test safety net) and closes the ~10pp gap to prevent silent decay.

<sup>Written for commit b111b84fb73d75b1743853ade32988b5a433f0f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing quality standards based on current development metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->