### PR TITLE
fix(player): warn not error on bridge exhaustion for unplayable tracks

### DIFF
--- a/packages/bot/src/handlers/player/streamBridge.spec.ts
+++ b/packages/bot/src/handlers/player/streamBridge.spec.ts
@@ -193,6 +193,14 @@ describe('createResilientStream', () => {
         await expect(
             createResilientStream(makeTrack({ title: 'Some Song' })),
         ).rejects.toThrow('Bridge exhausted')
+        // #1500: an unplayable track is an expected outcome → WARN, not
+        // error→Sentry (which produced false "regression" alerts, LUCKY-2T).
+        expect(mockWarnLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Bridge: all stages exhausted',
+            }),
+        )
+        expect(mockErrorLog).not.toHaveBeenCalled()
     })
 
     it('throws immediately when cleanedTitle is empty after yt-dlp fails', async () => {

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -2,7 +2,7 @@ import { spawn } from 'child_process'
 import { PassThrough } from 'stream'
 import type { Readable } from 'stream'
 import type { Track } from 'discord-player'
-import { errorLog, infoLog, warnLog, debugLog } from '@lucky/shared/utils'
+import { infoLog, warnLog, debugLog } from '@lucky/shared/utils'
 import { assertDefined } from '@lucky/shared/utils/guards'
 import {
     cleanTitle,
@@ -69,19 +69,28 @@ export function streamViaYtDlp(url: string): Promise<Readable> {
         }, 15_000)
 
         const stderrChunks: Buffer[] = []
-        assertDefined(proc.stderr, 'stderr guaranteed by stdio config').on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+        assertDefined(proc.stderr, 'stderr guaranteed by stdio config').on(
+            'data',
+            (chunk: Buffer) => stderrChunks.push(chunk),
+        )
 
         let settled = false
 
-        assertDefined(proc.stdout, 'stdout guaranteed by stdio config').once('data', (firstChunk: Buffer) => {
-            if (settled) return
-            settled = true
-            clearTimeout(timeout)
-            const through = new PassThrough()
-            through.write(firstChunk)
-            assertDefined(proc.stdout, 'stdout guaranteed by stdio config').pipe(through)
-            resolve(through)
-        })
+        assertDefined(proc.stdout, 'stdout guaranteed by stdio config').once(
+            'data',
+            (firstChunk: Buffer) => {
+                if (settled) return
+                settled = true
+                clearTimeout(timeout)
+                const through = new PassThrough()
+                through.write(firstChunk)
+                assertDefined(
+                    proc.stdout,
+                    'stdout guaranteed by stdio config',
+                ).pipe(through)
+                resolve(through)
+            },
+        )
 
         proc.once('error', (err) => {
             if (settled) return
@@ -174,7 +183,7 @@ export async function createResilientStream(
     }
 
     if (!cleanedTitle) {
-        errorLog({
+        warnLog({
             message:
                 'Bridge: yt-dlp failed and title is empty, cannot fallback',
             data: { url: track.url },
@@ -231,7 +240,7 @@ export async function createResilientStream(
         try {
             return await streamViaSoundCloud(coreTitle, track.duration)
         } catch (coreError) {
-            errorLog({
+            warnLog({
                 message: 'Bridge: all stages exhausted',
                 error: coreError,
                 data: {
@@ -249,7 +258,7 @@ export async function createResilientStream(
             })
         }
     } else {
-        errorLog({
+        warnLog({
             message: 'Bridge: all stages exhausted',
             data: {
                 title: track.title,


### PR DESCRIPTION
## What
Closes #1500. The stream bridge logged "Bridge: all stages exhausted" at `errorLog` → Sentry for tracks that are simply **unavailable** (deleted / region-locked / no SoundCloud match) — an *expected* outcome, not a crash. That produced false Sentry "regression" alerts (LUCKY-2T, 36× sporadic, 0 users impacted).

## Change
Downgrade all 3 exhaustion log sites (`errorLog` → `warnLog`) in `streamBridge.ts` (empty-title, soundcloud-core, soundcloud-title-only); keep the `{title, url, stages}` data. Per the policy in ADR 2026-06-18-youtube-extraction-reliability (expected unavailability = warn; reserve error for unexpected failures).

## Acceptance (#1500)
- ✅ Unplayable track → **WARN**, not error→Sentry.
- ✅ Clean user-facing reply already exists (`errorHandlers.ts:42`: "**<track>** could not be streamed from any source… Skipping to next track.").
- ✅ Bursts stay observable for outage detection via Loki `count_over_time({…} |= "Bridge: all stages exhausted" [w])` (the dedicated extraction-failure counter is the YT-reliability ADR's measurement sprint, tracked separately).
- ✅ LUCKY-2T stops re-regressing (no longer error-level → Sentry).

## Tests
Extended the exhaust test to assert `warnLog` is called with "Bridge: all stages exhausted" and `errorLog` is NOT. 15/15 streamBridge tests pass; type-check + eslint clean. (Removed the now-unused `errorLog` import.)

Closes #1500


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1500 by downgrading “Bridge: all stages exhausted” to WARN for expected unplayable tracks, preventing false Sentry alerts. Observability and user messaging stay the same.

- **Bug Fixes**
  - Switched all three exhaustion sites in `streamBridge.ts` from `errorLog` to `warnLog` (including the yt-dlp empty-title path); kept `{ title, url, stages }`.
  - Updated tests to assert `warnLog` is called and `errorLog` is not; removed the unused `errorLog` import.
  - Aligns with ADR policy: expected unavailability → warn; reserve error for unexpected failures.

<sup>Written for commit 9aa64462c7452c957218ff172bbee536b8c9f6a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted logging severity levels in stream exhaustion scenarios to better classify warning-level events versus errors.

* **Tests**
  * Updated exhaustion scenario tests to validate correct logging behavior and verify appropriate error log handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->