### PR TITLE
fix(schema): add unique guild+thread constraint to guildforumthread

### DIFF
--- a/packages/backend/src/routes/roles.ts
+++ b/packages/backend/src/routes/roles.ts
@@ -231,15 +231,26 @@ export function setupRolesRoutes(app: Express): void {
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
             const messageId = p(req.params.messageId)
-            const deleted =
-                await reactionRolesService.deleteReactionRoleMessage(
-                    messageId,
-                    guildId,
-                )
-            if (!deleted) {
-                throw AppError.notFound('Reaction role message not found')
+            try {
+                const deleted =
+                    await reactionRolesService.deleteReactionRoleMessage(
+                        messageId,
+                        guildId,
+                    )
+                if (!deleted) {
+                    throw AppError.notFound('Reaction role message not found')
+                }
+                res.json({ success: true })
+            } catch (error) {
+                if (error instanceof AppError) {
+                    throw error
+                }
+                const message =
+                    error instanceof Error
+                        ? error.message
+                        : 'Failed to delete reaction role message'
+                throw AppError.internalServerError(message)
             }
-            res.json({ success: true })
         }),
     )
 

--- a/packages/backend/tests/integration/routes/roles.test.ts
+++ b/packages/backend/tests/integration/routes/roles.test.ts
@@ -347,6 +347,19 @@ describe('Roles Routes', () => {
 
             expect(res.status).toBe(400)
         })
+
+        test('should return 500 when DB error occurs (not record not found)', async () => {
+            authed()
+            const dbError = new Error('Database connection lost')
+            mockDeleteReactionRole.mockRejectedValue(dbError)
+
+            const res = await request(app)
+                .delete(`/api/guilds/${GUILD_ID}/reaction-roles/${MESSAGE_ID}`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(500)
+            expect(res.body.error).toBeDefined()
+        })
     })
 
     describe('GET /api/guilds/:guildId/roles/exclusive', () => {

--- a/packages/bot/src/functions/general/handlers/reactionroleHandlers.spec.ts
+++ b/packages/bot/src/functions/general/handlers/reactionroleHandlers.spec.ts
@@ -262,6 +262,31 @@ describe('reactionroleHandlers', () => {
                 },
             })
         })
+
+        test('handles DB errors gracefully', async () => {
+            const guild = createGuild()
+            const interaction = createInteraction()
+
+            const dbError = new Error('Database connection lost')
+            deleteReactionRoleMessageMock.mockRejectedValueOnce(dbError)
+
+            await handleDelete(interaction, guild)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Error',
+                                description: expect.stringContaining('try again later'),
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
     })
 
     describe('handleList', () => {

--- a/packages/bot/src/functions/general/handlers/reactionroleHandlers.ts
+++ b/packages/bot/src/functions/general/handlers/reactionroleHandlers.ts
@@ -89,22 +89,33 @@ export async function handleDelete(
     guild: Guild,
 ) {
     const messageId = interaction.options.getString('message_id', true)
-    const deleted = await reactionRolesService.deleteReactionRoleMessage(
-        messageId,
-        guild.id,
-    )
 
-    if (deleted) {
-        await replyEmbed(
-            interaction,
-            createSuccessEmbed('Success', 'Reaction role message deleted.'),
+    try {
+        const deleted = await reactionRolesService.deleteReactionRoleMessage(
+            messageId,
+            guild.id,
         )
-    } else {
+
+        if (deleted) {
+            await replyEmbed(
+                interaction,
+                createSuccessEmbed('Success', 'Reaction role message deleted.'),
+            )
+        } else {
+            await replyEmbed(
+                interaction,
+                createErrorEmbed(
+                    'Error',
+                    'Reaction role message not found or you do not have permission to delete it.',
+                ),
+            )
+        }
+    } catch (_error) {
         await replyEmbed(
             interaction,
             createErrorEmbed(
                 'Error',
-                'Reaction role message not found or you do not have permission to delete it.',
+                'Failed to delete reaction role message. Please try again later.',
             ),
         )
     }


### PR DESCRIPTION
## Summary
Adds a unique index on `(guildId, threadId)` to prevent duplicate rows for the same thread in the `GuildForumThread` model.

The existing `@@unique([guildId, slug])` constraint only enforced slug uniqueness within a guild, not thread uniqueness. This left the schema vulnerable to duplicate entries for the same thread.

Closes #1534

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unique `(guildId, threadId)` constraint to `GuildForumThread` to prevent duplicate threads, and fix reaction-role deletion to return proper errors and show a clear bot message on failures.

- **Bug Fixes**
  - DELETE `/api/guilds/:guildId/reaction-roles/:messageId` now returns 500 for DB errors and 404 only when not found.
  - Bot `handleDelete` wraps deletion in try/catch and replies with an ephemeral error embed on failures.

- **Migration**
  - Run `prisma migrate deploy`.
  - If it fails, remove duplicate `(guildId, threadId)` rows from `guild_forum_threads` and rerun.

<sup>Written for commit 8bb854237a4613dacee9e419de6d4ef62a0877ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when deleting reaction-role messages, so unexpected failures now return a clear generic error instead of breaking the request.
  * Preserved the existing “not found” response when a reaction-role message doesn’t exist.
  * Updated bot responses to show a more helpful failure message when deletion can’t be completed.

* **Tests**
  * Added coverage for API and bot deletion failures to verify the new error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->