### PR TITLE
fix(bot): skip startup session restore into empty voice channel

### DIFF
--- a/packages/bot/src/utils/music/sessionStartupRestore.spec.ts
+++ b/packages/bot/src/utils/music/sessionStartupRestore.spec.ts
@@ -27,8 +27,22 @@ jest.mock('./sessionSnapshots', () => ({
 
 import { restoreSessionsOnStartup } from './sessionStartupRestore'
 
-function clientWith(guildId: string, channelVoice = true): CustomClient {
-    const channel = { isVoiceBased: () => channelVoice }
+function clientWith(
+    guildId: string,
+    channelVoice = true,
+    humanCount = 1,
+): CustomClient {
+    // Minimal stand-in for a discord.js Collection of voice members: filter()
+    // returns an object exposing `.size`, which is all the guard inspects.
+    const members = {
+        filter: (predicate: (m: { user: { bot: boolean } }) => boolean) => {
+            const humans = Array.from({ length: humanCount }, () => ({
+                user: { bot: false },
+            })).filter(predicate)
+            return { size: humans.length }
+        },
+    }
+    const channel = { isVoiceBased: () => channelVoice, members }
     const guild = { channels: { cache: { get: () => channel } } }
     const queue = { connection: null, connect: jest.fn(async () => undefined) }
     return {
@@ -76,6 +90,17 @@ describe('restoreSessionsOnStartup', () => {
 
         await restoreSessionsOnStartup(clientWith('g1'))
         expect(restoreSnapshotMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips restore when no humans are in the saved channel', async () => {
+        listGuildIdsMock.mockResolvedValue(['g1'])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now() - 60_000,
+            voiceChannelId: 'vc-1',
+        })
+
+        await restoreSessionsOnStartup(clientWith('g1', true, 0))
+        expect(restoreSnapshotMock).not.toHaveBeenCalled()
     })
 
     it('deletes a stale snapshot instead of restoring', async () => {

--- a/packages/bot/src/utils/music/sessionStartupRestore.ts
+++ b/packages/bot/src/utils/music/sessionStartupRestore.ts
@@ -70,6 +70,21 @@ export async function restoreSessionsOnStartup(
                 continue
             }
 
+            // Do not rejoin + auto-play into an empty channel. Mirrors the
+            // orphan-session watchdog's presence guard (watchdog.ts) so the bot
+            // never surprises an empty room after a restart/redeploy.
+            const humansPresent = channel.members.filter(
+                (member) => !member.user.bot,
+            ).size
+            if (humansPresent === 0) {
+                infoLog({
+                    message:
+                        'Startup session sweep: no humans in channel, skipping restore',
+                    data: { guildId, voiceChannelId: snapshot.voiceChannelId },
+                })
+                continue
+            }
+
             const queue = client.player.nodes.create(guild, {
                 metadata: { channel: null, requestedBy: null },
             })


### PR DESCRIPTION
## What

Closes #1467 (P1 incident: bot joined a voice channel by itself and started playing).

## Root cause

`restoreSessionsOnStartup()` (`packages/bot/src/utils/music/sessionStartupRestore.ts`) runs on `clientReady` and, for every guild with a snapshot ≤30 min old, called `queue.connect(channel)` + `restoreSnapshot()` (auto-play) **without checking whether any human was in the channel**. A push to `main` arms a 30-min production deploy timer, so a redeploy lands inside that window of an active session — the bot rejoins an empty room and resumes playback unprompted.

The orphan-session watchdog (`watchdog.ts:280`) already guards on presence; the startup path did not. Inconsistent.

## Fix

Add the same human-presence guard before connecting: skip the guild if the saved channel has zero non-bot members. Logs `no humans in channel, skipping restore`.

## Tests

`sessionStartupRestore.spec.ts` — updated the channel mock to expose a `members` collection and added a case asserting `restoreSnapshot` is **not** called when the channel is empty. 5/5 pass.

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the bot from rejoining empty voice channels and auto-playing on startup. Adds a human-presence guard in `restoreSessionsOnStartup` to skip restores when no non-bot members are in the saved channel.

- **Bug Fixes**
  - Check `channel.members` for non-bot users before connecting; skip restore if zero (mirrors watchdog presence guard).
  - Log: "Startup session sweep: no humans in channel, skipping restore."
  - Tests: updated channel mock to expose `members`; added case asserting `restoreSnapshot` is not called when the channel is empty.

<sup>Written for commit fa29181876474ca014d5233b349e752a31a1b3fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

