### PR TITLE
ci(release): add workflow_dispatch to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ on:
     push:
         branches:
             - main
+    workflow_dispatch: {}
 
 permissions:
     contents: write


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to release-please workflow
- Allows manual re-triggering when release-please aborts due to `autorelease: pending` stuck on a previously-merged PR

## Why
Release-please aborted today with `⚠ There are untagged, merged release PRs outstanding` because PR #1508 had `autorelease: pending` label still set after v2.18.0 was released. Fixed the label on #1508; this `workflow_dispatch` makes it easy to re-trigger without needing a dummy commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable manual runs of the `release-please` workflow by adding a `workflow_dispatch` trigger. This lets us re-run releases when `autorelease: pending` gets stuck or when `release-please` aborts due to untagged merged PRs, without a dummy commit.

<sup>Written for commit 2ae9bdb0e70d35582872c0679dcafa91a4695575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

