### PR TITLE
ci(deps): renovate dark-period health guard + adr (#1481)

### DIFF
--- a/.github/workflows/renovate-health.yml
+++ b/.github/workflows/renovate-health.yml
@@ -52,13 +52,14 @@ jobs:
                   if [ "$dashboard" -eq 0 ] && [ "$recent_prs" -eq 0 ]; then
                       echo "::error::Renovate appears DARK — no Dependency Dashboard and no bot PRs in 21d."
                       if [ -z "$existing" ]; then
+                          body=$(printf '%s\n\n%s\n\n%s' \
+                              "$marker" \
+                              "The \`Renovate Health\` scheduled check found **no open Dependency Dashboard issue** and **no renovate[bot] PR activity in the last 21 days**." \
+                              "Dependency + security-update automation is likely dark again (the #1481 / #1069 failure mode). Verify the Renovate App is still installed for this repo at <https://github.com/apps/renovate>, or switch to the self-hosted Renovate Action fallback documented in \`decisions/2026-06-17-renovate-reactivation.md\`.")
                           gh issue create --repo "$REPO" \
                               --title "ci(deps): Renovate automation appears dark — no Dashboard / recent PRs" \
                               --label "needs-triage" \
-                              --body "$marker
-The \`Renovate Health\` scheduled check found **no open Dependency Dashboard issue** and **no renovate[bot] PR activity in the last 21 days**.
-
-Dependency + security-update automation is likely dark again (the #1481 / #1069 failure mode). Verify the Renovate App is still installed for this repo at <https://github.com/apps/renovate>, or switch to the self-hosted Renovate Action fallback documented in \`decisions/2026-06-17-renovate-reactivation.md\`."
+                              --body "$body"
                       else
                           echo "Tracking issue #$existing already open — not duplicating."
                       fi

--- a/.github/workflows/renovate-health.yml
+++ b/.github/workflows/renovate-health.yml
@@ -32,25 +32,33 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  dashboard=$(gh issue list --repo "$REPO" --state open \
+                  # Renovate edits its Dependency Dashboard issue on every run, so a
+                  # recently-updated Dashboard is a liveness signal even when there are
+                  # no open PRs (e.g. everything is already up to date). Existence alone
+                  # is NOT — the issue is long-lived and stays open after the App lapses,
+                  # so checking the count would mask a real outage forever (see #1481).
+                  dashboard_fresh=$(gh issue list --repo "$REPO" --state open \
                       --search 'in:title "Dependency Dashboard" author:app/renovate' \
-                      --json number --jq 'length')
-
-                  # Any renovate[bot] PR (open or merged) in the last 21 days.
-                  recent_prs=$(gh pr list --repo "$REPO" --state all \
-                      --search 'author:app/renovate' --limit 20 \
                       --json updatedAt \
                       --jq "[.[] | select(.updatedAt > (now - 21*86400 | gmtime | strftime(\"%Y-%m-%dT%H:%M:%SZ\")))] | length")
 
-                  echo "Dependency Dashboard issues: $dashboard"
+                  # Any renovate[bot] PR (open or merged) updated in the last 21 days.
+                  # sort:updated-desc guarantees the most recent activity is within the
+                  # first --limit results, so the cap can't manufacture a false outage.
+                  recent_prs=$(gh pr list --repo "$REPO" --state all \
+                      --search 'author:app/renovate sort:updated-desc' --limit 20 \
+                      --json updatedAt \
+                      --jq "[.[] | select(.updatedAt > (now - 21*86400 | gmtime | strftime(\"%Y-%m-%dT%H:%M:%SZ\")))] | length")
+
+                  echo "Dependency Dashboard updated in last 21d: $dashboard_fresh"
                   echo "Renovate PRs updated in last 21d: $recent_prs"
 
                   marker='<!-- renovate-health-alert -->'
                   existing=$(gh issue list --repo "$REPO" --state open \
                       --search "in:body \"$marker\"" --json number --jq '.[0].number // ""')
 
-                  if [ "$dashboard" -eq 0 ] && [ "$recent_prs" -eq 0 ]; then
-                      echo "::error::Renovate appears DARK — no Dependency Dashboard and no bot PRs in 21d."
+                  if [ "$dashboard_fresh" -eq 0 ] && [ "$recent_prs" -eq 0 ]; then
+                      echo "::error::Renovate appears DARK — no Dashboard update and no bot PRs in 21d."
                       if [ -z "$existing" ]; then
                           body=$(printf '%s\n\n%s\n\n%s' \
                               "$marker" \

--- a/.github/workflows/renovate-health.yml
+++ b/.github/workflows/renovate-health.yml
@@ -1,0 +1,72 @@
+name: Renovate Health
+
+# Preventive guard for the failure mode behind #1481: the Renovate App install
+# is invisible + un-versioned, so when it lapsed after the #1069 migration the
+# automation went dark silently for ~3 weeks (a CVE had to be hand-patched).
+# This job makes that lapse self-surfacing: it asserts Renovate is alive by
+# checking for its Dependency Dashboard issue and recent bot PR activity, and
+# files (idempotently) a tracking issue if neither is found.
+# See decisions/2026-06-17-renovate-reactivation.md.
+
+on:
+    schedule:
+        # Tuesday 09:00 UTC — a day after Renovate's "before 6am Monday" run,
+        # so a healthy week has produced its Dashboard / PRs by the time we check.
+        - cron: '0 9 * * 2'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    issues: write
+    pull-requests: read
+
+jobs:
+    check:
+        name: Assert Renovate is alive
+        runs-on: ubuntu-latest
+        steps:
+            - name: Probe Dependency Dashboard + recent Renovate PRs
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  dashboard=$(gh issue list --repo "$REPO" --state open \
+                      --search 'in:title "Dependency Dashboard" author:app/renovate' \
+                      --json number --jq 'length')
+
+                  # Any renovate[bot] PR (open or merged) in the last 21 days.
+                  recent_prs=$(gh pr list --repo "$REPO" --state all \
+                      --search 'author:app/renovate' --limit 20 \
+                      --json updatedAt \
+                      --jq "[.[] | select(.updatedAt > (now - 21*86400 | gmtime | strftime(\"%Y-%m-%dT%H:%M:%SZ\")))] | length")
+
+                  echo "Dependency Dashboard issues: $dashboard"
+                  echo "Renovate PRs updated in last 21d: $recent_prs"
+
+                  marker='<!-- renovate-health-alert -->'
+                  existing=$(gh issue list --repo "$REPO" --state open \
+                      --search "in:body \"$marker\"" --json number --jq '.[0].number // ""')
+
+                  if [ "$dashboard" -eq 0 ] && [ "$recent_prs" -eq 0 ]; then
+                      echo "::error::Renovate appears DARK — no Dependency Dashboard and no bot PRs in 21d."
+                      if [ -z "$existing" ]; then
+                          gh issue create --repo "$REPO" \
+                              --title "ci(deps): Renovate automation appears dark — no Dashboard / recent PRs" \
+                              --label "needs-triage" \
+                              --body "$marker
+The \`Renovate Health\` scheduled check found **no open Dependency Dashboard issue** and **no renovate[bot] PR activity in the last 21 days**.
+
+Dependency + security-update automation is likely dark again (the #1481 / #1069 failure mode). Verify the Renovate App is still installed for this repo at <https://github.com/apps/renovate>, or switch to the self-hosted Renovate Action fallback documented in \`decisions/2026-06-17-renovate-reactivation.md\`."
+                      else
+                          echo "Tracking issue #$existing already open — not duplicating."
+                      fi
+                      exit 1
+                  fi
+
+                  echo "Renovate is alive."
+                  if [ -n "$existing" ]; then
+                      gh issue close "$existing" --repo "$REPO" \
+                          --comment "Renovate health restored (Dashboard present and/or recent PR activity). Auto-closing."
+                  fi

--- a/decisions/2026-06-17-renovate-reactivation.md
+++ b/decisions/2026-06-17-renovate-reactivation.md
@@ -1,0 +1,90 @@
+# ADR: Reactivate Renovate (App) + add a dark-period health guard
+
+**Date:** 2026-06-17
+**Status:** Accepted
+**Issue:** #1481 · **Builds on:** [2026-05-27-ci-merge-queue-and-renovate.md](2026-05-27-ci-merge-queue-and-renovate.md)
+
+## Context
+
+Dependency + security-update automation has been **dark since 2026-05-27**. The
+#1069 migration (ADR 2026-05-27) chose **Strict Status Checks + Renovate** and
+deleted `.github/dependabot.yml`, but listed two manual post-merge steps:
+
+1. Enable Merge Queue — **moot** (GitHub Merge Queue is Team/Enterprise-gated; this
+   repo is on Free; the `merge_group` CI triggers are forward-compatible no-ops).
+2. **Install the Renovate App + merge its onboarding PR — never done.**
+
+Consequence: zero `renovate[bot]` PRs since the migration, no Dependency Dashboard
+issue ever created, and Dependabot also silent (its config was deleted). A CVE
+(#1281) had to be patched **by hand** during the gap. `.renovaterc.json` is committed,
+complete, and **validates** (`renovate-config-validator` → "Config validated
+successfully"). Renovate ran on this repo earlier (PRs #81–#109, Feb–Mar 2026) and
+the sibling `homelab` repo runs this exact App-based config successfully, so the App
+is installable and the pattern is proven.
+
+The root cause of the outage was therefore **not** a config or tooling problem — it
+was a one-time forgotten manual step whose failure was **invisible and
+un-versioned** (nothing in the repo surfaced that automation had stopped).
+
+## Decision
+
+**Reactivate dependency automation via the Renovate GitHub App** (complete the one
+unfinished step of #1069) — no config change required — **and add a version-controlled
+health guard** so a future silent lapse self-surfaces.
+
+- **Operator step:** install the Renovate App for `LucasSantana-Dev/Lucky` at
+  <https://github.com/apps/renovate>, then review/merge the onboarding PR.
+- **Code step (this ADR's PR):** `.github/workflows/renovate-health.yml` — a weekly
+  scheduled job (Tuesday, after Renovate's Monday run) that asserts a Dependency
+  Dashboard issue exists _or_ a `renovate[bot]` PR was updated in the last 21 days,
+  and idempotently files a `needs-triage` tracking issue (and fails) if neither holds.
+
+This was reviewed by `decision-critic` (verdict **ACCEPT-WITH-REVISIONS**): the App
+path is the simplest correct restore, but its sole high-risk vector is the same
+silent-lapse failure that just occurred. The critic's load-bearing revision — make
+the revisit trigger **preventive, not reactive** — is adopted as the health guard.
+
+## Alternatives considered
+
+- **Self-hosted Renovate via GitHub Actions** (`renovatebot/github-action` on cron) —
+  the strongest alternative: needs no App install (removes the exact failure mode) and
+  is fully version-controlled. **Rejected as the primary** because it adds a PAT/token
+  secret + workflow maintenance and has **no in-org prior art** (homelab uses the App),
+  while the health guard recovers most of its observability benefit at lower cost.
+  **Retained as the documented fallback** if the App lapses again despite the guard.
+- **Revert to Dependabot** — reverses the recent (2026-05-27) ADR and loses
+  `rebaseStalePrs`, reintroducing the stale-cache Docker CI failures #1069 eliminated.
+- **Dependabot security-updates only + manual majors** — loses routine patch/minor
+  automation; partial.
+- **Kodiak / GitHub Merge Queue / status-quo-manual** — all rejected in the
+  2026-05-27 ADR (rebase-window doesn't kill root cause / plan-gated / unscalable toil).
+
+## Consequences
+
+**Positive**
+
+- Restores automated patch/minor auto-merge + manual majors + `vulnerabilityAlerts`
+  (parity with prior Dependabot surfaces: npm, github-actions, docker, dockerfile).
+- The health guard makes any future lapse self-announcing in the issue tracker —
+  converting the previous _reactive, human-vigilance_ trigger into an _automated_ one.
+- No architectural change, no ADR reversal; honors the proven org pattern.
+
+**Negative / friction**
+
+- Onboarding PR burst: ~47 outdated root deps — **3 major** (manual; 2 are
+  YouTube-adjacent → already manual-gated) + **44 minor/patch** (auto-merge, throttled
+  to 4/hr · 8 concurrent → ~11h drain). Bounded, not a flood.
+- The App install remains an out-of-repo state the guard _detects_ but cannot _prevent_.
+
+**Neutral**
+
+- The health-guard issue may briefly overlap with #1481 until the App is installed
+  and the first healthy run auto-closes it.
+
+## Revisit when
+
+- The health guard fires (automation dark >21d) **a second time** → the App is too
+  fragile for this repo; switch to the self-hosted Renovate Action fallback.
+- Onboarding PR-burst proves chronically disruptive despite the 4/hr·8-concurrent
+  throttle → tighten `prConcurrentLimit` / add grouping rules.
+- Repo moves to GitHub Team plan → revisit Merge Queue per the 2026-05-27 ADR.

--- a/decisions/2026-06-17-renovate-reactivation.md
+++ b/decisions/2026-06-17-renovate-reactivation.md
@@ -7,7 +7,7 @@
 ## Context
 
 Dependency + security-update automation has been **dark since 2026-05-27**. The
-#1069 migration (ADR 2026-05-27) chose **Strict Status Checks + Renovate** and
+`#1069` migration (ADR 2026-05-27) chose **Strict Status Checks + Renovate** and
 deleted `.github/dependabot.yml`, but listed two manual post-merge steps:
 
 1. Enable Merge Queue — **moot** (GitHub Merge Queue is Team/Enterprise-gated; this


### PR DESCRIPTION
Closes the code half of #1481. Records the decision in an ADR and ships a preventive guard; the App install itself is an operator step (below).

## Decision (`/research-and-decide`)
Automation has been dark since the #1069 migration **solely because one manual step was never done** — installing the Renovate App. The `.renovaterc.json` is committed and **validates** (`renovate-config-validator` → "Config validated successfully"); the merge-queue step from #1069 is moot (Team/Enterprise-gated). So the fix is: **reactivate the Renovate App** (operator) + **add a version-controlled health guard** so the next silent lapse self-surfaces.

`decision-critic` verdict: **ACCEPT-WITH-REVISIONS** — the App path is the simplest correct restore, but its one high-risk vector is the same invisible-lapse failure that just happened. Its load-bearing revision (make the revisit trigger *preventive*, not *reactive*) is adopted as this guard. Full rationale + alternatives (self-hosted Action as documented fallback; Dependabot revert rejected) in `decisions/2026-06-17-renovate-reactivation.md`.

## This PR
- `.github/workflows/renovate-health.yml` — weekly (Tue, after Renovate's Mon run) assert a Dependency Dashboard issue exists **or** a `renovate[bot]` PR was updated in the last 21d; idempotently files a `needs-triage` tracking issue (and fails) if neither, auto-closes it when health returns.
- ADR documenting the decision.

## Operator step (not automatable — App install is out-of-repo)
Install Renovate for this repo at <https://github.com/apps/renovate>, then review/merge the onboarding PR. Expected onboarding burst: ~47 outdated root deps → 3 major (manual; 2 YouTube-adjacent, already manual-gated) + 44 minor/patch (auto-merge, throttled 4/hr·8-concurrent ≈ 11h drain).

> Note: while automation is still dark, the scheduled guard will (correctly) report dark on its first run until the App is installed. It's `schedule`-only, so it never blocks PRs.

@cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a weekly Renovate health guard and an ADR to prevent silent lapses in dependency automation, addressing #1481. The job opens a tracking issue when the Renovate App is inactive and auto-closes it when activity resumes.

- **New Features**
  - Adds `.github/workflows/renovate-health.yml` (Tue 09:00 UTC) to assert the Dependency Dashboard was updated in the last 21 days or that recent `renovate[bot]` PRs exist (`sort:updated-desc`); when dark, opens a `needs-triage` tracking issue and fails; auto-closes once healthy. Schedule-only. Uses `printf` to build the issue body for actionlint.
  - Adds `decisions/2026-06-17-renovate-reactivation.md` documenting the decision and fallback.

- **Migration**
  - Install the Renovate GitHub App for this repo and merge the onboarding PR.
  - Expect an onboarding burst: minor/patch auto-merge; majors remain manual.

<sup>Written for commit 945aec30434e3349a3ccb50f390766b6ebbdcad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reactivated automated dependency updates through Renovate.
  * Added health monitoring to detect automation lapses and alert via tracking issues.

* **Chores**
  * Established automated weekly health check system for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->