### PR TITLE
ci(shared): enable stryker incremental mode with ci cache (#1438)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -5,7 +5,9 @@ name: Mutation Testing
 # `thresholds.break` in packages/shared/stryker.conf.json fails this job if the
 # score regresses, so weakened assertions can't land silently.
 #
-# Scope is currently one deep module (DatabaseService.ts) — the run is ~20s.
+# Scope is the gated shared modules listed in stryker.conf.json `mutate`. The run
+# uses Stryker incremental mode (#1438): the incremental cache is restored/saved
+# across runs so unchanged modules are skipped and only changed files re-mutate.
 # This is NOT a required status check yet; promote it in branch protection once
 # the score has stabilised, and widen `mutate` to more modules over time.
 
@@ -43,6 +45,13 @@ jobs:
         run: npx prisma generate
       - name: Build shared package
         run: npm run build:shared
+      - name: Restore Stryker incremental cache
+        uses: actions/cache@v4
+        with:
+          path: packages/shared/reports/stryker-incremental.json
+          key: stryker-incremental-shared-${{ github.run_id }}
+          restore-keys: |
+            stryker-incremental-shared-
       - name: Run mutation tests (shared)
         run: npm run test:mutation --workspace=packages/shared
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ docs/specs/
 # Stryker mutation-testing artifacts (generated)
 .stryker-tmp/
 packages/*/reports/mutation/
+packages/*/reports/stryker-incremental.json

--- a/packages/shared/stryker.conf.json
+++ b/packages/shared/stryker.conf.json
@@ -22,7 +22,8 @@
     "logLevel": "info",
     "concurrency": 2,
     "ignoreStatic": false,
-    "incremental": false,
+    "incremental": true,
+    "incrementalFile": "reports/stryker-incremental.json",
     "thresholds": {
         "high": 85,
         "low": 70,


### PR DESCRIPTION
Part of #1426. Closes #1438.

## What
- `stryker.conf.json`: `incremental: true` + `incrementalFile: reports/stryker-incremental.json`
- `.gitignore`: ignore the generated incremental cache file
- `mutation.yml`: `actions/cache` step restores/saves the incremental file across CI runs (key `stryker-incremental-shared-<run_id>`, restore-key prefix), so unchanged modules are skipped and only changed files re-mutate
- Corrected the stale header comment (was 'one deep module ~20s'; now describes the 7-module incremental run)

## Why
The mutation run is ~2 min across 7 gated modules and grows with each module added under #1426. Incremental mode keeps the gate fast as scope widens.

## Verification
CI `Mutation — shared` runs on this PR (paths match both the workflow and `packages/shared/**`) and fully validates the incremental config end-to-end; the combined break threshold (71%) is unchanged, so a green run proves no score regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Stryker incremental mode for `packages/shared` and cache the incremental file in CI so unchanged modules are skipped and runs stay fast. Closes #1438 and supports the module gate expansion in #1426.

- **New Features**
  - Enabled `"incremental": true` with `incrementalFile: "reports/stryker-incremental.json"` in `packages/shared/stryker.conf.json`.
  - Added `actions/cache@v4` to `mutation.yml` to restore/save the incremental file across runs.
  - Ignored `packages/*/reports/stryker-incremental.json` in `.gitignore` and updated the workflow comment.

<sup>Written for commit a60cb732ba60310294e0d659ea73ed6cdd2ad4d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

