### PR TITLE
ci(backend): unit-only stryker config + re-add authhealth mutate

### DIFF
--- a/packages/backend/jest.mutation.cjs
+++ b/packages/backend/jest.mutation.cjs
@@ -1,0 +1,26 @@
+// Jest config used ONLY by Stryker mutation runs (#1464).
+//
+// Stryker re-runs every test that *covers* a surviving mutant. The default
+// jest config (jest.config.cjs) includes the integration (supertest) suite,
+// and shared middleware/utils like validate.ts are transitively covered by
+// every route spec — so each mutant re-ran ~50 integration tests, pushing a
+// full run to ~10 minutes. Mutation testing wants fast, focused unit tests:
+// this config restricts the runner to tests/unit/** so each mutant re-runs
+// only the unit tests that exercise it.
+const base = require('./jest.config.cjs')
+
+module.exports = {
+    ...base,
+    testMatch: [
+        '<rootDir>/tests/unit/**/*.test.ts',
+        '<rootDir>/tests/unit/**/*.spec.ts',
+    ],
+    testPathIgnorePatterns: [
+        ...base.testPathIgnorePatterns,
+        '<rootDir>/tests/integration/',
+    ],
+    // Coverage is irrelevant under Stryker (it computes mutation score, not
+    // line coverage) and the threshold would fail on the unit-only subset.
+    collectCoverage: false,
+    coverageThreshold: undefined,
+}

