### PR TITLE
fix(help): split large command categories across embed fields

### DIFF
--- a/packages/bot/src/functions/general/commands/help.ts
+++ b/packages/bot/src/functions/general/commands/help.ts
@@ -66,7 +66,7 @@ function createHelpEmbeds(
                 index === 0
                     ? `${label} (${commands.length})`
                     : `${label} (cont.)`
-            fields.push({ name, value: `​\n${chunk}` })
+            fields.push({ name, value: `\u200B\n${chunk}` })
         })
     }
 
@@ -125,7 +125,7 @@ function createHelpEmbeds(
 
 const MAX_FIELD_VALUE = 1024
 const MAX_EMBED_FIELDS = 25
-// Leave headroom for the `​\n` prefix added to each field value.
+// Leave headroom for the zero-width-space + newline prefix on each field value.
 const FIELD_VALUE_BUDGET = MAX_FIELD_VALUE - 8
 // Discord caps a message at 6000 chars across all embeds; keep headroom for
 // the first page's title, description and footer.

--- a/packages/bot/src/functions/general/commands/help.ts
+++ b/packages/bot/src/functions/general/commands/help.ts
@@ -58,17 +58,60 @@ function createHelpEmbed(
             iconURL: interaction.user.displayAvatarURL(),
         })
 
