### PR TITLE
fix(infra): staging deploy git ownership (webhook container)

### DIFF
--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -63,6 +63,10 @@ if [[ ! -f "$ENV_FILE" ]]; then
 fi
 
 log "Fetching + checking out ref: $DEPLOY_REF"
+# This runs inside the webhook container, whose git user differs from the
+# bind-mounted checkout's owner (luk-server); without this, git aborts with
+# "detected dubious ownership in repository".
+git config --global --add safe.directory "$STAGING_DIR" 2>/dev/null || true
 git fetch --prune --quiet origin
 # Resolve the ref to a concrete SHA (works for branch names or SHAs).
 RESOLVED_SHA="$(git rev-parse --verify --quiet "origin/$DEPLOY_REF^{commit}" \


### PR DESCRIPTION
Follow-up to #1547/#1548. The webhook accepted the `deploy-staging` POST (200) but the deploy never ran: it executes **inside the webhook container**, whose git user differs from the bind-mounted staging checkout's owner, so git aborted with `detected dubious ownership in repository`.

Fix: `git config --global --add safe.directory "$STAGING_DIR"` before fetch/checkout. Verified on the homelab — the deploy now progresses through checkout → build → migrate → up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix staging deploys from the webhook by marking the bind-mounted checkout as a safe Git directory. Added `git config --global --add safe.directory "$STAGING_DIR"` before fetch/checkout in `scripts/deploy-staging.sh` to eliminate the "detected dubious ownership" error.

<sup>Written for commit 87ec2ea93ffd400b32f59f8d05b8e6de7707a7b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