--- a/packages/backend/stryker.conf.json
+++ b/packages/backend/stryker.conf.json
@@ -3,14 +3,14 @@
     "version": "7",
     "testRunner": "jest",
     "jest": {
-        "config": {
-            "configFile": "./jest.config.cjs"
-        }
+        "projectType": "custom",
+        "configFile": "./jest.mutation.cjs"
     },
     "mutate": [
         "src/utils/oauthRedirectUri.ts",
         "src/utils/frontendOrigin.ts",
         "src/utils/prismaErrors.ts",
+        "src/utils/authHealth.ts",
         "src/middleware/requestId.ts",
         "src/middleware/validate.ts",
         "src/middleware/errorHandler.ts"

--- a/packages/backend/tests/unit/utils/authHealth.test.ts
+++ b/packages/backend/tests/unit/utils/authHealth.test.ts
@@ -28,6 +28,20 @@ describe('authHealth utils', () => {
     })
 
     describe('buildAuthConfigHealth', () => {
+        // A fully-valid input (status 'ok', no warnings). Each test overrides
+        // only the fields it exercises so a single warning is isolated.
+        const base = (
+            over: Partial<Parameters<typeof buildAuthConfigHealth>[0]> = {},
+        ): Parameters<typeof buildAuthConfigHealth>[0] => ({
+            clientId: 'test-client-id',
+            redirectUri: 'https://lucky.lucassantana.tech/api/auth/callback',
+            frontendOrigins: ['https://lucky.lucassantana.tech'],
+            backendOrigins: ['https://lucky-api.lucassantana.tech'],
+            sessionSecretConfigured: true,
+            redisHealthy: true,
+            ...over,
+        })
+
         test('returns ok when redirect contract matches frontend origins', () => {
             const response = buildAuthConfigHealth({
                 clientId: 'test-client-id',
@@ -44,6 +58,9 @@ describe('authHealth utils', () => {
 
             expect(response.status).toBe('ok')
             expect(response.auth.clientId).toBe('test-client-id')
+            // A configured client id reports clientIdConfigured=true — pins the
+            // `clientId.length > 0` flag against an always-false mutant.
+            expect(response.auth.clientIdConfigured).toBe(true)
             expect(response.auth.authorizeUrlPreview).toContain(
                 'client_id=test-client-id',
             )
@@ -142,6 +159,12 @@ describe('authHealth utils', () => {
             expect(response.warnings).toContain(
                 'No WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL origins configured',
             )
+            // With nothing configured we cannot judge the redirect origin, so
+            // the mismatch warning must NOT fire (pins the `if
+            // (hasConfiguredOrigins)` guard against an always-true mutant).
+            expect(response.warnings).not.toContain(
+                'OAuth redirect origin is not in WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL',
+            )
         })
 
         test('ignores malformed configured origins and malformed request origin', () => {
@@ -178,6 +201,170 @@ describe('authHealth utils', () => {
             expect(response.warnings).toContain(
                 'CLIENT_ID does not match expected production app id (test-client-id)',
             )
+        })
+
+        test('warns and reports clientIdConfigured=false when client id is empty', () => {
+            const response = buildAuthConfigHealth(base({ clientId: '' }))
+
+            expect(response.warnings).toContain('CLIENT_ID not configured')
+            expect(response.auth.clientIdConfigured).toBe(false)
+            expect(response.status).toBe('degraded')
+        })
+
+        test('does not warn when client id matches expected after trimming whitespace', () => {
+            // Pins `expectedClientId?.trim()` (a no-trim mutant leaves the
+            // padded value, making it mismatch) and the `!==` comparison.
+            const response = buildAuthConfigHealth(
+                base({
+                    clientId: 'prod-app-id',
+                    expectedClientId: '  prod-app-id  ',
+                }),
+            )
+
+            expect(response.warnings).not.toContain(
+                'CLIENT_ID does not match expected production app id (prod-app-id)',
+            )
+            expect(response.status).toBe('ok')
+        })
+
+        test('warns when the session secret is not configured', () => {
+            const response = buildAuthConfigHealth(
+                base({ sessionSecretConfigured: false }),
+            )
+
+            expect(response.warnings).toContain(
+                'WEBAPP_SESSION_SECRET not configured',
+            )
+            expect(response.auth.sessionSecretConfigured).toBe(false)
+            expect(response.status).toBe('degraded')
+        })
+
+        test('warns when redis is not healthy', () => {
+            const response = buildAuthConfigHealth(
+                base({ redisHealthy: false }),
+            )
+
+            expect(response.warnings).toContain(
+                'Redis is not healthy for shared services',
+            )
+            expect(response.auth.redisHealthy).toBe(false)
+            expect(response.status).toBe('degraded')
+        })
+
+        test('ok when the redirect matches a frontend-only origin set', () => {
+            const response = buildAuthConfigHealth(
+                base({
+                    redirectUri: 'https://fe-only.tech/api/auth/callback',
+                    frontendOrigins: ['https://fe-only.tech'],
+                    backendOrigins: [],
+                }),
+            )
+
+            expect(response.status).toBe('ok')
+            expect(response.warnings).toEqual([])
+        })
+
+        test('degraded when frontend is the only configured origin and the redirect does not match it', () => {
+            // Frontend-only + mismatch: pins that frontendOrigins alone makes
+            // `hasConfiguredOrigins` true (a `length > 0 -> false` mutant would
+            // skip the check and miss the mismatch).
+            const response = buildAuthConfigHealth(
+                base({
+                    redirectUri: 'https://elsewhere.tech/api/auth/callback',
+                    frontendOrigins: ['https://fe-only.tech'],
+                    backendOrigins: [],
+                }),
+            )
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain(
+                'OAuth redirect origin is not in WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL',
+            )
+        })
+
+        test('ok when the redirect matches a backend-only origin set', () => {
+            const response = buildAuthConfigHealth(
+                base({
+                    redirectUri: 'https://be-only.tech/api/auth/callback',
+                    frontendOrigins: [],
+                    backendOrigins: ['https://be-only.tech'],
+                }),
+            )
+
+            expect(response.status).toBe('ok')
+            // Backend IS configured → no "nothing configured" warning, and the
+            // redirect matches → no mismatch warning. Isolates the backend
+            // operand of `hasConfiguredOrigins` and the no-origins ternary.
+            expect(response.warnings).toEqual([])
+        })
+
+        test('degraded when backend is the only configured origin and the redirect does not match it', () => {
+            // Backend-only + mismatch: pins the backend operand of
+            // `hasConfiguredOrigins` (a `length > 0 -> false` mutant would skip
+            // the redirect check).
+            const response = buildAuthConfigHealth(
+                base({
+                    redirectUri: 'https://elsewhere.tech/api/auth/callback',
+                    frontendOrigins: [],
+                    backendOrigins: ['https://be-only.tech'],
+                }),
+            )
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain(
+                'OAuth redirect origin is not in WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL',
+            )
+        })
+
+        test('degraded when request origin is the only configured origin and the redirect does not match it', () => {
+            // Request-origin-only + mismatch: pins the request-origin operand
+            // of `hasConfiguredOrigins`.
+            const response = buildAuthConfigHealth(
+                base({
+                    redirectUri: 'https://elsewhere.tech/api/auth/callback',
+                    frontendOrigins: [],
+                    backendOrigins: [],
+                    requestOrigin: 'https://req-only.tech',
+                }),
+            )
+
+            expect(response.status).toBe('degraded')
+            expect(response.warnings).toContain(
+                'OAuth redirect origin is not in WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL',
+            )
+        })
+
+        test('ok when the redirect matches the request origin only', () => {
+            const response = buildAuthConfigHealth(
+                base({
+                    redirectUri: 'https://req-only.tech/api/auth/callback',
+                    frontendOrigins: [],
+                    backendOrigins: [],
+                    requestOrigin: 'https://req-only.tech',
+                }),
+            )
+
+            expect(response.status).toBe('ok')
+            expect(response.warnings).toEqual([])
+            expect(response.warnings).not.toContain(
+                'No WEBAPP_FRONTEND_URL or WEBAPP_BACKEND_URL origins configured',
+            )
+        })
+
+        test('normalizes a path-bearing configured origin to its origin before matching', () => {
+            // The redirect origin matches only after the configured origin is
+            // run through `new URL(...).origin` (path stripped). Pins the
+            // `.map(origin => new URL(origin).origin)` normalization.
+            const response = buildAuthConfigHealth(
+                base({
+                    redirectUri: 'https://withpath.tech/api/auth/callback',
+                    frontendOrigins: ['https://withpath.tech/dashboard/home'],
+                    backendOrigins: [],
+                }),
+            )
+
+            expect(response.status).toBe('ok')
+            expect(response.warnings).toEqual([])
         })
     })
 })


### PR DESCRIPTION
## What

Closes #1464.

**#1464 — unit-only Stryker jest config.** Adds `packages/backend/jest.mutation.cjs`, a unit-test-only jest config, wired into Stryker via the correct `jest.configFile` + `jest.projectType: "custom"` options (the prior `jest.config.configFile` shape was a no-op, so Stryker silently auto-discovered `jest.config.cjs` — the full integration suite).

Result: mutation runtime drops **~9× (670s → ~100s)** with **zero mutation-score loss**. This empirically confirms #1464's hypothesis: the integration route suite contributed no unique kills for the gated middleware/utils — every mutant they killed was already killed by a unit test.

**Re-add `authHealth.ts`.** Now back in the `mutate` set (was deferred in #1463). Hardened `authHealth.test.ts` with 11 new cases (client-id-empty, session-secret-false, redis-unhealthy, per-origin match/mismatch matrix, path-bearing normalization), lifting it from 69.34% → 93.43% under the unit-only runner.

## Numbers

| Module | Score |
|---|---|
| errorHandler.ts | 100% |
| requestId.ts | 100% |
| validate.ts | 97.44% |
| authHealth.ts | 93.43% |
| frontendOrigin.ts | 100% |
| oauthRedirectUri.ts | 93.75% |
| prismaErrors.ts | 100% |
| **Combined** | **95.42%** vs break **82** |

Remaining survivors are equivalent mutants (catch-block string returns, harmless guard/filter flips, invalid-URL array defaults) — the ceiling predicted in the rollout ADR.

`break` stays at **82** (deliberate rollout floor — headroom for lower-scoring Tier-2 services; ratchet deferred until the tier set stabilizes).

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up Stryker by ~9× with a unit-only Jest config and restores mutation testing for `authHealth` with stronger unit tests, with no score loss. Closes #1464.

- **Refactors**
  - Added `packages/backend/jest.mutation.cjs` and pointed Stryker (`packages/backend/stryker.conf.json`) to it via `jest.projectType: "custom"` and `jest.configFile`, restricting runs to `tests/unit/**`. Runtime drops from ~670s to ~100s by excluding integration tests.
  - Re-added `src/utils/authHealth.ts` to `mutate` and expanded `tests/unit/utils/authHealth.test.ts` (+11 cases). Module score rises to 93.43%; combined score 95.42% (break 82).

<sup>Written for commit c4efece3116e7212687d635a3b5ed58b66808e73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

