### PR TITLE
feat(infra): homelab staging environment for visual PR review

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -37,11 +37,15 @@ jobs:
         steps:
             - name: Resolve ref to deploy
               id: ref
+              env:
+                  EVENT_NAME: ${{ github.event_name }}
+                  INPUT_REF: ${{ github.event.inputs.ref }}
+                  PR_REF: ${{ github.event.pull_request.head.ref }}
               run: |
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-                      echo "ref=${{ github.event.inputs.ref }}" >> "$GITHUB_OUTPUT"
+                  if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+                      echo "ref=$INPUT_REF" >> "$GITHUB_OUTPUT"
                   else
-                      echo "ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+                      echo "ref=$PR_REF" >> "$GITHUB_OUTPUT"
                   fi
 
             - name: Trigger staging deploy webhook
@@ -50,6 +54,7 @@ jobs:
                   WEBHOOK_SECRET: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}
                   DEPLOY_REF: ${{ steps.ref.outputs.ref }}
               run: |
+                  # shellcheck disable=SC2016  # ${...} below is JS, evaluated by node, not bash
                   set -euo pipefail
                   # Derive the staging hook URL (origin + /webhook/deploy-staging)
                   # from the prod webhook secret, keeping the curl injection-safe.

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,92 @@
+name: Deploy Staging
+
+# Visually verify a branch on the shared homelab staging environment
+# (https://lucky-staging.lucassantana.tech) before it merges to main.
+#
+# Staging is a SINGLE shared stack, so it hosts one PR at a time. Opt a PR in by
+# adding the `staging` label; every subsequent push to that PR redeploys it.
+# Manual deploys of any ref are available via workflow_dispatch.
+
+on:
+    pull_request:
+        types: [labeled, synchronize, reopened]
+    workflow_dispatch:
+        inputs:
+            ref:
+                description: Branch or commit SHA to deploy to staging
+                required: true
+                default: main
+
+concurrency:
+    group: deploy-staging
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    deploy-staging:
+        # Skip forks (no secrets, shouldn't deploy). For pull_request events only
+        # run when the PR carries the `staging` label.
+        if: >-
+            github.event_name == 'workflow_dispatch' ||
+            (github.event.pull_request.head.repo.full_name == github.repository &&
+             contains(github.event.pull_request.labels.*.name, 'staging'))
+        runs-on: ubuntu-latest
+        steps:
+            - name: Resolve ref to deploy
+              id: ref
+              run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                      echo "ref=${{ github.event.inputs.ref }}" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Trigger staging deploy webhook
+              env:
+                  WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+                  WEBHOOK_SECRET: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}
+                  DEPLOY_REF: ${{ steps.ref.outputs.ref }}
+              run: |
+                  set -euo pipefail
+                  # Derive the staging hook URL (origin + /webhook/deploy-staging)
+                  # from the prod webhook secret, keeping the curl injection-safe.
+                  STAGING_URL=$(node -e '
+                      const raw = (process.env.WEBHOOK_URL ?? "").trim();
+                      if (!raw) { console.error("DEPLOY_WEBHOOK_URL not set"); process.exit(1); }
+                      const u = new URL(raw);
+                      console.log(`${u.protocol}//${u.host}/webhook/deploy-staging`);
+                  ')
+                  echo "POST $STAGING_URL (ref=$DEPLOY_REF)"
+                  code=$(curl -s -o /tmp/resp.txt -w "%{http_code}" \
+                      -X POST \
+                      -H "X-Webhook-Secret: $WEBHOOK_SECRET" \
+                      -H "X-Deploy-Ref: $DEPLOY_REF" \
+                      --max-time 30 \
+                      "$STAGING_URL" || echo "000")
+                  echo "HTTP $code"; cat /tmp/resp.txt || true
+                  if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
+                      echo "::error::Staging webhook returned HTTP $code"
+                      exit 1
+                  fi
+
+            - name: Comment staging URL on PR
+              if: github.event_name == 'pull_request'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const url = 'https://lucky-staging.lucassantana.tech';
+                      const sha = context.payload.pull_request.head.sha.slice(0, 7);
+                      const marker = '<!-- lucky-staging-deploy -->';
+                      const body = `${marker}\n🧪 **Staging deploy triggered** — building \`${sha}\` on the homelab.\n\nOnce it's up (~2-3 min for the image build), review it at **${url}**.\n\n_Single shared environment — the most-recently-labeled PR occupies it. The build runs locally on the homelab; watch the deploy log there if it doesn't come up._`;
+                      const { owner, repo } = context.repo;
+                      const issue_number = context.payload.pull_request.number;
+                      const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+                      const existing = comments.data.find(c => c.body && c.body.includes(marker));
+                      if (existing) {
+                          await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                      } else {
+                          await github.rest.issues.createComment({ owner, repo, issue_number, body });
+                      }

--- a/deploy/hooks.json
+++ b/deploy/hooks.json
@@ -10,5 +10,17 @@
             { "source": "header", "name": "X-Webhook-Secret" },
             { "source": "header", "name": "X-Deploy-SHA" }
         ]
