### PR TITLE
feat(bot): utility join-onboarding message + in-bot growth adr

### DIFF
--- a/decisions/2026-06-18-in-bot-growth.md
+++ b/decisions/2026-06-18-in-bot-growth.md
@@ -1,0 +1,85 @@
+# In-bot growth: a utility-first activation aid, not an acquisition lever
+
+- Status: accepted-with-revisions (in-bot = activation/retention; acquisition stays external)
+- Date: 2026-06-18
+- Method: /research-and-decide (web research → decision-critic Opus artifact-only → plan → ADR)
+
+## Context
+
+"Bump users efficiently." The external-channel strategy is already decided
+(`decisions/2026-06-17-growth-channel-sequencing.md`). This ADR decides the **in-bot /
+product-led** question — should the bot _itself_ drive growth, and via which mechanics?
+
+Already shipped: `/invite` command + a one-line "• /invite to add Lucky" Now-Playing embed
+footer CTA (#1495); a top.gg `/voterewards` loop; `guildCreate`/`guildDelete` telemetry
+(#1494 — the same handler an onboarding message reuses).
+
+Web research (2026) against Discord's Platform Manipulation Policy + Developer Policy found:
+in-bot acquisition lift is **low across all mechanics**, and the high-lift ideas are
+**policy-prohibited** (invite rewards, referral incentives, unsolicited DMs) or
+**technically impossible** (referral attribution — Discord OAuth exposes no install
+source). Manipulation-pattern flags also jeopardize **bot verification** (the >75/100-server
+review), which is the gate for the App-Directory channel in the external ADR.
+
+## Decision
+
+1. **Frame:** in-bot growth is an **activation/retention aid, not a primary acquisition
+   lever.** In-bot acquisition is low-lift _and_ unmeasurable (no install-source
+   attribution). Its real value is helping new servers actually use the bot → retention →
+   which feeds the (external) growth flywheel.
+2. **DO now (low-effort, verification-safe):** a **pure-utility join-time onboarding
+   message** on `guildCreate` — getting-started / `/help` focused, **no invite or vote
+   CTA at join**. (The footer `/invite` CTA already covers discovery during playback;
+   doubling up at join adds redundancy and a verification gray-area for ~zero extra lift.)
+3. **DEFER (effort > current lift):** user-initiated `/share` cards; expanding vote rewards
+   to cosmetic/convenience perks.
+4. **HARD REJECT (policy / infeasible):**
+    - Unsolicited DMs to users/admins — Developer Policy prohibits.
+    - Referral / invite-reward attribution — Platform Manipulation Policy bans "invite
+      rewards"; also impossible (no install source in the OAuth flow).
+    - Frequent / aggressive in-channel nudges — high spam + verification risk, low lift.
+    - Gating **core** features behind votes — only cosmetic/convenience vote perks are allowed.
+5. **Guardrail:** keep all in-bot messaging utility-first to protect **bot verification** —
+   a manipulation flag there would block the App-Directory channel the external ADR depends
+   on. In-bot growth must never jeopardize the bigger external lever.
+
+## Plan (pilot)
+
+- Pilot: the pure-utility onboarding message on `guildCreate` (reuse the existing #1494
+  handler in `eventHandler.ts`). Posts one help/getting-started embed to a safe channel; no
+  invite/vote CTA.
+- Success: posts once on join; no verification flag; aids activation.
+- Rollback: remove the message — additive, trivial.
+- Measurement: **not** gated on acquisition attribution (infeasible); justified as activation.
+
+## Alternatives considered
+
+- **Aggressive in-channel nudges / "vote to unlock" CTAs** — rejected: high verification +
+  spam risk, low lift.
+- **Referral/invite-reward attribution** — rejected: policy-banned + technically impossible.
+- **Unsolicited DM outreach** — rejected: Developer Policy prohibits; reputation/ban risk.
+- **`/share` cards + cosmetic vote perks now** — deferred: compliant but low lift / effort;
+  revisit if community engagement becomes a goal.
+- **External-only (do nothing in-bot)** — rejected: the pure-utility onboarding is
+  near-zero-risk and aids activation while external channels are approval-gated.
+- **Join onboarding WITH a soft `/invite` CTA** — rejected (critic): a verification
+  gray-area for ~zero marginal lift over the existing footer CTA.
+
+## Consequences
+
+- **Positive:** near-zero-risk activation aid; records the hard-NOs so they aren't
+  re-attempted; doesn't endanger the external App-Directory lever.
+- **Negative:** minimal acquisition lift (activation, not viral); `/share` + vote-perks
+  deferred; the footer CTA and onboarding's acquisition effect are unmeasurable (no
+  attribution).
+- **Neutral:** external channels remain the acquisition lever; this only amplifies
+  activation/retention.
+
+## Revisit when
+
+- **External channels stall** (App-Directory blocked / verification far off / the
+  measurement sprint shows directories underperform) → reconsider `/share` + cosmetic vote
+  perks as the controllable alternative.
+- **Community engagement becomes a goal** → build `/share` cards + cosmetic vote rewards.
+- **Discord changes its messaging/manipulation policy** → re-check the onboarding/CTA line.
+- **Verification is attempted** → audit all in-bot messaging for manipulation flags first.

--- a/packages/bot/src/handlers/eventHandler.spec.ts
+++ b/packages/bot/src/handlers/eventHandler.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import {
     Events,
+    ChannelType,
     type ChatInputCommandInteraction,
     type Interaction,
 } from 'discord.js'
@@ -737,6 +738,65 @@ describe('eventHandler', () => {
                         error: dbError,
                     }),
                 )
