### PR TITLE
fix(infra): route staging via host port (drop tunnel network attach)

### DIFF
--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -103,18 +103,13 @@ fi
 log "Rolling out staging services..."
 dc up -d --remove-orphans backend frontend nginx
 
-# Ensure the production cloudflared tunnel can resolve this staging nginx. The
-# tunnel's remote ingress routes lucky-staging.* -> http://lucky-staging-nginx:8080,
-# which only resolves if lucky-tunnel is attached to the staging network. Re-apply
-# each deploy: a prod deploy that recreates lucky-tunnel drops the attachment.
-STAGING_NET="$(docker network ls --format '{{.Name}}' | grep -E 'lucky-staging.*network' | head -1)"
-if [[ -n "$STAGING_NET" ]] && docker ps --format '{{.Names}}' | grep -qx lucky-tunnel; then
-    if docker network connect "$STAGING_NET" lucky-tunnel 2>/dev/null; then
-        log "Connected lucky-tunnel -> $STAGING_NET"
-    else
-        log "lucky-tunnel already on $STAGING_NET (ok)"
-    fi
-fi
+# Routing is via the published HOST PORT: the production cloudflared tunnel's
+# remote ingress routes lucky-staging.* -> http://100.95.204.103:8093 (this nginx's
+# host port). Deliberately NOT attached to the tunnel's docker network — the
+# staging nginx service is named `nginx`, so sharing the tunnel's network would
+# make the `nginx` alias ambiguous between prod and staging and could misroute
+# production traffic. The host port is reachable from the tunnel's network, so
+# nothing to wire here.
 
 # --- health check --------------------------------------------------------------
 log "Health-checking staging (http://localhost:${HEALTH_PORT})..."


### PR DESCRIPTION
Follow-up to #1547. The `deploy-staging.sh` step that attached `lucky-tunnel` to the staging network made the `nginx` service alias ambiguous between prod and staging — a latent risk of misrouting **production** traffic, and the cause of the staging 502. 

Verified the tunnel's network reaches the staging nginx **host port** directly (`100.95.204.103:8093` → HTTP 200), which is collision-free and what `docs/STAGING.md` already specifies. This drops the network-attach; the tunnel ingress points at the host port instead.

(Prod was confirmed healthy throughout; the tunnel has been disconnected from the staging network.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route staging traffic through the `nginx` host port instead of attaching `lucky-tunnel` to the staging Docker network. This removes the prod/staging `nginx` name collision, fixes the staging 502, and matches docs.

- **Bug Fixes**
  - Removed `lucky-tunnel` → staging network connect in `scripts/deploy-staging.sh`.
  - Staging ingress uses `100.95.204.103:8093` (host port), keeping production isolated.

<sup>Written for commit af6a2f18aab6baf5a7ccf2907536e709a9ce877b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

