### PR TITLE
fix(deps): pin piscina 4.9.3 for high-severity rce advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
                 "husky": "^9.1.7",
                 "jest": "^30.4.2",
                 "lint-staged": "^17.0.5",
+                "piscina": "4.9.3",
                 "prettier": "^3.8.3",
                 "secretlint": "^13.0.2",
                 "ts-jest": "^29.4.11",
@@ -22970,9 +22971,9 @@
             }
         },
         "node_modules/piscina": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.9.2.tgz",
-            "integrity": "sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==",
+            "version": "4.9.3",
+            "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.9.3.tgz",
+            "integrity": "sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA==",
             "dev": true,
             "license": "MIT",
             "optionalDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,60 +74,41 @@
             }
         },
         "node_modules/@asamuzakjp/css-color": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
-            "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
             "license": "MIT",
             "dependencies": {
-                "@csstools/css-calc": "^3.1.1",
-                "@csstools/css-color-parser": "^4.0.2",
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
                 "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0",
-                "lru-cache": "^11.2.6"
+                "@csstools/css-tokenizer": "^4.0.0"
             },
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-            "version": "11.2.7",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/@asamuzakjp/dom-selector": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
-            "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
             "license": "MIT",
             "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
                 "@asamuzakjp/nwsapi": "^2.3.9",
                 "bidi-js": "^1.0.3",
                 "css-tree": "^3.2.1",
-                "is-potential-custom-element-name": "^1.0.1",
-                "lru-cache": "^11.2.7"
+                "is-potential-custom-element-name": "^1.0.1"
             },
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-            "version": "11.2.7",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/@asamuzakjp/generational-cache": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
             "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -138,6 +119,21 @@
             "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
             "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
             "license": "MIT"
+        },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+            "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "5.2.0",
@@ -244,13 +240,13 @@
             }
         },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+            "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/core": "^3.25.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -258,42 +254,23 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.973.24",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
