### PR TITLE
test(backend): mutation-gate tier-1 pilot on request-id middleware

### DIFF
--- a/packages/backend/stryker.conf.json
+++ b/packages/backend/stryker.conf.json
@@ -7,7 +7,7 @@
             "configFile": "./jest.config.cjs"
         }
     },
-    "mutate": ["src/utils/oauthRedirectUri.ts"],
+    "mutate": ["src/utils/oauthRedirectUri.ts", "src/middleware/requestId.ts"],
     "reporters": ["html", "clear-text", "progress"],
     "timeoutMS": 15000,
     "timeoutFactor": 1.5,
@@ -20,6 +20,6 @@
     "thresholds": {
         "high": 85,
         "low": 70,
-        "break": 90
+        "break": 82
     }
 }

--- a/packages/backend/tests/unit/middleware/requestId.test.ts
+++ b/packages/backend/tests/unit/middleware/requestId.test.ts
@@ -69,6 +69,20 @@ describe('requestId middleware', () => {
         expect(res.headers['X-Request-Id']).toBe(req.requestId)
     })
 
+    test('honours an inbound header of exactly 64 chars (upper boundary)', () => {
+        // The boundary itself must be accepted: 64 is valid, 65 is not.
+        // Pins the `{1,64}` quantifier so a `{1,63}` mutant cannot survive.
+        const id = 'a'.repeat(64)
+        const req = createReq(id)
+        const res = createRes()
+        const next = jest.fn()
+
+        requestId(req, res, next)
+
+        expect(req.requestId).toBe(id)
+        expect(res.headers['X-Request-Id']).toBe(id)
+    })
+
     test('mints a fresh id when the inbound header is empty', () => {
         const req = createReq('')
         const res = createRes()


### PR DESCRIPTION
## What

The **Tier-1 cost pilot** from the backend mutation-gate rollout ADR (`decisions/2026-06-16-backend-mutation-gate-rollout.md`). Adds the first *real* backend module to the Stryker `mutate` set and measures per-module cost before committing to full tiers.

- **Hardening:** one 64-char upper-boundary test on `requestId.ts`. The `SAFE_INBOUND_ID` `{1,64}` quantifier needs a valid input of *exactly* 64 chars to kill a `{1,63}` mutant — the existing 65-char/newline tests only cover rejection. (The `{0,64}`/`{1,0}` lower-bound mutants are equivalent — unreachable behind the `inbound &&` truthiness short-circuit — so they're never killable.)
- **Threshold:** `thresholds.break` 90 → 82, matching `packages/shared`. The canary's 90 was not transferable; 82 leaves headroom to absorb subsequent lower-scoring Tier-1 modules.

## Pilot measurement (fresh run, concurrency 2)

| Module | Score | Killed | Timeout | Survived |
|---|---|---|---|---|
| `requestId.ts` | **100.00%** | 9 | 1 | 0 |
| `oauthRedirectUri.ts` (canary) | 93.75% | 45 | 0 | 3 |
| **Combined** | **94.83%** | 54 | 1 | 3 |

- **Wall time: 33s** for both modules — far under the ADR's ~60s/module halt trigger.
- **No pervasive timeouts** — 1 of 58 mutants (~1.7%), and it is *detected* (counts as killed). 18.4 tests/mutant avg.

## ADR pilot gate → GREEN

Per-module time well under 60s, no pervasive timeouts, real module hardened to 100% with a single targeted test. The decision to **proceed by coverage tiers** is validated. Next executable unit: remaining Tier-1 utils + pure middleware (`validate.ts`, `errorHandler.ts`).

## Scope / posture

`mutation-backend` **stays advisory** — it is not a required status check; a red run does not block merge. No production code changed (one test added + config).

Refs #1426

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `src/middleware/requestId.ts` to the Stryker Tier‑1 mutate set and adds a 64‑char boundary test to validate max‑length IDs and kill off‑by‑one mutants, supporting #1426. Lowers the backend mutation break threshold to 82 to align with `packages/shared`; the mutation gate remains advisory.

<sup>Written for commit 48c91aff2a42b66797f9e146180f3064cf321ea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

