### PR TITLE
fix(backend): add validateparams to forums route guildid and slug

### DIFF
--- a/packages/backend/src/routes/forums.ts
+++ b/packages/backend/src/routes/forums.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import { getPrismaClient } from '@lucky/shared/utils'
 import { apiLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
+import { validateParams } from '../middleware/validate'
+import { managementSchemas as s } from '../schemas/management'
 
 const threadResponseSchema = z.object({
     threadId: z.string(),
@@ -21,6 +23,7 @@ export function setupForumsRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/threads/:slug',
         apiLimiter,
+        validateParams(s.forumThreadSlugParam),
         asyncHandler(async (req: Request, res: Response) => {
             const { guildId, slug } = req.params as {
                 guildId: string

--- a/packages/backend/src/schemas/management.ts
+++ b/packages/backend/src/schemas/management.ts
@@ -202,6 +202,10 @@ const addRoleToGroupBody = z
     })
     .strict()
 
+const forumThreadSlugParam = guildIdParam.extend({
+    slug: z.string().min(1, 'Slug is required').max(256),
+})
+
 export const managementSchemas = {
     guildIdParam,
     commandNameParam,
@@ -225,4 +229,5 @@ export const managementSchemas = {
     createRoleGroupBody,
     updateRoleGroupBody,
     addRoleToGroupBody,
+    forumThreadSlugParam,
 }

--- a/packages/backend/tests/unit/routes/forums.test.ts
+++ b/packages/backend/tests/unit/routes/forums.test.ts
@@ -113,4 +113,22 @@ describe('GET /api/guilds/:guildId/threads/:slug', () => {
             `https://discord.com/channels/${GUILD_ID}/THREAD_XYZ`,
         )
     })
+
+    test('returns 400 when guildId is malformed (not a snowflake)', async () => {
+        const res = await request(buildApp()).get(
+            `/api/guilds/invalid-guild-id/threads/${SLUG}`,
+        )
+
+        expect(res.status).toBe(400)
+        expect(res.body).toHaveProperty('error', 'Validation failed')
+        expect(mockFindUnique).not.toHaveBeenCalled()
+    })
+
+    test('returns 404 when slug is missing', async () => {
+        const res = await request(buildApp()).get(
+            `/api/guilds/${GUILD_ID}/threads/`,
+        )
+
+        expect(res.status).toBe(404)
+    })
 })


### PR DESCRIPTION
## Summary
Added schema validation to the forum thread route to ensure malformed parameters don't reach Prisma. Follows the established validation pattern from other routes.

- Added `forumThreadSlugParam` schema to management schemas
- Wired `validateParams` middleware for `guildId` and `slug` parameters
- Added test coverage for malformed guildId validation

Closes #1525

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add parameter validation to the forum thread route to block malformed `guildId` (snowflake) and `slug` before hitting Prisma. Prevents 500s and matches validation used in other routes.

- **Bug Fixes**
  - Added `forumThreadSlugParam` to management schemas.
  - Applied `validateParams` to `guildId` and `slug` on GET `/api/guilds/:guildId/threads/:slug`.
  - Added tests for malformed `guildId` (400) and missing `slug` (404).

<sup>Written for commit c961f44075df103c0a5af364c25cb1ca71e823be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

