### PR TITLE
fix(deploy): wire GITHUB_DEPLOY_STATUS_TOKEN into lucky-webhook container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,6 +233,7 @@ services:
             - DEPLOY_WEBHOOK_SECRET=${DEPLOY_WEBHOOK_SECRET}
             - DISCORD_DEPLOY_WEBHOOK=${DISCORD_DEPLOY_WEBHOOK:-}
             - DEPLOY_DIR=/home/luk-server/Lucky
+            - GITHUB_DEPLOY_STATUS_TOKEN=${GITHUB_DEPLOY_STATUS_TOKEN:-}
         volumes:
             # Read hooks.json from the directory-mounted repo (not a single-file
             # mount): a single-file bind-mount freezes to the original inode, so


### PR DESCRIPTION
## Summary

- Adds `GITHUB_DEPLOY_STATUS_TOKEN=${GITHUB_DEPLOY_STATUS_TOKEN:-}` to the `lucky-webhook` service environment in `docker-compose.yml`
- Allows `deploy.sh`'s `post_deploy_status()` to POST commit statuses (`homelab-deploy` context) to the GitHub API
- Token is optional — deploy still works if unset (function early-returns on empty)

## Server setup required after merge

```bash
# ssh server-do-luk
# 1. Create classic PAT at github.com/settings/tokens/new — scope: repo:status
# 2. Add to server .env:
echo 'GITHUB_DEPLOY_STATUS_TOKEN=ghp_YOUR_TOKEN_HERE' >> /home/luk-server/Lucky/.env
# 3. Restart webhook container:
cd /home/luk-server/Lucky && docker compose up -d lucky-webhook
```

Closes #1582

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GITHUB_DEPLOY_STATUS_TOKEN` to the `lucky-webhook` service in `docker-compose.yml` so `deploy.sh` can post GitHub commit statuses (`homelab-deploy`). Token is optional; deploys still work if unset.

- **Migration**
  - Create a GitHub classic PAT with `repo:status`.
  - Add `GITHUB_DEPLOY_STATUS_TOKEN` to `/home/luk-server/Lucky/.env`.
  - Restart: `cd /home/luk-server/Lucky && docker compose up -d lucky-webhook`.

<sup>Written for commit 36a9d6d5814cc964708a2cc6a50d1f3bc7c465d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated webhook handling to support an additional deployment status token when configured, helping deployment status updates work more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->