### PR TITLE
fix(frontend): default add-to-discord cta to public application id

### DIFF
--- a/packages/frontend/src/pages/Landing.test.tsx
+++ b/packages/frontend/src/pages/Landing.test.tsx
@@ -121,19 +121,23 @@ describe('Landing', () => {
         })
     })
 
-    test('renders disabled Add to Discord buttons when env var not set', () => {
+    test('falls back to the public default client id when env var not set', () => {
         const originalEnv = { ...import.meta.env }
         ;(import.meta.env as Record<string, unknown>).VITE_DISCORD_CLIENT_ID =
             ''
         try {
             render(<Landing />)
-            // Check that disabled buttons are rendered when env is not set
-            const disabledButtons = screen.getAllByRole('button', {
-                name: /Add to Discord \(not configured\)/i,
+            // With no env override, the CTA stays enabled and links to the
+            // bundled public Application ID — no operator config required.
+            const inviteLinks = screen.getAllByRole('link', {
+                name: /Add to Discord/i,
             })
-            expect(disabledButtons.length).toBeGreaterThanOrEqual(2)
-            disabledButtons.forEach((btn) => {
-                expect(btn).toBeDisabled()
+            expect(inviteLinks.length).toBeGreaterThanOrEqual(2)
+            inviteLinks.forEach((link) => {
+                expect(link).toHaveAttribute(
+                    'href',
+                    expect.stringContaining('client_id=962198089161134131'),
+                )
             })
         } finally {
             Object.assign(import.meta.env, originalEnv)

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -53,8 +53,14 @@ const CLONE_URL = 'https://github.com/LucasSantana-Dev/Lucky.git'
 // the bot needs is safer and converts better with server admins.
 const BOT_INVITE_PERMISSIONS = '3165184'
 
+// Public Discord Application ID (a.k.a. client_id). Safe to ship: it appears in
+// every OAuth invite link and is not a secret. Used as the default so the CTA
+// works out of the box; override via VITE_DISCORD_CLIENT_ID for a fork.
+const DEFAULT_DISCORD_CLIENT_ID = '962198089161134131'
+
 function getBotInviteUrl(): string {
-    const clientId = import.meta.env.VITE_DISCORD_CLIENT_ID || ''
+    const clientId =
+        import.meta.env.VITE_DISCORD_CLIENT_ID || DEFAULT_DISCORD_CLIENT_ID
     return clientId
         ? `https://discord.com/oauth2/authorize?client_id=${clientId}&scope=bot%20applications.commands&permissions=${BOT_INVITE_PERMISSIONS}`
         : ''


### PR DESCRIPTION
## What
Follow-up to #1494. The landing "Add to Discord" CTA was disabled until an operator set `VITE_DISCORD_CLIENT_ID` in the deploy env. Since the bot's **Application/client ID is public** (`962198089161134131` — it appears in every OAuth invite link, not a secret), bundle it as the **default** so the CTA works out of the box.

- `VITE_DISCORD_CLIENT_ID` still **overrides** the default (for forks/self-hosters).
- Removes the operator must-set-an-env-var follow-up from #1494.
- Permissions unchanged (minimal set, matches the `/invite` command — not Administrator).

## Tests
Flipped the "disabled when env unset" test → asserts the CTA stays enabled and links to the default client id when no env override is set. 22/22 Landing tests pass; type-check + eslint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted the landing “Add to Discord” CTA to the public Discord Application ID (`962198089161134131`) so it works without any env setup. `VITE_DISCORD_CLIENT_ID` still overrides for forks; permissions unchanged.

<sup>Written for commit 0a9ef42c06ad836032f0c352c8599dc179b22278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