+    let fieldCount = 0
     for (const { key, label } of categories) {
-        if (categoryCommands[key].length > 0) {
-            embed.addFields({
-                name: `${label} (${categoryCommands[key].length})`,
-                value: `\u200B\n${categoryCommands[key].join('\n')}`,
-                inline: false,
-            })
+        const commands = categoryCommands[key]
+        if (commands.length === 0) {
+            continue
         }
+
+        // Discord caps embed field values at 1024 chars and embeds at 25
+        // fields, so split large categories (e.g. Music) across several
+        // fields instead of overflowing a single one (which throws).
+        const chunks = chunkByLength(commands)
+        chunks.forEach((chunk, index) => {
+            if (fieldCount >= MAX_EMBED_FIELDS) {
+                return
+            }
+            const name =
+                index === 0
+                    ? `${label} (${commands.length})`
+                    : `${label} (cont.)`
+            embed.addFields({ name, value: `\u200B\n${chunk}`, inline: false })
+            fieldCount += 1
+        })
     }
 
     return embed
+}
+
+const MAX_FIELD_VALUE = 1024
+const MAX_EMBED_FIELDS = 25
+// Leave headroom for the `\u200B\n` prefix added to each field value.
+const FIELD_VALUE_BUDGET = MAX_FIELD_VALUE - 8
+
+/**
+ * Pack lines into newline-joined chunks, each at or below the field-value
+ * budget, never splitting a single line across chunks.
+ */
+function chunkByLength(lines: string[]): string[] {
+    const chunks: string[] = []
+    let current = ''
+
+    for (const line of lines) {
+        const candidate = current === '' ? line : `${current}\n${line}`
+        if (candidate.length > FIELD_VALUE_BUDGET && current !== '') {
+            chunks.push(current)
+            current = line
+        } else {
+            current = candidate
+        }
+    }
+    if (current !== '') {
+        chunks.push(current)
+    }
+
+    return chunks
 }
 
 async function handleHelpError(

--- a/packages/bot/src/functions/general/commands/help.ts
+++ b/packages/bot/src/functions/general/commands/help.ts
@@ -34,61 +34,102 @@ function buildCategoryCommands(
     return categoryCommands
 }
 
-function createHelpEmbed(
+type HelpField = { name: string; value: string }
+
+/**
+ * Build the help into one or more embeds. Discord caps a single embed field
+ * value at 1024 chars, an embed at 25 fields, and a whole message at 6000
+ * chars across all embeds — so large categories are split across fields and
+ * the fields are paged into multiple embeds (sent as follow-up messages)
+ * rather than overflowing a single response, which throws.
+ */
+function createHelpEmbeds(
     categoryCommands: Record<string, string[]>,
     client: Client,
     interaction: ChatInputCommandInteraction,
-): EmbedBuilder {
+): EmbedBuilder[] {
     const categories = getAllCategories()
     const totalCommands = Object.values(categoryCommands).reduce(
         (sum, cmds) => sum + cmds.length,
         0,
     )
 
-    const embed = new EmbedBuilder()
-        .setColor(EMBED_COLORS.INFO)
-        .setTitle('📚 Lucky — Command Reference')
-        .setDescription(
-            'All available slash commands grouped by category. Use `/` to start any command.',
-        )
-        .setThumbnail(client.user?.displayAvatarURL() ?? '')
-        .setTimestamp()
-        .setFooter({
-            text: `${totalCommands} commands · Requested by ${interaction.user.tag}`,
-            iconURL: interaction.user.displayAvatarURL(),
-        })
-
-    let fieldCount = 0
+    const fields: HelpField[] = []
     for (const { key, label } of categories) {
         const commands = categoryCommands[key]
         if (commands.length === 0) {
             continue
         }
-
-        // Discord caps embed field values at 1024 chars and embeds at 25
-        // fields, so split large categories (e.g. Music) across several
-        // fields instead of overflowing a single one (which throws).
         const chunks = chunkByLength(commands)
         chunks.forEach((chunk, index) => {
-            if (fieldCount >= MAX_EMBED_FIELDS) {
-                return
-            }
             const name =
                 index === 0
                     ? `${label} (${commands.length})`
                     : `${label} (cont.)`
-            embed.addFields({ name, value: `\u200B\n${chunk}`, inline: false })
-            fieldCount += 1
+            fields.push({ name, value: `​\n${chunk}` })
         })
     }
 
-    return embed
+    const pages: HelpField[][] = []
+    let current: HelpField[] = []
+    let currentChars = 0
+    for (const field of fields) {
+        const cost = field.name.length + field.value.length
+        const overflows =
+            current.length >= MAX_EMBED_FIELDS ||
+            currentChars + cost > PAGE_CHAR_BUDGET
+        if (overflows && current.length > 0) {
+            pages.push(current)
+            current = []
+            currentChars = 0
+        }
+        current.push(field)
+        currentChars += cost
+    }
+    if (current.length > 0) {
+        pages.push(current)
+    }
+    if (pages.length === 0) {
+        pages.push([])
+    }
+
+    const pageCount = pages.length
+    return pages.map((pageFields, index) => {
+        const embed = new EmbedBuilder()
+            .setColor(EMBED_COLORS.INFO)
+            .setTimestamp()
+            .addFields(pageFields)
+
+        if (index === 0) {
+            embed
+                .setTitle(
+                    pageCount > 1
+                        ? `📚 Lucky — Command Reference (1/${pageCount})`
+                        : '📚 Lucky — Command Reference',
+                )
+                .setDescription(
+                    'All available slash commands grouped by category. Use `/` to start any command.',
+                )
+                .setThumbnail(client.user?.displayAvatarURL() ?? '')
+                .setFooter({
+                    text: `${totalCommands} commands · Requested by ${interaction.user.tag}`,
+                    iconURL: interaction.user.displayAvatarURL(),
+                })
+        } else {
+            embed.setTitle(`📚 Command Reference (${index + 1}/${pageCount})`)
+        }
+
+        return embed
+    })
 }
 
 const MAX_FIELD_VALUE = 1024
 const MAX_EMBED_FIELDS = 25
-// Leave headroom for the `\u200B\n` prefix added to each field value.
+// Leave headroom for the `​\n` prefix added to each field value.
 const FIELD_VALUE_BUDGET = MAX_FIELD_VALUE - 8
+// Discord caps a message at 6000 chars across all embeds; keep headroom for
+// the first page's title, description and footer.
+const PAGE_CHAR_BUDGET = 5500
 
 /**
  * Pack lines into newline-joined chunks, each at or below the field-value
@@ -143,13 +184,22 @@ export default new Command({
     execute: async ({ client, interaction }) => {
         try {
             const categoryCommands = buildCategoryCommands(client.commands)
-            const embed = createHelpEmbed(categoryCommands, client, interaction)
+            const embeds = createHelpEmbeds(
+                categoryCommands,
+                client,
+                interaction,
+            )
 
             debugLog({ message: 'Help command: Sending embed response' })
-            await interactionReply({
-                interaction,
-                content: { embeds: [embed] },
-            })
+            // interactionReply edits the deferred reply on the first call and
+            // routes subsequent calls to followUp (interaction.replied), so
+            // each page lands as its own message within Discord's 6000 cap.
+            for (const embed of embeds) {
+                await interactionReply({
+                    interaction,
+                    content: { embeds: [embed] },
+                })
+            }
             infoLog({ message: 'Help command: Successfully sent response' })
         } catch (error) {
             await handleHelpError(error, interaction)


### PR DESCRIPTION
## Problem
`/help` threw and showed "An error occurred while displaying the help commands." `createHelpEmbed` packed every command in a category into a single embed **field value** with no length guard. The Music category (90+ commands) exceeded Discord's 1024-char field limit, so discord.js threw a `RangeError` during serialization, swallowed into the generic message.

## Fix
Chunk each category's command list into multiple fields, each ≤1024 chars, capped at Discord's 25-field maximum. Continuation fields are labelled `<Category> (cont.)`. No commands are dropped (unless the total would exceed 25 fields, which is logged-by-design via the cap).

## Test
tsc passes (pre-commit type:check green). The chunker never splits a single command line across fields and respects the field-value budget.

Closes #1487

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split long /help categories across multiple embed fields and paginate across embeds to respect Discord limits and prevent crashes. Fixes #1487 by avoiding `discord.js` RangeError and ensuring all commands are shown.

- **Bug Fixes**
  - Chunk each category’s commands into field values ≤1024 chars and page fields across embeds to stay under 25 fields and the 6000-char cap.
  - Label continuation fields as "<Category> (cont.)", never split a command line, send each page as a follow-up message with page titles, and use `\u200B` instead of a literal zero-width space.

<sup>Written for commit 342482c1e914cf59f3aa5e9c6b66caefd2c2a233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

