### PR TITLE
test(frontend): de-flake trackhistory stats assertion

### DIFF
--- a/packages/frontend/src/pages/TrackHistory.test.tsx
+++ b/packages/frontend/src/pages/TrackHistory.test.tsx
@@ -119,14 +119,19 @@ describe('TrackHistoryPage', () => {
 
         renderPage()
 
+        // Stats (getStats) and history (getHistory) resolve from separate
+        // promises; wait for the async-loaded content, not just the title, or
+        // the stats card can render a tick after the title under CI pressure.
         await waitFor(() => {
             expect(screen.getByText('Track History')).toBeInTheDocument()
+            expect(screen.getByText('42')).toBeInTheDocument()
+            expect(screen.getAllByText('Queen').length).toBeGreaterThanOrEqual(
+                1,
+            )
         })
 
-        expect(screen.getByText('42')).toBeInTheDocument()
         expect(screen.getByText('Tracks Played')).toBeInTheDocument()
         expect(screen.getByText('2h 0m')).toBeInTheDocument()
-        expect(screen.getAllByText('Queen').length).toBeGreaterThanOrEqual(1)
         expect(
             screen.getAllByText('Never Gonna Give You Up').length,
         ).toBeGreaterThanOrEqual(1)


### PR DESCRIPTION
## What

Closes #1465.

The `renders stats cards and track list on success` test `waitFor`'d on the page **title** only, then asserted stats (`42`, `2h 0m`) synchronously. Those stats come from `api.trackHistory.getStats` — a **separate** promise from `getHistory` — so under CI scheduling pressure the sync `getByText('42')` could run before `getStats` resolved → `Unable to find … 42` (surfaced on backend-only PR #1463; passes 10/10 locally).

## Fix

Move the async-loaded assertions (`42`, a `getHistory` item) into the `waitFor` so the test waits for actual content, not just the title.

## Verify
`npx vitest run src/pages/TrackHistory.test.tsx` → 10/10 pass.

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky Track History test by waiting on async-loaded stats and history, not just the page title. Moves the "42" and "Queen" checks into waitFor so `api.trackHistory.getStats`/`getHistory` resolve before asserting; closes #1465.

<sup>Written for commit 99b5fd6cfc85e73e8fb1e11bf8de657c61e0e7cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for track history page by ensuring async content loads before assertions are evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->