### PR TITLE
fix(autoplay): key track start-time per track, not per guild (#1275)

### DIFF
--- a/packages/bot/src/handlers/player/trackHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.spec.ts
@@ -584,4 +584,90 @@ describe('trackHandlers autoplay replenishment', () => {
             expect(recordRecommendationOutcomeMock).not.toHaveBeenCalled()
         })
     })
+
+    // #1275 probe: prod shows 0 rejected all-time despite a working accepted
+    // path. The isolated tests above pass, so the per-event logic is correct.
+    // These exercise the REALISTIC continuous-autoplay sequencing where the
+    // next track's playerStart interleaves with the previous track's terminal
+    // event — guildTrackStartTimes is keyed per-GUILD (one timestamp shared
+    // across overlapping track lifecycles), which the isolated tests never hit.
+    describe('interleaved continuous-autoplay sequencing (#1275 probe)', () => {
+        const autoplay = (id: string) =>
+            ({
+                ...createAutoplayTrack('listener-1'),
+                id,
+                durationMS: 100000,
+            }) as unknown as Track
+
+        it('records rejected for an early skip that follows a completed track (finish→start→skip order)', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const trackA = autoplay('seq-A')
+            const trackB = autoplay('seq-B')
+
+            await handlers.playerStart(queue, trackA)
+            jest.advanceTimersByTime(90000) // A plays to 90%
+            await handlers.playerFinish(queue, trackA) // accepted, clears startTime
+            await handlers.playerStart(queue, trackB) // startTime reset for B
+            jest.advanceTimersByTime(10000) // B plays 10%
+            await handlers.playerSkip(queue, trackB)
+
+            expect(recordRecommendationOutcomeMock).toHaveBeenCalledWith({
+                guildId: 'guild-1',
+                trackId: 'seq-A',
+                outcome: 'accepted',
+            })
+            expect(recordRecommendationOutcomeMock).toHaveBeenCalledWith({
+                guildId: 'guild-1',
+                trackId: 'seq-B',
+                outcome: 'rejected',
+            })
+        })
+
+        it('records rejected when the next track starts BEFORE the skip event fires (start→start→skip order)', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const trackA = autoplay('race-A')
+            const trackB = autoplay('race-B')
+
+            await handlers.playerStart(queue, trackA)
+            jest.advanceTimersByTime(10000) // A plays 10%, user skips
+            // discord-player advances to B before emitting skip for A
+            await handlers.playerStart(queue, trackB)
+            await handlers.playerSkip(queue, trackA)
+
+            // A was skipped early — it must register as a rejection, not vanish.
+            expect(recordRecommendationOutcomeMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    trackId: 'race-A',
+                    outcome: 'rejected',
+                }),
+            )
+        })
+
+        it('does NOT misrecord a completed track as rejected when the next track starts before its finish event (start→start→finish order)', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const trackA = autoplay('mis-A')
+            const trackB = autoplay('mis-B')
+
+            await handlers.playerStart(queue, trackA)
+            jest.advanceTimersByTime(90000) // A plays to 90% — a clear ACCEPT
+            // next track begins before A's (buffered) finish event arrives
+            await handlers.playerStart(queue, trackB)
+            await handlers.playerFinish(queue, trackA)
+
+            // A genuinely completed; the shared per-guild startTime must not
+            // cause it to be misclassified as a rejection.
+            expect(recordRecommendationOutcomeMock).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    trackId: 'mis-A',
+                    outcome: 'rejected',
+                }),
+            )
+        })
+    })
 })

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -40,11 +40,19 @@ export const lastPlayedTracks = new LRUCache<string, Track>({
     updateAgeOnGet: true,
 })
 