+    },
+    {
+        "id": "deploy-staging",
+        "execute-command": "/home/luk-server/Lucky/scripts/deploy-staging-wrapper.sh",
+        "command-working-directory": "/home/luk-server/Lucky",
+        "response-message": "Staging deploy triggered",
+        "include-command-output-in-response": true,
+        "include-command-output-in-response-on-error": true,
+        "pass-arguments-to-command": [
+            { "source": "header", "name": "X-Webhook-Secret" },
+            { "source": "header", "name": "X-Deploy-Ref" }
+        ]
     }
 ]

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,186 @@
+# Staging stack — an isolated, dashboard-only mirror of production for visually
+# verifying frontend/dashboard changes on a real branch before they reach prod.
+#
+# Differences vs docker-compose.yml (production):
+#   - NO bot service (the dashboard reads guild data via Discord REST; it does
+#     not need a running gateway bot — and two bots cannot share one token).
+#   - NO webhook / cloudflared services (staging reuses the PRODUCTION tunnel;
+#     an ingress rule in config-lucky.yml routes lucky-staging.* → this nginx's
+#     published host port 8093).
+#   - Its own project (`lucky-staging`), container names, network, and volumes
+#     so it never touches production data.
+#   - Service names stay `backend`/`frontend`/`nginx`/`postgres`/`redis` so the
+#     image-baked nginx upstreams (http://backend:3000, http://frontend:8080)
+#     resolve to THESE staging containers on the isolated staging network.
+#
+# Driven by .env.staging on the host (WEBAPP_* point at the staging domains).
+# Deployed by scripts/deploy-staging.sh (builds locally from the branch).
+
+name: lucky-staging
+
+x-small-svc: &small-svc
+    mem_limit: 128m
+    cpus: 0.25
+    restart: unless-stopped
+
+x-medium-svc: &medium-svc
+    mem_limit: 512m
+    cpus: 0.5
+    restart: unless-stopped
+
+x-large-svc: &large-svc
+    mem_limit: 1g
+    cpus: 1.0
+    restart: unless-stopped
+
+x-common-app-env: &common-app-env
+    NODE_ENV: production
+    DISCORD_TOKEN: ${DISCORD_TOKEN}
+    CLIENT_ID: ${CLIENT_ID}
+    SENTRY_DSN: ${SENTRY_DSN:-}
+    SENTRY_ENABLED: ${SENTRY_ENABLED:-false}
+    SENTRY_ENVIRONMENT: staging
+    DATABASE_URL: postgresql://discordbot:${POSTGRES_PASSWORD?POSTGRES_PASSWORD_required}@postgres:5432/discordbot
+    REDIS_HOST: redis
+    REDIS_PORT: 6379
+    REDIS_DB: ${REDIS_DB:-0}
+    LASTFM_API_KEY: ${LASTFM_API_KEY:-}
+    LASTFM_API_SECRET: ${LASTFM_API_SECRET:-}
+    LASTFM_LINK_SECRET: ${LASTFM_LINK_SECRET:-}
+    SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID:-}
+    SPOTIFY_CLIENT_SECRET: ${SPOTIFY_CLIENT_SECRET:-}
+    SPOTIFY_REDIRECT_URI: ${SPOTIFY_REDIRECT_URI:-}
+    SPOTIFY_LINK_SECRET: ${SPOTIFY_LINK_SECRET:-}
+    WEBAPP_REDIRECT_URI: ${WEBAPP_REDIRECT_URI:-}
+    WEBAPP_SESSION_SECRET: ${WEBAPP_SESSION_SECRET:-}
+
+services:
+    postgres:
+        <<: *large-svc
+        image: postgres:18-alpine
+        container_name: lucky-staging-postgres
+        environment:
+            POSTGRES_DB: discordbot
+            POSTGRES_USER: discordbot
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD?POSTGRES_PASSWORD_required}
+            PGDATA: /var/lib/postgresql/data
+        volumes:
+            - staging_postgres_data:/var/lib/postgresql/data
+        networks:
+            - lucky-staging-network
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U discordbot -d discordbot"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "10m"
+                max-file: "3"
+                tag: "{{.Name}}"
+
+    redis:
+        <<: *medium-svc
+        image: redis:8-alpine
+        container_name: lucky-staging-redis
+        command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+        volumes:
+            - staging_redis_data:/data
+        networks:
+            - lucky-staging-network
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "10m"
+                max-file: "3"
+                tag: "{{.Name}}"
+
+    backend:
+        <<: *medium-svc
+        image: ${IMAGE_PREFIX:-ghcr.io/lucassantana-dev/lucky}-backend:${IMAGE_TAG:-staging}
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: production-backend
+            args:
+                SERVICE: backend
+                NODE_ENV: production
+        container_name: lucky-staging-backend
+        env_file:
+            - .env.staging
+        depends_on:
+            postgres:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+        environment:
+            <<: *common-app-env
+            SENTRY_SERVICE_NAME: ${SENTRY_SERVICE_NAME:-backend}
+            LUCKY_NOTIFY_API_KEY: ${LUCKY_NOTIFY_API_KEY:-}
+            CLIENT_SECRET: ${CLIENT_SECRET}
+            WEBAPP_PORT: 3000
+            DEVELOPER_USER_IDS: ${DEVELOPER_USER_IDS:-}
+            WEBAPP_FRONTEND_URL: ${WEBAPP_FRONTEND_URL:-}
+            WEBAPP_BACKEND_URL: ${WEBAPP_BACKEND_URL:-}
+        networks:
+            - lucky-staging-network
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "10m"
+                max-file: "3"
+                tag: "{{.Name}}"
+
+    frontend:
+        <<: *small-svc
+        image: ${IMAGE_PREFIX:-ghcr.io/lucassantana-dev/lucky}-frontend:${IMAGE_TAG:-staging}
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: production-frontend
+        container_name: lucky-staging-frontend
+        networks:
+            - lucky-staging-network
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "10m"
+                max-file: "3"
+                tag: "{{.Name}}"
+
+    nginx:
+        <<: *small-svc
+        image: ${IMAGE_PREFIX:-ghcr.io/lucassantana-dev/lucky}-nginx:${IMAGE_TAG:-staging}
+        build:
+            context: .
+            dockerfile: Dockerfile.nginx
+        container_name: lucky-staging-nginx
+        depends_on:
+            - backend
+            - frontend
+        ports:
+            # Published on the host so the production cloudflared tunnel can
+            # route lucky-staging.* → http://100.95.204.103:8093 (config-lucky.yml).
+            - "${NGINX_PORT:-8093}:8080"
+        networks:
+            - lucky-staging-network
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "10m"
+                max-file: "3"
+                tag: "{{.Name}}"
+
+volumes:
+    staging_postgres_data:
+    staging_redis_data:
+
+networks:
+    lucky-staging-network:
+        driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,6 +240,9 @@ services:
             # the webhook on a stale hooks.json. The directory mount updates live,
             # so -hotreload picks up changes (e.g. new pass-arguments entries).
             - .:/home/luk-server/Lucky