+            })
+
+            it('posts a utility onboarding message to a postable channel', async () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = { cache: { size: 5 } } as any
+                const sendMock = jest
+                    .fn<() => Promise<void>>()
+                    .mockResolvedValue(undefined)
+                const systemChannel = {
+                    type: ChannelType.GuildText,
+                    send: sendMock,
+                    permissionsFor: jest.fn(() => ({ has: () => true })),
+                }
+
+                handleEvents(client as unknown as never)
+                getGuildCreateHandler(onMock)?.({
+                    id: 'g-onboard',
+                    name: 'Onboard Guild',
+                    memberCount: 9,
+                    members: { me: { id: 'bot' } },
+                    systemChannel,
+                    channels: { cache: { find: () => undefined } },
+                })
+
+                await new Promise<void>((resolve) => setImmediate(resolve))
+
+                expect(sendMock).toHaveBeenCalledTimes(1)
+                const embed = (
+                    sendMock.mock.calls[0][0] as { embeds: { toJSON(): any }[] }
+                ).embeds[0].toJSON()
+                // verification-safety: pure utility, no invite/vote CTA
+                expect(String(embed.description).toLowerCase()).not.toMatch(
+                    /invite|vote/,
+                )
+            })
+
+            it('skips onboarding when the bot cannot post (no throw)', async () => {
+                const { client, onMock } = createMockClient()
+                client.guilds = { cache: { size: 5 } } as any
+                const sendMock = jest.fn()
+                const systemChannel = {
+                    type: ChannelType.GuildText,
+                    send: sendMock,
+                    permissionsFor: jest.fn(() => ({ has: () => false })),
+                }
+
+                handleEvents(client as unknown as never)
+                getGuildCreateHandler(onMock)?.({
+                    id: 'g-nopost',
+                    name: 'No Post Guild',
+                    memberCount: 9,
+                    members: { me: { id: 'bot' } },
+                    systemChannel,
+                    channels: { cache: { find: () => undefined } },
+                })
+
+                await new Promise<void>((resolve) => setImmediate(resolve))
+
+                expect(sendMock).not.toHaveBeenCalled()
             })
         })
 

