### PR TITLE
ci(release): add release-tag-guard backstop for release-please auto-tag

### DIFF
--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
-      - name: Create tag + release if release-please did not
+      - name: Create release (and tag) if release-please did not
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
@@ -42,15 +42,24 @@ jobs:
           version="$(node -p "require('./.release-please-manifest.json')['.']")"
           tag="v${version}"
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-            echo "::notice::${tag} already exists — release-please (or a prior run) tagged it. Nothing to do."
+          # Idempotency keys on the GitHub *Release*, not just the tag — the
+          # Release (`release: published`) is what fires deploy.yml. Checking the
+          # tag alone would skip the partial-failure case (tag pushed but release
+          # creation failed), leaving deploy permanently broken on reruns.
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            echo "::notice::release ${tag} already exists — release-please (or a prior run) created it. Nothing to do."
             exit 0
           fi
 
-          echo "::warning::${tag} missing after a manifest bump — release-please did not auto-tag (see ADR 2026-06-22-release-please-group-title-pattern). Creating it."
-          git tag "${tag}"
-          git push origin "${tag}"
+          echo "::warning::release ${tag} missing after a manifest bump — release-please did not auto-release (see ADR 2026-06-22-release-please-group-title-pattern). Creating it."
+
+          # The tag may already exist from a prior partial run; only create+push if absent.
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            git tag "${tag}"
+            git push origin "${tag}"
+          fi
+
           gh release create "${tag}" \
             --title "${tag}" \
-            --notes "Automated release tag created by release-tag-guard (release-please did not auto-tag). See CHANGELOG.md." \
+            --notes "Automated release created by release-tag-guard (release-please did not auto-release). See CHANGELOG.md." \
             --verify-tag

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -1,0 +1,56 @@
+name: Release Tag Guard
+
+# Deterministic backstop for release-please's auto-tag (ADR 2026-06-22).
+#
+# release-please has repeatedly merged a release PR but NOT created the matching
+# git tag / GitHub Release (it aborts with "untagged, merged release PRs
+# outstanding") — silently breaking the prod deploy, which is gated on
+# `release: published`. The group-pull-request-title-pattern fix got the version
+# into the PR title, but release-please's release-creation step is still
+# unreliable in this single-package manifest setup.
+#
+# This guard runs after a release PR merges (the manifest version bumps) and
+# ensures `v<version>` exists. If release-please already tagged it, this is a
+# no-op. If it didn't, the guard creates the tag + Release so the release can
+# never silently fail to ship again. Uses the PAT (not GITHUB_TOKEN) so the
+# `release: published` event propagates and deploy.yml fires.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.release-please-manifest.json'
+
+permissions:
+  contents: write
+
+jobs:
+  ensure-release-tag:
+    name: Ensure release tag + GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Create tag + release if release-please did not
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./.release-please-manifest.json')['.']")"
+          tag="v${version}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "::notice::${tag} already exists — release-please (or a prior run) tagged it. Nothing to do."
+            exit 0
+          fi
+
+          echo "::warning::${tag} missing after a manifest bump — release-please did not auto-tag (see ADR 2026-06-22-release-please-group-title-pattern). Creating it."
+          git tag "${tag}"
+          git push origin "${tag}"
+          gh release create "${tag}" \
+            --title "${tag}" \
+            --notes "Automated release tag created by release-tag-guard (release-please did not auto-tag). See CHANGELOG.md." \
+            --verify-tag

--- a/decisions/2026-06-22-release-please-group-title-pattern.md
+++ b/decisions/2026-06-22-release-please-group-title-pattern.md
@@ -41,33 +41,35 @@ But on merging #1522, release-please **still aborted** with the same `⚠ There 
 ## Alternatives considered
 
 - **`separate-pull-requests: true`** — switches to per-package PRs, which _do_ read `pull-request-title-pattern` (already set), so `${version}` resolves. Rejected as primary: a larger behavioral change (PR structure + reviewer workflow) than needed for a one-package repo. It is the fallback if the group-pattern fix doesn't resolve `${version}`.