+            # Staging checkout, so the deploy-staging hook can build + run the
+            # isolated lucky-staging stack from this same webhook container.
+            - ${STAGING_DIR:-/home/luk-server/lucky-staging}:/home/luk-server/lucky-staging
             - ${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:${CLOUDFLARED_CONFIG_DIR:-/home/luk-server/.cloudflared}:ro
             - /var/run/docker.sock:/var/run/docker.sock
         working_dir: /home/luk-server/Lucky

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -1,0 +1,54 @@
+# Staging environment
+
+A shared, isolated mirror of production on the homelab for **visually verifying
+dashboard/frontend changes on a real branch before they merge to `main`**. The
+dashboard is a live Discord OAuth client, so it can't be meaningfully reviewed
+without real auth + guild data — staging provides exactly that.
+
+- **Frontend:** https://lucky-staging.lucassantana.tech
+- **Backend:** https://lucky-staging-api.lucassantana.tech
+- **Stack:** `docker-compose.staging.yml` (project `lucky-staging`) — postgres,
+  redis, backend, frontend, nginx. **No bot** (the dashboard reads guild data via
+  Discord REST; staging reuses the prod bot's presence in the test guild) and
+  **no tunnel/webhook of its own** (reuses production's).
+
+## How to use it
+
+1. Add the **`staging`** label to your PR.
+2. `Deploy Staging` (`.github/workflows/deploy-staging.yml`) fires, POSTs the
+   homelab `deploy-staging` webhook with the PR's branch, and comments the URL.
+3. The homelab builds the branch's images locally (~2-3 min) and brings up the
+   `lucky-staging` stack; every subsequent push to the labeled PR redeploys.
+4. Open the URL, log in with Discord, review with real data.
+
+Manual deploy of any ref: run the **Deploy Staging** workflow via
+`workflow_dispatch` with a branch/SHA.
+
+> Staging is a **single shared environment** — one PR occupies it at a time
+> (the most-recently-labeled/pushed wins). Coordinate if two changes need eyes
+> at once.
+
+## Isolation (why it's safe next to prod)
+
+| Layer | Production | Staging |
+|---|---|---|
+| Compose project | `lucky` | `lucky-staging` |
+| Containers | `lucky-*` | `lucky-staging-*` |
+| Network | `lucky_lucky-network` | `lucky-staging-network` |
+| DB / Redis volumes | `postgres_data` / `redis_data` | `staging_postgres_data` / `staging_redis_data` |
+| nginx host port | 8090 | 8093 |
+| Tunnel routing | `nginx:80` (docker net) | `http://100.95.204.103:8093` (host port) |
+| Discord OAuth | prod redirect | shares `CLIENT_ID`, adds the staging redirect URI |
+| Bot | runs the gateway | none (REST-only data via the prod bot's token) |
+
+## Host-managed (not in the repo)
+
+- `/home/luk-server/lucky-staging` — the staging git checkout (the deploy script
+  checks out the target ref here and builds from it).
+- `/home/luk-server/lucky-staging/.env.staging` — staging env: prod values with
+  `WEBAPP_*` pointed at the staging domains, a distinct `WEBAPP_SESSION_SECRET`,
+  and `NGINX_PORT=8093`.
+- `~/.cloudflared/config-lucky.yml` — ingress rules routing the two staging
+  hostnames to `http://100.95.204.103:8093`.
+- Cloudflare DNS — `lucky-staging` + `lucky-staging-api` CNAMEs → the tunnel.
+- Discord app `962198089161134131` — the staging redirect URI registered.

--- a/scripts/deploy-staging-wrapper.sh
+++ b/scripts/deploy-staging-wrapper.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Async wrapper for deploy-staging.sh — returns immediately while the staging
+# deploy runs detached, so the triggering curl never blocks on the build.
+# Mirrors deploy-wrapper.sh but targets the staging stack.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/deploy-staging.sh"
+LOG_FILE="/tmp/lucky-staging-deploy.log"
+
+if [[ ! -x "$DEPLOY_SCRIPT" ]]; then
+    echo "[deploy-staging-wrapper] ERROR: $DEPLOY_SCRIPT is not executable"
+    exit 1
+fi
+
+nohup bash "$DEPLOY_SCRIPT" "$@" > "$LOG_FILE" 2>&1 &
+echo "[deploy-staging-wrapper] Staging deploy started (pid=$!, log=$LOG_FILE)"

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -103,6 +103,19 @@ fi
 log "Rolling out staging services..."
 dc up -d --remove-orphans backend frontend nginx
 
+# Ensure the production cloudflared tunnel can resolve this staging nginx. The
+# tunnel's remote ingress routes lucky-staging.* -> http://lucky-staging-nginx:8080,
+# which only resolves if lucky-tunnel is attached to the staging network. Re-apply
+# each deploy: a prod deploy that recreates lucky-tunnel drops the attachment.
+STAGING_NET="$(docker network ls --format '{{.Name}}' | grep -E 'lucky-staging.*network' | head -1)"
+if [[ -n "$STAGING_NET" ]] && docker ps --format '{{.Names}}' | grep -qx lucky-tunnel; then
+    if docker network connect "$STAGING_NET" lucky-tunnel 2>/dev/null; then
+        log "Connected lucky-tunnel -> $STAGING_NET"
+    else
+        log "lucky-tunnel already on $STAGING_NET (ok)"
+    fi
+fi
+
 # --- health check --------------------------------------------------------------
 log "Health-checking staging (http://localhost:${HEALTH_PORT})..."
 ok=""

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Staging deploy — builds + runs the isolated `lucky-staging` stack from an
+# arbitrary branch/ref so a frontend/dashboard change can be visually verified
+# at https://lucky-staging.lucassantana.tech before it merges to main.
+#
+# Invoked by the homelab webhook (deploy/hooks.json → deploy-staging hook) with:
+#   $1 = X-Webhook-Secret   (validated against DEPLOY_WEBHOOK_SECRET)
+#   $2 = X-Deploy-Ref        (branch name or commit SHA to deploy)
+#
+# Self-contained on purpose: it must NEVER reuse prod's deploy.sh (which resets
+# the prod checkout to origin/main and restarts prod services). This script
+# operates only inside STAGING_DIR with the staging compose project.
+set -euo pipefail
+
+LOG_PREFIX="[deploy-staging]"
+log() { echo "$LOG_PREFIX $(date '+%H:%M:%S') $1"; }
+
+WEBHOOK_SECRET_ARG="${1:-}"
+DEPLOY_REF="${2:-main}"
+
+STAGING_DIR="${STAGING_DIR:-/home/luk-server/lucky-staging}"
+# Staging INFRA (compose) comes from the prod checkout (always main) so ANY
+# target branch can be staged even if it predates this file. The app SOURCE for
+# the build comes from STAGING_DIR via --project-directory.
+COMPOSE_FILE="${STAGING_COMPOSE_FILE:-/home/luk-server/Lucky/docker-compose.staging.yml}"
+ENV_FILE=".env.staging"
+PROJECT="lucky-staging"
+HEALTH_PORT="${NGINX_PORT:-8093}"
+
+# --- secret gate ---------------------------------------------------------------
+if [[ -z "${DEPLOY_WEBHOOK_SECRET:-}" ]]; then
+    log "ERROR: DEPLOY_WEBHOOK_SECRET not set in environment"
+    exit 1
+fi
+if [[ "$WEBHOOK_SECRET_ARG" != "$DEPLOY_WEBHOOK_SECRET" ]]; then
+    log "ERROR: webhook secret mismatch — refusing to deploy"
+    exit 1
+fi
+
+# --- single-flight lock --------------------------------------------------------
+LOCK_DIR="/tmp/lucky-staging-deploy.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    log "ERROR: another staging deploy is in progress ($LOCK_DIR) — aborting"
+    exit 1
+fi
+trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+dc() {
+    docker compose -p "$PROJECT" -f "$COMPOSE_FILE" \
+        --project-directory "$STAGING_DIR" --env-file "$STAGING_DIR/$ENV_FILE" "$@"
+}
+
+# --- checkout the requested ref ------------------------------------------------
+if [[ ! -d "$STAGING_DIR/.git" ]]; then
+    log "ERROR: staging checkout missing at $STAGING_DIR (clone the repo there first)"
+    exit 1
+fi
+cd "$STAGING_DIR"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    log "ERROR: $STAGING_DIR/$ENV_FILE missing (host-managed staging env)"
+    exit 1
+fi
+
+log "Fetching + checking out ref: $DEPLOY_REF"
+git fetch --prune --quiet origin
+# Resolve the ref to a concrete SHA (works for branch names or SHAs).
+RESOLVED_SHA="$(git rev-parse --verify --quiet "origin/$DEPLOY_REF^{commit}" \
+    || git rev-parse --verify --quiet "$DEPLOY_REF^{commit}" || true)"
+if [[ -z "$RESOLVED_SHA" ]]; then
+    log "ERROR: could not resolve ref '$DEPLOY_REF' to a commit"
+    exit 1
+fi
+git checkout --quiet --force --detach "$RESOLVED_SHA"
+log "Checked out $DEPLOY_REF -> ${RESOLVED_SHA:0:7}"
+export IMAGE_TAG="staging-${RESOLVED_SHA:0:7}"
+
+# --- build (locally; CI only builds main images) -------------------------------
+log "Building staging images (backend, frontend, nginx)..."
+if ! dc build backend frontend nginx; then
+    log "ERROR: BUILD_FAILED"
+    exit 1
+fi
+
+# --- data services + migrations ------------------------------------------------
+log "Starting postgres + redis..."
+dc up -d postgres redis
+
+log "Waiting for postgres..."
+for _ in $(seq 1 30); do
+    if dc exec -T postgres pg_isready -U discordbot -d discordbot >/dev/null 2>&1; then break; fi
+    sleep 2
+done
+
+log "Running database migrations (staging DB)..."
+if ! dc run --rm --no-deps backend \
+    sh -lc "npx prisma migrate deploy --config prisma/prisma.config.ts --schema prisma/schema.prisma"; then
+    log "ERROR: MIGRATION_FAILED"
+    exit 1
+fi
+
+# --- roll out ------------------------------------------------------------------
+log "Rolling out staging services..."
+dc up -d --remove-orphans backend frontend nginx
+
+# --- health check --------------------------------------------------------------
+log "Health-checking staging (http://localhost:${HEALTH_PORT})..."
+ok=""
+for _ in $(seq 1 30); do
+    if curl -fsS --max-time 4 "http://localhost:${HEALTH_PORT}/api/health" >/dev/null 2>&1; then
+        ok="1"; break
+    fi
+    sleep 3
+done
+if [[ -z "$ok" ]]; then
+    log "ERROR: HEALTH_FAILED — staging API did not become ready"
+    dc ps
+    dc logs --tail=60 --no-color backend nginx || true
+    exit 1
+fi
+
+# Verify the OAuth contract endpoint too (the dashboard depends on it).
+if ! curl -fsS --max-time 4 "http://localhost:${HEALTH_PORT}/api/health/auth-config" >/dev/null 2>&1; then
+    log "WARN: auth-config endpoint not ready (dashboard login may fail)"
+fi
+
+log "STAGING DEPLOY OK — ${DEPLOY_REF} (${RESOLVED_SHA:0:7}) live at https://lucky-staging.lucassantana.tech"


### PR DESCRIPTION
Adds an isolated **staging environment** so dashboard/frontend changes can be visually verified on a real branch — with real Discord OAuth + guild data — before they reach production. (The whole repaint-screenshot saga proved we had no way to do this.)

## What it is
A dashboard-only mirror of prod on the homelab, live at **https://lucky-staging.lucassantana.tech** (already stood up + verified — currently serving #1546 for review).

- `docker-compose.staging.yml` — isolated stack (project `lucky-staging`, own network/volumes/ports 8093, **no bot**, reuses the prod Discord app + the prod tunnel)
- `scripts/deploy-staging.sh` + wrapper — checkout ref → build locally → migrate → up → health-check (infra compose from main, app source from the branch); self-heals the tunnel↔staging-network link
- `deploy/hooks.json` — `deploy-staging` webhook hook; webhook container mounts the staging checkout
- `.github/workflows/deploy-staging.yml` — add the **`staging`** label to a PR → it auto-deploys + comments the URL (single shared env, one PR at a time); `workflow_dispatch` for any ref
- `docs/STAGING.md`

## Isolation
Separate compose project, containers (`lucky-staging-*`), network, DB/redis volumes, nginx host port (8093 vs 8090). Shares the prod Discord `CLIENT_ID` (staging redirect added) and tunnel (staging public-hostname added → `lucky-staging-nginx:8080`).

## Activation after merge
1. Host prod checkout syncs to main (next prod deploy) → `docker-compose.yml` webhook mount + `hooks.json` land
2. Recreate the webhook container once (picks up the staging-dir mount + the new hook)
3. Label any PR `staging` → auto-deploy

Host-side (staging `.env`, tunnel ingress, DNS, Discord redirect) is already configured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single, isolated homelab staging environment to visually review dashboard/frontend branches with real Discord OAuth and guild data before merging to main. Label a PR `staging` to auto-build and deploy the branch to https://lucky-staging.lucassantana.tech.

- **New Features**
  - Isolated `lucky-staging` stack via `docker-compose.staging.yml` (own project/network/volumes, port 8093); dashboard-only, no bot; reuses prod Discord app and Cloudflare tunnel.
  - Auto-deploys when a PR is labeled `staging` via `.github/workflows/deploy-staging.yml`; posts the URL on the PR; supports `workflow_dispatch` for any ref; actionlint-safe env handling.
  - Webhook in `deploy/hooks.json` runs `scripts/deploy-staging-wrapper.sh`; `docker-compose.yml` mounts the staging checkout for builds.
  - `scripts/deploy-staging.sh`: checks out the ref, builds images locally, runs migrations, brings up the stack, health-checks, and re-attaches `lucky-tunnel` to the staging network.
  - Docs: `docs/STAGING.md` with usage and isolation details. Single shared env; one PR at a time.

- **Migration**
  - After merge, recreate the webhook container once to pick up the new mount and hook; then label any PR `staging` to deploy. Host-side env, tunnel ingress, DNS, and Discord redirect are already configured.

<sup>Written for commit 95f08c2a242da05166f963a680d96dae5366735a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