--- a/packages/bot/src/handlers/eventHandler.ts
+++ b/packages/bot/src/handlers/eventHandler.ts
@@ -1,6 +1,11 @@
 import {
     Events,
+    EmbedBuilder,
+    ChannelType,
+    PermissionFlagsBits,
     type Client,
+    type Guild,
+    type GuildBasedChannel,
     type Interaction,
     type ChatInputCommandInteraction,
 } from 'discord.js'
@@ -56,6 +61,50 @@ function handleClientReady(client: Client): void {
     })
 }
 
+// Pure-utility onboarding embed (no invite/vote CTA — see ADR
+// 2026-06-18-in-bot-growth). Helps a new server start using the bot; keeping it
+// utility-first avoids the Platform-Manipulation flags that jeopardize verification.
+const ONBOARDING_EMBED = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle('🎵 Thanks for adding Lucky!')
+    .setDescription(
+        [
+            "Here's how to get started:",
+            '',
+            '`/play <song or url>` — play music in your voice channel',
+            '`/queue` — see the current and upcoming tracks',
+            '`/help` — browse every command',
+        ].join('\n'),
+    )
+    .setFooter({ text: 'Lucky' })
+
+// First text channel the bot can actually post to (system channel preferred).
+function findOnboardingChannel(guild: Guild): GuildBasedChannel | null {
+    const me = guild.members?.me
+    if (!me) return null
+    const canPost = (ch: GuildBasedChannel | null): boolean =>
+        ch?.type === ChannelType.GuildText &&
+        (ch
+            .permissionsFor(me)
+            ?.has([
+                PermissionFlagsBits.ViewChannel,
+                PermissionFlagsBits.SendMessages,
+                PermissionFlagsBits.EmbedLinks,
+            ]) ??
+            false)
+    if (canPost(guild.systemChannel)) return guild.systemChannel
+    return guild.channels.cache.find((ch) => canPost(ch)) ?? null
+}
+
+async function sendOnboardingMessage(guild: Guild): Promise<void> {
+    const channel = findOnboardingChannel(guild)
+    if (!channel || channel.type !== ChannelType.GuildText) {
+        // No channel the bot can post to — skip silently, never throw.
+        return
+    }
+    await channel.send({ embeds: [ONBOARDING_EMBED] })
+}
+
 function handleGuildCreate(client: Client): void {
     client.on(Events.GuildCreate, (guild) => {
         const totalGuilds = client.guilds.cache.size
@@ -72,6 +121,12 @@ function handleGuildCreate(client: Client): void {
         recordGuildJoin(guild).catch((error) => {
             errorLog({
                 message: 'Error recording guild join',
+                error,
+            })
+        })
+        sendOnboardingMessage(guild).catch((error) => {
+            errorLog({
+                message: 'Error sending onboarding message',
                 error,
             })
         })


### PR DESCRIPTION
## What
Implements the in-bot growth decision (ADR `decisions/2026-06-18-in-bot-growth.md`, from /research-and-decide, scoped distinct from the 2026-06-17 external-channel ADR).

**Decision:** in-bot growth is an **activation/retention aid, not an acquisition lever** (in-bot acquisition is low-lift *and* unmeasurable — Discord exposes no install source). Hard-rejects the policy-banned mechanics (unsolicited DMs, referral/invite-rewards, frequent nudges, core-feature vote-gating) so they aren't re-attempted.

**Pilot shipped here:** a **pure-utility join-time onboarding embed** on `guildCreate` — getting-started/`/help`, **no invite or vote CTA** (verification-safe; the footer `/invite` CTA already covers discovery). Posted only to a channel the bot can actually send to (ViewChannel+SendMessages+EmbedLinks), graceful skip otherwise — never throws.

## Why utility-first
Aggressive join-time CTAs risk Discord's Platform-Manipulation flags → bot **verification** denial → which would block the App-Directory channel the external ADR depends on.

## Tests
2 new eventHandler tests: posts the embed to a postable channel (+ asserts the embed carries **no invite/vote CTA**); skips when the bot can't post. 29/29 eventHandler tests pass; type-check + eslint clean.

Implements ADR 2026-06-18-in-bot-growth.
