### PR TITLE
fix(compose): tag container logs so loki labels them by name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
+                tag: "{{.Name}}"
 
     redis:
         <<: *medium-svc
@@ -87,6 +88,7 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
+                tag: "{{.Name}}"
 
     bot:
         <<: *large-svc
@@ -134,6 +136,7 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
+                tag: "{{.Name}}"
 
     backend:
         <<: *medium-svc
@@ -173,6 +176,7 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
+                tag: "{{.Name}}"
 
     frontend:
         <<: *small-svc
@@ -189,6 +193,7 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
+                tag: "{{.Name}}"
 
     nginx:
         <<: *small-svc
@@ -212,6 +217,7 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
+                tag: "{{.Name}}"
 
     webhook:
         <<: *small-svc
@@ -244,6 +250,7 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
+                tag: "{{.Name}}"
 
     # Cloudflare Tunnel — exposes nginx to lucky.lucassantana.tech
     cloudflared:
@@ -264,6 +271,7 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
+                tag: "{{.Name}}"
 
 volumes:
     postgres_data:


### PR DESCRIPTION
Part of #1474 (durable, queryable INFO logs).

## Problem
Lucky logs **are** already shipped to the homelab Loki (promtail scrapes all container logs), but the `container_name` Loki label is **empty** — so you can only find e.g. lucky-bot logs by its container-id `filename`, which changes on every redeploy. No stable "show me lucky-bot INFO logs" query.

Root cause: docker's `json-file` driver only writes an `attrs.tag` field when given a `tag` log-opt; our services set none. The homelab promtail pipeline already reads `attrs.tag` → `container_name`, so it just needed the source.

## Fix
Add `tag: "{{.Name}}"` to every service's `logging.options`. Verified empirically on the host that `json-file` + `tag` writes `{"attrs":{"tag":"..."}}`, which promtail extracts into `container_name`.

## Note
Takes effect on container (re)creation. Companion homelab fix (Loki persistence) in LucasSantana-Dev/homelab#191.

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tag all services’ Docker logs with the container name so Loki sets the `container_name` label. This makes INFO logs queryable by stable service name instead of ephemeral container IDs (part of #1474).

- **Migration**
  - Recreate containers to apply the tag: docker compose up -d --force-recreate

<sup>Written for commit 934a80ed843908289ddf5a7b136e54472bd34ccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

