### PR TITLE
feat: growth surfaces — /invite, landing SEO + CTA, guild telemetry

### DIFF
--- a/packages/bot/src/functions/general/commands/invite.spec.ts
+++ b/packages/bot/src/functions/general/commands/invite.spec.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+const infoLog = jest.fn()
+const errorLog = jest.fn()
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog,
+    debugLog: jest.fn(),
+    errorLog,
+}))
+
+jest.mock('@lucky/shared/constants', () => ({
+    TOP_GG_VOTE_URL: 'https://top.gg/bot/962198089161134131/vote',
+    COLOR: {
+        INFO_GREEN: 0x22c55e,
+    },
+}))
+
+const interactionReply = jest.fn() as jest.MockedFunction<
+    (args: { interaction: unknown; content: unknown }) => Promise<void>
+>
+jest.mock('../../../utils/general/interactionReply.js', () => ({
+    interactionReply,
+}))
+
+import inviteCommand from './invite.js'
+
+function makeInteraction() {
+    return {
+        user: { id: 'user-123', tag: 'testuser#0000' },
+    }
+}
+
+beforeEach(() => {
+    interactionReply.mockClear().mockResolvedValue(undefined)
+    infoLog.mockClear()
+    errorLog.mockClear()
+})
+
+describe('/invite', () => {
+    test('replies with an embed containing invite URL', async () => {
+        const mockClient = {
+            application: { id: '962198089161134131' },
+            user: { id: '962198089161134131' },
+        }
+        await inviteCommand.execute({
+            client: mockClient as never,
+            interaction: makeInteraction() as never,
+        })
+
+        expect(interactionReply).toHaveBeenCalledTimes(1)
+        const callArg = interactionReply.mock.calls[0][0]
+        const args = callArg as {
+            content: { embeds?: Array<Record<string, unknown>> }
+        }
+        const embeds = args.content.embeds
+
+        expect(embeds).toBeDefined()
+        expect(embeds).toHaveLength(1)
+        const embed = embeds![0]
+
+        expect(embed.title).toBe('🔗 Add Lucky to Your Server')
+        expect(typeof embed.description).toBe('string')
+        expect(embed.description as string).toContain(
+            'https://discord.com/oauth2/authorize?',
+        )
+    })
+
+    test('includes bot application ID in invite URL', async () => {
+        const mockClient = {
+            application: { id: '962198089161134131' },
+            user: { id: '962198089161134131' },
+        }
+        await inviteCommand.execute({
+            client: mockClient as never,
+            interaction: makeInteraction() as never,
+        })
+
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { embeds?: Array<{ description: unknown }> }
+        }
+        const description = args.content.embeds?.[0]?.description as string
+
+        expect(description).toContain('client_id=962198089161134131')
+    })
+
+    test('includes vote link in embed description', async () => {
+        const mockClient = {
+            application: { id: '962198089161134131' },
+            user: { id: '962198089161134131' },
+        }
+        await inviteCommand.execute({
+            client: mockClient as never,
+            interaction: makeInteraction() as never,
+        })
+
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { embeds?: Array<{ description: unknown }> }
+        }
+        const description = args.content.embeds?.[0]?.description as string
+
+        expect(description).toContain(
+            'https://top.gg/bot/962198089161134131/vote',
+        )
+    })
+
+    test('includes required permissions in invite URL', async () => {
+        const mockClient = {
+            application: { id: '962198089161134131' },
+            user: { id: '962198089161134131' },
+        }
+        await inviteCommand.execute({
+            client: mockClient as never,
+            interaction: makeInteraction() as never,
+        })
+
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { embeds?: Array<{ description: unknown }> }
+        }
+        const description = args.content.embeds?.[0]?.description as string
+
+        expect(description).toContain('permissions=')
+        expect(description).toContain('scope=bot%20applications.commands')
+    })
+
+    test('handles missing application ID gracefully', async () => {
+        const mockClient = {
+            application: null,
+            user: null,
+        }
+        await inviteCommand.execute({
+            client: mockClient as never,
+            interaction: makeInteraction() as never,
+        })
+
+        expect(interactionReply).toHaveBeenCalledTimes(1)
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { content: string }
+        }
+
+        expect(args.content.content).toContain('Unable to generate invite link')
+    })
+
+    test('falls back to client.user.id if application.id is missing', async () => {
+        const mockClient = {
+            application: null,
+            user: { id: '962198089161134131' },
+        }
+        await inviteCommand.execute({
+            client: mockClient as never,
+            interaction: makeInteraction() as never,
+        })
+
+        expect(interactionReply).toHaveBeenCalledTimes(1)
+        const args = interactionReply.mock.calls[0][0] as {
+            content: { embeds?: Array<Record<string, unknown>> }
+        }
+        const embed = args.content.embeds?.[0]
+
+        expect(embed).toBeDefined()
+        const description = embed?.description as string
+        expect(description).toContain('client_id=962198089161134131')
+    })
+})

