### PR TITLE
feat(autoplay): instrument outcome eval to disambiguate #1275

### DIFF
--- a/packages/bot/src/handlers/player/trackHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.spec.ts
@@ -585,6 +585,118 @@ describe('trackHandlers autoplay replenishment', () => {
         })
     })
 
+    describe('autoplay outcome diagnostic log (#1275)', () => {
+        const findEvalLog = ():
+            | { data?: Record<string, unknown> }
+            | undefined =>
+            infoLogMock.mock.calls.find(
+                (call) =>
+                    (call[0] as { message?: string } | undefined)?.message ===
+                    'Autoplay outcome eval',
+            )?.[0] as { data?: Record<string, unknown> } | undefined
+
+        it('logs path=skip, recordedOutcome=rejected for an autoplay skip before 30%', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const track = {
+                ...createAutoplayTrack('listener-1'),
+                id: 'diag-skip-reject',
+                durationMS: 100000,
+            } as unknown as Track
+
+            await handlers.playerStart(queue, track)
+            jest.advanceTimersByTime(15000) // 15%
+            await handlers.playerSkip(queue, track)
+
+            expect(findEvalLog()).toMatchObject({
+                data: {
+                    path: 'skip',
+                    trackId: 'diag-skip-reject',
+                    hasStartTime: true,
+                    playedRatio: 0.15,
+                    recordedOutcome: 'rejected',
+                },
+            })
+        })
+
+        it('logs recordedOutcome=ambiguous(dropped) for an autoplay skip after 30%', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const track = {
+                ...createAutoplayTrack('listener-1'),
+                id: 'diag-skip-ambig',
+                durationMS: 100000,
+            } as unknown as Track
+
+            await handlers.playerStart(queue, track)
+            jest.advanceTimersByTime(55000) // 55%
+            await handlers.playerSkip(queue, track)
+
+            expect(findEvalLog()).toMatchObject({
+                data: { path: 'skip', recordedOutcome: 'ambiguous(dropped)' },
+            })
+        })
+
+        it('logs path=finish, recordedOutcome=accepted for an autoplay finish past 30%', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const track = {
+                ...createAutoplayTrack('listener-1'),
+                id: 'diag-finish-accept',
+                durationMS: 100000,
+            } as unknown as Track
+
+            await handlers.playerStart(queue, track)
+            jest.advanceTimersByTime(40000)
+            await handlers.playerFinish(queue, track)
+
+            expect(findEvalLog()).toMatchObject({
+                data: { path: 'finish', recordedOutcome: 'accepted' },
+            })
+        })
+
+        it('flags hasStartTime=false / no-timing when a skip has no recorded start (the H1 race)', async () => {
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const track = {
+                ...createAutoplayTrack('listener-1'),
+                id: 'diag-no-timing',
+                durationMS: 100000,
+            } as unknown as Track
+
+            // No playerStart → no start time recorded for this track.
+            await handlers.playerSkip(queue, track)
+
+            expect(findEvalLog()).toMatchObject({
+                data: {
+                    hasStartTime: false,
+                    playedRatio: null,
+                    recordedOutcome: 'none(no-timing)',
+                },
+            })
+        })
+
+        it('does not emit the diagnostic for non-autoplay tracks', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            const track = {
+                ...createTrack('listener-1'),
+                id: 'diag-manual',
+                durationMS: 100000,
+            } as unknown as Track
+
+            await handlers.playerStart(queue, track)
+            jest.advanceTimersByTime(10000)
+            await handlers.playerSkip(queue, track)
+
+            expect(findEvalLog()).toBeUndefined()
+        })
+    })
+
     // #1275 probe: prod shows 0 rejected all-time despite a working accepted
     // path. The isolated tests above pass, so the per-event logic is correct.
     // These exercise the REALISTIC continuous-autoplay sequencing where the

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -296,6 +296,48 @@ async function scrobbleAndRecord(
     await addTrackToHistory(trackToRecord, queue.guild.id)
 }
 
