### PR TITLE
ci(release): gate release publish on tests (#1480)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
 
             - name: Run tests
               run: npm run test:ci
-              continue-on-error: true
 
             - name: Extract version from tag
               id: version


### PR DESCRIPTION
Part of #1480 (deploy posture). Addresses **F4 (safe half)**.

## Change
Remove `continue-on-error: true` from the `Run tests` step in `release.yml`. The `Create GitHub Release` step runs `if: success()` by default, so a failing `test:ci` now **blocks the release publish** (and the downstream `deploy.yml` `release: published` trigger) instead of being advisory.

## Why
Before: merge to `main` (0 required reviews) → tag → release with tests that **can't block** → prod. Tests were decorative at the release gate.

## Velocity preserved
The emergency hotfix fast-path uses `workflow_dispatch` on `deploy.yml`, **not** `release.yml` (`docs/runbooks/hotfix.md`), so a flaky release-test run cannot block an incident hotfix.

## Scope note
The release-please ADR (#1478) is merged but **not yet implemented** — `release.yml` is still the live release mechanism, so this hardens the current path. Harmless if `release.yml` is later replaced by release-please.

## Not included (operator/governance — see #1480 comment)
- F4 other half (require ≥1 review on `main`) — would break the solo-operator auto-merge ship-lane; deliberately not applied.

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate release publishing on passing tests by removing `continue-on-error` from the `Run tests` step in `release.yml`. A failing `npm run test:ci` now blocks `Create GitHub Release` and the downstream deploy trigger, aligning with #1480 (deploy posture F4).

<sup>Written for commit 3b98b14058c8d26c214ca2b7b960b7ae67949d5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to enforce test passage before creating releases, improving overall release reliability and preventing failed deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->