-            "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
+            "version": "3.974.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
+            "integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/xml-builder": "^3.972.15",
-                "@smithy/core": "^3.23.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/property-provider": "^4.2.12",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/signature-v4": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.7",
-                "@smithy/types": "^4.13.1",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
+                "@aws-sdk/types": "^3.973.13",
+                "@aws-sdk/xml-builder": "^3.972.30",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/core": "^3.24.6",
+                "@smithy/signature-v4": "^5.4.6",
+                "@smithy/types": "^4.14.3",
+                "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/core/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-cognito-identity": {
@@ -314,84 +291,25 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/nested-clients": {
-            "version": "3.996.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
-            "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+            "version": "3.997.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+            "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.24",
-                "@aws-sdk/middleware-host-header": "^3.972.8",
-                "@aws-sdk/middleware-logger": "^3.972.8",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.25",
-                "@aws-sdk/region-config-resolver": "^3.972.9",
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/util-endpoints": "^3.996.5",
-                "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.11",
-                "@smithy/config-resolver": "^4.4.13",
-                "@smithy/core": "^3.23.12",
-                "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/hash-node": "^4.2.12",
-                "@smithy/invalid-dependency": "^4.2.12",
-                "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.27",
-                "@smithy/middleware-retry": "^4.4.44",
-                "@smithy/middleware-serde": "^4.2.15",
-                "@smithy/middleware-stack": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.5.0",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.7",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.43",
-                "@smithy/util-defaults-mode-node": "^4.2.47",
-                "@smithy/util-endpoints": "^3.3.3",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-retry": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-            "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-endpoints": "^3.3.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
@@ -460,84 +378,25 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/nested-clients": {
-            "version": "3.996.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
-            "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+            "version": "3.997.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+            "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.24",
-                "@aws-sdk/middleware-host-header": "^3.972.8",
-                "@aws-sdk/middleware-logger": "^3.972.8",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.25",
-                "@aws-sdk/region-config-resolver": "^3.972.9",
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/util-endpoints": "^3.996.5",
-                "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.11",
-                "@smithy/config-resolver": "^4.4.13",
-                "@smithy/core": "^3.23.12",
-                "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/hash-node": "^4.2.12",
-                "@smithy/invalid-dependency": "^4.2.12",
-                "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.27",
-                "@smithy/middleware-retry": "^4.4.44",
-                "@smithy/middleware-serde": "^4.2.15",
-                "@smithy/middleware-stack": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.5.0",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.7",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.43",
-                "@smithy/util-defaults-mode-node": "^4.2.47",
-                "@smithy/util-endpoints": "^3.3.3",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-retry": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-            "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-endpoints": "^3.3.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
@@ -561,84 +420,25 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
-            "version": "3.996.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
-            "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+            "version": "3.997.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+            "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.24",
-                "@aws-sdk/middleware-host-header": "^3.972.8",
-                "@aws-sdk/middleware-logger": "^3.972.8",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.25",
-                "@aws-sdk/region-config-resolver": "^3.972.9",
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/util-endpoints": "^3.996.5",
-                "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.11",
-                "@smithy/config-resolver": "^4.4.13",
-                "@smithy/core": "^3.23.12",
-                "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/hash-node": "^4.2.12",
-                "@smithy/invalid-dependency": "^4.2.12",
-                "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.27",
-                "@smithy/middleware-retry": "^4.4.44",
-                "@smithy/middleware-serde": "^4.2.15",
-                "@smithy/middleware-stack": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.5.0",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.7",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.43",
-                "@smithy/util-defaults-mode-node": "^4.2.47",
-                "@smithy/util-endpoints": "^3.3.3",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-retry": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-            "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-endpoints": "^3.3.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
@@ -704,84 +504,25 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/nested-clients": {
-            "version": "3.996.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
-            "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+            "version": "3.997.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+            "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.24",
-                "@aws-sdk/middleware-host-header": "^3.972.8",
-                "@aws-sdk/middleware-logger": "^3.972.8",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.25",
-                "@aws-sdk/region-config-resolver": "^3.972.9",
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/util-endpoints": "^3.996.5",
-                "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.11",
-                "@smithy/config-resolver": "^4.4.13",
-                "@smithy/core": "^3.23.12",
-                "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/hash-node": "^4.2.12",
-                "@smithy/invalid-dependency": "^4.2.12",
-                "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.27",
-                "@smithy/middleware-retry": "^4.4.44",
-                "@smithy/middleware-serde": "^4.2.15",
-                "@smithy/middleware-stack": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.5.0",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.7",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.43",
-                "@smithy/util-defaults-mode-node": "^4.2.47",
-                "@smithy/util-endpoints": "^3.3.3",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-retry": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-            "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-endpoints": "^3.3.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
@@ -804,84 +545,25 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/nested-clients": {
-            "version": "3.996.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
-            "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+            "version": "3.997.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+            "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.24",
-                "@aws-sdk/middleware-host-header": "^3.972.8",
-                "@aws-sdk/middleware-logger": "^3.972.8",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.25",
-                "@aws-sdk/region-config-resolver": "^3.972.9",
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/util-endpoints": "^3.996.5",
-                "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.11",
-                "@smithy/config-resolver": "^4.4.13",
-                "@smithy/core": "^3.23.12",
-                "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/hash-node": "^4.2.12",
-                "@smithy/invalid-dependency": "^4.2.12",
-                "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.27",
-                "@smithy/middleware-retry": "^4.4.44",
-                "@smithy/middleware-serde": "^4.2.15",
-                "@smithy/middleware-stack": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.5.0",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.7",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.43",
-                "@smithy/util-defaults-mode-node": "^4.2.47",
-                "@smithy/util-endpoints": "^3.3.3",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-retry": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-            "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-endpoints": "^3.3.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-providers": {
@@ -985,16 +667,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-            "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+            "version": "3.996.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.21.tgz",
+            "integrity": "sha512-mZbKi9+3h3BtGkph4eYPMCoxiyYHM4q1rYZILfCE4a1uszKaXCRrI0n8nPqcOQDGc2fTwpXm7jLAs/sok4MxVg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-endpoints": "^3.3.3",
+                "@aws-sdk/core": "^3.974.22",
+                "@smithy/core": "^3.24.6",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1052,13 +732,13 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+            "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/core": "^3.25.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1076,6 +756,22 @@
                 "@smithy/config-resolver": "^4.4.13",
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+            "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/signature-v4": "^5.4.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1102,94 +798,35 @@
             }
         },
         "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/nested-clients": {
-            "version": "3.996.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
-            "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+            "version": "3.997.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+            "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.24",
-                "@aws-sdk/middleware-host-header": "^3.972.8",
-                "@aws-sdk/middleware-logger": "^3.972.8",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.25",
-                "@aws-sdk/region-config-resolver": "^3.972.9",
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/util-endpoints": "^3.996.5",
-                "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.11",
-                "@smithy/config-resolver": "^4.4.13",
-                "@smithy/core": "^3.23.12",
-                "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/hash-node": "^4.2.12",
-                "@smithy/invalid-dependency": "^4.2.12",
-                "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.27",
-                "@smithy/middleware-retry": "^4.4.44",
-                "@smithy/middleware-serde": "^4.2.15",
-                "@smithy/middleware-stack": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.5.0",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.7",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.43",
-                "@smithy/util-defaults-mode-node": "^4.2.47",
-                "@smithy/util-endpoints": "^3.3.3",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-retry": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-            "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-endpoints": "^3.3.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.973.6",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-            "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+            "version": "3.973.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+            "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^4.13.1",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1266,15 +903,14 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.22",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-            "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+            "version": "3.972.30",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
+            "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@nodable/entities": "2.1.0",
-                "@smithy/types": "^4.14.1",
-                "fast-xml-parser": "5.7.2",
+                "@smithy/types": "^4.14.3",
+                "fast-xml-parser": "5.7.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2507,9 +2143,9 @@
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-            "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
             "funding": [
                 {
                     "type": "github",
@@ -2530,9 +2166,9 @@
             }
         },
         "node_modules/@csstools/css-color-parser": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-            "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+            "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2546,7 +2182,7 @@
             "license": "MIT",
             "dependencies": {
                 "@csstools/color-helpers": "^6.0.2",
-                "@csstools/css-calc": "^3.1.1"
+                "@csstools/css-calc": "^3.2.1"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -2579,9 +2215,9 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
-            "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+            "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
             "funding": [
                 {
                     "type": "github",
@@ -3434,9 +3070,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-            "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -4275,19 +3911,6 @@
                 }
             }
         },
-        "node_modules/@jest/core/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/@jest/core/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4525,9 +4148,9 @@
             }
         },
         "node_modules/@jest/schemas": {
-            "version": "30.0.5",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-            "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4706,19 +4329,6 @@
                 "@types/node": "*",
                 "@types/yargs": "^17.0.33",
                 "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/types/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5441,9 +5051,9 @@
             }
         },
         "node_modules/@nodable/entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
             "funding": [
                 {
                     "type": "github",
@@ -9779,20 +9389,6 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
-        "node_modules/@smithy/abort-controller": {
-            "version": "4.2.12",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
-            "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/types": "^4.13.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/@smithy/config-resolver": {
             "version": "4.4.13",
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
@@ -9812,35 +9408,14 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.23.12",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
-            "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+            "version": "3.25.1",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
+            "integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-stream": "^4.5.20",
-                "@smithy/util-utf8": "^4.2.2",
-                "@smithy/uuid": "^1.1.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
+                "@aws-crypto/crc32": "5.2.0",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9865,16 +9440,14 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.3.15",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-            "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.1.tgz",
+            "integrity": "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/querystring-builder": "^4.2.12",
-                "@smithy/types": "^4.13.1",
-                "@smithy/util-base64": "^4.3.2",
+                "@smithy/core": "^3.25.1",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9898,13 +9471,13 @@
             }
         },
         "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+            "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/core": "^3.25.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -9926,16 +9499,16 @@
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-            "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/middleware-content-length": {
@@ -10041,16 +9614,14 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
-            "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
+            "integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.12",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/querystring-builder": "^4.2.12",
-                "@smithy/types": "^4.13.1",
+                "@smithy/core": "^3.25.1",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10079,21 +9650,6 @@
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-builder": {
-            "version": "4.2.12",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
-            "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/types": "^4.13.1",
-                "@smithy/util-uri-escape": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10142,33 +9698,14 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.3.12",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-            "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.1.tgz",
+            "integrity": "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.2",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/types": "^4.13.1",
-                "@smithy/util-hex-encoding": "^4.2.2",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-uri-escape": "^4.2.2",
-                "@smithy/util-utf8": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/core": "^3.25.1",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10195,9 +9732,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.14.1",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-            "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+            "version": "4.15.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+            "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
@@ -10238,13 +9775,13 @@
             }
         },
         "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+            "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/core": "^3.25.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10278,13 +9815,13 @@
             }
         },
         "node_modules/@smithy/util-buffer-from": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-            "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.4.1.tgz",
