### PR TITLE
test(shared): harden trackhistory + guildsettings mutation coverage

### DIFF
--- a/packages/shared/src/services/GuildSettingsService.spec.ts
+++ b/packages/shared/src/services/GuildSettingsService.spec.ts
@@ -429,5 +429,41 @@ describe('GuildSettingsService — settings CRUD + counter methods', () => {
             cUpsert.mockResolvedValue({})
             expect(await service.clearGuildSessions(GUILD)).toBe(false)
         })
+
+        it('returns false when a counter reset fails', async () => {
+            sDeleteMany.mockResolvedValue({ count: 1 })
+            cUpsert.mockRejectedValue(new Error('db'))
+            expect(await service.clearGuildSessions(GUILD)).toBe(false)
+        })
+    })
+
+    // Error-path coverage: every read/write falls back gracefully (catch blocks).
+    describe('counter error paths', () => {
+        it('getAutoplayCounter returns null on error', async () => {
+            cFindUnique.mockRejectedValue(new Error('db'))
+            expect(await service.getAutoplayCounter(GUILD)).toBeNull()
+        })
+        it('setAutoplayCounter returns false on error', async () => {
+            cUpsert.mockRejectedValue(new Error('db'))
+            expect(
+                await service.setAutoplayCounter(GUILD, {
+                    guildId: GUILD,
+                    count: 1,
+                    lastReset: new Date(),
+                }),
+            ).toBe(false)
+        })
+        it('getRepeatCount returns 0 on error', async () => {
+            cFindUnique.mockRejectedValue(new Error('db'))
+            expect(await service.getRepeatCount(GUILD)).toBe(0)
+        })
+        it('setRepeatCount returns false on error', async () => {
+            cUpsert.mockRejectedValue(new Error('db'))
+            expect(await service.setRepeatCount(GUILD, 3)).toBe(false)
+        })
+        it('incrementRepeatCount returns 0 on error', async () => {
+            cUpsert.mockRejectedValue(new Error('db'))
+            expect(await service.incrementRepeatCount(GUILD)).toBe(0)
+        })
     })
 })

--- a/packages/shared/src/services/TrackHistoryService.spec.ts
+++ b/packages/shared/src/services/TrackHistoryService.spec.ts
@@ -554,5 +554,58 @@ describe('TrackHistoryService', () => {
             // three spellings normalize to one artist with count 3 (> 2)
             expect(result.artists.has('the band')).toBe(true)
         })
+
+        it('getReplayFrequentTracks excludes an artist seen exactly twice', async () => {
+            mockFindMany.mockResolvedValue([
+                { trackId: 'a', author: 'Pair' },
+                { trackId: 'b', author: 'Pair' },
+            ])
+            const result =
+                await new TrackHistoryService().getReplayFrequentTracks(GUILD)
+            expect(result.artists.has('pair')).toBe(false)
+        })
+
+        it('clearHistory returns false on error', async () => {
+            mockDeleteMany.mockRejectedValue(new Error('db'))
+            expect(await new TrackHistoryService().clearHistory(GUILD)).toBe(
+                false,
+            )
+        })
+
+        it('clearAllGuildCaches swallows errors (no throw)', async () => {
+            mockDeleteMany.mockRejectedValue(new Error('db'))
+            await expect(
+                new TrackHistoryService().clearAllGuildCaches(GUILD),
+            ).resolves.toBeUndefined()
+        })
+
+        it('isDuplicateTrack is false when the matching play is outside the window', async () => {
+            mockFindMany.mockResolvedValue([
+                row({
+                    url: 'https://old/x',
+                    playedAt: new Date(Date.now() - 10 * 60 * 1000), // 10 min ago
+                }),
+            ])
+            expect(
+                await new TrackHistoryService().isDuplicateTrack(
+                    GUILD,
+                    'https://old/x',
+                    60_000, // 1-minute window
+                ),
+            ).toBe(false)
+        })
+
+        it('getTopArtists slices to the requested limit', async () => {
+            mockFindMany.mockResolvedValue([
+                row({ author: 'A' }),
+                row({ author: 'B' }),
+                row({ author: 'C' }),
+            ])
+            const result = await new TrackHistoryService().getTopArtists(
+                GUILD,
+                2,
+            )
+            expect(result).toHaveLength(2)
+        })
     })
 })

--- a/packages/shared/stryker.conf.json
+++ b/packages/shared/stryker.conf.json
@@ -26,6 +26,6 @@
     "thresholds": {
         "high": 85,
         "low": 70,
-        "break": 70
+        "break": 71
     }
 }


### PR DESCRIPTION
**#1426 Phase 2** — hardening pass on the two weakest gated modules.

## Scores
- GuildSettingsService **62.93% → 65.85%**
- TrackHistoryService **65.56% → 66.67%**
- Combined 7-module gate **72.80% → 73.75%**; ratcheted `break` **70 → 71**.

## What
11 tests: error-path coverage for the counter read/write methods (graceful null/0/false fallbacks), plus boundaries — `getReplayFrequentTracks` artist-seen-exactly-twice excluded, `isDuplicateTrack` outside-window, `clearHistory`/`clearAllGuildCaches` error handling, `getTopArtists` limit slice, `clearGuildSessions` counter-reset failure.

## Honest note (why not 75%)
These two plateau ~66% because the bulk of their remaining survivors are **low-value or equivalent**:
- **errorLog message strings** — only killable by asserting exact log text (the specs don't mock the log module; doing so to chase message-string mutants is coverage theater).
- **structurally-unkillable** mutants — `getDefaultSettings`' unused default values (rowToSettings reads most fields from the row, not defaults) and `markTrackAsPlayed`'s in-memory marker map (no public reader).

Chasing 75% per-module here would be theater; **the combined gate at 73.75% is the meaningful floor**, and it ratcheted up. (Separately: the run is ~2min for 7 modules — worth Stryker `incremental` mode before adding more.)

Refs #1426.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens mutation tests for TrackHistoryService and GuildSettingsService by adding 11 error-path and boundary tests, and bumps the Stryker `break` threshold. Aligns with Linear #1426 Phase 2: coverage rises to 65.85%/66.67%, and the 7‑module gate moves to 73.75% (`break` 71).

<sup>Written for commit f8e58401cf8e7a0fd33bb854cccbc513cdcf6286. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

