### PR TITLE
test(backend): mutation-gate tier-1 utils + pure middleware

### DIFF
--- a/packages/backend/stryker.conf.json
+++ b/packages/backend/stryker.conf.json
@@ -7,7 +7,14 @@
             "configFile": "./jest.config.cjs"
         }
     },
-    "mutate": ["src/utils/oauthRedirectUri.ts", "src/middleware/requestId.ts"],
+    "mutate": [
+        "src/utils/oauthRedirectUri.ts",
+        "src/utils/frontendOrigin.ts",
+        "src/utils/prismaErrors.ts",
+        "src/middleware/requestId.ts",
+        "src/middleware/validate.ts",
+        "src/middleware/errorHandler.ts"
+    ],
     "reporters": ["html", "clear-text", "progress"],
     "timeoutMS": 15000,
     "timeoutFactor": 1.5,

--- a/packages/backend/tests/unit/middleware/errorHandler.test.ts
+++ b/packages/backend/tests/unit/middleware/errorHandler.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals'
 import { errorHandler } from '../../../src/middleware/errorHandler'
 import { AppError } from '../../../src/errors/AppError'
+import { ValidationError } from '@lucky/shared/errors'
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
@@ -36,6 +37,10 @@ describe('errorHandler', () => {
         expect(res.json).toHaveBeenCalledWith({
             error: 'Invalid input',
         })
+        // No `details` on this error → the key must be absent, not present
+        // with an undefined value. Pins the `if (err.details)` guard against
+        // a mutant that always attaches details.
+        expect(Object.keys(res.json.mock.calls[0][0])).toEqual(['error'])
         expect(errorLog).not.toHaveBeenCalled()
         // Expected client errors (4xx) must not pollute Sentry.
         expect(captureException).not.toHaveBeenCalled()
@@ -44,6 +49,35 @@ describe('errorHandler', () => {
     test('should include details when present on AppError', () => {
         const details = [{ field: 'name', message: 'required' }]
         const err = AppError.badRequest('Validation failed', details)
+        const res = createRes()
+
+        errorHandler(err, createReq(), res, jest.fn())
+
+        expect(res.json).toHaveBeenCalledWith({
+            error: 'Validation failed',
+            details,
+        })
+    })
+
+    test('should handle ValidationError with 400 and no Sentry capture', () => {
+        const err = new ValidationError('Bad payload')
+        const res = createRes()
+
+        errorHandler(err, createReq(), res, jest.fn())
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ error: 'Bad payload' })
+        // No details → key must be absent (pins the `if (err.details)` guard
+        // on the ValidationError branch).
+        expect(Object.keys(res.json.mock.calls[0][0])).toEqual(['error'])
+        // ValidationError is a known 4xx — it must not log or hit Sentry.
+        expect(errorLog).not.toHaveBeenCalled()
+        expect(captureException).not.toHaveBeenCalled()
+    })
+
+    test('should include details on a ValidationError when present', () => {
+        const details = [{ field: 'email', message: 'invalid' }]
+        const err = new ValidationError('Validation failed', details)
         const res = createRes()
 
         errorHandler(err, createReq(), res, jest.fn())

--- a/packages/backend/tests/unit/middleware/validate.test.ts
+++ b/packages/backend/tests/unit/middleware/validate.test.ts
@@ -45,6 +45,19 @@ describe('validateBody', () => {
         expect(next).toHaveBeenCalled()
         expect(req.body).toEqual({ name: 'ok' })
     })
+
+    test('joins a nested error path with dots', () => {
+        // A 2-segment path is the only way to tell `path.join('.')` apart
+        // from `join('')`; it also pins the error-mapping callback (field +
+        // message) against null-object / undefined-return mutants.
+        const nested = z.object({ user: z.object({ name: z.string() }) })
+        const { req, res, next } = setup({ user: {} }, 'body')
+        validateBody(nested)(req, res, next)
+        const body = res.json.mock.calls[0][0]
+        expect(body.errors[0].field).toBe('user.name')
+        expect(typeof body.errors[0].message).toBe('string')
+        expect(next).not.toHaveBeenCalled()
+    })
 })
 
 describe('validateQuery', () => {
@@ -62,6 +75,14 @@ describe('validateQuery', () => {
         const { req, res, next } = setup({ limit: 'abc' }, 'query')
         validateQuery(schema)(req, res, next)
         expect(res.status).toHaveBeenCalledWith(400)
+        // Assert the error body, not just the status — pins the 400 JSON
+        // payload (`{ error, errors }`) against empty-object / empty-string
+        // mutants on the response and the error-mapping callback.
+        const body = res.json.mock.calls[0][0]
+        expect(body.error).toBe('Validation failed')
+        expect(Array.isArray(body.errors)).toBe(true)
+        expect(body.errors[0]).toHaveProperty('field')
+        expect(body.errors[0]).toHaveProperty('message')
         expect(next).not.toHaveBeenCalled()
     })
 
@@ -72,7 +93,10 @@ describe('validateQuery', () => {
     })
 
     test('should strip unknown query fields', () => {
-        const { req, res, next } = setup({ limit: '20', extra: 'ignored' }, 'query')
+        const { req, res, next } = setup(
+            { limit: '20', extra: 'ignored' },
+            'query',
+        )
         validateQuery(schema)(req, res, next)
         expect(next).toHaveBeenCalled()
         expect(req.query).toEqual({ limit: '20' })
@@ -83,6 +107,16 @@ describe('validateQuery', () => {
         validateQuery(schema)(req, res, next)
         expect(next).toHaveBeenCalled()
         expect(req.query).toEqual({})
+    })
+
+    test('joins a nested error path with dots', () => {
+        const nested = z.object({ page: z.object({ size: z.string() }) })
+        const { req, res, next } = setup({ page: {} }, 'query')
+        validateQuery(nested)(req, res, next)
+        const body = res.json.mock.calls[0][0]
+        expect(body.errors[0].field).toBe('page.size')
+        expect(typeof body.errors[0].message).toBe('string')
+        expect(next).not.toHaveBeenCalled()
     })
 })
 
@@ -138,5 +172,15 @@ describe('validateParams', () => {
         validateParams(schema)(req, res, next)
         expect(next).toHaveBeenCalled()
         expect(req.params).toEqual({ guildId: '123456789012345678' })
+    })
+
+    test('joins a nested error path with dots', () => {
+        const nested = z.object({ scope: z.object({ id: z.string() }) })
+        const { req, res, next } = setup({ scope: {} }, 'params')
+        validateParams(nested)(req, res, next)
+        const body = res.json.mock.calls[0][0]
+        expect(body.errors[0].field).toBe('scope.id')
+        expect(typeof body.errors[0].message).toBe('string')
+        expect(next).not.toHaveBeenCalled()
     })
 })

--- a/packages/backend/tests/unit/utils/frontendOrigin.test.ts
+++ b/packages/backend/tests/unit/utils/frontendOrigin.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals'
+import {
+    getFrontendOrigins,
+    getPrimaryFrontendUrl,
+} from '../../../src/utils/frontendOrigin'
+
+const DEFAULT = 'http://localhost:5173'
+const ENV_KEY = 'WEBAPP_FRONTEND_URL'
+
+describe('frontendOrigin', () => {
+    let saved: string | undefined
+
+    beforeEach(() => {
+        saved = process.env[ENV_KEY]
+    })
+
+    afterEach(() => {
+        if (saved === undefined) delete process.env[ENV_KEY]
+        else process.env[ENV_KEY] = saved
+    })
+
+    test('falls back to the localhost default when env is unset', () => {
+        delete process.env[ENV_KEY]
+        expect(getFrontendOrigins()).toEqual([DEFAULT])
+        expect(getPrimaryFrontendUrl()).toBe(DEFAULT)
+    })
+
+    test('returns a single configured origin', () => {
+        process.env[ENV_KEY] = 'https://app.example.com'
+        expect(getFrontendOrigins()).toEqual(['https://app.example.com'])
+        expect(getPrimaryFrontendUrl()).toBe('https://app.example.com')
+    })
+
+    test('splits comma-separated origins and trims surrounding whitespace', () => {
+        // Pins `.split(',')` (an empty-string mutant splits into characters)
+        // and `.map(trim)` (removing it leaves the leading/trailing spaces).
+        process.env[ENV_KEY] = 'https://a.example.com ,  https://b.example.com'
+        expect(getFrontendOrigins()).toEqual([
+            'https://a.example.com',
+            'https://b.example.com',
+        ])
+        expect(getPrimaryFrontendUrl()).toBe('https://a.example.com')
+    })
+
+    test('drops empty segments between separators', () => {
+        // Pins `.filter((o) => o.length > 0)` — a `>= 0` or removed mutant
+        // would keep the empty strings.
+        process.env[ENV_KEY] = 'https://a.example.com,, ,https://b.example.com'
+        expect(getFrontendOrigins()).toEqual([
+            'https://a.example.com',
+            'https://b.example.com',
+        ])
+    })
+
+    test('falls back to the default when the value is only separators/whitespace', () => {
+        // Pins the `origins.length > 0 ? origins : [DEFAULT]` fallback: after
+        // filtering this yields [], so the default must be returned.
+        process.env[ENV_KEY] = ' , , '
+        expect(getFrontendOrigins()).toEqual([DEFAULT])
+        expect(getPrimaryFrontendUrl()).toBe(DEFAULT)
+    })
+})

--- a/packages/backend/tests/unit/utils/prismaErrors.test.ts
+++ b/packages/backend/tests/unit/utils/prismaErrors.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from '@jest/globals'
+import { isUniqueViolation } from '../../../src/utils/prismaErrors'
+
+function errorWithCode(code: unknown): Error {
+    return Object.assign(new Error('boom'), { code })
+}
+
+describe('isUniqueViolation', () => {
+    test('true for an Error carrying the P2002 code', () => {
+        expect(isUniqueViolation(errorWithCode('P2002'))).toBe(true)
+    })
+
+    test('false for an Error with a different prisma code', () => {
+        // Pins `=== 'P2002'` (a `!==` or empty-string-literal mutant would
+        // accept this) and the second `&&` (an `||` mutant returns true here).
+        expect(isUniqueViolation(errorWithCode('P2003'))).toBe(false)
+    })
+
+    test('false for an Error with no code property', () => {
+        // Pins the `'code' in error` guard against a `false` mutant and the
+        // first `&&` against an `||` mutant.
+        expect(isUniqueViolation(new Error('plain'))).toBe(false)
+    })
+
+    test('false for a non-Error object even when it carries code P2002', () => {
+        // Pins `instanceof Error`: a `true`/removed mutant would accept this.
+        expect(isUniqueViolation({ code: 'P2002' })).toBe(false)
+    })
+
+    test('false for null/undefined/primitive inputs', () => {
+        expect(isUniqueViolation(null)).toBe(false)
+        expect(isUniqueViolation(undefined)).toBe(false)
+        expect(isUniqueViolation('P2002')).toBe(false)
+    })
+})


### PR DESCRIPTION
## What

Continues the backend Stryker rollout (ADR `decisions/2026-06-16-backend-mutation-gate-rollout.md`, Tier 1 = utils + pure middleware) after the requestId pilot (#1462). Adds four fast, unit-tested modules to the `mutate` set with the hardening needed to gate them.

## Results (fresh run, 6 modules)

| Module | Before | After |
|---|---|---|
| `errorHandler.ts` | 90.91% | **100%** |
| `validate.ts` | 79.49% | **97.44%** |
| `frontendOrigin.ts` | _(new)_ | **100%** |
| `prismaErrors.ts` | _(new)_ | **100%** |
| `requestId.ts` | 100% | 100% |
| `oauthRedirectUri.ts` (canary) | 93.75% | 93.75% |
| **Combined** | — | **97.28%** (139 killed / 4 timeout / 4 survived) |

Well above `thresholds.break: 82`.

## Hardening (test-only; no source changed)

- **`frontendOrigin`** (new test) — pins `split(',')` / `trim` / `filter(len>0)` / the default-fallback ternary.
- **`prismaErrors`** (new test) — pins `instanceof Error`, both `&&`, and `=== 'P2002'` (incl. non-Error / null / primitive inputs).
- **`errorHandler`** — adds the previously-uncovered `ValidationError` branch (lines 21-28) + key-absence assertions on the no-details cases (Jest's `toHaveBeenCalledWith` treated `{error, details: undefined}` as equal, so the `if (err.details)` mutants survived).
- **`validate`** — asserts the 400 response *body* on the query path + a nested-error-path test per function (a 2-segment path is the only way to distinguish `path.join('.')` from `join('')`). One equivalent mutant remains (`stripUnknownFields` L11 — the trailing `Object.assign` restores any over-deletion).

## Cost finding (the pilot's job) ⚠️

Even after **deferring `authHealth.ts`**, a fresh run is **~10 min** (49.83 tests/mutant). Reason: `validate.ts` and `oauthRedirectUri.ts` are transitively covered by the **full supertest route suite** (every route uses the validators), so each mutant re-runs ~50 integration specs — a structural cost, not authHealth-specific. Mitigations:
- **Incremental mode** (already on in CI) bounds steady-state cost to changed modules only.
- **Follow-up filed** to give Stryker a unit-test-only jest config — the real fix to bring per-mutant test count (and runtime) down. See linked issue.

**`authHealth.ts` deferred** from this batch: a pure util, but dragged through the auth/health integration suites (26 survivors, big equivalent tail, blows the ADR's ~60s/module gate). Tracked for a later isolation pass.

## Posture

`mutation-backend` **stays advisory** (not a required check). `break` held at **82** — the ADR's deliberate rollout floor, leaving headroom for the lower-scoring Tier-2 services; ratcheting deferred until the tier set stabilizes.

Refs #1426

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four Tier‑1 backend modules to Stryker’s `mutate` set—`src/utils/frontendOrigin.ts`, `src/utils/prismaErrors.ts`, `src/middleware/validate.ts`, and `src/middleware/errorHandler.ts`—with new/expanded unit tests to gate them. Combined mutation score is 97.28% (above `thresholds.break` 82); gate stays advisory, `authHealth.ts` is deferred due to integration test cost; aligns with Linear #1426 (Tier‑1 rollout).

<sup>Written for commit e0f3f8c9875f5f93f598774a57a7e865b9e36693. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for error handling response formatting, validation middleware error paths, frontend configuration utility behaviors, and database error detection patterns.

* **Chores**
  * Expanded mutation testing configuration to cover additional backend modules and utilities for improved mutation detection coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->