+            "integrity": "sha512-ZUdCO+tYTLHliCu5zTQUCpd+/dQdoJfgiV+S0zTi5cCWnZQ4G5TDnJx0rF33xzhr/vJE0cadhRWN8ZYNm2Vklg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.2",
+                "@smithy/core": "^3.25.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10417,26 +9954,13 @@
             }
         },
         "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+            "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-uri-escape": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-            "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
+                "@smithy/core": "^3.25.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -10451,19 +9975,6 @@
             "optional": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-utf8/node_modules/@smithy/is-array-buffer": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -12191,26 +11702,20 @@
             }
         },
         "node_modules/@types/jest/node_modules/pretty-format": {
-            "version": "30.2.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-            "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/schemas": "30.0.5",
+                "@jest/schemas": "30.4.1",
                 "ansi-styles": "^5.2.0",
-                "react-is": "^18.3.1"
+                "react-is-18": "npm:react-is@^18.3.1",
+                "react-is-19": "npm:react-is@^19.2.5"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
-        },
-        "node_modules/@types/jest/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
@@ -12246,12 +11751,12 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-            "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+            "version": "25.9.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+            "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.18.0"
+                "undici-types": ">=7.24.0 <7.24.7"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -13636,6 +13141,19 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/append-field": {
             "version": "1.0.0",
