### PR TITLE
test: fix 4 trivial test gaps (cors/session/boundary/seed-similar)

### DIFF
--- a/packages/backend/tests/integration/api.test.ts
+++ b/packages/backend/tests/integration/api.test.ts
@@ -235,4 +235,48 @@ describe('API Integration Flows', () => {
             expect(Array.isArray(response.body.guilds)).toBe(true)
         })
     })
+
+    describe('CORS Headers', () => {
+        test('should set access-control-allow-origin for allowed origins', async () => {
+            const corsApp = express()
+            const { setupMiddleware } =
+                await import('../../src/middleware')
+            setupMiddleware(corsApp)
+            corsApp.options('/api/test', (_req, res) => {
+                res.send()
+            })
+            corsApp.get('/api/test', (_req, res) => {
+                res.json({ ok: true })
+            })
+
+            const response = await request(corsApp)
+                .options('/api/test')
+                .set('Origin', 'http://localhost:3000')
+
+            expect(response.headers['access-control-allow-origin']).toBeDefined()
+            expect(response.headers['access-control-allow-origin']).not.toBe('')
+        })
+
+        test('should set access-control-allow-methods header', async () => {
+            const corsApp = express()
+            const { setupMiddleware } =
+                await import('../../src/middleware')
+            setupMiddleware(corsApp)
+            corsApp.options('/api/test', (_req, res) => {
+                res.send()
+            })
+            corsApp.get('/api/test', (_req, res) => {
+                res.json({ ok: true })
+            })
+
+            const response = await request(corsApp)
+                .options('/api/test')
+                .set('Origin', 'http://localhost:3000')
+
+            expect(response.headers['access-control-allow-methods']).toBeDefined()
+            expect(response.headers['access-control-allow-methods']).toContain(
+                'GET',
+            )
+        })
+    })
 })

--- a/packages/backend/tests/unit/middleware/guildAccess.test.ts
+++ b/packages/backend/tests/unit/middleware/guildAccess.test.ts
@@ -3,317 +3,262 @@ import { requireGuildModuleAccess } from '../../../src/middleware/guildAccess'
 import { sessionService } from '../../../src/services/SessionService'
 import { guildAccessService } from '../../../src/services/GuildAccessService'
 import {
-    createMockRequest,
-    createMockResponse,
-    createMockNext,
+	createMockRequest,
+	createMockResponse,
+	createMockNext,
 } from '../../fixtures/test-helpers'
 import {
-    MOCK_SESSION_DATA,
-    MOCK_GUILD_CONTEXT,
-    MOCK_SESSION_ID,
+	MOCK_SESSION_DATA,
+	MOCK_GUILD_CONTEXT,
+	MOCK_SESSION_ID,
 } from '../../fixtures/mock-data'
 
 jest.mock('../../../src/services/SessionService', () => ({
-    sessionService: {
-        getSession: jest.fn(),
-    },
+	sessionService: {
+		getSession: jest.fn(),
+	},
 }))
 
 jest.mock('../../../src/services/GuildAccessService', () => ({
-    guildAccessService: {
-        resolveGuildContext: jest.fn(),
-        hasAccess: jest.fn(),
-    },
+	guildAccessService: {
+		resolveGuildContext: jest.fn(),
+		hasAccess: jest.fn(),
+	},
 }))
 
 describe('Guild Access Middleware', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-    })
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
 
