### PR TITLE
docs(runbook): emergency hotfix-to-prod runbook + ADR

### DIFF
--- a/decisions/2026-06-16-release-cadence-automate-releases.md
+++ b/decisions/2026-06-16-release-cadence-automate-releases.md
@@ -1,0 +1,139 @@
+# Release cadence: automate releases with release-please, keep the deploy gate
+
+- Status: accepted (adopt release-please; pilot via dry-run before enabling on main)
+- Date: 2026-06-16
+
+## Context
+
+Production drifted badly stale and nobody noticed until SSH inspection during the
+Loki work (2026-06-16):
+
+- Prod ran image `ff5e0b6` (2026-06-14) — **135 commits / 8+ days behind `main`**.
+- The latest GitHub Release is **v2.17.0 (2026-06-08)**; `ff5e0b6` is newer than that
+  release and is **not** a release — it was a one-off manual `workflow_dispatch`.
+- **Two fixes for incidents that happened that same day were merged to `main` but not
+  in prod**: the bot auto-join-and-play bug (#1467/#1469) and the YouTube "no results"
+  bug (#1472). Production still had both bugs after we "fixed" them.
+
+Root cause is a process gap, not a broken pipeline:
+
+- On 2026-06-13 (#1397 / PR #1398), production deploys were intentionally gated to the
+  `release: published` event (plus manual `workflow_dispatch`), removing the previous
+  deploy-on-every-main-push behavior. Good intent: controlled, tagged, baked deploys.
+- But **releases are created fully manually** — hand-bump `package.json`, hand-write
+  `CHANGELOG.md`, tag `vX.Y.Z`, push (→ `release.yml` creates the GitHub Release →
+  `deploy.yml`). That manual step became an unstaffed bottleneck: no release was cut
+  for 135 commits, so the gate had nothing to fire on and prod silently rotted.
+
+The pipeline itself is sound and worth preserving: `docker-publish.yml` builds
+`:latest` + `:<sha>` per service on every main push (path-filtered); `deploy.yml`
+resolves the released SHA, waits a 30-minute `Production` environment bake, webhooks
+the homelab to pull `:<sha>`, runs prisma migrations, health-checks, and auto-rolls
+back to the last-good baked COMMIT_SHA. The single weak link is the **manual release
+step** in front of the gate.
+
+Enabling facts (verified):
+
+- Conventional-commit messages are enforced by commitlint; the last 50 main commits
+  are all compliant → release-please can compute versions/changelog cleanly.
+- Squash-merge to main means one conventional commit per PR (the PR title) → an
+  unambiguous bump per PR.
+- A `CHANGELOG.md` already exists (release-please will own it).
+- release-please **does not auto-merge** its release PR by default (verified) — a
+  human merges it; auto-merge is an opt-in.
+
+## Decision
+
+Adopt **release-please** (`googleapis/release-please-action`) to automate the release
+step, and **keep the `release: published` → `deploy.yml` gate unchanged**.
+
+- On every push to `main`, release-please maintains a single **release PR** that
+  accumulates conventional-commit changes and pre-computes the next semver bump +
+  CHANGELOG. The PR is always open and up to date — a standing, visible "N unreleased
+  changes" signal, the absence of which is exactly what let prod rot.
+- **Merging the release PR** creates the tag + publishes the GitHub Release →
+  `deploy.yml` fires (30-min bake, webhook, migrations, health-check, auto-rollback).
+- **Do not enable auto-merge** (for now). The one-click human merge is the deliberate
+  "ship to prod" checkpoint — it preserves #1397's controlled-deploy intent (review
+  before a migration-bearing prod deploy on a single-operator box) while removing the
+  real friction (manual version/changelog/tag effort + invisibility). Auto-merge stays
+  a documented opt-in if even that click later proves too much.
+- **Incident hotfixes keep the existing `workflow_dispatch` fast-path** — deploy any
+  SHA immediately, independent of release cadence. Release cadence is for normal flow;
+  incidents do not wait for a release PR.
+- **Replace `release.yml`:** it triggers on `v*` tag push and creates a GitHub Release
+  via `action-gh-release`. release-please does the same on PR merge, so leaving
+  `release.yml` active would double-create / conflict. Disable or repurpose it (its
+  build+test gate can move to CI if not already covered).
+
+This honors #1397 (controlled, gated, baked deploys) while fixing its unintended side
+effect (a manual bottleneck that stalled prod and stranded incident fixes).
+
+## Pilot / adoption plan
+
+1. **Dry-run on a feature branch first** (the critic's mandated gate). Enable the
+   release-please workflow on a branch; push a conventional commit; confirm: a release
+   PR is created with the right bump + changelog; on merge it tags `v*` and publishes a
+   Release; that Release event triggers `deploy.yml`; the 30-min bake + homelab webhook
+    - image-for-SHA resolution all still work end-to-end.
+2. **Seed the version** so release-please starts from 2.17.0 (manifest/bootstrap), so
+   the first managed release is 2.18.0, not a reset.
+3. **Disable `release.yml`** in the same change to avoid duplicate-release conflicts.
+4. **Success criteria:** (a) a release PR appears and stays current on main pushes;
+   (b) merging it deploys to prod through the unchanged gate; (c) prod's deployed SHA
+   tracks the latest merged release within one bake cycle; (d) the hotfix
+   `workflow_dispatch` path still ships an arbitrary SHA immediately.
+5. **Rollback:** if release-please misbehaves (wrong bump, duplicate/draft release,
+   malformed changelog), disable its workflow and fall back to the manual
+   tag/`workflow_dispatch` flow that exists today — zero data loss, reversible.
+
+Independent immediate action (NOT part of this decision, do regardless): ship today's
+incident fixes to prod now via `workflow_dispatch` (or by cutting the first release),
+since prod still runs the buggy `ff5e0b6`.
+
+## Alternatives considered
+
+- **Status quo — keep manual releases, "just cut them more often."** Rejected: the
+  bottleneck already failed (135 commits unreleased, incident fixes stranded). Relying
+  on the discipline that just lapsed is not a fix.
+- **Revert to deploy-on-every-main-push (pre-2026-06-13).** Rejected: fights the recent
+  #1397 decision, reintroduces per-merge deploy churn, and deploys unversioned /
+  unreleased SHAs with no changelog or human ship-checkpoint.
+- **whats-up-docker auto-pull of `:latest` on the box** (already running there).
+  Rejected: bypasses prisma-migration ordering, health-checks, SHA-pinning, and
+  auto-rollback that `deploy.yml` performs — and the gate entirely. Unsafe for a
+  migration-bearing app.
+- **Nightly scheduled deploy of latest `main`.** Rejected: a weaker automation that
+  still ships unversioned SHAs, adds a second deploy path, and bakes in up-to-24h lag.
+- **release-please WITH auto-merge.** Not rejected — deferred. Viable later if the
+  one-click checkpoint proves to be friction; kept off now to retain a human "ship"
+  gate consistent with #1397.
+- **semantic-release / changesets.** Reasonable peers; release-please chosen for the
+  release-PR model (visible, reviewable, no npm-publish coupling) and first-class
+  GitHub-Release output that the existing `release: published` gate already consumes.
+
+## Consequences
+
+- **Positive:** prod stops silently rotting — the open release PR makes "unreleased
+  changes" impossible to forget; releases become one-click with auto changelog +
+  semver; the deliberate gate, bake timer, migrations, and auto-rollback are all
+  preserved; the change is reversible (disable one workflow → back to manual).
+- **Negative:** one more GitHub Action dependency (Google-maintained; major-version
+  breaks possible); a human still must click "merge" to ship (intentional, but it is
+  not zero-touch); `release.yml` must be retired to avoid duplicate releases; semver
+  correctness now depends on PR-title/commit discipline (already enforced, but a
+  mislabeled squash title could mis-bump — caught by reviewing the release PR).
+- **Neutral:** versioning moves from hand-edited `package.json` to release-please's
+  managed bump; CHANGELOG ownership moves to the tool.
+
+## Revisit when
+
+- The one-click release-PR merge itself becomes the new thing that doesn't happen →
+  enable auto-merge (the deferred alternative) so prod tracks main fully automatically.
+- release-please proves flaky in this repo (wrong bumps, event-ordering misses,
+  changelog conflicts) over the first ~3 releases → fall back to manual + reassess
+  (semantic-release / changesets).
+- Deploy risk profile changes (e.g., migrations become routinely backward-incompatible)
+  → reconsider whether the human ship-checkpoint should become stricter, not looser.
+- The project gains a second maintainer / moves off the single-operator homelab →
+  re-evaluate cadence and whether continuous deployment is now appropriate.

--- a/decisions/2026-06-17-hotfix-runbook-workflow-dispatch.md
+++ b/decisions/2026-06-17-hotfix-runbook-workflow-dispatch.md
@@ -1,0 +1,128 @@
+# Hotfix to prod: a committed runbook over the workflow_dispatch fast-path
+
+- Status: accepted
+- Date: 2026-06-17
+
+## Context
+
+On 2026-06-16/17 the operator manually shipped two incident fixes to the
+production homelab. The deploy machinery worked well, but the _judgment_ around it
+was non-obvious and nearly went wrong:
+
+- Deploying `main` HEAD would have **failed** — HEAD was a compose-only commit
+  (`#1476`), and `docker-publish.yml` is path-filtered, so no `:<sha>` images
+  existed for it; the box's pinned-pull guard would have aborted. The correct
+  target was the newest commit whose `docker-publish` run succeeded (all four
+  images built) that still contained the fix (`2e7f1bbe`).
+- `rollback_sha` is the only `workflow_dispatch` input that pins an exact
+  already-built SHA, so it doubles as the "forward-deploy this exact SHA" lever.
+- The deploy needed pre-flight judgment: no un-applied prisma migrations in
+  range, all four images present, box reachable, and a sane `.deploy-last-good-sha`
+  rollback baseline.
+
+This is repeated operational friction with a real near-miss. It deserves captured,
+durable procedure rather than re-derivation each incident.
+
+A **generic global `/hotfix` agent skill already exists**, but it is built on a
+`release`-branch cadence (branch-from-main-not-release, manual `version-bump` +
+patch tag, `/ship-it`, cherry-pick back to `release`). Lucky is **main-as-trunk**
+(no live `release` branch), is adopting **release-please** to own
+versioning/tags/changelog (ADR 2026-06-16, accepted), and deploys via
+**`workflow_dispatch` of a SHA** to a homelab box — not a tag-and-ship. The global
+skill's phases would fail or conflict here.
+
+Enabling facts (verified in-repo, 2026-06-17):
+
+- `docker-publish.yml` matrix builds all four services per run; `conclusion=success`
+  ⟹ all four `:<short-sha>` images were pushed.
+- `deploy.yml` resets the box tree to `origin/main` but deploys the **pinned**
+  `IMAGE_TAG=<short-sha>` images; runs migrations; health-gates; auto-rolls-back
+  to `.deploy-last-good-sha`; aborts if the pinned image can't be pulled.
+- `.deploy-last-good-sha` is an on-disk file on the box, written by `deploy.sh`
+  after a healthy deploy from the running image's baked `COMMIT_SHA` (advanced
+  `ff5e0b68 → 2e7f1bbe` this session); persists across reboot; rollback is skipped
+  if it's empty or equals the deploying SHA.
+- The `Production` environment has no protection rules / no bake timer; a dispatch
+  deploy completes in ~1.5 min (GH) + ~2 min (box).
+- `deploy.yml` has `concurrency: deployment-production` (no cancel) and `deploy.sh`
+  holds a lockfile — concurrent hotfixes queue, they do not race.
+- `.claude/` in Lucky is local-only/untracked; agent-actionable context must be
+  committed to be the source of truth.
+
+## Decision
+
+Add a **committed `docs/runbooks/hotfix.md`** that codifies Lucky's verified
+emergency-deploy fast-path, and treat it as the authority over the generic global
+`/hotfix` skill when operating in this repo.
+
+The runbook: severity gate → land fix on `main` (prefer revert) → **resolve the
+target SHA** (newest commit with a successful `docker-publish` run that contains
+the fix, via a named `gh run list` query — NOT necessarily `main` HEAD) →
+pre-flight (migrations in range, images exist via the run conclusion, box health,
+sane rollback baseline) → deploy with `gh workflow run deploy.yml -f
+rollback_sha=<sha>` → monitor GH + box log to terminal → verify live + Sentry →
+**no manual version tag** (a hotfix deploys a SHA; the next normal release includes
+the already-merged fix).
+
+Every mechanical step names the **exact command** so an agent (or human) executes
+it deterministically rather than guessing — this folds the determinism of a script
+into the runbook without a second artifact that drifts from `deploy.yml`.
+
+## Alternatives considered
+
+- **Lucky-local agent skill (`.claude/skills/`).** Rejected: `.claude/` is
+  untracked → not SoT, lost on a clean clone, violates the commit-context rule.
+- **Fork/edit the global `/hotfix` skill to be Lucky-aware.** Rejected: pollutes a
+  generic cross-repo skill with Lucky homelab/`deploy.yml` specifics.
+- **`scripts/hotfix.sh` automating the gh + box calls.** Deferred, not chosen now:
+  it adds a second thing that drifts from `deploy.yml`, and shell is brittle for
+  the SHA-resolution judgment; an agent running the runbook's exact `--json`
+  commands already gets determinism. Promote to a script (with `--dry-run`) only if
+  hotfix frequency makes hand-running too slow (revisit trigger).
+- **Status quo / ad-hoc.** Rejected: the near-miss (almost deployed an imageless
+  commit) and the likelihood of recurrence show captured procedure has clear value.
+
+## Consequences
+
+- **Positive:** durable, committed, agent- and human-readable; encodes the
+  non-obvious SHA-resolution trap and the `rollback_sha`-as-forward-deploy lever;
+  reuses the existing robust `deploy.yml` (no new infrastructure); reversible
+  (delete a doc).
+- **Negative:** a runbook is not executable — it relies on being followed, and can
+  drift from `deploy.yml` if that workflow changes (mitigated by the revisit
+  trigger + the runbook citing the specific workflow behaviors it depends on); the
+  global `/hotfix` skill stays mismatched outside Lucky (only overridden here).
+- **Neutral:** when release-please lands, the "no manual tag" step is unchanged and
+  even clearer.
+
+## Decision-critic reconciliation
+
+`decision-critic` returned **ACCEPT-WITH-REVISIONS**. Reconciliation after
+verifying its Claims-To-Verify with tools it lacked:
+
+- **"CRITICAL: release-please can tag an older commit and clobber the hotfix" —
+  refuted.** release-please tags the release commit at `main` HEAD on PR merge, so
+  the tag is always at-or-ahead of the hotfix commit (which is on `main`); it never
+  tags backward. The box auto-rollback targets `.deploy-last-good-sha` (the
+  hotfix), not the latest release tag. So neither a normal release nor a rollback
+  can strand the hotfix. Added a one-line note that prod is briefly ahead of the
+  latest tag until the next release (benign).
+- **Release-please-independence claim — verified** against the 2026-06-16
+  release-cadence ADR ("incident hotfixes keep the workflow_dispatch fast-path …
+  independent of release cadence").
+- **`.deploy-last-good-sha` opacity — resolved** from `deploy.sh` (on-disk,
+  workflow-maintained, persistent); documented in the runbook.
+- **Concurrency — already mitigated** by `deploy.yml` concurrency group + box
+  lockfile; noted in the runbook.
+- **Accepted revisions:** named the exact SHA-resolution + image-existence commands
+  in the runbook. **Declined revision:** a separate `scripts/hotfix.sh` (drift +
+  maintenance the critic itself flagged), kept as a revisit trigger.
+
+## Revisit when
+
+- release-please is implemented → re-confirm the hotfix path bypasses the release
+  PR cleanly and the "no manual tag" step still holds.
+- `deploy.yml`'s SHA-resolution, image-tagging, or rollback mechanics change →
+  update the runbook in lockstep.
+- Hotfix frequency rises enough that hand-running the steps is too slow → promote
+  steps 2–3 to a committed `scripts/hotfix.sh` with a `--dry-run`.

--- a/docs/runbooks/hotfix.md
+++ b/docs/runbooks/hotfix.md
@@ -1,0 +1,160 @@
+# Runbook: emergency hotfix to production
+
+Ship a fix to the production homelab **now**, outside the normal release cadence,
+when prod is actively broken and waiting for the next release is not viable.
+
+This repo is **main-as-trunk** (no `release` branch) deployed to a single-operator
+homelab box via Docker Compose. The generic global `/hotfix` skill assumes a
+`release`-branch + manual-tag model and **does not apply here** — follow this
+runbook instead.
+
+> Decision record: `decisions/2026-06-17-hotfix-runbook-workflow-dispatch.md`.
+
+## When to use this (severity gate — always first)
+
+Use ONLY when prod is degraded/broken, a security issue is actively exploited, or
+a customer-blocking bug has no workaround. Otherwise ship through the normal
+PR → `main` → release flow (release-please once adopted; manual tag today).
+
+A hotfix here **deploys an exact commit SHA's images**. It does **not** cut a
+release or create a version tag — see step 7.
+
+## The deploy machinery this relies on (read once)
+
+- `docker-publish.yml` (on push to `main` touching `packages/**`, `prisma/**`,
+  `Dockerfile*`, `nginx/**`, `package*.json`) builds **all four** service images
+  (bot/backend/frontend/nginx) in one matrix run and tags each `:<short-sha>` +
+  `:latest`. **A commit that touches only non-build paths (docker-compose.yml,
+  docs, workflows) produces NO image — so `main` HEAD may not be deployable.**
+- `deploy.yml` (`workflow_dispatch` with input `rollback_sha`, or on
+  `release: published`) deploys a SHA: it `git reset --hard origin/main` for the
+  working tree but pulls the **pinned `:<short-sha>` images** via `IMAGE_TAG`,
+  runs `prisma migrate deploy`, health-gates (API + auth-config + OAuth contract),
+  and **auto-rolls-back** to the last-good SHA on failure. If the pinned image
+  can't be pulled it **aborts** (never builds current source under a pinned tag).
+- `rollback_sha` is the only `workflow_dispatch` lever to deploy an _exact
+  already-built SHA_, so it doubles as the "forward-deploy this SHA" mechanism.
+- Concurrency is safe: `deploy.yml` has `concurrency: deployment-production`
+  (no cancel) and the box `deploy.sh` holds a lockfile — parallel deploys queue.
+- The `Production` GitHub environment has **no protection rules / no bake timer**
+  — a dispatch deploy completes in ~1.5 min (box rollout ~2 min more).
+
+## Procedure
+
+### 1. Land the fix on `main`
+
+Open a PR (`hotfix: <subject>`, label `hotfix`), keep the change minimal (one
+regression test if feasible), and squash-merge to `main`. Prefer a **revert** over
+a forward-fix when reverting is safer. If the fix is already on `main`, skip here.
+
+### 2. Resolve the target SHA (the newest commit with built images that contains the fix)
+
+Do **not** assume `main` HEAD — confirm it has a successful `docker-publish` run:
+
+```bash
+gh run list --repo LucasSantana-Dev/Lucky --workflow=docker-publish.yml \
+  --limit 20 --json headSha,status,conclusion,createdAt,displayTitle \
+  --jq '.[] | select(.status=="completed" and .conclusion=="success")
+        | "\(.headSha[0:8]) \(.createdAt) \(.displayTitle)"'
+```
+
+Pick the **newest** SHA in that list that is an ancestor-or-equal of the fix
+commit (i.e. contains the fix). `conclusion=="success"` means all four images
+were pushed for that SHA. If `main` HEAD is a non-build commit (compose/docs only),
+the fix's own build SHA is your target — the trailing non-build commits change
+nothing in the running images.
+
+Confirm the fix is in that SHA:
+
+```bash
+git fetch origin main -q
+git merge-base --is-ancestor <fix-commit> <target-sha> && echo "fix is in target"
+```
+
+### 3. Pre-flight checks
+
+```bash
+# (a) No un-applied prisma migrations between current prod and target?
+PROD_SHA=$(ssh homelab 'cat /home/luk-server/Lucky/.deploy-last-good-sha')
+git diff --name-only "$PROD_SHA".."<target-sha>" -- prisma/migrations/
+# Empty output = migration-free (lowest risk). If non-empty, the deploy WILL run
+# them via `prisma migrate deploy`; proceed only if they are forward-safe, and
+# note them in the GH run comment for traceability.
+
+# (b) Box reachable + current state
+ssh homelab 'docker ps --filter name=lucky-bot --format "{{.Image}} {{.Status}}"'
+
+# (c) Rollback baseline is sane: .deploy-last-good-sha is the last HEALTHY
+# deployed SHA (on-disk on the box, written by deploy.sh from the running image's
+# COMMIT_SHA, persists across reboot). It must be a real 7-40 hex SHA and should
+# differ from the target (else auto-rollback has nowhere to go).
+echo "last-good (rollback target if this fails): $PROD_SHA"
+```
+
+### 4. Deploy
+
+```bash
+gh workflow run deploy.yml --repo LucasSantana-Dev/Lucky --ref main \
+  -f rollback_sha=<target-sha>
+```
+
+(If — and only if — the target SHA equals `main` HEAD and HEAD has built images,
+a plain `gh workflow run deploy.yml --ref main` also works. The `rollback_sha`
+form is the safe default for any exact SHA.)
+
+### 5. Monitor to a terminal state
+
+```bash
+# GH workflow
+gh run list --repo LucasSantana-Dev/Lucky --workflow=deploy.yml -L 1 \
+  --json databaseId,status,conclusion --jq '.[]'
+
+# Box rollout (the deploy runs inside the webhook container)
+ssh homelab 'docker exec lucky-webhook tail -40 /tmp/lucky-deploy.log'
+```
+
+Wait for `Deploy complete!` (success), `Rolled Back` (auto-rollback fired — fix
+did not become healthy; the original breakage may persist), or a failure. The
+GH run's "Validate deployed version" + auth-config + OAuth smoke steps gate
+success externally.
+
+### 6. Verify live
+
+```bash
+ssh homelab 'docker ps --filter name=lucky-bot --filter name=lucky-backend \
+  --format "{{.Names}} {{.Image}} {{.Status}}"   # all on :<target-sha>, healthy
+  && cat /home/luk-server/Lucky/.deploy-last-good-sha   # advanced to target'
+```
+
+Confirm in Sentry that the original issue stopped firing and no new issue
+appeared. If a new issue appeared or auto-rollback fired → this is now an
+incident, not a closed hotfix: escalate / investigate.
+
+### 7. Do **not** cut a version tag
+
+A hotfix deploys a SHA; it does not create `vX.Y.Z`. The fix is already on `main`
+and will be included in the next normal release. Prod is briefly **ahead of the
+latest release tag** until then — this is benign: release-please (once adopted)
+tags the release commit at `main` HEAD, i.e. at-or-ahead of the hotfix, and the
+box auto-rollback targets `.deploy-last-good-sha` (the hotfix), never the release
+tag. Manually tagging here would conflict with the managed release flow.
+
+## Failure / escalation
+
+- Target SHA has no images (`docker-publish` failed) → wait for / re-run
+  `docker-publish` for that SHA, or pick the prior built SHA that still contains
+  the fix.
+- Deploy aborts on `pinned image not found` → you picked an imageless SHA; redo
+  step 2.
+- `Rolled Back` in the log → the fix didn't pass health checks; prod is back on
+  the previous good SHA but **still broken**. Investigate the fix; do not retry
+  blindly.
+- Box unreachable → surface to operator; do not force.
+
+## Revisit / promote
+
+If hotfix frequency rises enough that running these commands by hand is too slow,
+promote steps 2–3 to a committed `scripts/hotfix.sh` (with `--dry-run`) that
+encodes SHA-resolution + pre-flight and prints the exact `gh workflow run`
+command. Kept as a runbook today to avoid a second thing that drifts from
+`deploy.yml`.


### PR DESCRIPTION
## What
Adds `docs/runbooks/hotfix.md` + `decisions/2026-06-17-hotfix-runbook-workflow-dispatch.md` — a committed, command-precise runbook for shipping an incident fix to the homelab via the `workflow_dispatch` fast-path, plus the ADR behind it.

## Why
This session's manual incident deploy (prod `ff5e0b6` → `2e7f1bbe`) had a near-miss: deploying `main` HEAD would have **failed** because HEAD was a compose-only commit (#1476) with no built image. The generic global `/hotfix` skill assumes a `release`-branch + manual-tag + cherry-pick model that **doesn't fit** this main-as-trunk repo (release-please owns tags; deploy is `workflow_dispatch` of a SHA to a homelab box). `.claude/` is untracked, so the procedure must be **committed** to be the source of truth.

## What the runbook captures
- Resolve the target SHA = newest commit with a **successful `docker-publish` run** (all 4 images) that contains the fix — *not* necessarily `main` HEAD.
- `rollback_sha` is the exact-built-SHA **forward-deploy** lever.
- Pre-flight: migrations-in-range, image existence (via run conclusion), box health, sane `.deploy-last-good-sha` rollback baseline.
- Monitor GH + box log to terminal; rely on built-in auto-rollback.
- **No manual version tag** (a hotfix deploys a SHA; the next release includes the merged fix).

## Decision quality
Ran `/research-and-decide`: `decision-critic` → ACCEPT-WITH-REVISIONS. The flagged CRITICAL risk (release-please clobbering a hotfixed SHA) was **refuted** on verification (release-please tags forward at `main` HEAD; auto-rollback uses `.deploy-last-good-sha`, not the release tag). Accepted revisions: named the exact resolution/verification commands. Declined: a separate `scripts/hotfix.sh` (drift surface) — kept as a revisit trigger. Full reconciliation in the ADR.

Docs-only; no code paths touched.

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a committed hotfix-to-prod runbook and an ADR documenting the `workflow_dispatch` fast-path for incidents. Docs-only; deploy an exact built SHA safely without tagging.

- New Features
  - Runbook `docs/runbooks/hotfix.md`: resolve the target SHA as the newest commit with a successful `docker-publish.yml` run that contains the fix (not always `main` HEAD), run pre-flight checks, deploy via `deploy.yml` with `rollback_sha=<sha>`, and monitor to completion.
  - ADR `decisions/2026-06-17-hotfix-runbook-workflow-dispatch.md`: rationale, overrides the generic `/hotfix` skill for this repo, and confirms no manual version tag (a hotfix ships a SHA).

<sup>Written for commit b37c060b642e355fbe9fd1b00e4c6079d30aed46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

