### PR TITLE
fix(download): drop invalid --extract-flat flag from yt-dlp download

### DIFF
--- a/packages/bot/src/functions/download/utils/ytDlpUtils/downloader/service.ts
+++ b/packages/bot/src/functions/download/utils/ytDlpUtils/downloader/service.ts
@@ -57,8 +57,6 @@ export class YtDlpDownloaderService {
         return [
             args.url,
             '--no-playlist',
-            '--extract-flat',
-            'false',
             '--write-info-json',
             '--write-thumbnail',
             '--embed-metadata',


### PR DESCRIPTION
## Problem
`/download` failed for every invocation with:
```
yt-dlp: error: no such option: --extract-flat
```
The arg builder passed `--extract-flat false` to the yt-dlp **CLI**, where that option does not exist (it is the Python-API name; the CLI equivalent is `--flat-playlist`), and flat-listing is meaningless for an actual download.

## Fix
Remove the two stray args from `buildYtDlpCommand` (`packages/bot/src/functions/download/utils/ytDlpUtils/downloader/service.ts`). The remaining args form a valid download command.

## Test
Confirmed via live Discord test that the flag was the failure; the rest of the command line is a standard yt-dlp download. tsc passes (pre-commit type:check green).

Closes #1486

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove invalid `--extract-flat false` args from the `yt-dlp` CLI invocation to fix `/download` failures. The command now uses only valid download flags; flat listing isn’t needed for actual downloads. Fixes #1486.

<sup>Written for commit 2c02cdbb71385c24af883e4f89db9b79ec9884cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