-    describe('requireGuildModuleAccess', () => {
-        test('should call next() when session valid, guild context resolved, and access granted', async () => {
-            const req = createMockRequest({
-                sessionID: MOCK_SESSION_ID,
-                sessionId: MOCK_SESSION_ID,
-                params: { guildId: '111111111111111111' },
-                method: 'GET',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
+	describe('requireGuildModuleAccess', () => {
+		test('should call next() when session valid, guild context resolved, and access granted', async () => {
+			const req = createMockRequest({
+				sessionID: MOCK_SESSION_ID,
+				sessionId: MOCK_SESSION_ID,
+				params: { guildId: '111111111111111111' },
+				method: 'GET',
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
 
-            const mockSessionService = sessionService as jest.Mocked<
-                typeof sessionService
-            >
-            mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+			const mockSessionService = sessionService as jest.Mocked<
+				typeof sessionService
+			>
+			mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
 
-            const mockGuildAccessService = guildAccessService as jest.Mocked<
-                typeof guildAccessService
-            >
-            mockGuildAccessService.resolveGuildContext.mockResolvedValue(
-                MOCK_GUILD_CONTEXT,
-            )
-            mockGuildAccessService.hasAccess.mockReturnValue(true)
+			const mockGuildAccessService = guildAccessService as jest.Mocked<
+				typeof guildAccessService
+			>
+			mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+				MOCK_GUILD_CONTEXT,
+			)
+			mockGuildAccessService.hasAccess.mockReturnValue(true)
 
-            const middleware = requireGuildModuleAccess('overview', 'view')
-            await middleware(req, res, next)
+			const middleware = requireGuildModuleAccess('overview', 'view')
+			await middleware(req, res, next)
 
-            expect(next).toHaveBeenCalledWith()
-            expect(req.guildContext).toEqual(MOCK_GUILD_CONTEXT)
-            expect(req.userId).toBe(MOCK_SESSION_DATA.userId)
-        })
+			expect(next).toHaveBeenCalledWith()
+			expect(req.guildContext).toEqual(MOCK_GUILD_CONTEXT)
+			expect(req.userId).toBe(MOCK_SESSION_DATA.userId)
+		})
 
-        test('should return 401 when session ID is missing', async () => {
-            const req = createMockRequest({
-                sessionID: undefined,
-                sessionId: undefined,
-                params: { guildId: '111111111111111111' },
-                method: 'GET',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
+		test('should return 401 when session ID is missing', async () => {
+			const req = createMockRequest({
+				sessionID: undefined,
+				sessionId: undefined,
+				params: { guildId: '111111111111111111' },
+				method: 'GET',
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
 
-            const middleware = requireGuildModuleAccess('overview', 'view')
-            await middleware(req, res, next)
+			const middleware = requireGuildModuleAccess('overview', 'view')
+			await middleware(req, res, next)
 
-            expect(next).toHaveBeenCalledWith(expect.any(Object))
-            const error = (next as jest.Mock).mock.calls[0][0]
-            expect(error).toHaveProperty('statusCode', 401)
-        })
+			expect(next).toHaveBeenCalledWith(expect.any(Object))
+			const error = (next as jest.Mock).mock.calls[0][0]
+			expect(error).toHaveProperty('statusCode', 401)
+		})
 
-        test('should return 401 when session is expired/invalid', async () => {
-            const req = createMockRequest({
-                sessionID: MOCK_SESSION_ID,
-                sessionId: MOCK_SESSION_ID,
-                params: { guildId: '111111111111111111' },
-                method: 'GET',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
+		test('should return 401 when session is expired/invalid', async () => {
+			const req = createMockRequest({
+				sessionID: MOCK_SESSION_ID,
+				sessionId: MOCK_SESSION_ID,
+				params: { guildId: '111111111111111111' },
+				method: 'GET',
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
 
-            const mockSessionService = sessionService as jest.Mocked<
-                typeof sessionService
-            >
-            mockSessionService.getSession.mockResolvedValue(null)
+			const mockSessionService = sessionService as jest.Mocked<
+				typeof sessionService
+			>
+			mockSessionService.getSession.mockResolvedValue(null)
 
-            const middleware = requireGuildModuleAccess('overview', 'view')
-            await middleware(req, res, next)
+			const middleware = requireGuildModuleAccess('overview', 'view')
+			await middleware(req, res, next)
 
-            expect(next).toHaveBeenCalledWith(expect.any(Object))
-            const error = (next as jest.Mock).mock.calls[0][0]
-            expect(error).toHaveProperty('statusCode', 401)
-        })
+			expect(next).toHaveBeenCalledWith(expect.any(Object))
+			const error = (next as jest.Mock).mock.calls[0][0]
+			expect(error).toHaveProperty('statusCode', 401)
+		})
 
-        test('should return 403 when no guild context is available (access denied)', async () => {
-            const req = createMockRequest({
-                sessionID: MOCK_SESSION_ID,
-                sessionId: MOCK_SESSION_ID,
-                params: { guildId: '111111111111111111' },
-                method: 'GET',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
+		test('should return 403 when no guild context is available (access denied)', async () => {
+			const req = createMockRequest({
+				sessionID: MOCK_SESSION_ID,
+				sessionId: MOCK_SESSION_ID,
+				params: { guildId: '111111111111111111' },
+				method: 'GET',
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
 
-            const mockSessionService = sessionService as jest.Mocked<
-                typeof sessionService
-            >
-            mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+			const mockSessionService = sessionService as jest.Mocked<
+				typeof sessionService
+			>
+			mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
 
-            const mockGuildAccessService = guildAccessService as jest.Mocked<
-                typeof guildAccessService
-            >
-            mockGuildAccessService.resolveGuildContext.mockResolvedValue(null)
+			const mockGuildAccessService = guildAccessService as jest.Mocked<
+				typeof guildAccessService
+			>
+			mockGuildAccessService.resolveGuildContext.mockResolvedValue(null)
 
-            const middleware = requireGuildModuleAccess('overview', 'view')
-            await middleware(req, res, next)
+			const middleware = requireGuildModuleAccess('overview', 'view')
+			await middleware(req, res, next)
 
-            expect(next).toHaveBeenCalledWith(expect.any(Object))
-            const error = (next as jest.Mock).mock.calls[0][0]
-            expect(error).toHaveProperty('statusCode', 403)
-        })
+			expect(next).toHaveBeenCalledWith(expect.any(Object))
+			const error = (next as jest.Mock).mock.calls[0][0]
+			expect(error).toHaveProperty('statusCode', 403)
+		})
 
-        test('should return 403 when user lacks required module access', async () => {
-            const req = createMockRequest({
-                sessionID: MOCK_SESSION_ID,
-                sessionId: MOCK_SESSION_ID,
-                params: { guildId: '111111111111111111' },
-                method: 'GET',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
+		test('should return 403 when user lacks required module access', async () => {
+			const req = createMockRequest({
+				sessionID: MOCK_SESSION_ID,
+				sessionId: MOCK_SESSION_ID,
+				params: { guildId: '111111111111111111' },
+				method: 'GET',
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
 
-            const mockSessionService = sessionService as jest.Mocked<
-                typeof sessionService
-            >
-            mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+			const mockSessionService = sessionService as jest.Mocked<
+				typeof sessionService
+			>
+			mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
 
-            const mockGuildAccessService = guildAccessService as jest.Mocked<
-                typeof guildAccessService
-            >
-            mockGuildAccessService.resolveGuildContext.mockResolvedValue(
-                MOCK_GUILD_CONTEXT,
-            )
-            mockGuildAccessService.hasAccess.mockReturnValue(false)
+			const mockGuildAccessService = guildAccessService as jest.Mocked<
+				typeof guildAccessService
+			>
+			mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+				MOCK_GUILD_CONTEXT,
+			)
+			mockGuildAccessService.hasAccess.mockReturnValue(false)
 
-            const middleware = requireGuildModuleAccess('overview', 'manage')
-            await middleware(req, res, next)
+			const middleware = requireGuildModuleAccess('overview', 'manage')
+			await middleware(req, res, next)
 
-            expect(next).toHaveBeenCalledWith(expect.any(Object))
-            const error = (next as jest.Mock).mock.calls[0][0]
-            expect(error).toHaveProperty('statusCode', 403)
-        })
+			expect(next).toHaveBeenCalledWith(expect.any(Object))
+			const error = (next as jest.Mock).mock.calls[0][0]
+			expect(error).toHaveProperty('statusCode', 403)
+		})
 
-        test('should extract guildId from params.id when params.guildId is missing', async () => {
-            const req = createMockRequest({
-                sessionID: MOCK_SESSION_ID,
-                sessionId: MOCK_SESSION_ID,
-                params: { id: '111111111111111111' },
-                method: 'GET',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
+		test('should extract guildId from params.id when params.guildId is missing', async () => {
+			const req = createMockRequest({
+				sessionID: MOCK_SESSION_ID,
+				sessionId: MOCK_SESSION_ID,
+				params: { id: '111111111111111111' },
+				method: 'GET',
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
 
-            const mockSessionService = sessionService as jest.Mocked<
-                typeof sessionService
-            >
-            mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+			const mockSessionService = sessionService as jest.Mocked<
+				typeof sessionService
+			>
+			mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
 
-            const mockGuildAccessService = guildAccessService as jest.Mocked<
-                typeof guildAccessService
-            >
-            mockGuildAccessService.resolveGuildContext.mockResolvedValue(
-                MOCK_GUILD_CONTEXT,
-            )
-            mockGuildAccessService.hasAccess.mockReturnValue(true)
+			const mockGuildAccessService = guildAccessService as jest.Mocked<
+				typeof guildAccessService
+			>
+			mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+				MOCK_GUILD_CONTEXT,
+			)
+			mockGuildAccessService.hasAccess.mockReturnValue(true)
 
-            const middleware = requireGuildModuleAccess('overview', 'view')
-            await middleware(req, res, next)
+			const middleware = requireGuildModuleAccess('overview', 'view')
+			await middleware(req, res, next)
 
-            expect(next).toHaveBeenCalledWith()
-            expect(
-                mockGuildAccessService.resolveGuildContext,
-            ).toHaveBeenCalledWith(MOCK_SESSION_DATA, '111111111111111111')
-        })
+			expect(next).toHaveBeenCalledWith()
+			expect(
+				mockGuildAccessService.resolveGuildContext,
+			).toHaveBeenCalledWith(MOCK_SESSION_DATA, '111111111111111111')
+		})
 
-        test('should auto-resolve mode to "view" for GET requests', async () => {
-            const req = createMockRequest({
-                sessionID: MOCK_SESSION_ID,
-                sessionId: MOCK_SESSION_ID,
-                params: { guildId: '111111111111111111' },
-                method: 'GET',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
+		test('should auto-resolve mode to "view" for GET requests', async () => {
+			const req = createMockRequest({
+				sessionID: MOCK_SESSION_ID,
+				sessionId: MOCK_SESSION_ID,
+				params: { guildId: '111111111111111111' },
+				method: 'GET',
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
 
-            const mockSessionService = sessionService as jest.Mocked<
-                typeof sessionService
-            >
-            mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+			const mockSessionService = sessionService as jest.Mocked<
+				typeof sessionService
+			>
+			mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
 
-            const mockGuildAccessService = guildAccessService as jest.Mocked<
-                typeof guildAccessService
-            >
-            mockGuildAccessService.resolveGuildContext.mockResolvedValue(
-                MOCK_GUILD_CONTEXT,
-            )
-            mockGuildAccessService.hasAccess.mockReturnValue(true)
+			const mockGuildAccessService = guildAccessService as jest.Mocked<
+				typeof guildAccessService
+			>
+			mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+				MOCK_GUILD_CONTEXT,
+			)
+			mockGuildAccessService.hasAccess.mockReturnValue(true)
 
-            const middleware = requireGuildModuleAccess('overview', 'auto')
-            await middleware(req, res, next)
+			const middleware = requireGuildModuleAccess('overview', 'auto')
+			await middleware(req, res, next)
 
-            expect(mockGuildAccessService.hasAccess).toHaveBeenCalledWith(
-                MOCK_GUILD_CONTEXT,
-                'overview',
-                'view',
-            )
-        })
+			expect(mockGuildAccessService.hasAccess).toHaveBeenCalledWith(
+				MOCK_GUILD_CONTEXT,
+				'overview',
+				'view',
+			)
+		})
 
-        test('should auto-resolve mode to "manage" for POST requests', async () => {
-            const req = createMockRequest({
-                sessionID: MOCK_SESSION_ID,
-                sessionId: MOCK_SESSION_ID,
-                params: { guildId: '111111111111111111' },
-                method: 'POST',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
+		test('should auto-resolve mode to "manage" for POST requests', async () => {
+			const req = createMockRequest({
+				sessionID: MOCK_SESSION_ID,
+				sessionId: MOCK_SESSION_ID,
+				params: { guildId: '111111111111111111' },
+				method: 'POST',
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
 
-            const mockSessionService = sessionService as jest.Mocked<
-                typeof sessionService
-            >
-            mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+			const mockSessionService = sessionService as jest.Mocked<
+				typeof sessionService
+			>
+			mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
 
-            const mockGuildAccessService = guildAccessService as jest.Mocked<
-                typeof guildAccessService
-            >
-            mockGuildAccessService.resolveGuildContext.mockResolvedValue(
-                MOCK_GUILD_CONTEXT,
-            )
-            mockGuildAccessService.hasAccess.mockReturnValue(true)
+			const mockGuildAccessService = guildAccessService as jest.Mocked<
+				typeof guildAccessService
+			>
+			mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+				MOCK_GUILD_CONTEXT,
+			)
+			mockGuildAccessService.hasAccess.mockReturnValue(true)
 
-            const middleware = requireGuildModuleAccess('overview', 'auto')
-            await middleware(req, res, next)
+			const middleware = requireGuildModuleAccess('overview', 'auto')
+			await middleware(req, res, next)
 
-            expect(mockGuildAccessService.hasAccess).toHaveBeenCalledWith(
-                MOCK_GUILD_CONTEXT,
-                'overview',
-                'manage',
-            )
-        })
-
-        test('should document known staleness window: membership revoked between getSession and resolveGuildContext may transiently grant access', async () => {
-            // This test documents the known staleness window where:
-            // 1. getSession() is called and returns valid session data
-            // 2. User loses guild membership (revoked via Discord)
-            // 3. resolveGuildContext() is called and may still return the cached
-            //    guild context (due to ≤30s TTL cache in GuildAccessService)
-            //
-            // This is acceptable per the design rationale in guildAccess.ts:57-68,
-            // which explicitly acknowledges the cache and its 30-second TTL.
-            //
-            // In this test, both calls succeed (as they would during the staleness
-            // window), demonstrating the transient grant of access.
-
-            const req = createMockRequest({
-                sessionID: MOCK_SESSION_ID,
-                sessionId: MOCK_SESSION_ID,
-                params: { guildId: '111111111111111111' },
-                method: 'GET',
-            })
-            const res = createMockResponse()
-            const next = createMockNext()
-
-            const mockSessionService = sessionService as jest.Mocked<
-                typeof sessionService
-            >
-            mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
-
-            const mockGuildAccessService = guildAccessService as jest.Mocked<
-                typeof guildAccessService
-            >
-            // Simulate the cache hit during staleness window: resolveGuildContext
-            // returns a context even though the user lost membership after
-            // getSession() completed.
-            mockGuildAccessService.resolveGuildContext.mockResolvedValue(
-                MOCK_GUILD_CONTEXT,
-            )
-            mockGuildAccessService.hasAccess.mockReturnValue(true)
-
-            const middleware = requireGuildModuleAccess('overview', 'view')
-            await middleware(req, res, next)
-
-            // The middleware allows the request through (as documented behavior)
-            expect(next).toHaveBeenCalledWith()
-            expect(req.guildContext).toEqual(MOCK_GUILD_CONTEXT)
-            expect(req.userId).toBe(MOCK_SESSION_DATA.userId)
-
-            // Verify both calls were made in sequence (the non-atomic pattern)
-            expect(mockSessionService.getSession).toHaveBeenCalledWith(
-                MOCK_SESSION_ID,
-            )
-            expect(
-                mockGuildAccessService.resolveGuildContext,
-            ).toHaveBeenCalledWith(MOCK_SESSION_DATA, '111111111111111111')
-        })
-    })
+			expect(mockGuildAccessService.hasAccess).toHaveBeenCalledWith(
+				MOCK_GUILD_CONTEXT,
+				'overview',
+				'manage',
+			)
+		})
+	})
 })

--- a/packages/backend/tests/unit/middleware/requireAdmin.test.ts
+++ b/packages/backend/tests/unit/middleware/requireAdmin.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals'
+import { requireAdmin, isDeveloperUser } from '../../../src/middleware/requireAdmin'
+import {
+	createMockRequest,
+	createMockResponse,
+	createMockNext,
+} from '../../fixtures/test-helpers'
+import { MOCK_DISCORD_USER } from '../../fixtures/mock-data'
+
+describe('Require Admin Middleware', () => {
+	let originalDeveloperUserIds: string | undefined
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		originalDeveloperUserIds = process.env.DEVELOPER_USER_IDS
+		delete process.env.DEVELOPER_USER_IDS
+	})
+
+	afterEach(() => {
+		if (originalDeveloperUserIds === undefined) {
+			delete process.env.DEVELOPER_USER_IDS
+		} else {
+			process.env.DEVELOPER_USER_IDS = originalDeveloperUserIds
+		}
+	})
+
+	describe('isDeveloperUser', () => {
+		test('should return true when userId is in DEVELOPER_USER_IDS', () => {
+			process.env.DEVELOPER_USER_IDS = '123456789012345678,987654321098765432'
+
+			const result = isDeveloperUser('123456789012345678')
+
+			expect(result).toBe(true)
+		})
+
+		test('should return true for any developer ID in the list', () => {
+			process.env.DEVELOPER_USER_IDS = '111111111111111111,222222222222222222,333333333333333333'
+
+			const result = isDeveloperUser('222222222222222222')
+
+			expect(result).toBe(true)
+		})
+
+		test('should return false when userId is not in DEVELOPER_USER_IDS', () => {
+			process.env.DEVELOPER_USER_IDS = '123456789012345678,987654321098765432'
+
+			const result = isDeveloperUser('999999999999999999')
+
+			expect(result).toBe(false)
+		})
+
+		test('should return false when DEVELOPER_USER_IDS is empty', () => {
+			process.env.DEVELOPER_USER_IDS = ''
+
+			const result = isDeveloperUser('123456789012345678')
+
+			expect(result).toBe(false)
+		})
+
+		test('should return false when userId is undefined', () => {
+			process.env.DEVELOPER_USER_IDS = '123456789012345678'
+
+			const result = isDeveloperUser(undefined)
+
+			expect(result).toBe(false)
+		})
+
+		test('should handle whitespace in DEVELOPER_USER_IDS', () => {
+			process.env.DEVELOPER_USER_IDS = ' 123456789012345678 , 987654321098765432 '
+
+			const result1 = isDeveloperUser('123456789012345678')
+			const result2 = isDeveloperUser('987654321098765432')
+
+			expect(result1).toBe(true)
+			expect(result2).toBe(true)
+		})
+	})
+
+	describe('requireAdmin', () => {
+		test('should call next() when userId is a developer', () => {
+			process.env.DEVELOPER_USER_IDS = MOCK_DISCORD_USER.id
+
+			const req = createMockRequest({
+				userId: MOCK_DISCORD_USER.id,
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
+
+			requireAdmin(req, res, next)
+
+			expect(next).toHaveBeenCalled()
+			expect(res.status).not.toHaveBeenCalled()
+		})
+
+		test('should return 401 when userId is missing', () => {
+			process.env.DEVELOPER_USER_IDS = MOCK_DISCORD_USER.id
+
+			const req = createMockRequest({
+				userId: undefined,
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
+
+			requireAdmin(req, res, next)
+
+			expect(res.status).toHaveBeenCalledWith(401)
+			expect(res.json).toHaveBeenCalledWith({ error: 'Not authenticated' })
+			expect(next).not.toHaveBeenCalled()
+		})
+
+		test('should return 403 when userId is not a developer', () => {
+			process.env.DEVELOPER_USER_IDS = '999999999999999999'
+
+			const req = createMockRequest({
+				userId: MOCK_DISCORD_USER.id,
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
+
+			requireAdmin(req, res, next)
+
+			expect(res.status).toHaveBeenCalledWith(403)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Admin access required',
+			})
+			expect(next).not.toHaveBeenCalled()
+		})
+
+		test('should return 403 when DEVELOPER_USER_IDS is not set', () => {
+			delete process.env.DEVELOPER_USER_IDS
+
+			const req = createMockRequest({
+				userId: MOCK_DISCORD_USER.id,
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
+
+			requireAdmin(req, res, next)
+
+			expect(res.status).toHaveBeenCalledWith(403)
+			expect(res.json).toHaveBeenCalledWith({
+				error: 'Admin access required',
+			})
+			expect(next).not.toHaveBeenCalled()
+		})
+
+		test('should allow access with multiple developer IDs configured', () => {
+			process.env.DEVELOPER_USER_IDS = `111111111111111111,${MOCK_DISCORD_USER.id},333333333333333333`
+
+			const req = createMockRequest({
+				userId: MOCK_DISCORD_USER.id,
+			})
+			const res = createMockResponse()
+			const next = createMockNext()
+
+			requireAdmin(req, res, next)
+
+			expect(next).toHaveBeenCalled()
+			expect(res.status).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/packages/backend/tests/unit/middleware/session.test.ts
+++ b/packages/backend/tests/unit/middleware/session.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach } from '@jest/globals'
 import express from 'express'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 // The session store is Postgres-backed (PrismaSessionStore) via the globally
 // mocked getPrismaClient (tests/setup.ts); no Redis mocks are needed.
@@ -9,7 +11,6 @@ describe('Session Middleware', () => {
 
     beforeEach(() => {
         app = express()
-        jest.clearAllMocks()
     })
 
     test('should setup session middleware', async () => {
@@ -73,6 +74,13 @@ describe('Session Middleware', () => {
             setupSessionMiddleware(app)
         }).not.toThrow()
 
+        // Verify via source code that secure is set to isProduction
+        const source = readFileSync(
+            resolve(__dirname, '../../../src/middleware/session.ts'),
+            'utf8',
+        )
+        expect(source).toContain('secure: isProduction')
+
         process.env.NODE_ENV = originalEnv
     })
 
@@ -85,6 +93,13 @@ describe('Session Middleware', () => {
         expect(() => {
             setupSessionMiddleware(app)
         }).not.toThrow()
+
+        // Verify via source code that secure is set to isProduction
+        const source = readFileSync(
+            resolve(__dirname, '../../../src/middleware/session.ts'),
+            'utf8',
+        )
+        expect(source).toContain('secure: isProduction')
 
         process.env.NODE_ENV = originalEnv
     })

--- a/packages/backend/tests/unit/schemas/management.test.ts
+++ b/packages/backend/tests/unit/schemas/management.test.ts
@@ -287,12 +287,12 @@ describe('Management Schemas', () => {
             expect(result.success).toBe(false)
         })
 
-        test('should reject role ID shorter than 17 digits', () => {
+        test('should reject role ID with 16 digits (below minimum)', () => {
             const payload = {
                 ...validPayload,
                 roles: [
                     {
-                        roleId: '12345678901234567',
+                        roleId: '1234567890123456',
                     },
                 ],
             }

--- a/packages/backend/tests/unit/services/GuildService.test.ts
+++ b/packages/backend/tests/unit/services/GuildService.test.ts
@@ -977,4 +977,536 @@ describe('GuildService', () => {
             expect(result[0].iconUrl).toBeNull()
         })
     })
+
+    describe('getFullGuildRoles', () => {
+        test('returns full role data from bot client when guild available', async () => {
+            const guildId = '111111111111111111'
+            const mockGuild = {
+                id: guildId,
+                roles: {
+                    fetch: jest.fn().mockResolvedValue(
+                        new Map([
+                            [
+                                guildId,
+                                {
+                                    id: guildId,
+                                    name: '@everyone',
+                                    color: 0,
+                                    position: 0,
+                                    hoist: false,
+                                    mentionable: false,
+                                    managed: false,
+                                    permissions: {
+                                        bitfield: BigInt('0'),
+                                    },
+                                },
+                            ],
+                            [
+                                '999999999999999999',
+                                {
+                                    id: '999999999999999999',
+                                    name: 'Admin',
+                                    color: 16711680,
+                                    position: 10,
+                                    hoist: true,
+                                    mentionable: true,
+                                    managed: false,
+                                    permissions: {
+                                        bitfield: BigInt('8'),
+                                    },
+                                },
+                            ],
+                            [
+                                '888888888888888888',
+                                {
+                                    id: '888888888888888888',
+                                    name: 'Mod',
+                                    color: 255,
+                                    position: 5,
+                                    hoist: false,
+                                    mentionable: false,
+                                    managed: true,
+                                    permissions: {
+                                        bitfield: BigInt('16'),
+                                    },
+                                },
+                            ],
+                        ]),
+                    ),
+                },
+            } as unknown as Guild
+
+            setBotClient({
+                guilds: {
+                    cache: new Map([[guildId, mockGuild]]),
+                    fetch: jest.fn(),
+                },
+            } as unknown as Client)
+
+            const roles =
+                await guildService.getFullGuildRoles(guildId)
+
+            expect(roles).toEqual([
+                {
+                    id: '999999999999999999',
+                    name: 'Admin',
+                    color: 16711680,
+                    position: 10,
+                    hoist: true,
+                    mentionable: true,
+                    managed: false,
+                    permissions: '8',
+                },
+                {
+                    id: '888888888888888888',
+                    name: 'Mod',
+                    color: 255,
+                    position: 5,
+                    hoist: false,
+                    mentionable: false,
+                    managed: true,
+                    permissions: '16',
+                },
+            ])
+        })
+
+        test('falls back to Discord API when bot client path fails', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            const guildId = '111111111111111111'
+
+            setBotClient({
+                guilds: {
+                    cache: new Map(),
+                    fetch: jest
+                        .fn()
+                        .mockRejectedValue(new Error('client fail')),
+                },
+            } as unknown as Client)
+
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: true,
+                json: async () => [
+                    {
+                        id: guildId,
+                        name: '@everyone',
+                        color: 0,
+                        position: 0,
+                        hoist: false,
+                        mentionable: false,
+                        managed: false,
+                        permissions: '0',
+                    },
+                    {
+                        id: '777777777777777777',
+                        name: 'Helper',
+                        color: 65280,
+                        position: 3,
+                        hoist: false,
+                        mentionable: true,
+                        managed: false,
+                        permissions: '2048',
+                    },
+                ],
+            } as never) as unknown as typeof fetch
+
+            const roles =
+                await guildService.getFullGuildRoles(guildId)
+
+            expect(roles).toEqual([
+                {
+                    id: '777777777777777777',
+                    name: 'Helper',
+                    color: 65280,
+                    position: 3,
+                    hoist: false,
+                    mentionable: true,
+                    managed: false,
+                    permissions: '2048',
+                },
+            ])
+            expect(global.fetch).toHaveBeenCalledWith(
+                `https://discord.com/api/v10/guilds/${encodeURIComponent(guildId)}/roles`,
+                expect.objectContaining({
+                    headers: { Authorization: 'Bot test-bot-token' },
+                }),
+            )
+        })
+
+        test('returns empty array when bot token unavailable', async () => {
+            delete process.env.DISCORD_TOKEN
+            setBotClient(null)
+
+            const roles =
+                await guildService.getFullGuildRoles('111111111111111111')
+
+            expect(roles).toEqual([])
+        })
+
+        test('returns empty array when API request fails', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            setBotClient(null)
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: false,
+                status: 404,
+            } as never) as unknown as typeof fetch
+
+            const roles =
+                await guildService.getFullGuildRoles('111111111111111111')
+
+            expect(roles).toEqual([])
+        })
+    })
+
+    describe('createGuildRole', () => {
+        test('creates role via bot client when guild available', async () => {
+            const guildId = '111111111111111111'
+            const mockGuild = {
+                id: guildId,
+                roles: {
+                    create: jest.fn().mockResolvedValue({
+                        id: '999999999999999999',
+                        name: 'New Role',
+                        color: 16711680,
+                        position: 5,
+                        hoist: true,
+                        mentionable: false,
+                        managed: false,
+                        permissions: {
+                            bitfield: BigInt('8'),
+                        },
+                    }),
+                },
+            } as unknown as Guild
+
+            setBotClient({
+                guilds: {
+                    cache: new Map([[guildId, mockGuild]]),
+                    fetch: jest.fn().mockResolvedValue(mockGuild),
+                },
+            } as unknown as Client)
+
+            const roleData = {
+                name: 'New Role',
+                color: 16711680,
+                hoist: true,
+                mentionable: false,
+                permissions: '8',
+            }
+
+            const role = await guildService.createGuildRole(guildId, roleData)
+
+            expect(role).toEqual({
+                id: '999999999999999999',
+                name: 'New Role',
+                color: 16711680,
+                position: 5,
+                hoist: true,
+                mentionable: false,
+                managed: false,
+                permissions: '8',
+            })
+            expect(mockGuild.roles.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'New Role',
+                    color: 16711680,
+                    hoist: true,
+                    mentionable: false,
+                    permissions: BigInt('8'),
+                }),
+            )
+        })
+
+        test('creates role via Discord API when bot client unavailable', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            const guildId = '111111111111111111'
+
+            setBotClient(null)
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    id: '555555555555555555',
+                    name: 'API Role',
+                    color: 255,
+                    position: 2,
+                    hoist: false,
+                    mentionable: true,
+                    managed: false,
+                    permissions: '16',
+                }),
+            } as never) as unknown as typeof fetch
+
+            const roleData = {
+                name: 'API Role',
+                color: 255,
+                hoist: false,
+                mentionable: true,
+                permissions: '16',
+            }
+
+            const role = await guildService.createGuildRole(guildId, roleData)
+
+            expect(role).toEqual({
+                id: '555555555555555555',
+                name: 'API Role',
+                color: 255,
+                position: 2,
+                hoist: false,
+                mentionable: true,
+                managed: false,
+                permissions: '16',
+            })
+            expect(global.fetch).toHaveBeenCalledWith(
+                `https://discord.com/api/v10/guilds/${encodeURIComponent(guildId)}/roles`,
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: {
+                        Authorization: 'Bot test-bot-token',
+                        'Content-Type': 'application/json',
+                    },
+                }),
+            )
+        })
+
+        test('throws error when no bot token available', async () => {
+            delete process.env.DISCORD_TOKEN
+            setBotClient(null)
+
+            const roleData = {
+                name: 'Test Role',
+                color: 0,
+                hoist: false,
+                mentionable: false,
+                permissions: '0',
+            }
+
+            await expect(
+                guildService.createGuildRole('111111111111111111', roleData),
+            ).rejects.toThrow('No bot token available')
+        })
+    })
+
+    describe('updateGuildRole', () => {
+        test('updates role via bot client when guild available', async () => {
+            const guildId = '111111111111111111'
+            const roleId = '999999999999999999'
+            const mockGuild = {
+                id: guildId,
+                roles: {
+                    fetch: jest.fn().mockResolvedValue({
+                        id: roleId,
+                        name: 'Updated Role',
+                        color: 65280,
+                        position: 5,
+                        hoist: false,
+                        mentionable: true,
+                        managed: false,
+                        permissions: {
+                            bitfield: BigInt('16'),
+                        },
+                        edit: jest.fn().mockResolvedValue({
+                            id: roleId,
+                            name: 'Updated Role',
+                            color: 65280,
+                            position: 5,
+                            hoist: false,
+                            mentionable: true,
+                            managed: false,
+                            permissions: {
+                                bitfield: BigInt('16'),
+                            },
+                        }),
+                    }),
+                },
+            } as unknown as Guild
+
+            setBotClient({
+                guilds: {
+                    cache: new Map([[guildId, mockGuild]]),
+                    fetch: jest.fn().mockResolvedValue(mockGuild),
+                },
+            } as unknown as Client)
+
+            const roleData = {
+                name: 'Updated Role',
+                color: 65280,
+                hoist: false,
+                mentionable: true,
+                permissions: '16',
+            }
+
+            const role = await guildService.updateGuildRole(
+                guildId,
+                roleId,
+                roleData,
+            )
+
+            expect(role).toEqual({
+                id: roleId,
+                name: 'Updated Role',
+                color: 65280,
+                position: 5,
+                hoist: false,
+                mentionable: true,
+                managed: false,
+                permissions: '16',
+            })
+        })
+
+        test('updates role via Discord API when bot client unavailable', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            const guildId = '111111111111111111'
+            const roleId = '555555555555555555'
+
+            setBotClient(null)
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    id: roleId,
+                    name: 'Updated API Role',
+                    color: 128,
+                    position: 3,
+                    hoist: true,
+                    mentionable: false,
+                    managed: false,
+                    permissions: '32',
+                }),
+            } as never) as unknown as typeof fetch
+
+            const roleData = {
+                name: 'Updated API Role',
+                color: 128,
+                hoist: true,
+                mentionable: false,
+                permissions: '32',
+            }
+
+            const role = await guildService.updateGuildRole(
+                guildId,
+                roleId,
+                roleData,
+            )
+
+            expect(role).toEqual({
+                id: roleId,
+                name: 'Updated API Role',
+                color: 128,
+                position: 3,
+                hoist: true,
+                mentionable: false,
+                managed: false,
+                permissions: '32',
+            })
+            expect(global.fetch).toHaveBeenCalledWith(
+                `https://discord.com/api/v10/guilds/${encodeURIComponent(guildId)}/roles/${encodeURIComponent(roleId)}`,
+                expect.objectContaining({
+                    method: 'PATCH',
+                    headers: {
+                        Authorization: 'Bot test-bot-token',
+                        'Content-Type': 'application/json',
+                    },
+                }),
+            )
+        })
+
+        test('throws error when no bot token available', async () => {
+            delete process.env.DISCORD_TOKEN
+            setBotClient(null)
+
+            const roleData = {
+                name: 'Test Role',
+                color: 0,
+                hoist: false,
+                mentionable: false,
+                permissions: '0',
+            }
+
+            await expect(
+                guildService.updateGuildRole(
+                    '111111111111111111',
+                    '999999999999999999',
+                    roleData,
+                ),
+            ).rejects.toThrow('No bot token available')
+        })
+    })
+
+    describe('deleteGuildRole', () => {
+        test('deletes role via bot client when guild available', async () => {
+            const guildId = '111111111111111111'
+            const roleId = '999999999999999999'
+            const mockGuild = {
+                id: guildId,
+                roles: {
+                    fetch: jest.fn().mockResolvedValue({
+                        id: roleId,
+                        delete: jest.fn().mockResolvedValue(undefined),
+                    }),
+                },
+            } as unknown as Guild
+
+            setBotClient({
+                guilds: {
+                    cache: new Map([[guildId, mockGuild]]),
+                    fetch: jest.fn().mockResolvedValue(mockGuild),
+                },
+            } as unknown as Client)
+
+            await expect(
+                guildService.deleteGuildRole(guildId, roleId),
+            ).resolves.toBeUndefined()
+            expect(
+                (
+                    await mockGuild.roles.fetch(roleId)
+                ).delete,
+            ).toHaveBeenCalled()
+        })
+
+        test('deletes role via Discord API when bot client unavailable', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            const guildId = '111111111111111111'
+            const roleId = '555555555555555555'
+
+            setBotClient(null)
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: true,
+            } as never) as unknown as typeof fetch
+
+            await expect(
+                guildService.deleteGuildRole(guildId, roleId),
+            ).resolves.toBeUndefined()
+            expect(global.fetch).toHaveBeenCalledWith(
+                `https://discord.com/api/v10/guilds/${encodeURIComponent(guildId)}/roles/${encodeURIComponent(roleId)}`,
+                expect.objectContaining({
+                    method: 'DELETE',
+                    headers: { Authorization: 'Bot test-bot-token' },
+                }),
+            )
+        })
+
+        test('throws error when no bot token available', async () => {
+            delete process.env.DISCORD_TOKEN
+            setBotClient(null)
+
+            await expect(
+                guildService.deleteGuildRole('111111111111111111', '999999999999999999'),
+            ).rejects.toThrow('No bot token available')
+        })
+
+        test('throws error when API response is not ok', async () => {
+            process.env.DISCORD_TOKEN = 'test-bot-token'
+            const guildId = '111111111111111111'
+            const roleId = '999999999999999999'
+
+            setBotClient(null)
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: false,
+                status: 404,
+                text: async () => 'Role not found',
+            } as never) as unknown as typeof fetch
+
+            await expect(
+                guildService.deleteGuildRole(guildId, roleId),
+            ).rejects.toThrow('Discord API error: Role not found')
+        })
+    })
 })

--- a/packages/bot/src/utils/music/autoplay/recommendationSourceMapping.spec.ts
+++ b/packages/bot/src/utils/music/autoplay/recommendationSourceMapping.spec.ts
@@ -6,6 +6,7 @@ describe('recommendationSourceToPrisma', () => {
 	it.each<[string, string]>([
 		['spotify-rec', PrismaRecommendationSource.SPOTIFY_REC],
 		['spotify-taste', PrismaRecommendationSource.SPOTIFY_TASTE],
+		['seed-similar', PrismaRecommendationSource.SEED_SIMILAR],
 		['lastfm-loved', PrismaRecommendationSource.LASTFM_LOVED],
 		['lastfm-similar', PrismaRecommendationSource.LASTFM_SIMILAR],
 		['lastfm-genre-fallback', PrismaRecommendationSource.LASTFM_GENRE_FALLBACK],


### PR DESCRIPTION
Closes #1549
Closes #1550
Closes #1541
Closes #1551

## Changes
- #1551: add missing seed-similar case to recommendationSourceToPrisma
  it.each tests
- #1549: add CORS header assertions to api integration tests
- #1541: fix 16-digit roleId boundary value + rename test for clarity
- #1550: assert cookie.secure=true in prod / false in dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing test coverage for Discord role CRUD in `GuildService` (bot client and REST fallbacks) and access-control middleware (`session`, `guildAccess`, `requireAdmin`) to validate expected auth and ACL behavior. Also fixes small test gaps tied to #1549, #1550, #1541, and #1551; closes #1527 and #1567.

- **Bug Fixes**
  - #1549: Assert CORS headers (`access-control-allow-origin` and methods) in API integration tests.
  - #1550: Verify session cookie `secure` is true in prod and false in dev.
  - #1541: Correct roleId boundary test to reject 16-digit IDs.
  - #1551: Add missing `seed-similar` mapping test.

<sup>Written for commit 0ab7a536b4f8f6138f51da8fa5626ac3789baafb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

