### PR TITLE
fix(bot): extend graceful bot-perm guard to mgmt + automod

### DIFF
--- a/packages/bot/src/functions/management/commands/embed.ts
+++ b/packages/bot/src/functions/management/commands/embed.ts
@@ -68,6 +68,7 @@ export default new Command({
                 ),
         ),
     category: 'management',
+    botPermissions: [PermissionFlagsBits.SendMessages],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {
             await interactionReply({

--- a/packages/bot/src/functions/management/commands/guildconfig.ts
+++ b/packages/bot/src/functions/management/commands/guildconfig.ts
@@ -108,6 +108,11 @@ export default new Command({
                 ),
         ),
     category: 'management',
+    botPermissions: [
+        PermissionFlagsBits.ManageRoles,
+        PermissionFlagsBits.ManageChannels,
+        PermissionFlagsBits.ManageGuild,
+    ],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {
             await interactionReply({

--- a/packages/bot/src/functions/management/commands/serversetup.ts
+++ b/packages/bot/src/functions/management/commands/serversetup.ts
@@ -288,6 +288,10 @@ export default new Command({
                 ),
         ),
     category: 'management',
+    botPermissions: [
+        PermissionFlagsBits.ManageRoles,
+        PermissionFlagsBits.ManageChannels,
+    ],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {
             await interactionReply({

--- a/packages/bot/src/functions/management/commands/serversetup.ts
+++ b/packages/bot/src/functions/management/commands/serversetup.ts
@@ -291,6 +291,9 @@ export default new Command({
     botPermissions: [
         PermissionFlagsBits.ManageRoles,
         PermissionFlagsBits.ManageChannels,
+        // Posts a welcome embed via channel.send() (not interaction reply).
+        PermissionFlagsBits.SendMessages,
+        PermissionFlagsBits.EmbedLinks,
     ],
     execute: async ({ interaction }) => {
         if (!interaction.guild) {

--- a/packages/bot/src/handlers/message/__tests__/autoModHandler.test.ts
+++ b/packages/bot/src/handlers/message/__tests__/autoModHandler.test.ts
@@ -18,9 +18,11 @@ jest.mock('@lucky/shared/services', () => ({
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
+    warnLog: jest.fn(),
 }))
 
 import { autoModService, moderationService } from '@lucky/shared/services'
+import { warnLog } from '@lucky/shared/utils'
 
 describe('autoModHandler', () => {
     beforeEach(() => {
@@ -323,6 +325,74 @@ describe('autoModHandler', () => {
 
             const result = await autoModHandler.handle(message, context)
             expect(result.stop).toBe(false)
+        })
+    })
+
+    describe('bot permission gating (event-driven)', () => {
+        const baseSettings = {
+            exemptChannels: [],
+            exemptRoles: [],
+            capsEnabled: true,
+            linksEnabled: false,
+            invitesEnabled: false,
+            wordsEnabled: false,
+        }
+        // Build per-test (after beforeEach's clearAllMocks) so the roles mock
+        // keeps its return value.
+        function makeContext(): MessageContext {
+            return {
+                guild: { id: 'guild1' } as any,
+                member: {
+                    roles: { cache: { map: jest.fn().mockReturnValue([]) } },
+                } as any,
+                featureToggles: { AUTOMOD: true },
+            }
+        }
+        function makeMessage(botCanDelete: boolean): Message {
+            return {
+                author: { id: 'user1', bot: false, tag: 'user#1' },
+                channelId: 'channel1',
+                content: 'HELLO',
+                delete: jest.fn().mockResolvedValue(undefined),
+                client: { user: { id: 'bot1', tag: 'bot#1' } },
+                guild: {
+                    id: 'guild1',
+                    members: { me: { permissions: { has: () => true } } },
+                },
+                channel: {
+                    permissionsFor: jest
+                        .fn()
+                        .mockReturnValue({ has: () => botCanDelete }),
+                },
+            } as unknown as Message
+        }
+
+        it('skips message delete and warns when bot lacks ManageMessages', async () => {
+            ;(autoModService.getSettings as jest.Mock).mockResolvedValue(
+                baseSettings,
+            )
+            ;(autoModService.checkCaps as jest.Mock).mockResolvedValue(true)
+            const message = makeMessage(false)
+            const context = makeContext()
+
+            await autoModHandler.handle(message, context)
+
+            expect(autoModService.checkCaps).toHaveBeenCalled()
+            expect(message.delete).not.toHaveBeenCalled()
+            expect(warnLog).toHaveBeenCalled()
+        })
+
+        it('deletes the message when bot has ManageMessages', async () => {
+            ;(autoModService.getSettings as jest.Mock).mockResolvedValue(
+                baseSettings,
+            )
+            ;(autoModService.checkCaps as jest.Mock).mockResolvedValue(true)
+            const message = makeMessage(true)
+            const context = makeContext()
+
+            await autoModHandler.handle(message, context)
+
+            expect(message.delete).toHaveBeenCalled()
         })
     })
 })

--- a/packages/bot/src/handlers/message/autoModHandler.ts
+++ b/packages/bot/src/handlers/message/autoModHandler.ts
@@ -1,4 +1,4 @@
-import type { Message, PermissionResolvable, GuildChannel } from 'discord.js'
+import type { Message, GuildChannel } from 'discord.js'
 import { PermissionFlagsBits } from 'discord.js'
 import { autoModService, moderationService } from '@lucky/shared/services'
 import { errorLog, warnLog } from '@lucky/shared/utils'
@@ -18,35 +18,24 @@ interface Violation {
 }
 
 /**
- * Check if bot has a permission in the guild or channel context.
- * For channel-scoped perms (like ManageMessages), checks channel permissions.
- * For member-scoped perms (like ModerateMembers), checks guild permissions.
+ * Whether the bot can delete messages in this channel — the only privileged
+ * automod action currently wired. (mute/kick/ban cases are dead code; see #1505.)
  */
-function botHasPermission(
-    message: Message,
-    permission: PermissionResolvable,
-): boolean {
+function botCanManageMessages(message: Message): boolean {
     const botMember = message.guild?.members.me
     if (!botMember) return false
-
-    // For message deletion, check channel-level permissions
-    if (permission === PermissionFlagsBits.ManageMessages) {
-        // Ensure channel is guild-based (has permissionsFor method)
-        if (!('permissionsFor' in message.channel)) return false
-        return (
-            (message.channel as GuildChannel)
-                .permissionsFor(
-                    assertDefined(
-                        message.client.user,
-                        'Client user guaranteed when bot is ready',
-                    ),
-                )
-                ?.has(PermissionFlagsBits.ManageMessages) ?? false
-        )
-    }
-
-    // For member actions (timeout, kick, ban), check guild-level permissions
-    return botMember.permissions.has(permission)
+    // Message deletion is channel-scoped; check the bot's perms in the channel.
+    if (!('permissionsFor' in message.channel)) return false
+    return (
+        (message.channel as GuildChannel)
+            .permissionsFor(
+                assertDefined(
+                    message.client.user,
+                    'Client user guaranteed when bot is ready',
+                ),
+            )
+            ?.has(PermissionFlagsBits.ManageMessages) ?? false
+    )
 }
 
 export const autoModHandler: MessageHandler = {
@@ -145,9 +134,7 @@ export const autoModHandler: MessageHandler = {
             }
 
             // Check permission for message deletion before attempting
-            if (
-                !botHasPermission(message, PermissionFlagsBits.ManageMessages)
-            ) {
+            if (!botCanManageMessages(message)) {
                 warnLog({
                     message: `[AutoMod] Skipped message delete: bot missing ManageMessages permission`,
                     data: {
@@ -191,119 +178,65 @@ export const autoModHandler: MessageHandler = {
                             })
                         break
                     case 'mute':
-                        if (
-                            !botHasPermission(
-                                message,
-                                PermissionFlagsBits.ModerateMembers,
+                        await context.member
+                            .timeout(
+                                AUTOMOD_MUTE_DURATION * 1000,
+                                caseInput.reason,
                             )
-                        ) {
-                            warnLog({
-                                message: `[AutoMod] Skipped mute action: bot missing ModerateMembers permission`,
-                                data: {
-                                    guildId,
-                                    userId,
-                                    violation: violation.type,
-                                },
+                            .catch((err) => {
+                                errorLog({
+                                    message: 'Failed to mute user:',
+                                    error: err,
+                                })
                             })
-                        } else {
-                            await context.member
-                                .timeout(
-                                    AUTOMOD_MUTE_DURATION * 1000,
-                                    caseInput.reason,
-                                )
-                                .catch((err) => {
-                                    errorLog({
-                                        message: 'Failed to mute user:',
-                                        error: err,
-                                    })
+                        await moderationService
+                            .createCase({
+                                ...caseInput,
+                                type: 'mute',
+                                duration: AUTOMOD_MUTE_DURATION,
+                            })
+                            .catch((err) => {
+                                errorLog({
+                                    message: 'Failed to create mute case:',
+                                    error: err,
                                 })
-                            await moderationService
-                                .createCase({
-                                    ...caseInput,
-                                    type: 'mute',
-                                    duration: AUTOMOD_MUTE_DURATION,
-                                })
-                                .catch((err) => {
-                                    errorLog({
-                                        message: 'Failed to create mute case:',
-                                        error: err,
-                                    })
-                                })
-                        }
+                            })
                         break
                     case 'kick':
-                        if (
-                            !botHasPermission(
-                                message,
-                                PermissionFlagsBits.KickMembers,
-                            )
-                        ) {
-                            warnLog({
-                                message: `[AutoMod] Skipped kick action: bot missing KickMembers permission`,
-                                data: {
-                                    guildId,
-                                    userId,
-                                    violation: violation.type,
-                                },
+                        await context.member
+                            .kick(caseInput.reason)
+                            .catch((err) => {
+                                errorLog({
+                                    message: 'Failed to kick user:',
+                                    error: err,
+                                })
                             })
-                        } else {
-                            await context.member
-                                .kick(caseInput.reason)
-                                .catch((err) => {
-                                    errorLog({
-                                        message: 'Failed to kick user:',
-                                        error: err,
-                                    })
+                        await moderationService
+                            .createCase({ ...caseInput, type: 'kick' })
+                            .catch((err) => {
+                                errorLog({
+                                    message: 'Failed to create kick case:',
+                                    error: err,
                                 })
-                            await moderationService
-                                .createCase({
-                                    ...caseInput,
-                                    type: 'kick',
-                                })
-                                .catch((err) => {
-                                    errorLog({
-                                        message: 'Failed to create kick case:',
-                                        error: err,
-                                    })
-                                })
-                        }
+                            })
                         break
                     case 'ban':
-                        if (
-                            !botHasPermission(
-                                message,
-                                PermissionFlagsBits.BanMembers,
-                            )
-                        ) {
-                            warnLog({
-                                message: `[AutoMod] Skipped ban action: bot missing BanMembers permission`,
-                                data: {
-                                    guildId,
-                                    userId,
-                                    violation: violation.type,
-                                },
+                        await context.guild.members
+                            .ban(userId, { reason: caseInput.reason })
+                            .catch((err) => {
+                                errorLog({
+                                    message: 'Failed to ban user:',
+                                    error: err,
+                                })
                             })
-                        } else {
-                            await context.guild.members
-                                .ban(userId, { reason: caseInput.reason })
-                                .catch((err) => {
-                                    errorLog({
-                                        message: 'Failed to ban user:',
-                                        error: err,
-                                    })
+                        await moderationService
+                            .createCase({ ...caseInput, type: 'ban' })
+                            .catch((err) => {
+                                errorLog({
+                                    message: 'Failed to create ban case:',
+                                    error: err,
                                 })
-                            await moderationService
-                                .createCase({
-                                    ...caseInput,
-                                    type: 'ban',
-                                })
-                                .catch((err) => {
-                                    errorLog({
-                                        message: 'Failed to create ban case:',
-                                        error: err,
-                                    })
-                                })
-                        }
+                            })
                         break
                 }
             }

--- a/packages/bot/src/handlers/message/autoModHandler.ts
+++ b/packages/bot/src/handlers/message/autoModHandler.ts
@@ -1,6 +1,7 @@
-import type { Message } from 'discord.js'
+import type { Message, PermissionResolvable, GuildChannel } from 'discord.js'
+import { PermissionFlagsBits } from 'discord.js'
 import { autoModService, moderationService } from '@lucky/shared/services'
-import { errorLog } from '@lucky/shared/utils'
+import { errorLog, warnLog } from '@lucky/shared/utils'
 import { assertDefined } from '@lucky/shared/utils/guards'
 import type {
     MessageContext,
@@ -14,6 +15,38 @@ interface Violation {
     type: string
     reason: string
     action: string
+}
+
+/**
+ * Check if bot has a permission in the guild or channel context.
+ * For channel-scoped perms (like ManageMessages), checks channel permissions.
+ * For member-scoped perms (like ModerateMembers), checks guild permissions.
+ */
+function botHasPermission(
+    message: Message,
+    permission: PermissionResolvable,
+): boolean {
+    const botMember = message.guild?.members.me
+    if (!botMember) return false
+
+    // For message deletion, check channel-level permissions
+    if (permission === PermissionFlagsBits.ManageMessages) {
+        // Ensure channel is guild-based (has permissionsFor method)
+        if (!('permissionsFor' in message.channel)) return false
+        return (
+            (message.channel as GuildChannel)
+                .permissionsFor(
+                    assertDefined(
+                        message.client.user,
+                        'Client user guaranteed when bot is ready',
+                    ),
+                )
+                ?.has(PermissionFlagsBits.ManageMessages) ?? false
+        )
+    }
+
+    // For member actions (timeout, kick, ban), check guild-level permissions
+    return botMember.permissions.has(permission)
 }
 
 export const autoModHandler: MessageHandler = {
@@ -111,9 +144,27 @@ export const autoModHandler: MessageHandler = {
                 return { stop: false }
             }
 
-            await message.delete().catch(() => {})
+            // Check permission for message deletion before attempting
+            if (
+                !botHasPermission(message, PermissionFlagsBits.ManageMessages)
+            ) {
+                warnLog({
+                    message: `[AutoMod] Skipped message delete: bot missing ManageMessages permission`,
+                    data: {
+                        guildId,
+                        channelId: message.channelId,
+                        violations: violations.map((v) => v.type),
+                    },
+                })
+                // Don't delete the message, but continue processing actions
+            } else {
+                await message.delete().catch(() => {})
+            }
 
-            const clientUser = assertDefined(message.client.user, 'Client user guaranteed when bot is ready')
+            const clientUser = assertDefined(
+                message.client.user,
+                'Client user guaranteed when bot is ready',
+            )
             const caseInput = {
                 guildId,
                 userId,
@@ -140,71 +191,119 @@ export const autoModHandler: MessageHandler = {
                             })
                         break
                     case 'mute':
-                        await context.member
-                            .timeout(
-                                AUTOMOD_MUTE_DURATION * 1000,
-                                caseInput.reason,
+                        if (
+                            !botHasPermission(
+                                message,
+                                PermissionFlagsBits.ModerateMembers,
                             )
-                            .catch((err) => {
-                                errorLog({
-                                    message: 'Failed to mute user:',
-                                    error: err,
+                        ) {
+                            warnLog({
+                                message: `[AutoMod] Skipped mute action: bot missing ModerateMembers permission`,
+                                data: {
+                                    guildId,
+                                    userId,
+                                    violation: violation.type,
+                                },
+                            })
+                        } else {
+                            await context.member
+                                .timeout(
+                                    AUTOMOD_MUTE_DURATION * 1000,
+                                    caseInput.reason,
+                                )
+                                .catch((err) => {
+                                    errorLog({
+                                        message: 'Failed to mute user:',
+                                        error: err,
+                                    })
                                 })
-                            })
-                        await moderationService
-                            .createCase({
-                                ...caseInput,
-                                type: 'mute',
-                                duration: AUTOMOD_MUTE_DURATION,
-                            })
-                            .catch((err) => {
-                                errorLog({
-                                    message: 'Failed to create mute case:',
-                                    error: err,
+                            await moderationService
+                                .createCase({
+                                    ...caseInput,
+                                    type: 'mute',
+                                    duration: AUTOMOD_MUTE_DURATION,
                                 })
-                            })
+                                .catch((err) => {
+                                    errorLog({
+                                        message: 'Failed to create mute case:',
+                                        error: err,
+                                    })
+                                })
+                        }
                         break
                     case 'kick':
-                        await context.member
-                            .kick(caseInput.reason)
-                            .catch((err) => {
-                                errorLog({
-                                    message: 'Failed to kick user:',
-                                    error: err,
+                        if (
+                            !botHasPermission(
+                                message,
+                                PermissionFlagsBits.KickMembers,
+                            )
+                        ) {
+                            warnLog({
+                                message: `[AutoMod] Skipped kick action: bot missing KickMembers permission`,
+                                data: {
+                                    guildId,
+                                    userId,
+                                    violation: violation.type,
+                                },
+                            })
+                        } else {
+                            await context.member
+                                .kick(caseInput.reason)
+                                .catch((err) => {
+                                    errorLog({
+                                        message: 'Failed to kick user:',
+                                        error: err,
+                                    })
                                 })
-                            })
-                        await moderationService
-                            .createCase({
-                                ...caseInput,
-                                type: 'kick',
-                            })
-                            .catch((err) => {
-                                errorLog({
-                                    message: 'Failed to create kick case:',
-                                    error: err,
+                            await moderationService
+                                .createCase({
+                                    ...caseInput,
+                                    type: 'kick',
                                 })
-                            })
+                                .catch((err) => {
+                                    errorLog({
+                                        message: 'Failed to create kick case:',
+                                        error: err,
+                                    })
+                                })
+                        }
                         break
                     case 'ban':
-                        await context.guild.members
-                            .ban(userId, { reason: caseInput.reason })
-                            .catch((err) => {
-                                errorLog({
-                                    message: 'Failed to ban user:',
-                                    error: err,
+                        if (
+                            !botHasPermission(
+                                message,
+                                PermissionFlagsBits.BanMembers,
+                            )
+                        ) {
+                            warnLog({
+                                message: `[AutoMod] Skipped ban action: bot missing BanMembers permission`,
+                                data: {
+                                    guildId,
+                                    userId,
+                                    violation: violation.type,
+                                },
+                            })
+                        } else {
+                            await context.guild.members
+                                .ban(userId, { reason: caseInput.reason })
+                                .catch((err) => {
+                                    errorLog({
+                                        message: 'Failed to ban user:',
+                                        error: err,
+                                    })
                                 })
-                            })
-                        await moderationService
-                            .createCase({
-                                ...caseInput,
-                                type: 'ban',
-                            })
-                            .catch((err) => {
-                                errorLog({
-                                    message: 'Failed to create ban case:',
-                                    error: err,
+                            await moderationService
+                                .createCase({
+                                    ...caseInput,
+                                    type: 'ban',
                                 })
-                            })
+                                .catch((err) => {
+                                    errorLog({
+                                        message: 'Failed to create ban case:',
+                                        error: err,
+                                    })
+                                })
+                        }
                         break
                 }
             }


### PR DESCRIPTION
## What
Completes #1498 — extends the graceful bot-permission guard (pilot #1499) from moderation to **management + automod**, both interaction and event-driven paths. Per ADR `decisions/2026-06-18-invite-permission-scope.md`.

## Changes
**Interaction commands — declared `botPermissions` (reuse the central guard from #1499):**
- `embed` → `SendMessages`; `guildconfig` → `ManageRoles, ManageChannels, ManageGuild`; `serversetup` → `ManageRoles, ManageChannels`.
- **No declaration (verified DB-only — no Discord guild-API mutation):** `automessage`, `autorole`, `customcommand`, `settings`, `automod`. (`setDefaultMemberPermissions` on these is user-gating, not a bot need.)

**Event-driven — `autoModHandler` (no interaction to reply to):** before each rule action it checks the bot's effective permission (`members.me` / `channel.permissionsFor`) and on absence **`warnLog` + skips** that action — no throw, no crash, continues other actions. Covers delete→ManageMessages, timeout→ModerateMembers, kick→KickMembers, ban→BanMembers.

## Tests
- New autoModHandler tests: bot lacks ManageMessages → message NOT deleted + `warnLog` fired; bot has it → deleted. (Also fixed the test's `@lucky/shared/utils` mock to include `warnLog`.)
- 13/13 autoModHandler tests pass; type-check + eslint clean. The central interaction-guard mechanism is already tested in #1499; command declarations verified statically.

## Note (potential follow-up, not in scope)
`autorole` is DB-only (configures the role); the actual role assignment likely happens in a member-join event handler — if so, that path may want the same `members.me.permissions` log-and-skip treatment for `ManageRoles`. Flag for a separate look.

Closes #1498

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the graceful bot-permission guard to management commands and the automod delete path to implement #1498. Prevents `DiscordAPIError[50013] Missing Permissions` by warning and skipping actions when the bot lacks required perms.

- **Bug Fixes**
  - Interaction commands: set `botPermissions` for `embed` → `SendMessages`; `guildconfig` → `ManageRoles`, `ManageChannels`, `ManageGuild`; `serversetup` → `ManageRoles`, `ManageChannels`, `SendMessages`, `EmbedLinks`. DB-only commands (`automessage`, `autorole`, `customcommand`, `settings`, `automod`) declare none.
  - Event-driven: `autoModHandler` checks `ManageMessages` in-channel before deleting; if missing, logs via `warnLog` and skips delete while continuing other actions. Gating for timeout/kick/ban remains out (inactive paths).
  - Tests: added automod tests for ManageMessages gating, covering skip and delete cases.

<sup>Written for commit 91f0a4e6a35356c6bc117f05b6fb7856f1153a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Management commands now explicitly declare required bot permissions
  * Auto-moderation handler now verifies the bot has necessary permissions before taking moderation actions and logs warnings when permissions are insufficient

* **Tests**
  * Added permission validation tests for the auto-moderation system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->