-- **CI auto-tag guard alone** — codifies the manual workaround but doesn't fix the root cause; kept as the companion, not the fix.
-- **Replace release-please with tag-on-merge** — reverses ADR 2026-06-16; heavy; rejected.
+- **CI auto-tag guard** — initially considered the companion to the title fix. After the validation outcome below, it was **promoted to the primary durable mechanism** (shipped in `.github/workflows/release-tag-guard.yml`), because the title fix alone did not make release-please tag reliably.
+- **`separate-pull-requests: true`** — still available as a further fallback if even the title generation regresses; not needed, since the guard makes tagging deterministic regardless.
+- **Replace release-please with tag-on-merge** — reverses ADR 2026-06-16; heavy; rejected. (The guard is effectively a narrow tag-on-merge backstop _layered on_ release-please, keeping its version-bump + changelog value.)
 
 ## Consequences
 
 Positive:
 
-- Releases auto-tag → auto-deploy, no manual `git tag` step per release.
-- One-line, reversible config change; no workflow or version-bump/changelog regression.
+- Releases tag + release deterministically: release-please does version-bump + changelog + PR; the **guard guarantees the `v<version>` tag + GitHub Release** (and thus the deploy) on merge. No manual `git tag` per release.
+- The title fix is a one-line, reversible config change with no version-bump/changelog regression; the guard is idempotent (keys on the Release) and a no-op when release-please does tag.
 
 Negative / residual risk:
 
-- `${version}` resolving in the _group_ pattern is verified-by-design (single package, standard interpolation) but **proven only on the next release** — v2.20.1 is the live test. Mitigated by explicitly watching that release (not relying on silent success) + the companion guard.
+- Two mechanisms can now create the release (release-please + guard). The guard's Release-existence check makes this safe (no double-release), but a future release-please that _does_ tag will make the guard a silent no-op — fine, but worth knowing when debugging.
 
 Neutral:
 
-- The stale #1519 (created with the old title) won't be retitled; it must be closed so release-please regenerates a correctly-titled PR (see plan).
+- The stale #1519 (old title) was closed so release-please regenerated a correctly-titled PR (#1522).
 
-## Plan / validation
+## Plan / validation — DONE
 
