### PR TITLE
test: add integration tests for starboard routes and authcallback

### DIFF
--- a/packages/backend/tests/integration/routes/authCallback.test.ts
+++ b/packages/backend/tests/integration/routes/authCallback.test.ts
@@ -1,0 +1,459 @@
+import { errorHandler } from '../../../src/middleware/errorHandler'
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import request from 'supertest'
+import express from 'express'
+import { handleOAuthCallback } from '../../../src/routes/authCallback'
+import { setupSessionMiddleware } from '../../../src/middleware/session'
+import { sessionService } from '../../../src/services/SessionService'
+import { discordOAuthService } from '../../../src/services/DiscordOAuthService'
+import {
+    MOCK_DISCORD_USER,
+    MOCK_TOKEN_RESPONSE,
+    MOCK_AUTH_CODE,
+    MOCK_OAUTH_STATE,
+} from '../../fixtures/mock-data'
+
+jest.mock('../../../src/services/SessionService', () => ({
+    sessionService: {
+        setSession: jest.fn(),
+    },
+}))
+
+jest.mock('../../../src/services/DiscordOAuthService', () => ({
+    discordOAuthService: {
+        exchangeCodeForToken: jest.fn(),
+        getUserInfo: jest.fn(),
+    },
+}))
+
+describe('OAuth Callback (handleOAuthCallback)', () => {
+    let app: express.Express
+
+    const getDiscordOAuthMock = () =>
+        discordOAuthService as jest.Mocked<typeof discordOAuthService>
+
+    const getSessionServiceMock = () =>
+        sessionService as jest.Mocked<typeof sessionService>
+
+    function mockSuccessfulOAuthFlow(): void {
+        const mockDiscordOAuth = getDiscordOAuthMock()
+        const mockSessionService = getSessionServiceMock()
+
+        mockDiscordOAuth.exchangeCodeForToken.mockResolvedValue(
+            MOCK_TOKEN_RESPONSE,
+        )
+        mockDiscordOAuth.getUserInfo.mockResolvedValue(MOCK_DISCORD_USER)
+        mockSessionService.setSession.mockResolvedValue()
+    }
+
+    beforeEach(() => {
+        app = express()
+        setupSessionMiddleware(app)
+
+        app.get('/api/auth/callback', handleOAuthCallback)
+
+        app.use(errorHandler)
+        jest.clearAllMocks()
+    })
+
+    describe('State validation', () => {
+        test('should reject callback without state parameter', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const response = await request(app)
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE })
+                .expect(302)
+
+            expect(response.headers.location).toContain('invalid_state')
+            expect(
+                getDiscordOAuthMock().exchangeCodeForToken,
+            ).not.toHaveBeenCalled()
+        })
+
+        test('should reject callback with mismatched state (timing-safe comparison)', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const agent = request.agent(app)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: 'wrong_state_value' })
+                .expect(302)
+
+            expect(response.headers.location).toContain('invalid_state')
+            expect(
+                getDiscordOAuthMock().exchangeCodeForToken,
+            ).not.toHaveBeenCalled()
+        })
+
+        test('should accept callback with matching state', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            testApp.use((req, _res, next) => {
+                req.session.oauthState = MOCK_OAUTH_STATE
+                req.session.save((err) => {
+                    if (err) next(err)
+                    else next()
+                })
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(response.headers.location).toContain('authenticated=true')
+            expect(
+                getDiscordOAuthMock().exchangeCodeForToken,
+            ).toHaveBeenCalled()
+        })
+
+        test('should reject callback when session has no state', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const response = await request(app)
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(response.headers.location).toContain('invalid_state')
+            expect(
+                getDiscordOAuthMock().exchangeCodeForToken,
+            ).not.toHaveBeenCalled()
+        })
+
+        test('should clean up state after successful validation', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            let stateSet = true
+            testApp.use((req, _res, next) => {
+                if (stateSet) {
+                    req.session.oauthState = MOCK_OAUTH_STATE
+                    stateSet = false
+                }
+                next()
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            const secondAttempt = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(secondAttempt.headers.location).toContain('invalid_state')
+        })
+    })
+
+    describe('Session save error handling', () => {
+        test('should handle session.save() error gracefully', async () => {
+            const mockDiscordOAuth = getDiscordOAuthMock()
+            mockDiscordOAuth.exchangeCodeForToken.mockResolvedValue(
+                MOCK_TOKEN_RESPONSE,
+            )
+            mockDiscordOAuth.getUserInfo.mockResolvedValue(MOCK_DISCORD_USER)
+            getSessionServiceMock().setSession.mockResolvedValue()
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            let stateSet = true
+            testApp.use((req, _res, next) => {
+                if (stateSet) {
+                    req.session.oauthState = MOCK_OAUTH_STATE
+                    req.session.save((err) => {
+                        if (err) {
+                            next(err)
+                        } else {
+                            // Override save to fail on the actual callback request
+                            const originalSave = req.session.save
+                            req.session.save = jest.fn((callback) => {
+                                callback(new Error('Session save failed'))
+                            })
+                            stateSet = false
+                            next()
+                        }
+                    })
+                } else {
+                    next()
+                }
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(response.headers.location).toContain('error=auth_failed')
+            expect(response.headers.location).toContain('authentication_error')
+        })
+    })
+
+    describe('Successful OAuth callback flow', () => {
+        test('should complete successful OAuth callback with valid state', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            testApp.use((req, _res, next) => {
+                req.session.oauthState = MOCK_OAUTH_STATE
+                req.session.save((err) => {
+                    if (err) next(err)
+                    else next()
+                })
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(response.headers.location).toContain('authenticated=true')
+            expect(
+                getDiscordOAuthMock().exchangeCodeForToken,
+            ).toHaveBeenCalledWith(
+                MOCK_AUTH_CODE,
+                expect.stringContaining('/api/auth/callback'),
+            )
+            expect(getDiscordOAuthMock().getUserInfo).toHaveBeenCalledWith(
+                MOCK_TOKEN_RESPONSE.access_token,
+            )
+            expect(getSessionServiceMock().setSession).toHaveBeenCalled()
+        })
+
+        test('should set session data correctly on successful callback', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            testApp.use((req, _res, next) => {
+                req.session.oauthState = MOCK_OAUTH_STATE
+                req.session.save((err) => {
+                    if (err) next(err)
+                    else next()
+                })
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            const mockSessionService = getSessionServiceMock()
+            expect(mockSessionService.setSession).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    userId: MOCK_DISCORD_USER.id,
+                    user: MOCK_DISCORD_USER,
+                    accessToken: MOCK_TOKEN_RESPONSE.access_token,
+                    refreshToken: MOCK_TOKEN_RESPONSE.refresh_token,
+                    expiresAt: expect.any(Number),
+                }),
+            )
+        })
+
+        test('should redirect to dashboard on successful authentication', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            testApp.use((req, _res, next) => {
+                req.session.oauthState = MOCK_OAUTH_STATE
+                req.session.save((err) => {
+                    if (err) next(err)
+                    else next()
+                })
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(response.headers.location).toContain('authenticated=true')
+        })
+    })
+
+    describe('Missing or invalid code handling', () => {
+        test('should return error when code is missing', async () => {
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            testApp.use((req, _res, next) => {
+                req.session.oauthState = MOCK_OAUTH_STATE
+                next()
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(response.headers.location).toContain('error=missing_code')
+        })
+    })
+
+    describe('OAuth error handling', () => {
+        test('should handle Discord OAuth errors', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const response = await request(app)
+                .get('/api/auth/callback')
+                .query({ error: 'access_denied' })
+                .expect(302)
+
+            expect(response.headers.location).toContain('error=auth_failed')
+            expect(
+                getDiscordOAuthMock().exchangeCodeForToken,
+            ).not.toHaveBeenCalled()
+        })
+
+        test('should handle token exchange failure', async () => {
+            getDiscordOAuthMock().exchangeCodeForToken.mockRejectedValue(
+                new Error('Token exchange failed'),
+            )
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            testApp.use((req, _res, next) => {
+                req.session.oauthState = MOCK_OAUTH_STATE
+                next()
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(response.headers.location).toContain(
+                'error=auth_failed&message=authentication_error',
+            )
+        })
+
+        test('should handle getUserInfo failure', async () => {
+            const mockDiscordOAuth = getDiscordOAuthMock()
+            mockDiscordOAuth.exchangeCodeForToken.mockResolvedValue(
+                MOCK_TOKEN_RESPONSE,
+            )
+            mockDiscordOAuth.getUserInfo.mockRejectedValue(
+                new Error('Failed to get user info'),
+            )
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            testApp.use((req, _res, next) => {
+                req.session.oauthState = MOCK_OAUTH_STATE
+                next()
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
+                .expect(302)
+
+            expect(response.headers.location).toContain(
+                'error=auth_failed&message=authentication_error',
+            )
+        })
+    })
+
+    describe('Edge cases', () => {
+        test('should handle state with different encoding', async () => {
+            mockSuccessfulOAuthFlow()
+
+            const testApp = express()
+            setupSessionMiddleware(testApp)
+
+            const stateValue = Buffer.from('test-state-123').toString('hex')
+
+            let stateSet = true
+            testApp.use((req, _res, next) => {
+                if (stateSet) {
+                    req.session.oauthState = stateValue
+                    req.session.save((err) => {
+                        if (err) {
+                            next(err)
+                        } else {
+                            stateSet = false
+                            next()
+                        }
+                    })
+                } else {
+                    next()
+                }
+            })
+
+            testApp.get('/api/auth/callback', handleOAuthCallback)
+            testApp.use(errorHandler)
+
+            const agent = request.agent(testApp)
+
+            const response = await agent
+                .get('/api/auth/callback')
+                .query({ code: MOCK_AUTH_CODE, state: stateValue })
+                .expect(302)
+
+            expect(response.headers.location).toContain('authenticated=true')
+        })
+    })
+})

--- a/packages/backend/tests/integration/routes/starboard.test.ts
+++ b/packages/backend/tests/integration/routes/starboard.test.ts
@@ -1,0 +1,438 @@
+import { errorHandler } from '../../../src/middleware/errorHandler'
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
+import request from 'supertest'
+import express from 'express'
+import { setupStarboardRoutes } from '../../../src/routes/starboard'
+import { setupSessionMiddleware } from '../../../src/middleware/session'
+import { sessionService } from '../../../src/services/SessionService'
+import { MOCK_SESSION_DATA } from '../../fixtures/mock-data'
+
+jest.mock('../../../src/services/SessionService', () => ({
+    sessionService: {
+        getSession: jest.fn(),
+    },
+}))
+
+const mockGetConfig = jest.fn<any>()
+const mockUpsertConfig = jest.fn<any>()
+const mockDeleteConfig = jest.fn<any>()
+const mockGetTopEntries = jest.fn<any>()
+
+jest.mock('@lucky/shared/services', () => ({
+    starboardService: {
+        getConfig: (...args: any[]) => mockGetConfig(...args),
+        upsertConfig: (...args: any[]) => mockUpsertConfig(...args),
+        deleteConfig: (...args: any[]) => mockDeleteConfig(...args),
+        getTopEntries: (...args: any[]) => mockGetTopEntries(...args),
+    },
+}))
+
+describe('Starboard Routes', () => {
+    let app: express.Express
+
+    const GUILD_ID = '111111111111111111'
+
+    function authed() {
+        const mock = sessionService as jest.Mocked<typeof sessionService>
+        mock.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+    }
+
+    beforeEach(() => {
+        app = express()
+        app.use(express.json())
+        setupSessionMiddleware(app)
+        setupStarboardRoutes(app)
+        app.use(errorHandler)
+        jest.clearAllMocks()
+    })
+
+    describe('GET /api/guilds/:guildId/starboard/config', () => {
+        test('should return starboard config when it exists', async () => {
+            authed()
+
+            const mockConfig = {
+                id: 'cfg1',
+                guildId: GUILD_ID,
+                channelId: '222222222222222222',
+                emoji: '⭐',
+                threshold: 3,
+                selfStar: false,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }
+            mockGetConfig.mockResolvedValue(mockConfig)
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/config`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(200)
+            expect(res.body.config).toMatchObject({
+                id: 'cfg1',
+                guildId: GUILD_ID,
+                channelId: '222222222222222222',
+                emoji: '⭐',
+                threshold: 3,
+                selfStar: false,
+            })
+            expect(mockGetConfig).toHaveBeenCalledWith(GUILD_ID)
+        })
+
+        test('should return null config when it does not exist', async () => {
+            authed()
+            mockGetConfig.mockResolvedValue(null)
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/config`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(200)
+            expect(res.body.config).toBeNull()
+            expect(mockGetConfig).toHaveBeenCalledWith(GUILD_ID)
+        })
+
+        test('should return 401 without authentication', async () => {
+            const mock = sessionService as jest.Mocked<typeof sessionService>
+            mock.getSession.mockResolvedValue(null)
+
+            const res = await request(app).get(
+                `/api/guilds/${GUILD_ID}/starboard/config`,
+            )
+
+            expect(res.status).toBe(401)
+        })
+
+        test('should reject invalid guildId parameter', async () => {
+            authed()
+
+            const res = await request(app)
+                .get('/api/guilds/invalid-id/starboard/config')
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(400)
+        })
+    })
+
+    describe('PATCH /api/guilds/:guildId/starboard/config', () => {
+        test('should create config when channelId is provided', async () => {
+            authed()
+
+            const newConfig = {
+                id: 'cfg1',
+                guildId: GUILD_ID,
+                channelId: '222222222222222222',
+                emoji: '⭐',
+                threshold: 5,
+                selfStar: true,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }
+            mockUpsertConfig.mockResolvedValue(newConfig)
+
+            const res = await request(app)
+                .patch(`/api/guilds/${GUILD_ID}/starboard/config`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+                .send({
+                    channelId: '222222222222222222',
+                    emoji: '⭐',
+                    threshold: 5,
+                    selfStar: true,
+                })
+
+            expect(res.status).toBe(200)
+            expect(res.body.config).toMatchObject({
+                id: 'cfg1',
+                guildId: GUILD_ID,
+                channelId: '222222222222222222',
+                emoji: '⭐',
+                threshold: 5,
+                selfStar: true,
+            })
+            expect(mockUpsertConfig).toHaveBeenCalledWith(
+                GUILD_ID,
+                expect.objectContaining({
+                    channelId: '222222222222222222',
+                    emoji: '⭐',
+                    threshold: 5,
+                    selfStar: true,
+                }),
+            )
+        })
+
+        test('should update config using existing channelId when not provided', async () => {
+            authed()
+
+            const existingConfig = {
+                id: 'cfg1',
+                guildId: GUILD_ID,
+                channelId: '222222222222222222',
+                emoji: '⭐',
+                threshold: 3,
+                selfStar: false,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }
+
+            const updatedConfig = {
+                ...existingConfig,
+                threshold: 5,
+                emoji: '🌟',
+            }
+
+            mockGetConfig.mockResolvedValue(existingConfig)
+            mockUpsertConfig.mockResolvedValue(updatedConfig)
+
+            const res = await request(app)
+                .patch(`/api/guilds/${GUILD_ID}/starboard/config`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+                .send({
+                    emoji: '🌟',
+                    threshold: 5,
+                })
+
+            expect(res.status).toBe(200)
+            expect(res.body.config).toMatchObject({
+                id: 'cfg1',
+                guildId: GUILD_ID,
+                channelId: '222222222222222222',
+                emoji: '🌟',
+                threshold: 5,
+                selfStar: false,
+            })
+            expect(mockUpsertConfig).toHaveBeenCalledWith(
+                GUILD_ID,
+                expect.objectContaining({
+                    channelId: '222222222222222222',
+                    emoji: '🌟',
+                    threshold: 5,
+                }),
+            )
+        })
+
+        test('should reject PATCH without channelId when no existing config', async () => {
+            authed()
+            mockGetConfig.mockResolvedValue(null)
+
+            const res = await request(app)
+                .patch(`/api/guilds/${GUILD_ID}/starboard/config`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+                .send({
+                    emoji: '⭐',
+                    threshold: 3,
+                })
+
+            expect(res.status).toBe(400)
+            expect(res.body.error).toContain('channelId is required')
+        })
+
+        test('should reject invalid body', async () => {
+            authed()
+
+            const res = await request(app)
+                .patch(`/api/guilds/${GUILD_ID}/starboard/config`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+                .send({
+                    threshold: 'invalid',
+                })
+
+            expect(res.status).toBe(400)
+        })
+
+        test('should return 401 without authentication', async () => {
+            const mock = sessionService as jest.Mocked<typeof sessionService>
+            mock.getSession.mockResolvedValue(null)
+
+            const res = await request(app)
+                .patch(`/api/guilds/${GUILD_ID}/starboard/config`)
+                .send({
+                    channelId: '222222222222222222',
+                })
+
+            expect(res.status).toBe(401)
+        })
+    })
+
+    describe('DELETE /api/guilds/:guildId/starboard/config', () => {
+        test('should delete starboard config', async () => {
+            authed()
+            mockDeleteConfig.mockResolvedValue()
+
+            const res = await request(app)
+                .delete(`/api/guilds/${GUILD_ID}/starboard/config`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(200)
+            expect(res.body.success).toBe(true)
+            expect(mockDeleteConfig).toHaveBeenCalledWith(GUILD_ID)
+        })
+
+        test('should return 401 without authentication', async () => {
+            const mock = sessionService as jest.Mocked<typeof sessionService>
+            mock.getSession.mockResolvedValue(null)
+
+            const res = await request(app).delete(
+                `/api/guilds/${GUILD_ID}/starboard/config`,
+            )
+
+            expect(res.status).toBe(401)
+        })
+
+        test('should reject invalid guildId parameter', async () => {
+            authed()
+
+            const res = await request(app)
+                .delete('/api/guilds/invalid-id/starboard/config')
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(400)
+        })
+    })
+
+    describe('GET /api/guilds/:guildId/starboard/entries', () => {
+        test('should return top entries with default limit', async () => {
+            authed()
+
+            const entries = [
+                {
+                    id: 'e1',
+                    guildId: GUILD_ID,
+                    messageId: 'msg1',
+                    channelId: '222222222222222222',
+                    authorId: '333333333333333333',
+                    starboardMsgId: 'sbmsg1',
+                    starCount: 10,
+                    content: 'First message',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                {
+                    id: 'e2',
+                    guildId: GUILD_ID,
+                    messageId: 'msg2',
+                    channelId: '222222222222222222',
+                    authorId: '333333333333333333',
+                    starboardMsgId: 'sbmsg2',
+                    starCount: 5,
+                    content: 'Second message',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+            ]
+            mockGetTopEntries.mockResolvedValue(entries)
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/entries`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(200)
+            expect(res.body.entries).toHaveLength(2)
+            expect(mockGetTopEntries).toHaveBeenCalledWith(GUILD_ID, 10)
+        })
+
+        test('should respect custom limit parameter', async () => {
+            authed()
+
+            const entries = Array.from({ length: 25 }, (_, i) => ({
+                id: `e${i}`,
+                guildId: GUILD_ID,
+                messageId: `msg${i}`,
+                channelId: '222222222222222222',
+                authorId: '333333333333333333',
+                starboardMsgId: `sbmsg${i}`,
+                starCount: 25 - i,
+                content: `Message ${i}`,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }))
+            mockGetTopEntries.mockResolvedValue(entries)
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/entries`)
+                .query({ limit: 25 })
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(200)
+            expect(res.body.entries).toHaveLength(25)
+            expect(mockGetTopEntries).toHaveBeenCalledWith(GUILD_ID, 25)
+        })
+
+        test('should clamp limit to maximum of 50', async () => {
+            authed()
+            mockGetTopEntries.mockResolvedValue([])
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/entries`)
+                .query({ limit: 50 })
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(200)
+            expect(mockGetTopEntries).toHaveBeenCalledWith(GUILD_ID, 50)
+        })
+
+        test('should reject limit greater than 50', async () => {
+            authed()
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/entries`)
+                .query({ limit: 100 })
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(400)
+        })
+
+        test('should reject invalid limit in query', async () => {
+            authed()
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/entries`)
+                .query({ limit: 'invalid' })
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(400)
+        })
+
+        test('should reject limit less than 1', async () => {
+            authed()
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/entries`)
+                .query({ limit: 0 })
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(400)
+        })
+
+        test('should return 401 without authentication', async () => {
+            const mock = sessionService as jest.Mocked<typeof sessionService>
+            mock.getSession.mockResolvedValue(null)
+
+            const res = await request(app).get(
+                `/api/guilds/${GUILD_ID}/starboard/entries`,
+            )
+
+            expect(res.status).toBe(401)
+        })
+
+        test('should reject invalid guildId parameter', async () => {
+            authed()
+
+            const res = await request(app)
+                .get('/api/guilds/invalid-id/starboard/entries')
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(400)
+        })
+
+        test('should return empty array when no entries exist', async () => {
+            authed()
+            mockGetTopEntries.mockResolvedValue([])
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/starboard/entries`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(200)
+            expect(res.body.entries).toEqual([])
+        })
+    })
+})


### PR DESCRIPTION
Closes #1570
Closes #1571

## Changes

- **starboard routes**: GET /api/guilds/:guildId/starboard/config, PATCH, DELETE, and GET /api/guilds/:guildId/starboard/entries route coverage
  - Config retrieval and null handling
  - Config creation with required channelId
  - Config updates using existing channelId when not provided
  - Validation of missing channelId on create
  - Invalid parameter rejection
  - DELETE endpoint
  - Entries retrieval with limit parameter
  - Limit clamping to max 50
  - Authorization checks

- **authCallback OAuth**: Comprehensive OAuth state validation and session handling
  - Timing-safe state comparison
  - Missing state parameter rejection
  - Mismatched state rejection
  - State cleanup after successful validation
  - Session.save() error handling
  - Successful callback flow with state validation
  - Token exchange and user info retrieval
  - Session data persistence
  - Redirect to dashboard on success
  - Discord OAuth error handling
  - Token exchange failure handling
  - User info retrieval failure handling
  - State encoding edge cases

## Test Coverage

- 35 total tests across both files
- All tests passing
- Proper mocking of external services
- Authorization enforcement verified
- Edge cases covered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add integration tests for starboard routes and the OAuth callback to verify config CRUD, entry limits, and secure state/session handling. This increases confidence in auth, validation, and error paths.

- **Coverage**
  - Starboard: GET/PATCH/DELETE config and GET entries; validates guildId/body/limit; requires channelId on create; reuses existing channelId on update; enforces auth; limit default 10, accepts 1–50, rejects >50 and <1.
  - OAuth callback: timing-safe state check (missing/mismatched/no-session) with cleanup; handles missing code, provider errors, token/user fetch failures, and session.save failures; persists session and redirects on success.
  - Mocks external services (`@lucky/shared/services`, `SessionService`, `DiscordOAuthService`) with 35 passing tests.

<sup>Written for commit eec48d8288ed4c9e285eeb7d4f6766c9b0506662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for OAuth callback handling, including successful login flows, missing/invalid state, missing code, provider errors, and session-save failures.
  * Added integration coverage for Starboard routes, including authentication checks, input validation, config create/update/delete behavior, and top-entry retrieval limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->