### PR TITLE
fix(deploy): derive require_running_containers from docker compose

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -145,13 +145,27 @@ verify_cloudflared_config() {
 }
 
 require_running_containers() {
-    local required
-    required=(lucky-backend lucky-frontend lucky-nginx lucky-postgres lucky-redis lucky-bot)
     local missing=()
     local not_running=()
-    local container running
+    local container running expected_service
 
-    for container in "${required[@]}"; do
+    # Derive expected services from docker-compose config, excluding one-shots.
+    # cloudflared runs with a profile and is not required for core deploy success.
+    # webhook is a deployment helper (not a user-facing service) and runs on demand.
+    local excluded_pattern="^(cloudflared|webhook)$"
+    local expected_services
+    expected_services=$(docker_compose config --services 2>/dev/null | grep -v -E "$excluded_pattern" || true)
+
+    if [[ -z "$expected_services" ]]; then
+        log "ERROR: could not derive expected services from docker-compose config"
+        return 1
+    fi
+
+    # Prefix service names with project name to get container names.
+    # docker-compose creates containers named <project>-<service>.
+    while IFS= read -r expected_service; do
+        container="${COMPOSE_PROJECT_NAME}-${expected_service}"
+
         if ! docker inspect "$container" >/dev/null 2>&1; then
             missing+=("$container")
             continue
@@ -161,7 +175,7 @@ require_running_containers() {
         if [[ "$running" != "true" ]]; then
             not_running+=("$container")
         fi
-    done
+    done <<< "$expected_services"
 
     if [[ "${#missing[@]}" -gt 0 ]] || [[ "${#not_running[@]}" -gt 0 ]]; then
         [[ "${#missing[@]}" -gt 0 ]] && log "ERROR: missing containers: ${missing[*]}"


### PR DESCRIPTION
## Summary
Replace hand-written container list in `require_running_containers()` with dynamic derivation from `docker compose config --services`. The static list drifted twice in the past, causing silent deploy failures where the health check reported success while a service was actually down.

## Changes
- Derive expected services dynamically from compose config at runtime
- Exclude `cloudflared` (optional profile) and `webhook` (deploy helper, not user-facing)
- Prefix service names with project name to get container names
- Fail early if compose config cannot be read

## Why this matters
The deploy script runs on the production server inside the repo directory, so `docker compose config --services` is always available. This keeps the gate automatically in sync with compose — no more manual list maintenance or drift.

Fixes #1575

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derive required containers from `docker compose` at deploy time so health checks stay in sync with `docker-compose.yml` and avoid green deploys when a service is down. Fixes #1575.

- **Bug Fixes**
  - Read expected services via `docker compose config --services`, then check `${COMPOSE_PROJECT_NAME}-<service>` containers.
  - Skip `cloudflared` (profile-based) and `webhook` (deploy helper).
  - Fail fast if the compose config can’t be read or returns no services.

<sup>Written for commit 98f1cd3f9b5e3c17314cb0ddf9514a676b23ea2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