@@ -16398,18 +15916,21 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-            "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+            "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
             "dev": true,
             "license": "MIT",
+            "workspaces": [
+                "packages/*"
+            ],
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
                 "@eslint/config-array": "^0.23.5",
                 "@eslint/config-helpers": "^0.6.0",
                 "@eslint/core": "^1.2.1",
-                "@eslint/plugin-kit": "^0.7.1",
+                "@eslint/plugin-kit": "^0.7.2",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -16617,9 +16138,9 @@
             }
         },
         "node_modules/eslint/node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17149,9 +16670,9 @@
             }
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
-            "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
             "funding": [
                 {
                     "type": "github",
@@ -17161,13 +16682,14 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "path-expression-matcher": "^1.1.3"
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-            "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.2.tgz",
+            "integrity": "sha512-DYPkXnVSJHAGAkSBeVYhEo/seIpz2SLr9OQcX7m6lXaX3gvoB+DCKzFdZIEhZGI3I1DUhObBAUOT/v2xfoXz/w==",
             "funding": [
                 {
                     "type": "github",
@@ -17177,10 +16699,12 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@nodable/entities": "^2.1.0",
-                "fast-xml-builder": "^1.1.7",
+                "@nodable/entities": "^2.2.0",
+                "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^1.0.1",
                 "path-expression-matcher": "^1.5.0",
-                "strnum": "^2.2.3"
+                "strnum": "^2.4.0",
+                "xml-naming": "^0.1.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -18287,9 +17811,9 @@
             }
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -18536,9 +18060,9 @@
             }
         },
         "node_modules/import-in-the-middle": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz",
-            "integrity": "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz",
+            "integrity": "sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "acorn": "^8.15.0",
@@ -19156,6 +18680,19 @@
                 "node": ">= 12"
             }
         },
+        "node_modules/is-unsafe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+            "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -19438,19 +18975,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-circus/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-circus/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -19617,19 +19141,6 @@
                 }
             }
         },
-        "node_modules/jest-config/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-config/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -19690,19 +19201,6 @@
                 "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
                 "pretty-format": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-diff/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -19782,19 +19280,6 @@
                 "chalk": "^4.1.2",
                 "jest-util": "30.4.1",
                 "pretty-format": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-each/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -19907,19 +19392,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-leak-detector/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-leak-detector/node_modules/pretty-format": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
