### PR TITLE
test(shared): harden moderationservice tests, 18->80% mutation

### DIFF
--- a/packages/shared/src/services/ModerationService.spec.ts
+++ b/packages/shared/src/services/ModerationService.spec.ts
@@ -18,7 +18,20 @@ jest.mock('../utils/database/prismaClient', () => ({
     disconnectPrisma: jest.fn(),
 }))
 
+jest.mock('./moderationSettings', () => ({
+    getModerationSettings: jest.fn(),
+    updateModerationSettings: jest.fn(),
+    hasModPermissions: jest.fn(),
+    getModerationStats: jest.fn(),
+}))
+
 import { ModerationService } from './ModerationService'
+import {
+    getModerationSettings,
+    updateModerationSettings,
+    hasModPermissions,
+    getModerationStats,
+} from './moderationSettings'
 
 describe('ModerationService', () => {
     let service: ModerationService
@@ -305,6 +318,251 @@ describe('ModerationService', () => {
 
             // Should be called MAX_RETRIES (5) times
             expect(mockTransaction).toHaveBeenCalledTimes(5)
+        })
+    })
+
+    // #1433: the query + delegation methods below had ZERO test coverage
+    // (mutation score 17.76%, 70 no-coverage mutants). These assert the exact
+    // prisma query clauses, conditional spreads, and return values, plus that
+    // the settings-delegating methods forward to moderationSettings.
+    describe('query methods', () => {
+        function setupCaseMock() {
+            const caseMock = {
+                findUnique: jest.fn<(args?: any) => Promise<any>>(),
+                findMany: jest.fn<(args?: any) => Promise<any>>(),
+                count: jest.fn<(args?: any) => Promise<any>>(),
+                updateMany: jest.fn<(args?: any) => Promise<any>>(),
+                update: jest.fn<(args?: any) => Promise<any>>(),
+            }
+            // @ts-ignore — partial Prisma client mock
+            mockGetPrismaClient.mockReturnValue({ moderationCase: caseMock })
+            return caseMock
+        }
+
+        it('getCase queries by the composite guildId_caseNumber key', async () => {
+            const m = setupCaseMock()
+            m.findUnique.mockResolvedValue(null)
+
+            const result = await service.getCase('guild-1', 7)
+
+            expect(m.findUnique).toHaveBeenCalledWith({
+                where: {
+                    guildId_caseNumber: { guildId: 'guild-1', caseNumber: 7 },
+                },
+            })
+            expect(result).toBeNull()
+        })
+
+        it('getUserCases queries by guild+user ordered by createdAt desc (no active filter by default)', async () => {
+            const m = setupCaseMock()
+            m.findMany.mockResolvedValue([])
+
+            await service.getUserCases('guild-1', 'user-1')
+
+            expect(m.findMany).toHaveBeenCalledWith({
+                where: { guildId: 'guild-1', userId: 'user-1' },
+                orderBy: { createdAt: 'desc' },
+            })
+        })
+
+        it('getUserCases adds active:true when activeOnly is set', async () => {
+            const m = setupCaseMock()
+            m.findMany.mockResolvedValue([])
+
+            await service.getUserCases('guild-1', 'user-1', true)
+
+            expect(m.findMany).toHaveBeenCalledWith({
+                where: { guildId: 'guild-1', userId: 'user-1', active: true },
+                orderBy: { createdAt: 'desc' },
+            })
+        })
+
+        it('getRecentCases applies the limit as take', async () => {
+            const m = setupCaseMock()
+            m.findMany.mockResolvedValue([])
+
+            await service.getRecentCases('guild-1', 25)
+
+            expect(m.findMany).toHaveBeenCalledWith({
+                where: { guildId: 'guild-1' },
+                orderBy: { createdAt: 'desc' },
+                take: 25,
+            })
+        })
+
+        it('getCasesSince filters by createdAt gte the given date', async () => {
+            const m = setupCaseMock()
+            m.findMany.mockResolvedValue([])
+            const since = new Date('2026-01-01')
+
+            await service.getCasesSince('guild-1', since)
+
+            expect(m.findMany).toHaveBeenCalledWith({
+                where: { guildId: 'guild-1', createdAt: { gte: since } },
+                orderBy: { createdAt: 'desc' },
+            })
+        })
+
+        it('getActiveWarningsCount counts active warn cases and returns the count', async () => {
+            const m = setupCaseMock()
+            m.count.mockResolvedValue(3)
+
+            const result = await service.getActiveWarningsCount(
+                'guild-1',
+                'user-1',
+            )
+
+            expect(m.count).toHaveBeenCalledWith({
+                where: {
+                    guildId: 'guild-1',
+                    userId: 'user-1',
+                    type: 'warn',
+                    active: true,
+                },
+            })
+            expect(result).toBe(3)
+        })
+
+        it('clearWarnings deactivates active warns and returns the updated count', async () => {
+            const m = setupCaseMock()
+            m.updateMany.mockResolvedValue({ count: 4 })
+
+            const result = await service.clearWarnings('guild-1', 'user-1')
+
+            expect(m.updateMany).toHaveBeenCalledWith({
+                where: {
+                    guildId: 'guild-1',
+                    userId: 'user-1',
+                    type: 'warn',
+                    active: true,
+                },
+                data: { active: false },
+            })
+            expect(result).toBe(4)
+        })
+
+        it('deactivateCase sets active:false by id', async () => {
+            const m = setupCaseMock()
+            m.update.mockResolvedValue({})
+
+            await service.deactivateCase('case-1')
+
+            expect(m.update).toHaveBeenCalledWith({
+                where: { id: 'case-1' },
+                data: { active: false },
+            })
+        })
+
+        it('appealCase records the appeal with reason and timestamp', async () => {
+            const m = setupCaseMock()
+            m.update.mockResolvedValue({})
+
+            await service.appealCase({
+                caseId: 'case-1',
+                appealReason: 'mistake',
+            })
+
+            expect(m.update).toHaveBeenCalledWith({
+                where: { id: 'case-1' },
+                data: expect.objectContaining({
+                    appealed: true,
+                    appealReason: 'mistake',
+                    appealedAt: expect.any(Date),
+                }),
+            })
+        })
+
+        it('reviewAppeal deactivates the case when approved', async () => {
+            const m = setupCaseMock()
+            m.update.mockResolvedValue({})
+
+            await service.reviewAppeal('case-1', true)
+
+            expect(m.update).toHaveBeenCalledWith({
+                where: { id: 'case-1' },
+                data: {
+                    appealReviewed: true,
+                    appealApproved: true,
+                    active: false,
+                },
+            })
+        })
+
+        it('reviewAppeal leaves the case active when rejected', async () => {
+            const m = setupCaseMock()
+            m.update.mockResolvedValue({})
+
+            await service.reviewAppeal('case-1', false)
+
+            expect(m.update).toHaveBeenCalledWith({
+                where: { id: 'case-1' },
+                data: { appealReviewed: true, appealApproved: false },
+            })
+        })
+
+        it('getExpiredCases finds active cases past their expiry', async () => {
+            const m = setupCaseMock()
+            m.findMany.mockResolvedValue([])
+
+            await service.getExpiredCases()
+
+            expect(m.findMany).toHaveBeenCalledWith({
+                where: { active: true, expiresAt: { lte: expect.any(Date) } },
+            })
+        })
+    })
+
+    describe('settings delegation', () => {
+        it('getSettings forwards to getModerationSettings and returns its result', async () => {
+            const settings = { guildId: 'guild-1', maxWarnings: 3 }
+            // @ts-ignore
+            jest.mocked(getModerationSettings).mockResolvedValue(settings)
+
+            const result = await service.getSettings('guild-1')
+
+            expect(getModerationSettings).toHaveBeenCalledWith('guild-1')
+            expect(result).toBe(settings)
+        })
+
+        it('updateSettings forwards guildId and data to updateModerationSettings', async () => {
+            const updated = { guildId: 'guild-1', maxWarnings: 5 }
+            // @ts-ignore
+            jest.mocked(updateModerationSettings).mockResolvedValue(updated)
+
+            const result = await service.updateSettings('guild-1', {
+                maxWarnings: 5,
+            })
+
+            expect(updateModerationSettings).toHaveBeenCalledWith('guild-1', {
+                maxWarnings: 5,
+            })
+            expect(result).toBe(updated)
+        })
+
+        it('hasModPermissions forwards guild and roles and returns the verdict', async () => {
+            jest.mocked(hasModPermissions).mockResolvedValue(true)
+
+            const result = await service.hasModPermissions('guild-1', [
+                'role-a',
+                'role-b',
+            ])
+
+            expect(hasModPermissions).toHaveBeenCalledWith('guild-1', [
+                'role-a',
+                'role-b',
+            ])
+            expect(result).toBe(true)
+        })
+
+        it('getStats forwards to getModerationStats and returns its result', async () => {
+            const stats = { total: 10 }
+            // @ts-ignore
+            jest.mocked(getModerationStats).mockResolvedValue(stats)
+
+            const result = await service.getStats('guild-1')
+
+            expect(getModerationStats).toHaveBeenCalledWith('guild-1')
+            expect(result).toBe(stats)
         })
     })
 })

