### PR TITLE
fix(bot): harden youtube extractor registration (#1468)

### DIFF
--- a/decisions/2026-06-16-youtube-extraction-reliability.md
+++ b/decisions/2026-06-16-youtube-extraction-reliability.md
@@ -1,7 +1,43 @@
 # YouTube extraction reliability: po_token on the existing extractor, gated on a homelab verification test
 
-- Status: deferred (direction decided; commit gated on a homelab verification test)
+- Status: superseded by verification (2026-06-16) — po_token NOT needed; root
+  cause was extractor-registration timing. See "Update" below.
 - Date: 2026-06-16
+
+## Update (2026-06-16) — verification gate run, decision reversed
+
+The user authorized running the gate. Tested from the home network's residential
+egress IP (the same public IP the homelab uses), with the installed
+`discord-player-youtubei@3.0.0-beta.4` / `youtubei.js@17.0.1`:
+
+- Raw `youtubei.js` `getBasicInfo` with full player retrieval → `playability: OK`,
+  **26 streaming formats**, no po_token.
+- The extractor's own path (`discord-player-youtubei` registered on a real
+  `discord.js` Client then `Player`, exactly as the bot does), **no po_token**:
+  standard `watch?v=` URL → 1 track + stream OK; `youtu.be` short URL → 1 track +
+  stream OK; plain-text search → 19 tracks + stream OK.
+
+**Conclusion: the IP is not bot-detection-blocked and po_token is not needed.** The
+po_token plan below is therefore **not adopted** (it would add a per-video refresh
+daemon fixing nothing). The decision-critic's instinct to gate on the unverified
+"generator works on this IP" claim was correct — the gate killed the option before
+any code shipped.
+
+**Actual root cause (`playerFactory.ts`):** YouTube extractor registration is
+fire-and-forget and was sequenced **behind** an awaited, un-timed
+`play-dl.getFreeClientID()` network call (play-dl is unmaintained), and any
+registration failure was swallowed by `warnLog`. So a slow/hung play-dl init or a
+transient registration failure — likely right after the ~17:00 restart that also
+caused the auto-join (#1467) — left the bot with no YouTube extractor, and every
+`#play <url>` returned "No results found" until restart.
+
+**New decision (adopted, shipped):** harden registration — register YouTube before
+the play-dl init, bound the play-dl call with a timeout, retry youtubei
+registration, and escalate a final failure to `errorLog` so the degraded state is
+visible. See #1468 / the fix PR. The po_token analysis below is retained for the
+record and as the contingency if a real IP block ever appears.
+
+---
 
 ## Context
 

--- a/packages/bot/src/handlers/player/playerFactory.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.spec.ts
@@ -1,6 +1,32 @@
 import { describe, it, expect } from '@jest/globals'
+import { withTimeout } from './withTimeout'
 
 describe('playerFactory', () => {
+    describe('withTimeout', () => {
+        it('resolves with the value when the promise wins', async () => {
+            await expect(
+                withTimeout(Promise.resolve('ok'), 1_000, 'fast'),
+            ).resolves.toBe('ok')
+        })
+
+        it('rejects with a labelled error when the timeout wins', async () => {
+            const slow = new Promise((resolve) => setTimeout(resolve, 50))
+            await expect(withTimeout(slow, 5, 'slow-op')).rejects.toThrow(
+                'slow-op timed out after 5ms',
+            )
+        })
+
+        it('propagates the underlying rejection unchanged', async () => {
+            await expect(
+                withTimeout(
+                    Promise.reject(new Error('boom')),
+                    1_000,
+                    'failing',
+                ),
+            ).rejects.toThrow('boom')
+        })
+    })
+
     describe('createPlayer', () => {
         it('should identify YouTube URLs correctly', () => {
             const isYouTubeUrl = (url: string): boolean =>

--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -11,6 +11,7 @@ import * as playdl from 'play-dl'
 import type { CustomClient } from '../../types'
 import { errorLog, infoLog, warnLog } from '@lucky/shared/utils'
 import { createResilientStream } from './streamBridge'
+import { withTimeout } from './withTimeout'
 
 type CreatePlayerParams = {
     client: CustomClient
@@ -49,11 +50,19 @@ const registerExtractorsInOrder = async (player: Player): Promise<void> => {
     // 1. Spotify — first priority for searches and Spotify URLs
     await registerSpotifyExtractor(player)
 
-    // 2. YouTube — via resilient yt-dlp bridge
-    await initPlayDlSoundCloud()
+    // 2. YouTube — register BEFORE the play-dl SoundCloud init. play-dl is
+    //    unmaintained and getFreeClientID() is a network call; sequencing it
+    //    ahead of YouTube meant a slow/hanging play-dl call delayed YouTube
+    //    registration, leaving #play of YouTube URLs returning "No results
+    //    found" until the call resolved (#1468). Extractor priority is
+    //    unchanged (Spotify → YouTube → SoundCloud …).
     await loadYoutubeExtractor(player)
 
-    // 3. SoundCloud, Apple Music, Vimeo, Attachments
+    // 3. play-dl SoundCloud client id — used only at stream time by the bridge;
+    //    bounded so a hang cannot stall the remaining registrations.
+    await initPlayDlSoundCloud()
+
+    // 4. SoundCloud, Apple Music, Vimeo, Attachments
     await registerRemainingExtractors(player)
 }
 
@@ -109,7 +118,11 @@ const registerRemainingExtractors = async (player: Player): Promise<void> => {
 
 const initPlayDlSoundCloud = async (): Promise<void> => {
     try {
-        const clientId = await playdl.getFreeClientID()
+        const clientId = await withTimeout(
+            playdl.getFreeClientID(),
+            10_000,
+            'play-dl getFreeClientID',
+        )
         await playdl.setToken({ soundcloud: { client_id: clientId } })
         infoLog({ message: 'play-dl: SoundCloud client ID initialized' })
     } catch (error) {
@@ -126,45 +139,71 @@ type YoutubeExtractorModule = {
     YoutubeiExtractor?: typeof BaseExtractor<object>
 }
 
+const YOUTUBE_REGISTER_ATTEMPTS = 2
+
 const loadYoutubeExtractor = async (player: Player): Promise<void> => {
-    try {
-        const mod = (await import(
-            'discord-player-youtubei'
-        )) as YoutubeExtractorModule
+    // Retry: a transient import/activation failure here used to be swallowed,
+    // leaving the bot with NO YouTube extractor until the next restart — every
+    // #play of a YouTube URL then returns "No results found" (#1468).
+    for (let attempt = 1; attempt <= YOUTUBE_REGISTER_ATTEMPTS; attempt++) {
+        try {
+            const mod =
+                (await import('discord-player-youtubei')) as YoutubeExtractorModule
 
-        // v3 renamed YoutubeiExtractor → YoutubeExtractor
-        const YoutubeExtractor = mod.YoutubeExtractor ?? mod.YoutubeiExtractor
-        if (!YoutubeExtractor) {
+            // v3 renamed YoutubeiExtractor → YoutubeExtractor
+            const YoutubeExtractor =
+                mod.YoutubeExtractor ?? mod.YoutubeiExtractor
+            if (!YoutubeExtractor) {
+                warnLog({
+                    message:
+                        'discord-player-youtubei: no extractor export found — skipping YouTube extractor',
+                })
+                return
+            }
+
+            const registered = await player.extractors.register(
+                YoutubeExtractor,
+                { createStream: createResilientStream },
+            )
+
+            if (registered) {
+                infoLog({
+                    message:
+                        'Registered YoutubeExtractor (SoundCloud bridge + YouTube fallback)',
+                })
+                return
+            }
+
             warnLog({
-                message:
-                    'discord-player-youtubei: no extractor export found — skipping YouTube extractor',
+                message: `YoutubeExtractor registration returned null (attempt ${attempt}/${YOUTUBE_REGISTER_ATTEMPTS})`,
             })
-            return
+        } catch (error) {
+            warnLog({
+                message: `YouTube extractor registration failed (attempt ${attempt}/${YOUTUBE_REGISTER_ATTEMPTS})`,
+                error,
+            })
         }
 
-        const registered = await player.extractors.register(YoutubeExtractor, {
-            createStream: createResilientStream,
-        })
-
-        if (!registered) {
-            warnLog({
-                message:
-                    'YoutubeExtractor registration returned null — activation may have failed',
-            })
-            return
+        if (attempt < YOUTUBE_REGISTER_ATTEMPTS) {
+            await new Promise((resolve) => setTimeout(resolve, 1_000))
         }
-
-        infoLog({
-            message:
-                'Registered YoutubeExtractor (SoundCloud bridge + YouTube fallback)',
-        })
-    } catch (error) {
-        warnLog({
-            message: 'YouTube extractor unavailable. Using SoundCloud/Spotify.',
-            error,
-        })
     }
+
+    // Escalate to errorLog (not warn): the bot is now running degraded and
+    // YouTube playback will fail until restart — this must be visible.
+    errorLog({
+        message:
+            'YouTube extractor unavailable after retries — #play of YouTube URLs will fail until restart. Falling back to SoundCloud/Spotify only.',
+    })
 }
 
-export { streamViaYtDlp, streamViaYtDlpSearch, createResilientStream } from './streamBridge'
-export { streamViaSoundCloud, findMatchingSoundCloudResult, parseDurationString } from './soundcloudMatcher'
+export {
+    streamViaYtDlp,
+    streamViaYtDlpSearch,
+    createResilientStream,
+} from './streamBridge'
+export {
+    streamViaSoundCloud,
+    findMatchingSoundCloudResult,
+    parseDurationString,
+} from './soundcloudMatcher'

--- a/packages/bot/src/handlers/player/withTimeout.ts
+++ b/packages/bot/src/handlers/player/withTimeout.ts
@@ -19,6 +19,9 @@ export const withTimeout = async <T>(
     try {
         return await Promise.race([promise, timeout])
     } finally {
-        if (timer) clearTimeout(timer)
+        // `timer` is always assigned: the Promise executor above runs
+        // synchronously during construction, before this finally can run.
+        // clearTimeout tolerates undefined regardless, so no guard is needed.
+        clearTimeout(timer)
     }
 }

--- a/packages/bot/src/handlers/player/withTimeout.ts
+++ b/packages/bot/src/handlers/player/withTimeout.ts
@@ -1,0 +1,24 @@
+/**
+ * Races a promise against a timeout so an unbounded hang (e.g. an unmaintained
+ * dependency's network call) cannot stall a sequential init chain. On timeout
+ * the returned promise rejects with a labelled error; otherwise it settles with
+ * the underlying promise's value or rejection.
+ */
+export const withTimeout = async <T>(
+    promise: Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T> => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+            () => reject(new Error(`${label} timed out after ${ms}ms`)),
+            ms,
+        )
+    })
+    try {
+        return await Promise.race([promise, timeout])
+    } finally {
+        if (timer) clearTimeout(timer)
+    }
+}


### PR DESCRIPTION
## What

Closes #1468 — the `#play` "No results found" half of the 2026-06-16 incident.

## Verification reversed the diagnosis

The prior ADR (#1471) guessed po_token / YouTube IP-blocking. I ran the verification gate from the home network's **residential** egress IP (same public IP the homelab uses), with the installed `discord-player-youtubei@3.0.0-beta.4`:

- raw `youtubei.js` `getBasicInfo` (full player) → `playability: OK`, **26 streaming formats**, no po_token
- the extractor's real path (`discord-player-youtubei` on a real `discord.js` Client → `Player`, as the bot registers it), **no po_token**: `watch?v=` URL → 1 track + stream OK; `youtu.be` → 1 track + stream OK; text search → 19 tracks + stream OK

**→ the IP is not blocked and po_token is not needed.** ADR updated to record the reversal.

## Actual root cause (`playerFactory.ts`)

Extractor registration is fire-and-forget, and YouTube was sequenced **behind** an awaited, **un-timed** `play-dl.getFreeClientID()` network call (play-dl is unmaintained). Registration failures were swallowed by `warnLog`. So a slow/hung play-dl init or a transient registration failure — likely right after the ~17:00 restart that also caused the #1467 auto-join — left the bot with **no YouTube extractor**, and every `#play <url>` returned "No results found" until restart.

## Fix

- register YouTube **before** the play-dl SoundCloud init (extractor priority unchanged: Spotify → YouTube → SoundCloud …)
- bound `play-dl.getFreeClientID()` with a 10 s timeout (new dependency-free `withTimeout` helper)
- retry youtubei registration once; **escalate a final failure to `errorLog`** so the degraded state is visible instead of silently swallowed

## Tests

- `withTimeout.ts` covered by 3 new cases in `playerFactory.spec.ts` (resolve / timeout / propagate-rejection) — 20/20 pass
- existing `playerFactory.test.ts` 11/11 pass; bot type-check clean
- live reproduction above confirms the extractor itself is healthy

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened YouTube extractor registration to stop the “No results found” regression for `#play`. We register YouTube earlier, bound the `play-dl` SoundCloud init with a timeout, and added retry + clear error logging to avoid silent degraded boots.

- **Bug Fixes**
  - Register `discord-player-youtubei` before `play-dl` SoundCloud init; extractor priority unchanged.
  - Add `withTimeout` and bound `play-dl.getFreeClientID()` to 10s.
  - Retry YouTube extractor registration once and escalate a final failure to `errorLog`.
  - Updated ADR after verification: `po_token` not needed; added tests for `withTimeout`.

- **Refactors**
  - Simplified `withTimeout` by removing a dead timer guard.

<sup>Written for commit 2999d59b82386d1ab5f346ef8668342c12fa19f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