--- a/packages/bot/src/functions/general/commands/invite.ts
+++ b/packages/bot/src/functions/general/commands/invite.ts
@@ -1,0 +1,108 @@
+import { SlashCommandBuilder, EmbedBuilder } from '@discordjs/builders'
+import { PermissionFlagsBits } from 'discord.js'
+import Command from '../../../models/Command'
+import { infoLog, errorLog } from '@lucky/shared/utils'
+import { interactionReply } from '../../../utils/general/interactionReply'
+import { TOP_GG_VOTE_URL, COLOR } from '@lucky/shared/constants'
+
+/**
+ * Build the OAuth2 invite URL for the bot using its application ID
+ */
+function buildInviteUrl(
+    applicationId: string | undefined | null,
+): string | null {
+    if (!applicationId) return null
+
+    const permissions = [
+        PermissionFlagsBits.ViewChannel,
+        PermissionFlagsBits.SendMessages,
+        PermissionFlagsBits.EmbedLinks,
+        PermissionFlagsBits.Connect,
+        PermissionFlagsBits.Speak,
+    ]
+
+    const permissionBits = permissions.reduce((acc, perm) => acc | perm, 0n)
+    const permissionValue = permissionBits.toString()
+
+    return `https://discord.com/oauth2/authorize?client_id=${encodeURIComponent(
+        applicationId,
+    )}&permissions=${encodeURIComponent(
+        permissionValue,
+    )}&scope=bot%20applications.commands`
+}
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('invite')
+        .setDescription('🔗 Get the invite link to add Lucky to your server.'),
+    category: 'general',
+    execute: async ({ client, interaction }) => {
+        try {
+            infoLog({
+                message: `invite command requested by ${interaction.user.tag}`,
+            })
+
+            const applicationId =
+                client.application?.id || client.user?.id || null
+            const inviteUrl = buildInviteUrl(applicationId)
+
+            if (!inviteUrl) {
+                await interactionReply({
+                    interaction,
+                    content: {
+                        content:
+                            '❌ Unable to generate invite link — bot application ID not available.',
+                    },
+                })
+                return
+            }
+
+            const embed = new EmbedBuilder()
+                .setTitle('🔗 Add Lucky to Your Server')
+                .setColor(COLOR.INFO_GREEN)
+                .setDescription(
+                    [
+                        'Click the link below to add Lucky to your Discord server. Lucky will bring music, autoplay, and moderation tools to your community.',
+                        '',
+                        `[🎵 Invite Lucky](${inviteUrl})`,
+                        '',
+                        'Already have Lucky in your server? Consider supporting us:',
+                        '',
+                        `[💛 Vote for Lucky on top.gg](${TOP_GG_VOTE_URL})`,
+                    ].join('\n'),
+                )
+                .setFooter({
+                    text: 'Lucky • Music Bot',
+                })
+                .setTimestamp()
+
+            await interactionReply({
+                interaction,
+                content: { embeds: [embed.toJSON()] },
+            })
+
+            infoLog({
+                message: 'invite command: Successfully sent response',
+            })
+        } catch (error) {
+            errorLog({
+                message: 'invite command error:',
+                error,
+            })
+            try {
+                await interactionReply({
+                    interaction,
+                    content: {
+                        content:
+                            '❌ An error occurred while generating the invite link.',
+                    },
+                })
+            } catch (replyError) {
+                errorLog({
+                    message: 'Failed to send error reply for invite command:',
+                    error: replyError,
+                })
+            }
+        }
+    },
+})

--- a/packages/bot/src/handlers/eventHandler.spec.ts
+++ b/packages/bot/src/handlers/eventHandler.spec.ts
@@ -26,6 +26,8 @@ const handleReactionRolesMock = jest.fn()
 const recordGuildJoinMock = jest.fn(async () => undefined)
 const recordGuildLeaveMock = jest.fn(async () => undefined)
 const syncGuildsOnReadyMock = jest.fn(async () => undefined)
