### PR TITLE
test(shared): mutation-gate support report service module (#1440)

### DIFF
--- a/packages/shared/src/services/SupportReportService.spec.ts
+++ b/packages/shared/src/services/SupportReportService.spec.ts
@@ -220,6 +220,81 @@ describe('SupportReportService', () => {
                 }),
             ).rejects.toThrow('Unique constraint failed')
         })
+
+        it('persists a provided submissionKey verbatim', async () => {
+            const createMock = jest
+                .fn<(args: unknown) => Promise<{ id: string }>>()
+                .mockResolvedValue({ id: 'report-sk' })
+            // @ts-ignore - partial prisma client mock
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: { create: createMock },
+            })
+
+            await service.create({
+                context: 'Error occurred',
+                surface: 'web',
+                submissionKey: 'sub-key-xyz',
+            })
+
+            expect(createMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        submissionKey: 'sub-key-xyz',
+                    }),
+                }),
+            )
+        })
+
+        it('rethrows when the thrown value is not an Error instance', async () => {
+            // A plain object (not instanceof Error) must NOT be treated as a
+            // P2002 dedup — the guard requires a real Error.
+            const notAnError = { code: 'P2002' }
+            // @ts-ignore - partial prisma client mock
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    create: jest
+                        .fn<(args: unknown) => Promise<{ id: string }>>()
+                        .mockRejectedValue(notAnError),
+                    findUnique: jest
+                        .fn<(args: unknown) => Promise<{ id: string }>>()
+                        .mockResolvedValue({ id: 'should-not-be-used' }),
+                },
+            })
+
+            await expect(
+                service.create({
+                    context: 'Error occurred',
+                    surface: 'web',
+                    submissionKey: 'sub-key-123',
+                }),
+            ).rejects.toEqual({ code: 'P2002' })
+        })
+
+        it('rethrows a non-P2002 error code instead of deduping', async () => {
+            const p2003 = Object.assign(
+                new Error('Foreign key constraint failed'),
+                { code: 'P2003' },
+            )
+            // @ts-ignore - partial prisma client mock
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: {
+                    create: jest
+                        .fn<(args: unknown) => Promise<{ id: string }>>()
+                        .mockRejectedValue(p2003),
+                    findUnique: jest
+                        .fn<(args: unknown) => Promise<{ id: string }>>()
+                        .mockResolvedValue({ id: 'should-not-be-used' }),
+                },
+            })
+
+            await expect(
+                service.create({
+                    context: 'Error occurred',
+                    surface: 'web',
+                    submissionKey: 'sub-key-123',
+                }),
+            ).rejects.toThrow('Foreign key constraint failed')
+        })
     })
 
     describe('get', () => {
@@ -264,6 +339,22 @@ describe('SupportReportService', () => {
             const result = await service.get('nonexistent')
 
             expect(result).toBeNull()
+        })
+
+        it('queries findUnique by the given id', async () => {
+            const findUniqueMock = jest
+                .fn<(args: unknown) => Promise<null>>()
+                .mockResolvedValue(null)
+            // @ts-ignore - partial prisma client mock
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: { findUnique: findUniqueMock },
+            })
+
+            await service.get('report-42')
+
+            expect(findUniqueMock).toHaveBeenCalledWith({
+                where: { id: 'report-42' },
+            })
         })
     })
 
@@ -356,6 +447,25 @@ describe('SupportReportService', () => {
             expect(findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     where: { status: 'triaged' },
+                }),
+            )
+        })
+
+        it('paginates with a cursor and skips the cursor row', async () => {
+            const findMany = jest
+                .fn<(args: unknown) => Promise<Array<{ id: string }>>>()
+                .mockResolvedValue([])
+            // @ts-ignore - partial prisma client mock
+            mockGetPrismaClient.mockReturnValue({
+                supportReport: { findMany },
+            })
+
+            await service.list({ cursor: 'cur-1' })
+
+            expect(findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    cursor: { id: 'cur-1' },
+                    skip: 1,
                 }),
             )
         })

--- a/packages/shared/stryker.conf.json
+++ b/packages/shared/stryker.conf.json
@@ -14,6 +14,7 @@
         "src/services/ModerationService.ts",
         "src/services/PremiumService.ts",
         "src/services/recommendationTelemetryReadService.ts",
+        "src/services/SupportReportService.ts",
         "src/services/TrackHistoryService.ts",
         "src/services/embedValidation.ts"
     ],
@@ -28,6 +29,6 @@
     "thresholds": {
         "high": 85,
         "low": 70,
-        "break": 75
+        "break": 77
     }
 }


### PR DESCRIPTION
Part of #1426. Closes #1440.

## What
Adds `SupportReportService` (9th gated module), hardening its spec from **85.9% → 100%**.

Survivors killed (10 + 1 no-coverage → 0):
- **create() submissionKey** — assert the persisted `data.submissionKey` when provided (the `|| null` fallback was unasserted)
- **P2002 dedup guard** — the `error instanceof Error && 'code' in error && code==='P2002'` chain now has its negative paths: a non-Error throw and a non-P2002 error code must **rethrow**, not dedup
- **get()** — assert `findUnique({ where: { id } })` args
- **list() cursor** — pagination branch (`cursor: { id }`, `skip: 1`) was entirely uncovered; now exercised + asserted

## Gate
Combined **76.01% → 77.53%**; `break` ratcheted **75 → 77**. Module spec 21 tests pass; CI `Mutation — shared` re-runs the full 9-module gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SupportReportService` to the mutation gate and expands its tests to 100% mutation score (85.9% → 100%). This raises the shared gate to 77.53% and ratchets the break from 75 → 77, covering submissionKey persistence, P2002 guard negative paths, findUnique-by-id, and cursor pagination.

- **Dependencies**
  - Update `packages/shared/stryker.conf.json`: add `src/services/SupportReportService.ts` to `mutate`; set `thresholds.break` to 77.

<sup>Written for commit c2938309ce328ad3958907b23d8729fdd5a5b6cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