-1. PR the config change → merge to `main`.
-2. **Close #1519** so release-please regenerates the release PR — it should now be titled `chore: release 2.20.1`.
-3. Merge the regenerated PR → confirm release-please **auto-creates the v2.20.1 tag + GitHub release** (no manual flip) → `release: published` fires the deploy. This both ships v2.20.1 and **validates the fix**.
-4. If step 3 still requires a manual tag → the group-pattern fix didn't take → switch to `separate-pull-requests: true` and build the CI auto-tag guard.
+1. ✅ PR the config change (#1521) → merged.
+2. ✅ Closed #1519 → release-please regenerated #1522 titled **`chore: release 2.20.1`** (title fix confirmed).
+3. ❌ Merged #1522 → release-please **still aborted**, no v2.20.1 tag → title fix necessary but not sufficient (see Validation outcome above).
+4. ✅ Shipped v2.20.1 via the manual workaround one last time; built + shipped the **CI auto-tag guard** (#1523) as the durable fix.
 
 ## Revisit when
 
-- **A release PR again merges without an auto-created tag** → the fix regressed; build the CI auto-tag guard and/or switch to `separate-pull-requests: true`.
-- **A 2nd package is added to the manifest** → `${version}` becomes ambiguous in the combined group PR; move to per-component titles/tags.
-- **release-please major upgrade** changes title-pattern/interpolation semantics → re-verify.
+- **The guard ever creates a release that release-please should have** (check Actions warnings) — expected for now; if release-please starts tagging reliably again (e.g. after an upgrade), the guard becomes a redundant no-op and could be removed.
+- **A release merges with neither release-please nor the guard tagging it** → the guard regressed; debug the workflow (PAT scope, paths filter, manifest key).
+- **A 2nd package is added to the manifest** → `${version}` becomes ambiguous in the combined group PR _and_ the guard's single-version assumption breaks; move to per-component titles/tags.
+- **release-please major upgrade** changes title-pattern/interpolation or release-creation semantics → re-verify and reconsider whether the guard is still needed.

--- a/decisions/2026-06-22-release-please-group-title-pattern.md
+++ b/decisions/2026-06-22-release-please-group-title-pattern.md
@@ -30,6 +30,14 @@ Add **`"group-pull-request-title-pattern": "chore: release ${version}"`** to `re
 
 **Companion guard (per critic — ship as fast-follow):** add a CI step that, when a `release-please` PR merges without producing a tag, surfaces it loudly (or auto-creates the tag). Four prior _silent_ failures mean a regression should not be able to fail quietly again. This is gated by the first revisit trigger below — built immediately if v2.20.1 doesn't auto-tag, and recommended regardless within the release cycle.
 
+## Validation outcome (2026-06-22) — title fix was NECESSARY BUT NOT SUFFICIENT
+
+The group-pattern fix worked **for the title**: after it merged, release-please regenerated the release PR (#1522) titled `chore: release 2.20.1` (version present, no longer `chore: release main`). Confirmed.
+
+But on merging #1522, release-please **still aborted** with the same `⚠ There are untagged, merged release PRs outstanding - aborting` and did **not** create the v2.20.1 tag. With `skip-github-release: false` and the PAT, its release-creation step still failed to associate the squash-merged release PR and tag it — the accumulated manual-tag history + squash-merge association is a deeper release-please reliability problem than the title alone.
+
+**Conclusion:** release-please's auto-tag cannot be relied on in this repo. The title fix is kept (it is a precondition and harmless), but the **durable fix is the CI auto-tag guard** (`.github/workflows/release-tag-guard.yml`), shipped now rather than deferred — exactly the critic's "ship alongside" recommendation, promoted from companion to primary mechanism. The guard fires on a manifest-version bump (release PR merge) and creates `v<version>` + the Release via the PAT if release-please didn't, so a release can never silently fail to ship again. v2.20.1 itself was tagged via the one-last-time manual workaround.
+
 ## Alternatives considered
 
 - **`separate-pull-requests: true`** — switches to per-package PRs, which _do_ read `pull-request-title-pattern` (already set), so `${version}` resolves. Rejected as primary: a larger behavioral change (PR structure + reviewer workflow) than needed for a one-package repo. It is the fallback if the group-pattern fix doesn't resolve `${version}`.


### PR DESCRIPTION
## Why
The `group-pull-request-title-pattern` fix (PR #1521) got the version into the release PR title (`chore: release 2.20.1` ✅) — but on merge, release-please **still aborted** (`untagged, merged release PRs outstanding`) and did **not** tag v2.20.1. With `skip-github-release: false` + the PAT, its release-creation step is still unreliable here (squash-merge association + accumulated manual-tag state). v2.20.1 was tagged via the manual workaround one last time.

So release-please's auto-tag can't be relied on. This adds a deterministic backstop.

## What
`.github/workflows/release-tag-guard.yml` — on a `.release-please-manifest.json` bump (i.e. a release PR merged to main), ensure `v<version>` exists:
- If the tag already exists (release-please did tag it) → no-op.
- If missing → create the tag + GitHub Release via the **PAT** (so `release: published` fires `deploy.yml`).

Idempotent, paths-filtered to fire only on release merges. Pairs with the title fix (kept as a precondition).

## Validation
- The guard only acts when a manifest bump leaves `v<version>` untagged — exactly the 4× failure mode.
- Next release is the live test: merge the release PR → guard ensures the tag with no manual step.

ADR: `decisions/2026-06-22-release-please-group-title-pattern.md` (updated with the validation outcome). decision-critic recommended shipping this alongside the config fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI guard that auto-creates the `v<version>` tag and GitHub Release after a manifest bump, as a backstop for unreliable `release-please` auto-tagging. It prevents silent deploy skips by ensuring the release is published via the PAT and is idempotent on the GitHub Release.

- **New Features**
  - Added `.github/workflows/release-tag-guard.yml` triggered on `.release-please-manifest.json` changes to `main`.
  - If GitHub Release `v<version>` exists → no-op; if missing → create the tag (if absent) and the Release using `RELEASE_PLEASE_TOKEN` so `release: published` triggers `deploy.yml`.
  - Idempotent by checking the Release (covers partial runs where the tag exists but the Release does not); paths-filtered to run only on release merges.

<sup>Written for commit 62cf24dcd87814c08f59a98ca8aac62a6ee55dd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release creation workflow for more reliable deployment consistency.
  * Updated internal release automation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->