### PR TITLE
ci(danger): narrow lockfile guard to dependency-field changes

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -84,16 +84,45 @@ if (
 }
 
 // --- 4. Lockfile guard ------------------------------------------------------
-// package.json without package-lock.json (or vice versa) usually means
-// someone forgot to commit one half of a dependency change.
-const packageJsonChanged = modified.some((p) => /(^|\/)package\.json$/.test(p))
+// A package.json *dependency* change without a matching package-lock.json
+// update usually means someone forgot to commit the resolved lockfile.
+// Narrowed to fire ONLY when a dependency-bearing field actually changed:
+// a script-/metadata-only edit (e.g. adding an npm script, bumping a private
+// `version`) needs no lockfile churn and must not fail (false-positive on
+// PR #1455, #1458). JSONDiffForFile keys only on CHANGED top-level fields —
+// a field is absent from the diff when it didn't change.
+const DEP_FIELDS = [
+    'dependencies',
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies',
+    'overrides',
+] as const
 // Cover both modified and newly-created lockfiles (first-time npm install case).
 const lockChanged = all.some((p) => p === 'package-lock.json')
-if (packageJsonChanged && !lockChanged) {
-    fail(
-        `**\`package.json\` changed but \`package-lock.json\` did not.** ` +
-            `Run \`npm install\` and commit the lockfile.`,
-    )
+const changedPackageJsons = all.filter((p) => /(^|\/)package\.json$/.test(p))
+
+async function checkLockfileGuard(): Promise<void> {
+    if (changedPackageJsons.length === 0 || lockChanged) return
+    for (const path of changedPackageJsons) {
+        let depFieldChanged = false
+        try {
+            const diff = await danger.git.JSONDiffForFile(path)
+            // A dependency field appears in the diff only when it changed.
+            depFieldChanged = DEP_FIELDS.some((f) => Boolean(diff?.[f]))
+        } catch {
+            // If the diff can't be computed (e.g. malformed JSON), fall back
+            // to the conservative guard rather than silently passing.
+            depFieldChanged = true
+        }
+        if (depFieldChanged) {
+            fail(
+                `**\`${path}\` changed a dependency field but \`package-lock.json\` did not.** ` +
+                    `Run \`npm install\` and commit the lockfile.`,
+            )
+            return
+        }
+    }
 }
 
 // --- 5. .env protection -----------------------------------------------------
@@ -201,7 +230,11 @@ async function runAsyncChecks(): Promise<void> {
         )
     }
 
-    await Promise.all([checkConsoleLogs(), checkLargeFiles()])
+    await Promise.all([
+        checkConsoleLogs(),
+        checkLargeFiles(),
+        checkLockfileGuard(),
+    ])
 }
 
 // Hand the async work to Danger's scheduler. Danger awaits any promises


### PR DESCRIPTION
## What

Rule 4 in `dangerfile.ts` failed **any** PR that touched a `package.json` without also changing `package-lock.json` — including script-/metadata-only edits that need no lockfile churn. It mis-fired on PR #1455 (which only added a `test:mutation` npm script).

## Fix

Narrow the guard to fire **only when a dependency-bearing field actually changed**. Per changed `package.json`, run `danger.git.JSONDiffForFile()` and fail only if one of `dependencies` / `devDependencies` / `optionalDependencies` / `peerDependencies` / `overrides` is present in the diff (JSONDiffForFile keys only on **changed** top-level fields, so presence ⇒ real change — API verified against danger-js docs, not guessed).

- New `package.json` with deps → diffs against an empty base → dep fields present → still requires the lockfile. ✓
- Script-/`version`-only edit → no dep field in diff → passes. ✓ (the fixed false-positive)
- Malformed/undiffable JSON → conservative fallback to the old fail. ✓
- Converted from a sync check to an async one wired into the existing `schedule(runAsyncChecks())` `Promise.all`.

## Verification

dangerfile.ts is CI-only (not in any local tsconfig/eslint graph; danger installs at runtime), so verified by: danger-js API docs + reasoning over the diff shape + isolated `tsc` transpile (only the expected missing-`danger`-module error). danger is not a required check, so blast radius is low.

Closes #1458

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `dangerfile.ts` so the lockfile guard only triggers when dependency fields in `package.json` change. This prevents false positives on script/metadata-only edits and addresses #1458.

- **Bug Fixes**
  - Use `danger.git.JSONDiffForFile()` per changed `package.json`; fail only when `dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`, or `overrides` changed and `package-lock.json` did not.
  - Fallback to the old failure if the JSON diff can't be read.
  - Converted the rule to async (`checkLockfileGuard()`) and added it to `runAsyncChecks()`.

<sup>Written for commit 0daedbc97980cdf216304e2f27166501c6e3da19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI lockfile validation logic to more precisely detect when dependency-bearing configuration fields change, as opposed to flagging all configuration file modifications as potentially requiring lockfile updates.
  * Improved error handling and fallback validation behavior for edge cases such as malformed or invalid package configuration files encountered during CI validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->