--- a/packages/shared/stryker.conf.json
+++ b/packages/shared/stryker.conf.json
@@ -10,6 +10,7 @@
     "mutate": [
         "src/services/database/DatabaseService.ts",
         "src/services/FeatureToggleService.ts",
+        "src/services/ModerationService.ts",
         "src/services/PremiumService.ts",
         "src/services/embedValidation.ts"
     ],


### PR DESCRIPTION
Closes #1433.

ModerationService scored only **17.76%** mutation (70 *no-coverage* mutants) because only `createCase` was tested — the other **14 methods had zero coverage** despite a healthy line ratio.

## What
Added behaviour tests for all 14 untested methods:
- **Query methods** (getCase / getUserCases / getRecentCases / getCasesSince / getActiveWarningsCount / clearWarnings / deactivateCase / appealCase / reviewAppeal / getExpiredCases): assert the exact prisma `where` / `orderBy` / `take` / `data` clauses, the conditional spreads (`getUserCases` activeOnly → `active:true`; `reviewAppeal` approved → `active:false`), and return values (`count`, `result.count`).
- **Settings delegation** (getSettings / updateSettings / hasModPermissions / getStats): mock `./moderationSettings` and assert argument forwarding + return propagation.

## Result
**Mutation 17.76% → 80.37%** (85 killed / 18 survived / 3 no-cov). Added `ModerationService.ts` back to the Stryker `mutate` set — the combined shared gate is now **79.79% across 5 modules**, still passing `break: 75`. Shared suite **932/932**; ~45s mutation run.

Refs #1426.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened tests for `ModerationService` to cover 14 previously untested methods and re-enabled mutation testing for `src/services/ModerationService.ts`, raising mutation score from 17.76% to 80.37% and keeping the shared gate above the 75 break. Closes #1433 by asserting correct Prisma query shapes and settings delegation.

- **Refactors**
  - Added behavior tests for query methods (e.g., getCase, getUserCases, getRecentCases, getCasesSince, getActiveWarningsCount, clearWarnings, deactivateCase, appealCase, reviewAppeal, getExpiredCases), asserting exact where/orderBy/take/data and conditional fields; verified returned values.
  - Mocked `./moderationSettings` to assert forwarding for getSettings, updateSettings, hasModPermissions, getStats; included `src/services/ModerationService.ts` in `packages/shared/stryker.conf.json` mutate set.

<sup>Written for commit 96de5b803b8c941661d806eb4ef629f24cb8b90b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

