### PR TITLE
fix(moderation): route context menus in the live event handler

### DIFF
--- a/packages/bot/src/handlers/eventHandler.spec.ts
+++ b/packages/bot/src/handlers/eventHandler.spec.ts
@@ -16,6 +16,8 @@ const handleExternalScrobblerMock = jest.fn()
 const handleReactionEventsMock = jest.fn()
 const handleMusicButtonInteractionMock = jest.fn()
 const handleButtonInteractionMock = jest.fn()
+const executeContextMenuMock = jest.fn()
+const handleMoveMessageSelectMock = jest.fn()
 const errorLogMock = jest.fn()
 const infoLogMock = jest.fn()
 const debugLogMock = jest.fn()
@@ -65,6 +67,16 @@ jest.mock('./reactionHandler', () => ({
 jest.mock('./musicButtonHandler', () => ({
     handleMusicButtonInteraction: (...args: unknown[]) =>
         handleMusicButtonInteractionMock(...args),
+}))
+
+jest.mock('./commandsHandler', () => ({
+    executeContextMenu: (...args: unknown[]) => executeContextMenuMock(...args),
+}))
+
+jest.mock('./moveMessageHandler', () => ({
+    handleMoveMessageSelect: (...args: unknown[]) =>
+        handleMoveMessageSelectMock(...args),
+    MOVE_MESSAGE_SELECT_PREFIX: 'movemsg:',
 }))
 
 jest.mock('@lucky/shared/services', () => ({
@@ -193,6 +205,8 @@ describe('eventHandler', () => {
         interactionHandler?.({
             isAutocomplete: () => false,
             isButton: () => false,
+            isMessageContextMenuCommand: () => false,
+            isChannelSelectMenu: () => false,
             isChatInputCommand: () => true,
             commandName: 'unknown',
             replied: false,
@@ -210,6 +224,51 @@ describe('eventHandler', () => {
         })
     })
 
+    it('routes a message context-menu interaction to executeContextMenu', async () => {
+        const { client, onMock } = createMockClient()
+        handleEvents(client as unknown as never)
+        const interactionHandler = getInteractionCreateHandler(onMock)
+
+        const interaction = {
+            isAutocomplete: () => false,
+            isButton: () => false,
+            isMessageContextMenuCommand: () => true,
+            isChannelSelectMenu: () => false,
+            isChatInputCommand: () => false,
+        } as unknown as Interaction
+
+        interactionHandler?.(interaction)
+        await flushAsyncHandlers()
+
+        expect(executeContextMenuMock).toHaveBeenCalledWith({
+            interaction,
+            client,
+        })
+    })
+
+    it('routes the move-message channel select to handleMoveMessageSelect', async () => {
+        const { client, onMock } = createMockClient()
+        handleEvents(client as unknown as never)
+        const interactionHandler = getInteractionCreateHandler(onMock)
+
+        const interaction = {
+            isAutocomplete: () => false,
+            isButton: () => false,
+            isMessageContextMenuCommand: () => false,
+            isChannelSelectMenu: () => true,
+            isChatInputCommand: () => false,
+            customId: 'movemsg:src:msg',
+        } as unknown as Interaction
+
+        interactionHandler?.(interaction)
+        await flushAsyncHandlers()
+
+        expect(handleMoveMessageSelectMock).toHaveBeenCalledWith(
+            interaction,
+            client,
+        )
+    })
+
     it('sends user-friendly error reply when command execution fails', async () => {
         const { client, onMock } = createMockClient()
         client.commands.set('broken', {
@@ -223,6 +282,8 @@ describe('eventHandler', () => {
         interactionHandler?.({
             isAutocomplete: () => false,
             isButton: () => false,
+            isMessageContextMenuCommand: () => false,
+            isChannelSelectMenu: () => false,
             isChatInputCommand: () => true,
             commandName: 'broken',
             replied: true,
@@ -260,6 +321,8 @@ describe('eventHandler', () => {
         interactionHandler?.({
             isAutocomplete: () => false,
             isButton: () => false,
+            isMessageContextMenuCommand: () => false,
+            isChannelSelectMenu: () => false,
             isChatInputCommand: () => true,
             commandName: 'broken',
             guildId: 'guild-123',
@@ -310,6 +373,8 @@ describe('eventHandler', () => {
         interactionHandler?.({
             isAutocomplete: () => false,
             isButton: () => false,
+            isMessageContextMenuCommand: () => false,
+            isChannelSelectMenu: () => false,
             isChatInputCommand: () => true,
             commandName: 'broken',
             guildId: 'guild-123',

--- a/packages/bot/src/handlers/eventHandler.ts
+++ b/packages/bot/src/handlers/eventHandler.ts
@@ -24,6 +24,11 @@ import { handleAuditEvents } from './auditHandler'
 import { handleExternalScrobbler } from './externalScrobbler'
 import { handleReactionEvents } from './reactionHandler'
 import { handleMusicButtonInteraction } from './musicButtonHandler'
+import { executeContextMenu } from './commandsHandler'
+import {
+    handleMoveMessageSelect,
+    MOVE_MESSAGE_SELECT_PREFIX,
+} from './moveMessageHandler'
 import { reactionRolesService } from '@lucky/shared/services'
 import { syncAllGuildFollowerRoles } from '../twitch/followerRoleSync'
 import { aiDevToolkitService } from '../services/AiDevToolkitService'
@@ -269,6 +274,22 @@ async function handleInteractionCreate(
                 return
             }
             await reactionRolesService.handleButtonInteraction(interaction)
+            return
+        }
+
+        if (interaction.isMessageContextMenuCommand()) {
+            await executeContextMenu({
+                interaction,
+                client: client as CustomClient,
+            })
+            return
+        }
+
+        if (
+            interaction.isChannelSelectMenu() &&
+            interaction.customId.startsWith(MOVE_MESSAGE_SELECT_PREFIX)
+        ) {
+            await handleMoveMessageSelect(interaction, client as CustomClient)
             return
         }
 


### PR DESCRIPTION
## What
The **Move message** context menu silently failed in production — Discord showed *"The application did not respond"* with zero bot logs.

## Root cause
The context-menu + channel-select routing was added to `interactionHandler.ts`, but that file is **dead code** — nothing wires its `handleInteraction`. The actually-wired `InteractionCreate` listener is `eventHandler.ts`'s `handleInteractionCreate`, whose `if (!interaction.isChatInputCommand()) return` dropped every context-menu and select-menu interaction before it could route. Slash commands worked (they hit `isChatInputCommand`), so the gap was invisible until the first context menu.

## Fix
Route inside the live handler, before the chat-input guard:
- `isMessageContextMenuCommand()` → `executeContextMenu`
- `isChannelSelectMenu()` + `movemsg:` prefix → `handleMoveMessageSelect`

Plus `eventHandler.spec.ts` regression tests so a context-menu / select routing miss is caught in CI (the original tests covered the dead handler, which is why this slipped).

## Verification
- `tsc` clean across workspaces (pre-commit).
- **Proven live in prod** via a temporary hot-patch of this exact change (right-click → Apps → Move message → picker → move succeeded).
- Full suite runs in CI here.

## Follow-up (separate issue)
`interactionHandler.ts` is dead/duplicate of `eventHandler.ts` — it should be deleted so this class of "edited the wrong handler" bug can't recur. Filing separately.

Non-destructive change (routing only — no new irreversible Discord API calls), so the destructive-interaction gate does not apply.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes routing for message context menus and the move-message channel select in the live `InteractionCreate` handler so the Move message action works again in production.

- **Bug Fixes**
  - Route `isMessageContextMenuCommand()` to `executeContextMenu`.
  - Route `isChannelSelectMenu()` with `movemsg:` prefix to `handleMoveMessageSelect`.
  - Added `eventHandler.spec.ts` tests to cover context-menu and select routing.

<sup>Written for commit 110bb27d3cd5a0f0e138d3b26b2487757ba54059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