+// #1275 diagnostic: the per-event accept/reject logic is correct and
+// unit-tested (incl. the interleaving probe), yet prod records 0 rejected.
+// The existing "Track skipped" log lacks the fields to tell a code issue
+// (missing start time, skips routing through playerFinish, the real skipRatio
+// distribution) from a genuinely-rare signal (most picks are over-queued and
+// never played → 'pending'). Emit the decision inputs for every autoplay
+// terminal event, on both paths, so Loki can disambiguate H1 vs H2.
+const logAutoplayOutcomeEval = (
+    path: 'finish' | 'skip',
+    queue: GuildQueue,
+    track: Track,
+    startTime: number | undefined,
+): void => {
+    const playedRatio =
+        startTime !== undefined && track.durationMS
+            ? (Date.now() - startTime) / track.durationMS
+            : null
+    const recordedOutcome =
+        playedRatio === null
+            ? 'none(no-timing)'
+            : playedRatio < OUTCOME_ACCEPT_PLAY_RATIO
+              ? 'rejected'
+              : path === 'finish'
+                ? 'accepted'
+                : 'ambiguous(dropped)'
+    infoLog({
+        message: 'Autoplay outcome eval',
+        data: {
+            path,
+            guildId: queue.guild.id,
+            trackId: track.id,
+            hasStartTime: startTime !== undefined,
+            durationMS: track.durationMS ?? null,
+            playedRatio:
+                playedRatio === null
+                    ? null
+                    : Math.round(playedRatio * 1000) / 1000,
+            recordedOutcome,
+        },
+    })
+}
+
 const handlePlayerFinish = async (
     queue: GuildQueue,
     track?: Track,
@@ -307,6 +349,9 @@ const handlePlayerFinish = async (
             const startTime = trackStartTimes.get(
                 trackStartKey(queue.guild.id, track.id),
             )
+            if (isRecommendationAutoplay(track)) {
+                logAutoplayOutcomeEval('finish', queue, track, startTime)
+            }
             if (startTime && track.durationMS) {
                 const completionRatio =
                     (Date.now() - startTime) / track.durationMS
@@ -369,6 +414,9 @@ const handlePlayerSkip = async (
             const startTime = trackStartTimes.get(
                 trackStartKey(queue.guild.id, track.id),
             )
+            if (isRecommendationAutoplay(track)) {
+                logAutoplayOutcomeEval('skip', queue, track, startTime)
+            }
             if (startTime && track.durationMS) {
                 const skipRatio = (Date.now() - startTime) / track.durationMS
                 // Implicit-dislike noise filter: only for tracks long enough that


### PR DESCRIPTION
## Context
#1275 (re-opened): autoplay `rejected` telemetry reads **0 all-time** (269 rows) despite a working `accepted` path. The issue body's original "sub-5s dead zone" root cause is **stale** — #1276 (c2824143) already records `rejected` for any skip <30% (and finish ≤30%), and the existing `trackHandlers.spec.ts` covers every classification band *plus* an interleaving "#1275 probe". So **criterion #1 and #4 are already met**, and a code race is largely ruled out.

What's left is empirical — **H1 (code)** vs **H2 (signal genuinely rare)** — and it can't be settled from the current logs: `"Track skipped"` only carries title/url, not the decision inputs.

## Change (observability + tests only — no behavior change)
- Emit a structured **`Autoplay outcome eval`** INFO log for every **autoplay** terminal event on **both** `playerFinish` and `playerSkip`, carrying `{ path, guildId, trackId, hasStartTime, durationMS, playedRatio, recordedOutcome }`. It fires even when the start time is missing (`hasStartTime: false`) — capturing the H1 race directly.
- `recordedOutcome` ∈ `rejected | accepted | ambiguous(dropped) | none(no-timing)` so Loki queries are one-liners.
- 5 new tests asserting the diagnostic shape across bands + the no-timing case + non-autoplay exclusion. Full suite: **25/25 green**, type-check clean.

## Why not "fix" now
Per the re-open analysis, patching the suspected non-bug would just add noise. This makes the prod distribution observable so the next read **settles** H1 vs H2.

## After deploy — operator read (LogQL)
```
{container_name="lucky-bot"} |= `Autoplay outcome eval`
```
- Many `recordedOutcome=ambiguous(dropped)` or `accepted` on `path=finish` for real skips → **H1** (skips route through finish / threshold mis-tuned) → then adjust.
- Few autoplay terminal events at all, most picks never played → **H2** (signal rare; instrument is correct) → close as working-as-intended + revisit over-queueing.

Issue stays **open** pending that read; this PR does not close it.

Refs #1275

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured autoplay outcome diagnostics to investigate why `rejected` reads as zero in prod (refs #1275). No behavior changes; logs fire on both skip and finish with tests added.

- **New Features**
  - Emit `Autoplay outcome eval` INFO logs for autoplay terminal events on `playerFinish` and `playerSkip` (non-autoplay excluded).
  - Fields: { path, guildId, trackId, hasStartTime, durationMS, playedRatio, recordedOutcome∈`rejected|accepted|ambiguous(dropped)|none(no-timing)` }; logs even without a start time; `playedRatio` rounded to 3 decimals.
  - Outcome rules: < threshold → `rejected`; finish ≥ threshold → `accepted`; skip ≥ threshold → `ambiguous(dropped)`. Tests: 5 cases cover skip/finish bands, no-timing, and non-autoplay exclusion.

<sup>Written for commit 7eb3f851779182c105166160fe7f99d607cdb680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

