### PR TITLE
fix(frontend): fix CF Pages API routing and remove Vercel Analytics

### DIFF
--- a/.github/workflows/deploy-frontend-cf.yml
+++ b/.github/workflows/deploy-frontend-cf.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: packages/frontend
         run: npm run build
         env:
-          VITE_API_BASE_URL: https://lucky-api.lucassantana.tech
+          VITE_API_BASE_URL: https://lucky-api.lucassantana.tech/api
           VITE_SENTRY_ENVIRONMENT: production
           VITE_COMMIT_SHA: ${{ github.sha }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -9,7 +9,6 @@ import {
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ShieldAlert } from 'lucide-react'
-import { Analytics } from '@vercel/analytics/react'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { useAuthStore } from './stores/authStore'
 import { useGuildStore } from './stores/guildStore'
@@ -274,7 +273,6 @@ function App() {
                         <PublicRoutes />
                     </Suspense>
                 </ErrorBoundary>
-                <Analytics />
             </div>
         )
     }
@@ -284,7 +282,6 @@ function App() {
         return (
             <div className='dark'>
                 <PageLoader />
-                <Analytics />
             </div>
         )
     }
@@ -304,7 +301,6 @@ function App() {
                         </Routes>
                     </Suspense>
                 </ErrorBoundary>
-                <Analytics />
             </div>
         )
     }
@@ -318,7 +314,6 @@ function App() {
                     </Suspense>
                 </Layout>
             </ErrorBoundary>
-            <Analytics />
         </div>
     )
 }

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -108,7 +108,9 @@ apiClient.interceptors.response.use(
             typeof globalThis !== 'undefined' &&
             'window' in globalThis
         ) {
-            globalThis.window.location.assign('/api/auth/discord')
+            globalThis.window.location.assign(
+                `${NORMALIZED_API_BASE}/auth/discord`,
+            )
         }
 
         return Promise.reject(new ApiError(status, message, data?.details))


### PR DESCRIPTION
## Summary

- **VITE_API_BASE_URL**: Added `/api` suffix (`https://lucky-api.lucassantana.tech/api`) so axios base URL resolves to the correct backend path — all routes in `API_ROUTES` use paths like `/guilds`, `/auth/status` that require the `/api` prefix on the base
- **401 interceptor** (`api.ts`): changed from relative `/api/auth/discord` (broken on CF Pages separate origin) to absolute `${NORMALIZED_API_BASE}/auth/discord` 
- **Vercel Analytics**: removed `@vercel/analytics` import and all 4 `<Analytics />` usages — CF Pages serves `/_vercel/insights/script.js` as SPA HTML fallback, causing "Refused to execute script" console errors

**Infrastructure fix (CF tunnel, already live):** updated nexus tunnel config via CF API — `lucky-api.lucassantana.tech` now routes to `http://lucky-nginx:8080` (Docker-internal container name, reachable from `lucky-tunnel` in same network) instead of `http://100.95.204.103:8090` (Tailscale IP, unreachable from inside the container network).

## Test plan

- [ ] `https://lucky-api.lucassantana.tech/api/stats/public` returns JSON (already verified ✓)
- [ ] `https://lucky-api.lucassantana.tech/api/auth/status` returns 200 (already verified ✓)
- [ ] After CF Pages redeploy: login flow redirects correctly to Discord OAuth
- [ ] No `/_vercel/insights` console errors on any route

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CF Pages API routing and restore the Discord login by using the `/api` base URL and an absolute 401 redirect. Remove `@vercel/analytics` to stop CF Pages `/_vercel/insights` script errors.

- **Bug Fixes**
  - Set `VITE_API_BASE_URL` to `https://lucky-api.lucassantana.tech/api` (CI workflow) so axios hits backend routes.
  - Update 401 interceptor to `${NORMALIZED_API_BASE}/auth/discord` for cross-origin redirects.
  - Remove `@vercel/analytics` and all `<Analytics />` usages to eliminate insights script errors.

<sup>Written for commit 07d5ca86204d171931e6a6898559cd300cbbc550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login redirects so authentication now sends users to the correct sign-in flow when access is denied.
  * Updated the frontend to use the correct API endpoint, helping requests reach the right service in production.
  * Removed an analytics widget from the app interface, reducing unnecessary tracking overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->