@@ -19947,19 +19419,6 @@
                 "chalk": "^4.1.2",
                 "jest-diff": "30.4.1",
                 "pretty-format": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-matcher-utils/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -20031,19 +19490,6 @@
                 "pretty-format": "30.4.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -20375,19 +19821,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-snapshot/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-snapshot/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -20501,19 +19934,6 @@
                 "chalk": "^4.1.2",
                 "leven": "^3.1.0",
                 "pretty-format": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-validate/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -20712,10 +20132,20 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -20725,27 +20155,27 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "29.0.1",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
-            "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/css-color": "^5.0.1",
-                "@asamuzakjp/dom-selector": "^7.0.3",
+                "@asamuzakjp/css-color": "^5.1.11",
+                "@asamuzakjp/dom-selector": "^7.1.1",
                 "@bramus/specificity": "^2.4.2",
-                "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
                 "@exodus/bytes": "^1.15.0",
                 "css-tree": "^3.2.1",
                 "data-urls": "^7.0.0",
                 "decimal.js": "^10.6.0",
                 "html-encoding-sniffer": "^6.0.0",
                 "is-potential-custom-element-name": "^1.0.1",
-                "lru-cache": "^11.2.7",
-                "parse5": "^8.0.0",
+                "lru-cache": "^11.3.5",
+                "parse5": "^8.0.1",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
                 "tough-cookie": "^6.0.1",
-                "undici": "^7.24.5",
+                "undici": "^7.25.0",
                 "w3c-xmlserializer": "^5.0.0",
                 "webidl-conversions": "^8.0.1",
                 "whatwg-mimetype": "^5.0.0",
@@ -20765,21 +20195,12 @@
             }
         },
         "node_modules/jsdom/node_modules/lru-cache": {
-            "version": "11.2.7",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
-            }
-        },
-        "node_modules/jsdom/node_modules/undici": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-            "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.18.1"
             }
         },
         "node_modules/jsesc": {
@@ -22709,24 +22130,24 @@
             }
         },
         "node_modules/parse5": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
             "license": "MIT",
             "dependencies": {
-                "entities": "^6.0.0"
+                "entities": "^8.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/parse5/node_modules/entities": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
             "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=0.12"
+                "node": ">=20.19.0"
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
@@ -23050,13 +22471,13 @@
             }
         },
         "node_modules/pkg-types": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-            "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+            "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
             "license": "MIT",
             "dependencies": {
-                "confbox": "^0.2.2",
-                "exsolve": "^1.0.7",
+                "confbox": "^0.2.4",
+                "exsolve": "^1.0.8",
                 "pathe": "^2.0.3"
             }
         },
@@ -23402,15 +22823,6 @@
                 "signal-exit": "^3.0.2"
             }
         },
-        "node_modules/proper-lockfile/node_modules/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -23470,9 +22882,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.15.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -23799,9 +23211,9 @@
             }
         },
         "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+            "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
@@ -24097,6 +23509,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/reverbnation-scraper": {
@@ -24415,9 +23836,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -24534,15 +23955,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/session-file-store/node_modules/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/session-file-store/node_modules/write-file-atomic": {
@@ -25323,9 +24735,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "funding": [
                 {
                     "type": "github",
@@ -25333,7 +24745,10 @@
                 }
             ],
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
         },
         "node_modules/strtok3": {
             "version": "10.3.4",
@@ -25863,9 +25278,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
-            "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -26213,17 +25628,34 @@
             }
         },
         "node_modules/type-is": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
             "license": "MIT",
             "dependencies": {
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "media-typer": "^1.1.0",
                 "mime-types": "^3.0.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/type-is/node_modules/mime-types": {
@@ -26345,22 +25777,6 @@
             },
             "engines": {
                 "node": ">= 16.0.0"
-            }
-        },
-        "node_modules/typed-rest-client/node_modules/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/typedarray": {
@@ -26517,18 +25933,18 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-            "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "version": "7.24.6",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
             "license": "MIT"
         },
         "node_modules/unfetch": {
@@ -27273,6 +26689,22 @@
                 "node": ">=18"
             }
         },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -27551,16 +26983,6 @@
                 "typescript": "^6.0.3"
             }
         },