+const guildJoinsTotalIncMock = jest.fn()
+const guildLeavesTotalIncMock = jest.fn()
 
 jest.mock('../utils/general/interactionReply', () => ({
     interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
@@ -102,6 +104,15 @@ jest.mock('../services/guildMembershipService', () => ({
         syncGuildsOnReadyMock(...args),
 }))
 
+jest.mock('../utils/monitoring/prometheus', () => ({
+    guildJoinsTotal: {
+        inc: (...args: unknown[]) => guildJoinsTotalIncMock(...args),
+    },
+    guildLeavesTotal: {
+        inc: (...args: unknown[]) => guildLeavesTotalIncMock(...args),
+    },
+}))
+
 function createMockClient() {
     const onMock = jest.fn()
     const onceMock = jest.fn()
@@ -112,6 +123,9 @@ function createMockClient() {
             string,
             { execute: (...args: unknown[]) => Promise<void> }
         >(),
+        guilds: {
+            cache: { size: 0 },
+        },
     }
 
     return { client, onMock, onceMock }
@@ -318,7 +332,8 @@ describe('eventHandler', () => {
                 guildId: 'guild-123',
             }),
             content: {
-                content: 'An unexpected error occurred. Please try again later.',
+                content:
+                    'An unexpected error occurred. Please try again later.',
                 ephemeral: true,
             },
         })
@@ -603,6 +618,221 @@ describe('eventHandler', () => {
             expect(aiDevToolkitStartMock).toHaveBeenCalled()
 
             delete process.env.AI_DEV_TOOLKIT_BOARD_ENABLED
+        })
+    })
+
+    describe('guild telemetry', () => {
+        function getGuildCreateHandler(
+            onMock: jest.Mock,
+        ): ((guild: unknown) => void) | undefined {
+            const call = onMock.mock.calls.find(
+                (args) => args[0] === Events.GuildCreate,
+            )
+            return call?.[1] as ((guild: unknown) => void) | undefined
+        }
+
+        function getGuildDeleteHandler(
+            onMock: jest.Mock,
+        ): ((guild: unknown) => Promise<void>) | undefined {
+            const call = onMock.mock.calls.find(
+                (args) => args[0] === Events.GuildDelete,
+            )
+            return call?.[1] as ((guild: unknown) => Promise<void>) | undefined
+        }
+
+        describe('handleGuildCreate', () => {
+            it('logs guild join with telemetry data', () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = {
+                    cache: { size: 42 },
+                } as any
+
+                handleEvents(client as unknown as never)
+
+                const handler = getGuildCreateHandler(onMock)
+                expect(handler).toBeDefined()
+
+                handler?.({
+                    id: 'guild-123',
+                    name: 'Test Guild',
+                    memberCount: 500,
+                })
+
+                expect(infoLogMock).toHaveBeenCalledWith({
+                    message: 'Guild joined',
+                    data: {
+                        guildId: 'guild-123',
+                        guildName: 'Test Guild',
+                        memberCount: 500,
+                        totalGuilds: 42,
+                    },
+                })
+            })
+
+            it('increments guild joins counter', () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = {
+                    cache: { size: 10 },
+                } as any
+
+                handleEvents(client as unknown as never)
+
+                const handler = getGuildCreateHandler(onMock)
+                handler?.({
+                    id: 'new-guild',
+                    name: 'New Guild',
+                    memberCount: 100,
+                })
+
+                expect(guildJoinsTotalIncMock).toHaveBeenCalledTimes(1)
+            })
+
+            it('records guild join in the database', async () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = {
+                    cache: { size: 1 },
+                } as any
+                recordGuildJoinMock.mockResolvedValue(undefined)
+
+                handleEvents(client as unknown as never)
+
+                const handler = getGuildCreateHandler(onMock)
+                handler?.({
+                    id: 'db-test-guild',
+                    name: 'DB Test Guild',
+                    memberCount: 250,
+                })
+
+                await new Promise<void>((resolve) => setImmediate(resolve))
+
+                expect(recordGuildJoinMock).toHaveBeenCalledWith({
+                    id: 'db-test-guild',
+                    name: 'DB Test Guild',
+                    memberCount: 250,
+                })
+            })
+
+            it('logs error if recording guild join fails', async () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = {
+                    cache: { size: 1 },
+                } as any
+                const dbError = new Error('Database error')
+                recordGuildJoinMock.mockRejectedValueOnce(dbError)
+
+                handleEvents(client as unknown as never)
+
+                const handler = getGuildCreateHandler(onMock)
+                handler?.({
+                    id: 'error-guild',
+                    name: 'Error Guild',
+                    memberCount: 50,
+                })
+
+                await new Promise<void>((resolve) => setImmediate(resolve))
+
+                expect(errorLogMock).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: 'Error recording guild join',
+                        error: dbError,
+                    }),
+                )
+            })
+        })
+
+        describe('handleGuildDelete', () => {
+            it('logs guild leave with telemetry data', async () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = {
+                    cache: { size: 41 },
+                } as any
+
+                handleEvents(client as unknown as never)
+
+                const handler = getGuildDeleteHandler(onMock)
+                expect(handler).toBeDefined()
+
+                await handler?.({
+                    id: 'guild-456',
+                    name: 'Departing Guild',
+                    memberCount: 300,
+                })
+
+                expect(infoLogMock).toHaveBeenCalledWith({
+                    message: 'Guild left',
+                    data: {
+                        guildId: 'guild-456',
+                        guildName: 'Departing Guild',
+                        memberCount: 300,
+                        totalGuilds: 41,
+                    },
+                })
+            })
+
+            it('increments guild leaves counter', async () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = {
+                    cache: { size: 5 },
+                } as any
+
+                handleEvents(client as unknown as never)
+
+                const handler = getGuildDeleteHandler(onMock)
+                await handler?.({
+                    id: 'remove-guild',
+                    name: 'Remove Guild',
+                    memberCount: 100,
+                })
+
+                expect(guildLeavesTotalIncMock).toHaveBeenCalledTimes(1)
+            })
+
+            it('records guild leave in the database', async () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = {
+                    cache: { size: 0 },
+                } as any
+                recordGuildLeaveMock.mockResolvedValue(undefined)
+
+                handleEvents(client as unknown as never)
+
+                const handler = getGuildDeleteHandler(onMock)
+                await handler?.({
+                    id: 'db-leave-guild',
+                    name: 'DB Leave Guild',
+                    memberCount: 75,
+                })
+
+                expect(recordGuildLeaveMock).toHaveBeenCalledWith(
+                    'db-leave-guild',
+                    'DB Leave Guild',
+                )
+            })
+
+            it('logs error if recording guild leave fails', async () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = {
+                    cache: { size: 1 },
+                } as any
+                const dbError = new Error('Database connection lost')
+                recordGuildLeaveMock.mockRejectedValueOnce(dbError)
+
+                handleEvents(client as unknown as never)
+
+                const handler = getGuildDeleteHandler(onMock)
+                await handler?.({
+                    id: 'error-leave-guild',
+                    name: 'Error Leave Guild',
+                    memberCount: 25,
+                })
+
+                expect(errorLogMock).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: 'Error recording guild leave',
+                        error: dbError,
+                    }),
+                )
+            })
         })
     })
 })

