### PR TITLE
test(shared): mutation-gate telemetry read service module (#1439)

### DIFF
--- a/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
+++ b/packages/shared/src/services/recommendationTelemetryReadService.spec.ts
@@ -276,6 +276,18 @@ describe('recommendationTelemetryReadService', () => {
             expect(mockGroupBy).toHaveBeenCalled()
         })
 
+        it('groups by the mode column', async () => {
+            mockGroupBy.mockResolvedValue([])
+
+            await getPerModeAcceptance('guild-123')
+
+            expect(mockGroupBy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    by: ['mode', 'isAccepted', 'isRejected'],
+                }),
+            )
+        })
+
         it('returns rows for all three modes', async () => {
             mockGroupBy.mockResolvedValue([
                 // similar: 7 accepted, 2 rejected, 1 pending
@@ -562,6 +574,61 @@ describe('recommendationTelemetryReadService', () => {
                 -2,
             )
         })
+
+        it('queries each bucket with the correct accept/reject filters', async () => {
+            mockCount
+                .mockResolvedValueOnce({ count: 100 }) // total picks
+                .mockResolvedValueOnce({ count: 65 }) // accepted
+                .mockResolvedValueOnce({ count: 25 }) // rejected
+                .mockResolvedValueOnce({ count: 10 }) // pending
+
+            await getSummary('guild-xyz')
+
+            const where = (i: number) =>
+                (mockCount.mock.calls[i][0] as any).where
+
+            // total picks: no accept/reject filter
+            expect(where(0)).toEqual(
+                expect.objectContaining({ guildId: 'guild-xyz' }),
+            )
+            expect(where(0).isAccepted).toBeUndefined()
+            expect(where(0).isRejected).toBeUndefined()
+            // accepted bucket filters isAccepted: true
+            expect(where(1)).toEqual(
+                expect.objectContaining({
+                    guildId: 'guild-xyz',
+                    isAccepted: true,
+                }),
+            )
+            // rejected bucket filters isRejected: true
+            expect(where(2)).toEqual(
+                expect.objectContaining({
+                    guildId: 'guild-xyz',
+                    isRejected: true,
+                }),
+            )
+            // pending bucket filters both null
+            expect(where(3)).toEqual(
+                expect.objectContaining({
+                    guildId: 'guild-xyz',
+                    isAccepted: null,
+                    isRejected: null,
+                }),
+            )
+            // every bucket carries the rolling time window
+            for (let i = 0; i < 4; i++) {
+                expect(where(i).createdAt.gte).toBeInstanceOf(Date)
+            }
+        })
+
+        it('handles prisma count returning a plain number', async () => {
+            mockCount.mockResolvedValue(7) // plain number, not { count }
+
+            const result = await getSummary('guild-123')
+
+            expect(result.totalPicks).toBe(7)
+            expect(result.accepted).toBe(7)
+        })
     })
 
     describe('getAutoplaySkipRateForGuild', () => {
@@ -648,6 +715,51 @@ describe('recommendationTelemetryReadService', () => {
                 rejectedCount: 0,
                 canTrip: false,
             })
+        })
+
+        it('filters by isAccepted/isRejected and a precise 24h window', async () => {
+            mockCount.mockResolvedValueOnce(3).mockResolvedValueOnce(2)
+            const before = Date.now()
+
+            await getAutoplaySkipRateForGuild('guild-aa')
+
+            const w0 = (mockCount.mock.calls[0][0] as any).where
+            const w1 = (mockCount.mock.calls[1][0] as any).where
+            // accepted query
+            expect(w0).toEqual(
+                expect.objectContaining({
+                    guildId: 'guild-aa',
+                    isAccepted: true,
+                }),
+            )
+            // rejected query
+            expect(w1).toEqual(
+                expect.objectContaining({
+                    guildId: 'guild-aa',
+                    isRejected: true,
+                }),
+            )
+            // exactly a 24h window (catches arithmetic drift in the cutoff)
+            const expectedGte = before - 24 * 60 * 60 * 1000
+            const gte = w0.createdAt.gte.getTime()
+            expect(gte).toBeGreaterThan(expectedGte - 5_000)
+            expect(gte).toBeLessThan(expectedGte + 5_000)
+        })
+
+        it('handles prisma count returning { count } objects', async () => {
+            mockCount
+                .mockResolvedValueOnce({ count: 4 })
+                .mockResolvedValueOnce({ count: 1 })
+
+            const result = await getAutoplaySkipRateForGuild('guild-bb')
+
+            expect(result).toEqual(
+                expect.objectContaining({
+                    acceptedCount: 4,
+                    rejectedCount: 1,
+                    sampleSize: 5,
+                }),
+            )
         })
     })
 })

--- a/packages/shared/stryker.conf.json
+++ b/packages/shared/stryker.conf.json
@@ -13,6 +13,7 @@
         "src/services/GuildSettingsService.ts",
         "src/services/ModerationService.ts",
         "src/services/PremiumService.ts",
+        "src/services/recommendationTelemetryReadService.ts",
         "src/services/TrackHistoryService.ts",
         "src/services/embedValidation.ts"
     ],
@@ -27,6 +28,6 @@
     "thresholds": {
         "high": 85,
         "low": 70,
-        "break": 71
+        "break": 75
     }
 }


### PR DESCRIPTION
Part of #1426. Closes #1439.

## What
Adds `recommendationTelemetryReadService` (8th gated module) to the Stryker `mutate` array and hardens its spec from **79% → 100%** mutation score.

Survivors killed (21 → 0):
- **where-clause filters** — `getSummary`'s 4 count buckets (total / isAccepted:true / isRejected:true / both-null) and `getAutoplaySkipRate`'s accepted+rejected queries now assert their `where` clauses (were unasserted; the count mock ignored args)
- **24h window** — assert the rolling cutoff is within tolerance of now−24h (catches arithmetic drift in `24*60*60*1000`)
- **getCountValue branch** — cover both prisma `count` return shapes (plain number vs `{ count }`)
- **groupBy('mode')** — assert the grouping column

## Gate
Combined gate **73.75% → 76.01%**; `thresholds.break` ratcheted **71 → 75**. Local full run: 4 new + 1 grouping test, 28 module tests pass; CI `Mutation — shared` enforces the new floor.

## Verification
CI `Mutation — shared` re-runs the full 8-module gate on this PR; a green run proves the combined score holds above the new break threshold.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `recommendationTelemetryReadService` to Stryker’s `mutate` array and strengthens its tests to hit 100% mutation score (was 79%) by asserting where-clause filters, the 24h window, both Prisma count shapes, and `groupBy('mode')` (part of #1426; closes #1439). Raises the shared gate to 76.01% and bumps `thresholds.break` to 75 in `packages/shared/stryker.conf.json`.

<sup>Written for commit ac80440bb418cae64868552a2f3ffd8c3ca9ca17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for recommendation telemetry service with additional test cases for acceptance metrics, summary calculations, and skip rate tracking.

* **Chores**
  * Updated testing framework configuration to strengthen code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->