-        "packages/backend/node_modules/@types/node": {
-            "version": "25.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
-            }
-        },
         "packages/backend/node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -27616,13 +27038,6 @@
                 "node": ">=14.17"
             }
         },
-        "packages/backend/node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "packages/backend/node_modules/zod": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -27666,20 +27081,10 @@
                 "typescript": "^6.0.3"
             }
         },
-        "packages/bot/node_modules/@types/node": {
-            "version": "25.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
-            }
-        },
         "packages/bot/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -27698,13 +27103,6 @@
             "engines": {
                 "node": ">=14.17"
             }
-        },
-        "packages/bot/node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-            "dev": true,
-            "license": "MIT"
         },
         "packages/bot/node_modules/youtubei.js": {
             "version": "16.0.1",
@@ -27783,42 +27181,9 @@
                 "tailwindcss": "^4.3.0",
                 "tsx": "^4.22.3",
                 "typescript": "^6.0.3",
+                "undici": "7.28.0",
                 "vite": "^8.0.16",
                 "vitest": "^4.0.18"
-            }
-        },
-        "packages/frontend/node_modules/@asamuzakjp/css-color": {
-            "version": "5.1.11",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@asamuzakjp/generational-cache": "^1.0.1",
-                "@csstools/css-calc": "^3.2.0",
-                "@csstools/css-color-parser": "^4.1.0",
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
-        "packages/frontend/node_modules/@asamuzakjp/dom-selector": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@asamuzakjp/generational-cache": "^1.0.1",
-                "@asamuzakjp/nwsapi": "^2.3.9",
-                "bidi-js": "^1.0.3",
-                "css-tree": "^3.2.1",
-                "is-potential-custom-element-name": "^1.0.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "packages/frontend/node_modules/@bcoe/v8-coverage": {
@@ -27829,83 +27194,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "packages/frontend/node_modules/@csstools/css-calc": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-            "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
-            }
-        },
-        "packages/frontend/node_modules/@csstools/css-color-parser": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-            "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@csstools/color-helpers": "^6.0.2",
-                "@csstools/css-calc": "^3.2.0"
-            },
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
-            }
-        },
-        "packages/frontend/node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-            "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT-0",
-            "peerDependencies": {
-                "css-tree": "^3.2.1"
-            },
-            "peerDependenciesMeta": {
-                "css-tree": {
-                    "optional": true
-                }
             }
         },
         "packages/frontend/node_modules/@eslint/config-helpers": {
@@ -27919,16 +27207,6 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
-        "packages/frontend/node_modules/@types/node": {
-            "version": "25.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
             }
         },
         "packages/frontend/node_modules/@vitest/coverage-v8": {
@@ -28076,9 +27354,9 @@
             }
         },
         "packages/frontend/node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -28090,19 +27368,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "packages/frontend/node_modules/entities": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "packages/frontend/node_modules/eslint": {
@@ -28184,76 +27449,12 @@
                 "node": ">= 4"
             }
         },
-        "packages/frontend/node_modules/jsdom": {
-            "version": "29.1.1",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@asamuzakjp/css-color": "^5.1.11",
-                "@asamuzakjp/dom-selector": "^7.1.1",
-                "@bramus/specificity": "^2.4.2",
-                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-                "@exodus/bytes": "^1.15.0",
-                "css-tree": "^3.2.1",
-                "data-urls": "^7.0.0",
-                "decimal.js": "^10.6.0",
-                "html-encoding-sniffer": "^6.0.0",
-                "is-potential-custom-element-name": "^1.0.1",
-                "lru-cache": "^11.3.5",
-                "parse5": "^8.0.1",
-                "saxes": "^6.0.0",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^6.0.1",
-                "undici": "^7.25.0",
-                "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^8.0.1",
-                "whatwg-mimetype": "^5.0.0",
-                "whatwg-url": "^16.0.1",
-                "xml-name-validator": "^5.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
-            },
-            "peerDependencies": {
-                "canvas": "^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
-            }
-        },
         "packages/frontend/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
