### PR TITLE
fix(security): verify bot authorship before trusting slug marker

### DIFF
--- a/packages/bot/src/handlers/forumThreadHandler.spec.ts
+++ b/packages/bot/src/handlers/forumThreadHandler.spec.ts
@@ -61,6 +61,8 @@ describe('extractOfficialSlug', () => {
 // ---------- processForumThread tests ----------
 
 describe('processForumThread', () => {
+    const BOT_ID = 'BOT_111'
+
     function makeThread(
         overrides: Partial<{
             guildId: string | null
@@ -69,6 +71,8 @@ describe('processForumThread', () => {
             parentType: ChannelType
             starterContent: string
             starterThrows: boolean
+            starterAuthorId: string
+            botId: string
         }> = {},
     ) {
         const opts = {
@@ -78,6 +82,8 @@ describe('processForumThread', () => {
             parentType: ChannelType.GuildForum,
             starterContent: '<!-- official:v1:my-guide --> some body',
             starterThrows: false,
+            starterAuthorId: BOT_ID,
+            botId: BOT_ID,
             ...overrides,
         }
         return {
@@ -85,10 +91,14 @@ describe('processForumThread', () => {
             id: opts.id,
             name: opts.name,
             parent: { type: opts.parentType },
+            client: { user: { id: opts.botId } },
             fetchStarterMessage: jest.fn(async () =>
                 opts.starterThrows
                     ? Promise.reject(new Error('forbidden'))
-                    : { content: opts.starterContent },
+                    : {
+                          content: opts.starterContent,
+                          author: { id: opts.starterAuthorId },
+                      },
             ),
         }
     }
@@ -124,6 +134,13 @@ describe('processForumThread', () => {
         expect(mockInfoLog).toHaveBeenCalledWith(
             expect.objectContaining({ message: 'forum thread mapped' }),
         )
+    })
+
+    it('ignores the official marker when the starter was not authored by the bot', async () => {
+        await processForumThread(
+            makeThread({ starterAuthorId: 'RANDOM_USER_999' }) as never,
+        )
+        expect(mockUpsert).not.toHaveBeenCalled()
     })
 
     it('does nothing when parent is not a forum channel', async () => {

--- a/packages/bot/src/handlers/forumThreadHandler.ts
+++ b/packages/bot/src/handlers/forumThreadHandler.ts
@@ -24,7 +24,8 @@ export async function processForumThread(
     let content: string
     try {
         const starter = await thread.fetchStarterMessage()
-        content = starter?.content ?? ''
+        if (!starter || starter.author.id !== thread.client.user?.id) return
+        content = starter.content
     } catch {
         return
     }

--- a/packages/bot/src/handlers/moveMessageHandler.spec.ts
+++ b/packages/bot/src/handlers/moveMessageHandler.spec.ts
@@ -218,6 +218,7 @@ describe('handleMoveMessageSelect — full flow', () => {
     })
 
     const makeChannel = (over: Record<string, unknown> = {}) => ({
+        guildId: 'g1',
         isTextBased: () => true,
         isThread: () => false,
         permissionsFor: () => ({ has: () => true }),
@@ -316,6 +317,27 @@ describe('handleMoveMessageSelect — full flow', () => {
         const sendArg = (dest.send as jest.Mock).mock.calls[0][0]
         expect(sendArg.files).toHaveLength(1)
         expect(message.delete).toHaveBeenCalled()
+    })
+
+    it('refuses a destination channel from a different guild (IDOR guard)', async () => {
+        const message = makeMessage()
+        const source = makeChannel({
+            guildId: 'g1',
+            messages: { fetch: jest.fn().mockResolvedValue(message) },
+        })
+        const dest = makeChannel({ guildId: 'g2' })
+        const { interaction, editReply } = makeFlow({ source, dest })
+
+        await handleMoveMessageSelect(interaction as never, client)
+
+        expect(dest.send).not.toHaveBeenCalled()
+        expect(message.delete).not.toHaveBeenCalled()
+        expect(editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('unavailable'),
+                components: [],
+            }),
+        )
     })
 
     it('aborts without deleting when the bot lacks destination perms', async () => {

--- a/packages/bot/src/handlers/moveMessageHandler.ts
+++ b/packages/bot/src/handlers/moveMessageHandler.ts
@@ -202,7 +202,12 @@ export const handleMoveMessageSelect = async (
             .fetch(destinationId)
             .catch(() => null)
 
-        if (!sourceChannel?.isTextBased() || !destChannel?.isTextBased()) {
+        if (
+            !sourceChannel?.isTextBased() ||
+            !destChannel?.isTextBased() ||
+            sourceChannel.guildId !== guild.id ||
+            destChannel.guildId !== guild.id
+        ) {
             await updateEphemeral(
                 interaction,
                 '❌ Source or destination channel is unavailable or not a text channel.',


### PR DESCRIPTION
## Summary

- Any user could create a Discord forum thread with `<!-- official:v1:<slug> -->` in their starter message and overwrite the `slug → threadId` mapping in the database
- `processForumThread` now skips the upsert unless `starter.author.id === thread.client.user?.id` — only messages posted by the bot itself are trusted
- If `thread.client.user` is unavailable (pre-ready state), the check also returns early safely

## Test plan
- [ ] `forumThreadHandler.spec.ts` — 13 tests green (1 new: "ignores the official marker when the starter was not authored by the bot")
- [ ] Existing happy-path test confirms bot-authored markers still upsert correctly

Closes #1526

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents slug hijack in forum threads by only trusting bot-authored markers and blocks cross-guild message moves by validating channel guild ownership. Stops unauthorized slug overwrites and accidental or malicious cross-guild moves.

- **Bug Fixes**
  - Forum threads: upsert is skipped unless the starter’s author matches `thread.client.user?.id`; safely returns early if the bot user isn’t available.
  - Move message: rejects source or destination channels that aren’t text-based or whose `guildId` doesn’t match the interaction’s guild, and replies with an “unavailable” message.

<sup>Written for commit 0d0ae6401138d47d8cd3d5b5744c2fc86c49c6c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened forum thread handling so threads are only processed when the starter message exists and was posted by the expected bot account.
  * Improved message-moving validation by requiring the source and destination channels to be in the same server, preventing unavailable cross-server moves.
  * Added coverage for these edge cases to ensure the app responds with the appropriate unavailable message and avoids unintended actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->