### PR TITLE
docs(decisions): loki already-running reality + two real fixes

### DIFF
--- a/decisions/2026-06-16-info-log-aggregation-loki.md
+++ b/decisions/2026-06-16-info-log-aggregation-loki.md
@@ -1,7 +1,46 @@
 # Info/usage log storage: self-hosted Grafana Loki, adopted via a measurement-gated pilot
 
-- Status: accepted (adopt Loki; pilot gated on a log-volume measurement + a label-cardinality guard)
+- Status: accepted (adopt Loki) — **implemented; the "stand up Loki" plan was largely moot, see the 2026-06-16 update below**
 - Date: 2026-06-16
+
+## Update (2026-06-16) — homelab reality reversed the build plan
+
+Once homelab SSH access was available, inspection of the box reversed the plan's
+premise (the same "verify before building" lesson as the YouTube ADR):
+
+- **Loki + promtail + Grafana + Prometheus were already running** (6+ days uptime).
+  promtail already scrapes every container's logs to Loki, so **the lucky INFO logs
+  were already in Loki** — the "ephemeral stdout only" premise was false. No Alloy
+  needed; no greenfield stand-up.
+- **Retention was already 30 d** (`720h`) and **disk alerts already existed**
+  (`LowDiskSpace` <20% free, `CriticalDiskSpace` <10%). The ADR's measure-first /
+  retention / alert items were already satisfied.
+
+The real, verified gaps were two bugs, both now fixed:
+
+1. **Loki persistence (P1 data loss).** Loki wrote to `/tmp/loki` (the ephemeral
+   container layer) while the persistent bind mount `appdata/loki → /loki` sat unused
+   (root-owned, unwritable by Loki's uid 10001 — that's why someone redirected to the
+   writable `/tmp`). On any container _recreate_ all logs were lost. Fixed: chown the
+   bind dir to 10001, migrate data, repoint config to `/loki`, restart. SoT in
+   homelab PR #191. This is what actually delivered success criterion (c) "survives
+   restart/redeploy."
+2. **No stable log identity.** `container_name` was empty because the json-file
+   driver only emits `attrs.tag` when given a `tag` log-opt, and the lucky services
+   set none — so logs were findable only by ephemeral container-id `filename`. Fixed
+   by adding `tag: "{{.Name}}"` to each service's `logging.options`
+   (Lucky #1476, merged) → promtail's existing `attrs.tag → container_name`
+   extraction now populates `{container_name="lucky-bot"}` etc.
+
+Measured volume (with labels working): ~172 MB/day across **all** containers;
+lucky-bot+backend ~5k lines/day idle; Loki's own data dir is ~311 MB. The host disk
+sits at 88% but **not because of logs** — so 30 d retention is comfortable and going
+to 90 d (≈+15 GB onto an 88% disk) is the wrong move. The "size to disk, don't keep
+forever" reasoning holds; 30 d stays.
+
+Net: the decision (self-hosted Loki, single Grafana pane, low-cardinality labels) was
+right, but the _work_ was fixing two config bugs in an existing stack, not building a
+new one. Alloy was unnecessary — promtail already does the job.
 
 ## Context
 


### PR DESCRIPTION
Updates the Loki ADR after homelab SSH inspection reversed its build premise (third 'verify before building' reversal this session).

**Reality on the box:** Loki + promtail + Grafana already running 6+ days; lucky INFO logs already in Loki; retention already 30d; disk alerts already exist. The 'stand up Loki via Alloy + measure first' plan was largely moot.

**Real gaps (both fixed):**
1. Loki persistence P1 bug — wrote to ephemeral `/tmp/loki`; persistent `/loki` mount unused (root-owned vs uid 10001). Fixed live + homelab#191.
2. Empty `container_name` — json-file needs a `tag` opt; added `tag: {{.Name}}` (#1476, merged). Loki now labels lucky logs by name.

Measured: ~172 MB/day all containers; Loki data ~311 MB; host disk 88% is not from logs → 30d retention stays.

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Loki ADR after homelab inspection: `Loki` + `promtail` + `Grafana` + `Prometheus` were already running, so the Alloy stand-up plan is dropped and the ADR is marked implemented. The doc records two fixes (persistent `/loki` data path and `container_name` via json-file `tag`), notes existing disk alerts, measures ~172 MB/day, and confirms 30‑day retention.

<sup>Written for commit ca7ec2c8208ed1ec44b4dce36aa3b6b5b6d02636. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated logging architecture documentation reflecting current Loki deployment status and operational configuration
  * Documented resolution of log persistence issues preventing data loss on container restart
  * Fixed container identification in log aggregation pipeline for improved log traceability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->