### PR TITLE
fix(infra): staging deploy health check (wget + host IP)

### DIFF
--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -26,6 +26,10 @@ COMPOSE_FILE="${STAGING_COMPOSE_FILE:-/home/luk-server/Lucky/docker-compose.stag
 ENV_FILE=".env.staging"
 PROJECT="lucky-staging"
 HEALTH_PORT="${NGINX_PORT:-8093}"
+# Health-check via the host IP, not localhost: this runs inside the webhook
+# container, whose localhost is NOT the host where the staging nginx port is
+# published. The host IP is reachable from the container's network.
+HEALTH_HOST="${STAGING_HOST_IP:-100.95.204.103}"
 
 # --- secret gate ---------------------------------------------------------------
 if [[ -z "${DEPLOY_WEBHOOK_SECRET:-}" ]]; then
@@ -116,10 +120,10 @@ dc up -d --remove-orphans backend frontend nginx
 # nothing to wire here.
 
 # --- health check --------------------------------------------------------------
-log "Health-checking staging (http://localhost:${HEALTH_PORT})..."
+log "Health-checking staging (http://${HEALTH_HOST}:${HEALTH_PORT})..."
 ok=""
 for _ in $(seq 1 30); do
-    if curl -fsS --max-time 4 "http://localhost:${HEALTH_PORT}/api/health" >/dev/null 2>&1; then
+    if wget -q -O /dev/null --timeout=4 "http://${HEALTH_HOST}:${HEALTH_PORT}/api/health" 2>/dev/null; then
         ok="1"; break
     fi
     sleep 3
@@ -132,7 +136,7 @@ if [[ -z "$ok" ]]; then
 fi
 
 # Verify the OAuth contract endpoint too (the dashboard depends on it).
-if ! curl -fsS --max-time 4 "http://localhost:${HEALTH_PORT}/api/health/auth-config" >/dev/null 2>&1; then
+if ! wget -q -O /dev/null --timeout=4 "http://${HEALTH_HOST}:${HEALTH_PORT}/api/health/auth-config" 2>/dev/null; then
     log "WARN: auth-config endpoint not ready (dashboard login may fail)"
 fi
 


### PR DESCRIPTION
Third and final webhook-container fix (after #1548 routing, #1554 git-ownership). The post-deploy health check used `curl http://localhost:8093`, but the deploy runs **inside the webhook container**, which has **no curl** (only wget) and whose localhost isn't the host's published staging port. So deploys logged `HEALTH_FAILED` even though staging was up + healthy — a false negative that also masks real failures.

Fix: `wget` against the host IP (`100.95.204.103:8093`, reachable from the container's network). Verified on the homelab — deploys now report `STAGING DEPLOY OK` correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false staging deploy failures by running the health check with wget against the host IP from inside the webhook container. Deploys now correctly report staging health.

- **Bug Fixes**
  - Replaced `curl localhost` with `wget http://${HEALTH_HOST}:${HEALTH_PORT}`; `HEALTH_HOST` comes from `STAGING_HOST_IP` (default `100.95.204.103`).
  - Applies to both `/api/health` and `/api/health/auth-config` checks to ensure accurate post-deploy status.

<sup>Written for commit f813ac8fb62997a77282e45040e7f2bcb71ea018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