--- a/packages/bot/src/handlers/eventHandler.ts
+++ b/packages/bot/src/handlers/eventHandler.ts
@@ -28,6 +28,10 @@ import {
     recordGuildLeave,
     syncGuildsOnReady,
 } from '../services/guildMembershipService'
+import {
+    guildJoinsTotal,
+    guildLeavesTotal,
+} from '../utils/monitoring/prometheus'
 
 function handleClientReady(client: Client): void {
     client.once('clientReady', () => {
@@ -54,10 +58,17 @@ function handleClientReady(client: Client): void {
 
 function handleGuildCreate(client: Client): void {
     client.on(Events.GuildCreate, (guild) => {
+        const totalGuilds = client.guilds.cache.size
         infoLog({
-            message: 'Joined guild',
-            data: { guildId: guild.id, name: guild.name },
+            message: 'Guild joined',
+            data: {
+                guildId: guild.id,
+                guildName: guild.name,
+                memberCount: guild.memberCount,
+                totalGuilds,
+            },
         })
+        guildJoinsTotal.inc()
         recordGuildJoin(guild).catch((error) => {
             errorLog({
                 message: 'Error recording guild join',
@@ -228,10 +239,17 @@ function handleDebug(client: Client): void {
 
 function handleGuildDelete(client: Client): void {
     client.on(Events.GuildDelete, async (guild) => {
+        const totalGuilds = client.guilds.cache.size
         infoLog({
-            message: 'Left guild',
-            data: { guildId: guild.id, name: guild.name },
+            message: 'Guild left',
+            data: {
+                guildId: guild.id,
+                guildName: guild.name,
+                memberCount: guild.memberCount,
+                totalGuilds,
+            },
         })
+        guildLeavesTotal.inc()
         await recordGuildLeave(guild.id, guild.name).catch((error) => {
             errorLog({
                 message: 'Error recording guild leave',

--- a/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.spec.ts
@@ -330,6 +330,68 @@ describe('trackNowPlaying handlers', () => {
             )
             expect(hasWhyField).toBe(false)
         })
+
+        it('appends /invite CTA to footer for non-autoplay tracks', async () => {
+            mockChannel.send = jest.fn().mockResolvedValueOnce({
+                id: 'msg-123',
+                react: jest.fn().mockResolvedValue(undefined),
+            })
+
+            const userTrack = {
+                ...mockTrack,
+                requestedBy: { id: 'user-123', username: 'TestUser' },
+                metadata: {},
+            } as unknown as Track
+
+            await sendNowPlayingEmbed(mockQueue, userTrack, false)
+
+            const embedCall = createEmbedMock.mock.calls[0][0]
+            expect(embedCall.footer).toContain('/invite to add Lucky')
+            expect(embedCall.footer).toContain('TestUser')
+        })
+
+        it('appends /invite CTA to autoplay footer', async () => {
+            getAutoplayCountMock.mockResolvedValueOnce(5)
+            mockChannel.send = jest.fn().mockResolvedValueOnce({
+                id: 'msg-123',
+                react: jest.fn().mockResolvedValue(undefined),
+            })
+
+            const autoplayTrack = {
+                ...mockTrack,
+                requestedBy: undefined,
+                metadata: {},
+            } as unknown as Track
+
+            await sendNowPlayingEmbed(mockQueue, autoplayTrack, true)
+
+            const embedCall = createEmbedMock.mock.calls[0][0]
+            expect(embedCall.footer).toContain('Autoplay')
+            expect(embedCall.footer).toContain('/invite to add Lucky')
+            expect(embedCall.footer).toContain('5/50')
+        })
+
+        it('does not duplicate /invite CTA if already present in footer', async () => {
+            mockChannel.send = jest.fn().mockResolvedValueOnce({
+                id: 'msg-123',
+                react: jest.fn().mockResolvedValue(undefined),
+            })
+
+            const userTrack = {
+                ...mockTrack,
+                requestedBy: { id: 'user-123', username: 'TestUser' },
+                metadata: {},
+            } as unknown as Track
+
+            await sendNowPlayingEmbed(mockQueue, userTrack, false)
+
+            const embedCall = createEmbedMock.mock.calls[0][0]
+            const footer = embedCall.footer
+
+            // Count occurrences of '/invite' in footer
+            const inviteCount = (footer.match(/\/invite/g) || []).length
+            expect(inviteCount).toBe(1)
+        })
     })
 
     describe('updateLastFmNowPlaying', () => {

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -192,9 +192,13 @@ export async function sendNowPlayingEmbed(
     const autoplayCount = isAutoplay
         ? await getAutoplayCount(queue.guild.id)
         : null
-    const footer = isAutoplay
+    const baseFooter = isAutoplay
         ? `Autoplay • ${autoplayCount ?? 0}/${constants.MAX_AUTOPLAY_TRACKS ?? 50} songs`
         : requesterInfo
+    const footer =
+        baseFooter && !baseFooter.includes('/invite')
+            ? `${baseFooter} • /invite to add Lucky`
+            : baseFooter
 
     const fields = [
         {
@@ -297,7 +301,12 @@ export async function sendNowPlayingEmbed(
         })
     }
 
-    registerNowPlayingMessage(queue.guild.id, message.id, metadata.channel.id, track.url)
+    registerNowPlayingMessage(
+        queue.guild.id,
+        message.id,
+        metadata.channel.id,
+        track.url,
+    )
 
     debugLog({
         message: 'Sent now playing message to channel',

--- a/packages/bot/src/utils/monitoring/prometheus.ts
+++ b/packages/bot/src/utils/monitoring/prometheus.ts
@@ -64,6 +64,26 @@ export const guildAutomationUsageTotal = new Counter<'operation'>({
 })
 
 /**
+ * Counter: Bot guild joins (GuildCreate events).
+ * Incremented each time the bot is added to a guild.
+ */
+export const guildJoinsTotal = new Counter({
+    name: 'lucky_bot_guild_joins_total',
+    help: 'Total count of Discord guilds the bot has been added to.',
+    registers: [registry],
+})
+
+/**
+ * Counter: Bot guild leaves (GuildDelete events).
+ * Incremented each time the bot is removed from a guild.
+ */
+export const guildLeavesTotal = new Counter({
+    name: 'lucky_bot_guild_leaves_total',
+    help: 'Total count of Discord guilds the bot has been removed from.',
+    registers: [registry],
+})
+
+/**
  * Render the registry as Prometheus text exposition format.
  */
 export async function renderMetrics(): Promise<string> {

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -4,21 +4,21 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Lucky — Discord Bot with Music, Moderation & Dashboard</title>
-    <meta name="description" content="The all-in-one Discord bot for your community. Music, moderation, custom commands, auto-mod, and a full web dashboard. Free forever." />
+    <title>Lucky — Free Discord music bot with autoplay & dashboard</title>
+    <meta name="description" content="YouTube, Spotify, SoundCloud music bot with genre-aware autoplay, smart radio, moderation, and web dashboard. Open-source, self-hostable, free forever." />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Lucky — Discord Bot with Music, Moderation & Dashboard" />
-    <meta property="og:description" content="The all-in-one Discord bot for your community. Music, moderation, custom commands, auto-mod, and a full web dashboard. Free forever." />
+    <meta property="og:title" content="Lucky — Free Discord music bot with autoplay & dashboard" />
+    <meta property="og:description" content="YouTube, Spotify, SoundCloud music bot with genre-aware autoplay, smart radio, moderation, and web dashboard. Open-source, self-hostable, free forever." />
     <meta property="og:image" content="https://lucky.lucassantana.tech/og-image.png" />
     <meta property="og:url" content="https://lucky.lucassantana.tech" />
     <!-- canonical + per-route SEO head are injected at build time by scripts/prerender-seo.ts -->
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Lucky — Discord Bot with Music, Moderation & Dashboard" />
-    <meta name="twitter:description" content="The all-in-one Discord bot for your community. Music, moderation, custom commands, auto-mod, and a full web dashboard. Free forever." />
+    <meta name="twitter:title" content="Lucky — Free Discord music bot with autoplay & dashboard" />
+    <meta name="twitter:description" content="YouTube, Spotify, SoundCloud music bot with genre-aware autoplay, smart radio, moderation, and web dashboard. Open-source, self-hostable, free forever." />
     <meta name="twitter:image" content="https://lucky.lucassantana.tech/og-image.png" />
 
     <!-- JSON-LD Schema -->

--- a/packages/frontend/src/lib/seo/routeMeta.ts
+++ b/packages/frontend/src/lib/seo/routeMeta.ts
@@ -36,9 +36,9 @@ export interface RouteMeta {
 export const PUBLIC_ROUTES: RouteMeta[] = [
     {
         path: '/',
-        title: 'Lucky — A Discord bot you can actually self-host',
+        title: 'Lucky — Free Discord music bot with autoplay & dashboard',
         description:
-            'Open-source Discord bot with music, moderation, custom commands, and a web dashboard. Free forever. Run it on your own box.',
+            'YouTube, Spotify, SoundCloud music bot with genre-aware autoplay, smart radio, moderation, and web dashboard. Open-source, self-hostable, free forever.',
     },
     {
         path: '/docs',

--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -167,8 +167,8 @@
     },
     "landing": {
         "meta": {
-            "title": "Lucky — A Discord bot you can actually self-host",
-            "description": "Open-source Discord bot with music, moderation, custom commands, and a web dashboard. Free forever. Run it on your own box."
+            "title": "Lucky — Free Discord music bot with autoplay & dashboard",
+            "description": "YouTube, Spotify, SoundCloud music bot with genre-aware autoplay, smart radio, moderation, and web dashboard. Open-source, self-hostable, free forever."
         },
         "hero": {
             "eyebrow": "Open source · Apache 2.0",

--- a/packages/frontend/src/pages/Landing.test.tsx
+++ b/packages/frontend/src/pages/Landing.test.tsx
@@ -68,13 +68,16 @@ describe('Landing', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         setupMocks()
+        // Mock the Discord client ID env var for tests
+        ;(import.meta.env as Record<string, unknown>).VITE_DISCORD_CLIENT_ID =
+            '962198089161134131'
     })
 
     test('sets page metadata on mount', () => {
         render(<Landing />)
         expect(usePageMetadata).toHaveBeenCalledWith({
-            title: expect.stringMatching(/self-host/i),
-            description: expect.stringMatching(/open-source/i),
+            title: expect.stringMatching(/discord music bot/i),
+            description: expect.stringMatching(/autoplay/i),
         })
     })
 
@@ -102,7 +105,7 @@ describe('Landing', () => {
         expect(screen.getByText(/And yours to run\./i)).toBeInTheDocument()
     })
 
-    test('renders Add to Discord primary CTA in hero and nav', () => {
+    test('renders Add to Discord primary CTA in hero and nav when invite URL is set', () => {
         render(<Landing />)
         const inviteLinks = screen.getAllByRole('link', {
             name: /Add to Discord/i,
@@ -116,6 +119,25 @@ describe('Landing', () => {
             expect(link).toHaveAttribute('target', '_blank')
             expect(link).toHaveAttribute('rel', 'noopener noreferrer')
         })
+    })
+
+    test('renders disabled Add to Discord buttons when env var not set', () => {
+        const originalEnv = { ...import.meta.env }
+        ;(import.meta.env as Record<string, unknown>).VITE_DISCORD_CLIENT_ID =
+            ''
+        try {
+            render(<Landing />)
+            // Check that disabled buttons are rendered when env is not set
+            const disabledButtons = screen.getAllByRole('button', {
+                name: /Add to Discord \(not configured\)/i,
+            })
+            expect(disabledButtons.length).toBeGreaterThanOrEqual(2)
+            disabledButtons.forEach((btn) => {
+                expect(btn).toBeDisabled()
+            })
+        } finally {
+            Object.assign(import.meta.env, originalEnv)
+        }
     })
 
     test('renders Self-host on GitHub secondary CTA in hero', () => {

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -45,10 +45,20 @@ function GithubMark({
     )
 }
 
-const CLIENT_ID = '962198089161134131'
-const BOT_INVITE_URL = `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot%20applications.commands&permissions=8`
 const REPO_URL = 'https://github.com/LucasSantana-Dev/Lucky'
 const CLONE_URL = 'https://github.com/LucasSantana-Dev/Lucky.git'
+
+// Minimal permission set (View Channels, Send Messages, Embed Links, Connect,
+// Speak) — matches the /invite command. NOT Administrator: requesting only what
+// the bot needs is safer and converts better with server admins.
+const BOT_INVITE_PERMISSIONS = '3165184'
+
+function getBotInviteUrl(): string {
+    const clientId = import.meta.env.VITE_DISCORD_CLIENT_ID || ''
+    return clientId
+        ? `https://discord.com/oauth2/authorize?client_id=${clientId}&scope=bot%20applications.commands&permissions=${BOT_INVITE_PERMISSIONS}`
+        : ''
+}
 
 type RepoStats = {
     servers: number
@@ -118,6 +128,7 @@ export default function Landing() {
 }
 
 function TopNav({ onOpenDashboard }: { onOpenDashboard: () => void }) {
+    const botInviteUrl = getBotInviteUrl()
     return (
         <header className='sticky top-0 z-30 border-b border-lucky-border-soft bg-lucky-surface-canvas/85 backdrop-blur supports-[backdrop-filter]:bg-lucky-surface-canvas/65'>
             <div className='mx-auto flex h-14 max-w-6xl items-center justify-between px-4 md:px-8'>
@@ -158,14 +169,26 @@ function TopNav({ onOpenDashboard }: { onOpenDashboard: () => void }) {
                     >
                         dashboard
                     </button>
-                    <a
-                        href={BOT_INVITE_URL}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                        className='ml-1 inline-flex items-center gap-1 rounded-md bg-lucky-brand px-3 py-1.5 font-semibold text-white hover:bg-lucky-brand-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas'
-                    >
-                        add to discord <ArrowUpRight size={12} aria-hidden />
-                    </a>
+                    {botInviteUrl ? (
+                        <a
+                            href={botInviteUrl}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            className='ml-1 inline-flex items-center gap-1 rounded-md bg-lucky-brand px-3 py-1.5 font-semibold text-white hover:bg-lucky-brand-strong transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas'
+                        >
+                            add to discord{' '}
+                            <ArrowUpRight size={12} aria-hidden />
+                        </a>
+                    ) : (
+                        <button
+                            disabled
+                            className='ml-1 inline-flex items-center gap-1 rounded-md bg-lucky-border-soft px-3 py-1.5 font-semibold text-lucky-text-muted cursor-not-allowed opacity-50'
+                            aria-label='Add to Discord (not configured)'
+                        >
+                            add to discord{' '}
+                            <ArrowUpRight size={12} aria-hidden />
+                        </button>
+                    )}
                 </nav>
             </div>
         </header>
@@ -180,6 +203,7 @@ type HeroProps = {
 function Hero({ stats, prefersReducedMotion }: HeroProps) {
     const { t, i18n } = useTranslation()
     const locale = i18n.resolvedLanguage ?? i18n.language
+    const botInviteUrl = getBotInviteUrl()
 
     const animProps = prefersReducedMotion
         ? {}
@@ -236,19 +260,34 @@ function Hero({ stats, prefersReducedMotion }: HeroProps) {
                         {t('landing.hero.subtitle')}
                     </p>
                     <div className='flex flex-col gap-2.5 sm:flex-row sm:items-center'>
-                        <a
-                            href={BOT_INVITE_URL}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            className='group inline-flex h-11 items-center justify-center gap-2 rounded-md bg-lucky-brand px-5 font-semibold text-white shadow-[0_6px_24px_-8px_rgba(236,72,153,0.55)] hover:bg-lucky-brand-strong transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
-                        >
-                            {t('landing.hero.ctaPrimary')}
-                            <ArrowUpRight
-                                size={15}
-                                className='transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5'
-                                aria-hidden
-                            />
-                        </a>
+                        {botInviteUrl ? (
+                            <a
+                                href={botInviteUrl}
+                                target='_blank'
+                                rel='noopener noreferrer'
+                                className='group inline-flex h-11 items-center justify-center gap-2 rounded-md bg-lucky-brand px-5 font-semibold text-white shadow-[0_6px_24px_-8px_rgba(236,72,153,0.55)] hover:bg-lucky-brand-strong transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lucky-brand focus-visible:ring-offset-2 focus-visible:ring-offset-lucky-surface-canvas active:scale-[0.98]'
+                            >
+                                {t('landing.hero.ctaPrimary')}
+                                <ArrowUpRight
+                                    size={15}
+                                    className='transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5'
+                                    aria-hidden
+                                />
+                            </a>
+                        ) : (
+                            <button
+                                disabled
+                                className='inline-flex h-11 items-center justify-center gap-2 rounded-md bg-lucky-border-soft px-5 font-semibold text-lucky-text-muted cursor-not-allowed opacity-50 shadow-[0_6px_24px_-8px_rgba(236,72,153,0.0)]'
+                                aria-label='Add to Discord (not configured)'
+                            >
+                                {t('landing.hero.ctaPrimary')}
+                                <ArrowUpRight
+                                    size={15}
+                                    className='transition-transform'
+                                    aria-hidden
+                                />
+                            </button>
+                        )}
                         <a
                             href={REPO_URL}
                             target='_blank'


### PR DESCRIPTION
## What
Three low-risk, additive **growth surfaces** for Lucky (from the "how do we get more users" discussion). Discoverability × measurement, no behavior changes to existing flows.

### 1. `/invite` command + Now-Playing CTA (`packages/bot`)
- New `/invite` slash command: builds the OAuth2 invite URL **at runtime from the app id** (no hardcoded client ID), minimal non-admin permission set (View Channels, Send Messages, Embed Links, Connect, Speak), and reuses `TOP_GG_VOTE_URL`.
- Unobtrusive ` • /invite to add Lucky` appended to the Now-Playing embed footer (guarded: only when a footer exists and not already present) — turns every server Lucky's in into a discovery surface.

### 2. Landing SEO + "Add to Discord" CTA (`packages/frontend`)
- Title/description/OG/Twitter meta targeting real demand ("free Discord music bot", YouTube/autoplay), wired through the existing **build-time prerender** source of truth (`routeMeta.ts` + `index.html`).
- Prominent "Add to Discord" CTA (nav + hero) linking the invite URL, built from `VITE_DISCORD_CLIENT_ID`; **disabled fallback** when the env var is unset. Permissions match the `/invite` command (minimal, **not** Administrator).

### 3. Guild growth telemetry (`packages/bot`)
- `guildCreate`/`guildDelete` handlers (augmented existing ones) emit structured INFO logs (`Guild joined`/`Guild left` + `{guildId, guildName, memberCount, totalGuilds}`) → Loki, and increment label-free Prometheus counters `lucky_bot_guild_joins_total` / `lucky_bot_guild_leaves_total`.
- **Scope note:** measures growth *rate* (joins/leaves/net), **not** invite-source attribution — Discord doesn't reliably expose where an add originated.

## Tests / gates
- Bot: `/invite` 6 tests, footer 3 tests, guild-telemetry 8 tests — all green; type-check + eslint clean.
- Frontend: 22 Landing tests green; prerender build verified; type-check + eslint clean.

## ⚠️ Operator follow-up (one env var)
Set **`VITE_DISCORD_CLIENT_ID`** in the frontend deploy env (Vercel) so the landing CTA activates — it's a public client ID, not a secret. Until set, the CTA renders disabled (safe).

Built via subagent-driven-development (implement → spec review → quality review per task; an Administrator-permissions slip on the landing CTA was caught and fixed in review).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three low-risk growth surfaces: a new /invite flow, landing page SEO + “Add to Discord” CTA, and guild join/leave telemetry. Improves discovery and lets us measure growth without changing existing flows.

- New Features
  - `packages/bot`: New `/invite` command builds the OAuth2 invite URL at runtime from the bot application ID with minimal permissions (View Channels, Send Messages, Embed Links, Connect, Speak). Now-Playing footer appends “• /invite to add Lucky” when not already present.
  - `packages/frontend`: Updated landing SEO title/description targeting “Discord music bot” and autoplay. Added “Add to Discord” CTA in nav and hero using `VITE_DISCORD_CLIENT_ID`; disabled fallback when unset. Permissions match the `/invite` command (not Administrator).
  - `packages/bot`: `guildCreate`/`guildDelete` emit structured INFO logs (guildId, guildName, memberCount, totalGuilds) and increment Prometheus counters `lucky_bot_guild_joins_total` and `lucky_bot_guild_leaves_total`.

- Migration
  - Set `VITE_DISCORD_CLIENT_ID` in the frontend deploy so the “Add to Discord” buttons are enabled.

<sup>Written for commit 9f50cdec777e4a5144a62d45db42f555c606e2ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