-const guildTrackStartTimes = new LRUCache<string, number>({
+// Keyed per TRACK (guildId + track id), not per guild: autoplay track
+// lifecycles overlap — discord-player can emit the next track's playerStart
+// before the previous track's playerFinish/playerSkip. A single per-guild
+// timestamp gets clobbered by that interleaving, making completionRatio ≈ 0
+// for the wrong track and corrupting the accept/reject classification (#1275).
+const trackStartTimes = new LRUCache<string, number>({
     max: MAX_GUILD_ENTRIES,
     ttl: TRACK_STATE_TTL_MS,
     updateAgeOnGet: true,
 })
+
+const trackStartKey = (guildId: string, trackId: string): string =>
+    `${guildId}::${trackId}`
 
 const guildRecentSkipCounts = new LRUCache<string, number>({
     max: MAX_GUILD_ENTRIES,
@@ -231,7 +239,7 @@ const handlePlayerStart = async (
 ): Promise<void> => {
     try {
         evictOldEntries()
-        guildTrackStartTimes.set(queue.guild.id, Date.now())
+        trackStartTimes.set(trackStartKey(queue.guild.id, track.id), Date.now())
         infoLog({
             message: `Started playing "${track.title}" in ${queue.guild.name}`,
         })
@@ -296,7 +304,9 @@ const handlePlayerFinish = async (
         await scrobbleAndRecord(queue, track)
 
         if (track) {
-            const startTime = guildTrackStartTimes.get(queue.guild.id)
+            const startTime = trackStartTimes.get(
+                trackStartKey(queue.guild.id, track.id),
+            )
             if (startTime && track.durationMS) {
                 const completionRatio =
                     (Date.now() - startTime) / track.durationMS
@@ -324,7 +334,7 @@ const handlePlayerFinish = async (
                     })
                 }
             }
-            guildTrackStartTimes.delete(queue.guild.id)
+            trackStartTimes.delete(trackStartKey(queue.guild.id, track.id))
         }
 
         await handleQueueExhaustion(queue, (q, t) =>
@@ -356,7 +366,9 @@ const handlePlayerSkip = async (
         await scrobbleCurrentTrackIfLastFm(queue, track)
 
         if (track) {
-            const startTime = guildTrackStartTimes.get(queue.guild.id)
+            const startTime = trackStartTimes.get(
+                trackStartKey(queue.guild.id, track.id),
+            )
             if (startTime && track.durationMS) {
                 const skipRatio = (Date.now() - startTime) / track.durationMS
                 // Implicit-dislike noise filter: only for tracks long enough that
@@ -387,7 +399,7 @@ const handlePlayerSkip = async (
                     })
                 }
             }
-            guildTrackStartTimes.delete(queue.guild.id)
+            trackStartTimes.delete(trackStartKey(queue.guild.id, track.id))
         }
 
         await handleQueueExhaustion(queue, (q, t) =>


### PR DESCRIPTION
## What

Key the autoplay track start-time map **per track** (`guildId::trackId`) instead of **per guild**.

## Why (the bug, found via TDD)

`trackHandlers` recorded the start timestamp in a single per-guild slot. During continuous autoplay, discord-player can emit the **next** track's `playerStart` *before* the **previous** track's `playerFinish`/`playerSkip`. That overlap clobbers the per-guild timestamp, so when the previous track finally finishes the handler reads the wrong (later) start time, computes `completionRatio ≈ 0`, and misclassifies a fully-played track as **rejected** — corrupting the accept/reject signal that feeds recommendation outcomes (#1275).

A TDD probe (`interleaved continuous-autoplay sequencing (#1275 probe)`) reproduced this: the `start→start→finish` case asserted the completed track must **not** be recorded as rejected — that test went RED on per-guild keying and GREEN after per-track keying.

## Change

- `guildTrackStartTimes` → `trackStartTimes`, keyed by `trackStartKey(guildId, trackId)`.
- `playerStart` sets, `playerFinish`/`playerSkip` get+delete by the per-track key.
- 3 new probe tests covering interleaved lifecycles (20/20 in the suite pass).

## Scope (honest)

This hardens telemetry correctness against lifecycle interleaving. It is **not** proven to be the sole cause of the prod "0 rejected outcomes" observation — signal rarity (H2) is still under Loki observation, so this **links** #1275 rather than closing it.

## Verification

- `npm test` (packages/bot, trackHandlers) → 20/20 green
- lint + type:check green (pre-commit)

@cubic-dev-ai


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes autoplay outcome misclassification by tracking start time per track (`guildId::trackId`) instead of per guild. Prevents overlaps when `discord-player` starts the next track before the previous finishes, aligning with #1275.

- **Bug Fixes**
  - Replaced per-guild slot with per-track `trackStartTimes` and `trackStartKey(guildId, track.id)`; updated `playerStart`, `playerFinish`, and `playerSkip` to set/get/delete with the per-track key.
  - Added 3 tests for interleaved autoplay sequences (start→start→finish, start→start→skip, finish→start→skip) to guard against misclassification.
  - Improves accept/reject telemetry; links #1275.

<sup>Written for commit 4e2e4c34a61ae60f354cf4688a5305dd933cb6ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

