### PR TITLE
fix(bot): graceful bot-permission guard + moderation pilot (#1498)

### DIFF
--- a/packages/bot/src/functions/moderation/commands/ban.ts
+++ b/packages/bot/src/functions/moderation/commands/ban.ts
@@ -46,6 +46,7 @@ export default new Command({
                 .setRequired(false),
         ),
     category: 'moderation',
+    botPermissions: [PermissionFlagsBits.BanMembers],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {
             await interactionReply({

--- a/packages/bot/src/functions/moderation/commands/kick.ts
+++ b/packages/bot/src/functions/moderation/commands/kick.ts
@@ -32,6 +32,7 @@ export default new Command({
                 .setRequired(false),
         ),
     category: 'moderation',
+    botPermissions: [PermissionFlagsBits.KickMembers],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {
             await interactionReply({

--- a/packages/bot/src/functions/moderation/commands/lockdown.ts
+++ b/packages/bot/src/functions/moderation/commands/lockdown.ts
@@ -28,6 +28,7 @@ export default new Command({
                 .setRequired(false),
         ),
     category: 'moderation',
+    botPermissions: [PermissionFlagsBits.ManageChannels],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {
             await interactionReply({

--- a/packages/bot/src/functions/moderation/commands/mute.ts
+++ b/packages/bot/src/functions/moderation/commands/mute.ts
@@ -47,6 +47,7 @@ export default new Command({
                 .setRequired(false),
         ),
     category: 'moderation',
+    botPermissions: [PermissionFlagsBits.ModerateMembers],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {
             await interactionReply({

--- a/packages/bot/src/functions/moderation/commands/unmute.ts
+++ b/packages/bot/src/functions/moderation/commands/unmute.ts
@@ -26,6 +26,7 @@ export default new Command({
                 .setRequired(false),
         ),
     category: 'moderation',
+    botPermissions: [PermissionFlagsBits.ModerateMembers],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {
             await interactionReply({

--- a/packages/bot/src/handlers/commandsHandler.spec.ts
+++ b/packages/bot/src/handlers/commandsHandler.spec.ts
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals'
-import { Collection } from 'discord.js'
+import {
+    Collection,
+    PermissionFlagsBits,
+    PermissionsBitField,
+} from 'discord.js'
 import type { ChatInputCommandInteraction } from 'discord.js'
 import { executeCommand, setCommands, groupCommands } from './commandsHandler'
 import type { CustomClient } from '../types'
@@ -183,6 +187,135 @@ describe('commandsHandler', () => {
                     context: 'command-execution-failure',
                 }),
             )
+        })
+
+        it('should check bot permissions and block command if missing', async () => {
+            const command = createMockCommand({
+                botPermissions: [PermissionFlagsBits.BanMembers],
+            })
+            const interaction = createMockInteraction({
+                appPermissions: new PermissionsBitField(),
+            })
+            const client = createMockClient()
+            client.commands.set('test', command)
+
+            await executeCommand({ interaction, client })
+
+            expect(interactionReply).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    content: expect.stringContaining('missing'),
+                    ephemeral: true,
+                },
+            })
+            expect(command.execute).not.toHaveBeenCalled()
+        })
+
+        it('should allow command if bot has required permissions', async () => {
+            const command = createMockCommand({
+                botPermissions: [PermissionFlagsBits.BanMembers],
+            })
+            const interaction = createMockInteraction({
+                appPermissions: new PermissionsBitField(
+                    PermissionFlagsBits.BanMembers,
+                ),
+            })
+            const client = createMockClient()
+            client.commands.set('test', command)
+
+            await executeCommand({ interaction, client })
+
+            expect(command.execute).toHaveBeenCalledWith({
+                interaction,
+                client,
+            })
+            expect(interactionReply).not.toHaveBeenCalled()
+        })
+
+        it('should allow command without botPermissions check', async () => {
+            const command = createMockCommand({ botPermissions: undefined })
+            const interaction = createMockInteraction({
+                appPermissions: new PermissionsBitField(),
+            })
+            const client = createMockClient()
+            client.commands.set('test', command)
+
+            await executeCommand({ interaction, client })
+
+            expect(command.execute).toHaveBeenCalledWith({
+                interaction,
+                client,
+            })
+        })
+
+        it('should handle null appPermissions defensively', async () => {
+            const command = createMockCommand({
+                botPermissions: [PermissionFlagsBits.BanMembers],
+            })
+            const interaction = createMockInteraction({
+                appPermissions: null,
+            })
+            const client = createMockClient()
+            client.commands.set('test', command)
+
+            await executeCommand({ interaction, client })
+
+            expect(interactionReply).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    content: expect.stringContaining('missing'),
+                    ephemeral: true,
+                },
+            })
+            expect(command.execute).not.toHaveBeenCalled()
+        })
+
+        it('should check multiple bot permissions and block if any missing', async () => {
+            const command = createMockCommand({
+                botPermissions: [
+                    PermissionFlagsBits.BanMembers,
+                    PermissionFlagsBits.KickMembers,
+                ],
+            })
+            const interaction = createMockInteraction({
+                appPermissions: new PermissionsBitField(
+                    PermissionFlagsBits.BanMembers,
+                ),
+            })
+            const client = createMockClient()
+            client.commands.set('test', command)
+
+            await executeCommand({ interaction, client })
+
+            expect(interactionReply).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    content: expect.stringContaining('missing'),
+                    ephemeral: true,
+                },
+            })
+            expect(command.execute).not.toHaveBeenCalled()
+        })
+
+        it('should include permission names in the reply message', async () => {
+            const command = createMockCommand({
+                botPermissions: [PermissionFlagsBits.BanMembers],
+            })
+            const interaction = createMockInteraction({
+                appPermissions: new PermissionsBitField(),
+            })
+            const client = createMockClient()
+            client.commands.set('test', command)
+
+            await executeCommand({ interaction, client })
+
+            expect(interactionReply).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    content: expect.stringContaining('BanMembers'),
+                    ephemeral: true,
+                },
+            })
         })
     })
 

--- a/packages/bot/src/handlers/commandsHandler.ts
+++ b/packages/bot/src/handlers/commandsHandler.ts
@@ -88,6 +88,9 @@ export const executeCommand = async ({
                     missingPerms.reduce((acc, perm) => acc | perm, 0n),
                 ).toArray()
                 const readablePerm = permissionNames.join(', ')
+                const isPlural = permissionNames.length > 1
+                const permNoun = isPlural ? 'permissions' : 'permission'
+                const grantPronoun = isPlural ? 'them' : 'it'
 
                 debugLog({
                     message: `Command ${interaction.commandName} missing permissions: ${readablePerm}`,
@@ -96,7 +99,7 @@ export const executeCommand = async ({
                 await interactionReply({
                     interaction,
                     content: {
-                        content: `I'm missing the **${readablePerm}** permission — ask an admin to grant it or re-invite me.`,
+                        content: `I'm missing the **${readablePerm}** ${permNoun} — ask an admin to grant ${grantPronoun} or re-invite me.`,
                         ephemeral: true,
                     },
                 })

--- a/packages/bot/src/handlers/commandsHandler.ts
+++ b/packages/bot/src/handlers/commandsHandler.ts
@@ -1,4 +1,8 @@
-import { Collection, type ChatInputCommandInteraction } from 'discord.js'
+import {
+    Collection,
+    type ChatInputCommandInteraction,
+    PermissionsBitField,
+} from 'discord.js'
 import { errorLog, debugLog, captureException } from '@lucky/shared/utils'
 import { featureToggleService } from '@lucky/shared/services'
 import type { FeatureToggleName } from '@lucky/shared/types'
@@ -62,6 +66,37 @@ export const executeCommand = async ({
                     interaction,
                     content: {
                         content: 'This feature is currently disabled.',
+                        ephemeral: true,
+                    },
+                })
+                return
+            }
+        }
+
+        if (command.botPermissions?.length) {
+            const appPermissions = interaction.appPermissions
+            const missingPerms: bigint[] = []
+
+            for (const perm of command.botPermissions) {
+                if (!appPermissions?.has(perm)) {
+                    missingPerms.push(perm)
+                }
+            }
+
+            if (missingPerms.length > 0) {
+                const permissionNames = new PermissionsBitField(
+                    missingPerms.reduce((acc, perm) => acc | perm, 0n),
+                ).toArray()
+                const readablePerm = permissionNames.join(', ')
+
+                debugLog({
+                    message: `Command ${interaction.commandName} missing permissions: ${readablePerm}`,
+                })
+
+                await interactionReply({
+                    interaction,
+                    content: {
+                        content: `I'm missing the **${readablePerm}** permission — ask an admin to grant it or re-invite me.`,
                         ephemeral: true,
                     },
                 })

--- a/packages/bot/src/models/Command.ts
+++ b/packages/bot/src/models/Command.ts
@@ -5,16 +5,19 @@ type CommandOptions = {
     data: TCommandData
     execute: TCommandExecute
     category: CommandCategory
+    botPermissions?: bigint[]
 }
 
 export default class Command {
     data: TCommandData
     execute: TCommandExecute
     category: CommandCategory
+    botPermissions?: bigint[]
 
     constructor(options: CommandOptions) {
         this.data = options.data
         this.execute = options.execute
         this.category = options.category
+        this.botPermissions = options.botPermissions
     }
 }


### PR DESCRIPTION
## What
Graceful bot-permission guard (ADR `decisions/2026-06-18-invite-permission-scope.md`, prereq for the curated-invite change). Fixes the latent bug where privileged commands threw a raw `DiscordAPIError[50013] Missing Permissions` to the user when the **bot** lacked the perm (0 bot-perm checks existed).

## How — declarative + central
- `Command` model gains an optional `botPermissions?: bigint[]`.
- `commandsHandler.executeCommand` checks it after the feature-gate, before `execute()`: missing perms (vs `interaction.appPermissions`, null-safe) → friendly reply *"I'm missing the **X** permission — ask an admin to grant it or re-invite me"* (names via `PermissionsBitField.toArray()`), and `execute` is NOT called.

## Pilot scope (this PR)
Declared `botPermissions` on moderation: ban→BanMembers, kick→KickMembers, mute/unmute→ModerateMembers, lockdown→ManageChannels.

## Tests
commandsHandler guard: missing → blocked + named message; has → executes; none declared → unaffected; null appPermissions handled; multi-missing listed. 23/23 commandsHandler tests; full bot suite green; type-check + eslint clean.

## Follow-up (stays in #1498)
- Management + automod commands (reuse the same `botPermissions` field).
- Event-driven paths (automod triggers / scheduled actions — no interaction to reply to) → separate log-and-skip treatment.

Refs #1498

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a central bot-permission guard that intercepts commands when the bot lacks required permissions and sends a friendly, ephemeral reply instead of Discord 50013 errors. Piloted on moderation commands; aligns with Linear #1498.

- **New Features**
  - `Command` accepts `botPermissions`.
  - `commandsHandler` checks `interaction.appPermissions` (null-safe); if missing, replies “I’m missing X” (names via `PermissionsBitField`, with correct singular/plural) and skips execution.
  - Declared perms for moderation: ban→BanMembers, kick→KickMembers, mute/unmute→ModerateMembers, lockdown→ManageChannels.

<sup>Written for commit 94b413965895d8a583503a3b5ebfda16006d2eae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