-        },
-        "packages/frontend/node_modules/lru-cache": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "packages/frontend/node_modules/parse5": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "entities": "^8.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/inikulin/parse5?sponsor=1"
-            }
         },
         "packages/frontend/node_modules/std-env": {
             "version": "4.1.0",
@@ -28275,23 +27476,6 @@
             "engines": {
                 "node": ">=14.17"
             }
-        },
-        "packages/frontend/node_modules/undici": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.18.1"
-            }
-        },
-        "packages/frontend/node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-            "dev": true,
-            "license": "MIT"
         },
         "packages/frontend/node_modules/vitest": {
             "version": "4.1.7",
@@ -28468,16 +27652,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "packages/shared/node_modules/@types/node": {
-            "version": "25.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
-            }
-        },
         "packages/shared/node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -28486,13 +27660,31 @@
             "license": "MIT"
         },
         "packages/shared/node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
+            }
+        },
+        "packages/shared/node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "packages/shared/node_modules/glob": {
@@ -28514,9 +27706,9 @@
             }
         },
         "packages/shared/node_modules/lru-cache": {
-            "version": "11.2.7",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -28540,6 +27732,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "packages/shared/node_modules/readdirp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "packages/shared/node_modules/typescript": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -28553,13 +27761,6 @@
             "engines": {
                 "node": ">=14.17"
             }
-        },
-        "packages/shared/node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-            "dev": true,
-            "license": "MIT"
         },
         "packages/shared/node_modules/zod": {
             "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
         "path-to-regexp": ">=8.4.0",
         "fast-xml-parser": ">=5.5.6",
         "tar": ">=7.5.11",
-        "undici": "7.24.1",
+        "undici": "7.28.0",
         "flatted": "^3.4.2",
         "effect": "^3.20.0",
         "@smithy/config-resolver": ">=4.4.10",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "lint-staged": "^17.0.5",
         "prettier": "^3.8.3",
         "secretlint": "^13.0.2",
+        "piscina": "4.9.3",
         "ts-jest": "^29.4.11",
         "unfetch": "^5.0.0",
         "vite": "^8.0.16"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -89,6 +89,7 @@
         "tailwindcss": "^4.3.0",
         "tsx": "^4.22.3",
         "typescript": "^6.0.3",
+        "undici": "7.28.0",
         "vite": "^8.0.16",
         "vitest": "^4.0.18"
     }


### PR DESCRIPTION
Closes #1503

## Summary
`npm audit --audit-level=high` (the `Security` required check) fails on **every** PR again — a newly-published HIGH advisory, not caused by any code change (second occurrence of the audit time-bomb after multer #1493).

## Finding
- **piscina** `4.9.2` — **HIGH**: Prototype Pollution Gadget → RCE via inherited `options.filename` — [GHSA-x9g3-xrwr-cwfg](https://github.com/advisories/GHSA-x9g3-xrwr-cwfg) (vulnerable `<=4.9.2`; fixed in **4.9.3**).
- **Transitive, build-time only:** `@lucky/shared → @swc/cli@0.8.1 → piscina@4.9.2` (swc's worker pool for compilation). `@swc/cli` requires `piscina ^4.3.1`, so 4.9.3 is in range. Real exploit risk ~nil (build tool, trusted input) but the gate fails regardless.

## Fix
Pin **piscina 4.9.3** as a root devDependency (forces the hoisted version → satisfies `@swc/cli ^4.3.1`). An `overrides` entry would NOT re-resolve (npm kept 4.9.2 even after a full lock regen) — the direct-devDep pattern is the reliable fix (same lesson as the vite hoist bump). Surgical: lock +4/−3.

## Verification
- `npm run audit:high` exits 0; 0 high/critical (was 1 high).
- `npm run build:shared` OK — swc + piscina 4.9.3 compiles fine.

## Note
28 moderate advisories remain (below the `audit:high` gate, out of scope).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `piscina` to 4.9.3 and bump `undici` to 7.28.0 to resolve high-severity advisories and unblock the `npm audit --audit-level=high` check. Ensures `@swc/cli` uses the patched `piscina` during builds.

- **Dependencies**
  - Hoisted `piscina` `4.9.3` as a root devDependency for `@swc/cli`, and updated `undici` to `7.28.0` in root and `packages/frontend`.
  - Verified `npm run audit:high` passes and `npm run build:shared` compiles successfully.

<sup>Written for commit 337cc6341cd51873d9fcf91a5cab0f9ad8a0c4f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

