### PR TITLE
test(shared): widen mutation testing to four shared services

### DIFF
--- a/packages/shared/stryker.conf.json
+++ b/packages/shared/stryker.conf.json
@@ -7,7 +7,12 @@
             "configFile": "./jest.config.cjs"
         }
     },
-    "mutate": ["src/services/database/DatabaseService.ts"],
+    "mutate": [
+        "src/services/database/DatabaseService.ts",
+        "src/services/FeatureToggleService.ts",
+        "src/services/PremiumService.ts",
+        "src/services/embedValidation.ts"
+    ],
     "reporters": ["html", "clear-text", "progress"],
     "timeoutMS": 15000,
     "timeoutFactor": 1.5,


### PR DESCRIPTION
**#1426 Phase 2 widening** — extends the Stryker `mutate` scope beyond DatabaseService.

## Now mutation-tested (combined 79.66%, ~38s run)
| Module | Mutation score |
|---|---|
| DatabaseService | 80.1% |
| FeatureToggleService | 80.5% |
| PremiumService | 86.2% |
| embedValidation | 74.7% |

Passes the existing `break: 75` with margin. The CI `Mutation — shared` gate now covers four core shared services instead of one.

## ModerationService deliberately excluded → filed separately
It mutation-scored only **17.76%** (70 *no-coverage* mutants) despite a 1.1x line ratio — its tests barely exercise the code. Including it would drag the combined score to 68% and **dilute the gate** for the well-tested modules. Filed as a dedicated assertion-hardening target (the same treatment DatabaseService got in #1429).

Refs #1426.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widens Stryker mutation testing in packages/shared to four core services. Combined mutation score is 79.66% (~38s), passing the break: 75; aligns with #1426 Phase 2.

- **Refactors**
  - Update packages/shared/stryker.conf.json to mutate DatabaseService, FeatureToggleService, PremiumService, and embedValidation.
  - Exclude ModerationService for now (17.76%); handled separately under #1426.

<sup>Written for commit 86f1b130237006e1e59f6c908e3bfbed1c463e03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing configuration to expand mutation test coverage across additional service modules.

---

**Note:** This is an internal development change with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->