### PR TITLE
fix(backend): propagate db errors from deleteReactionRoleMessage

### DIFF
--- a/packages/backend/src/routes/roles.ts
+++ b/packages/backend/src/routes/roles.ts
@@ -231,26 +231,23 @@ export function setupRolesRoutes(app: Express): void {
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
             const messageId = p(req.params.messageId)
+            let deleted: boolean
             try {
-                const deleted =
+                deleted =
                     await reactionRolesService.deleteReactionRoleMessage(
                         messageId,
                         guildId,
                     )
-                if (!deleted) {
-                    throw AppError.notFound('Reaction role message not found')
-                }
-                res.json({ success: true })
-            } catch (error) {
-                if (error instanceof AppError) {
-                    throw error
-                }
-                const message =
-                    error instanceof Error
-                        ? error.message
-                        : 'Failed to delete reaction role message'
-                throw new AppError(500, message)
+            } catch {
+                throw new AppError(
+                    500,
+                    'Failed to delete reaction role message',
+                )
             }
+            if (!deleted) {
+                throw AppError.notFound('Reaction role message not found')
+            }
+            res.json({ success: true })
         }),
     )
 

--- a/packages/backend/src/routes/roles.ts
+++ b/packages/backend/src/routes/roles.ts
@@ -231,15 +231,26 @@ export function setupRolesRoutes(app: Express): void {
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
             const messageId = p(req.params.messageId)
-            const deleted =
-                await reactionRolesService.deleteReactionRoleMessage(
-                    messageId,
-                    guildId,
-                )
-            if (!deleted) {
-                throw AppError.notFound('Reaction role message not found')
+            try {
+                const deleted =
+                    await reactionRolesService.deleteReactionRoleMessage(
+                        messageId,
+                        guildId,
+                    )
+                if (!deleted) {
+                    throw AppError.notFound('Reaction role message not found')
+                }
+                res.json({ success: true })
+            } catch (error) {
+                if (error instanceof AppError) {
+                    throw error
+                }
+                const message =
+                    error instanceof Error
+                        ? error.message
+                        : 'Failed to delete reaction role message'
+                throw AppError.internalServerError(message)
             }
-            res.json({ success: true })
         }),
     )
 

--- a/packages/backend/src/routes/roles.ts
+++ b/packages/backend/src/routes/roles.ts
@@ -249,7 +249,7 @@ export function setupRolesRoutes(app: Express): void {
                     error instanceof Error
                         ? error.message
                         : 'Failed to delete reaction role message'
-                throw AppError.internalServerError(message)
+                throw new AppError(500, message)
             }
         }),
     )

--- a/packages/backend/tests/integration/routes/roles.test.ts
+++ b/packages/backend/tests/integration/routes/roles.test.ts
@@ -347,6 +347,19 @@ describe('Roles Routes', () => {
 
             expect(res.status).toBe(400)
         })
+
+        test('should return 500 when DB error occurs (not record not found)', async () => {
+            authed()
+            const dbError = new Error('Database connection lost')
+            mockDeleteReactionRole.mockRejectedValue(dbError)
+
+            const res = await request(app)
+                .delete(`/api/guilds/${GUILD_ID}/reaction-roles/${MESSAGE_ID}`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(500)
+            expect(res.body.error).toBeDefined()
+        })
     })
 
     describe('GET /api/guilds/:guildId/roles/exclusive', () => {

--- a/packages/bot/src/functions/general/handlers/reactionroleHandlers.spec.ts
+++ b/packages/bot/src/functions/general/handlers/reactionroleHandlers.spec.ts
@@ -1,5 +1,12 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals'
 
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+    infoLog: jest.fn(),
+    debugLog: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
 jest.mock('@lucky/shared/services', () => ({
     reactionRolesService: {
         createReactionRoleMessage: jest.fn(),

--- a/packages/bot/src/functions/general/handlers/reactionroleHandlers.spec.ts
+++ b/packages/bot/src/functions/general/handlers/reactionroleHandlers.spec.ts
@@ -262,6 +262,31 @@ describe('reactionroleHandlers', () => {
                 },
             })
         })
+
+        test('handles DB errors gracefully', async () => {
+            const guild = createGuild()
+            const interaction = createInteraction()
+
+            const dbError = new Error('Database connection lost')
+            deleteReactionRoleMessageMock.mockRejectedValueOnce(dbError)
+
+            await handleDelete(interaction, guild)
+
+            expect(interactionReplyMock).toHaveBeenCalledWith({
+                interaction,
+                content: {
+                    embeds: [
+                        expect.objectContaining({
+                            data: expect.objectContaining({
+                                title: 'Error',
+                                description: expect.stringContaining('try again later'),
+                            }),
+                        }),
+                    ],
+                    ephemeral: true,
+                },
+            })
+        })
     })
 
     describe('handleList', () => {

--- a/packages/bot/src/functions/general/handlers/reactionroleHandlers.ts
+++ b/packages/bot/src/functions/general/handlers/reactionroleHandlers.ts
@@ -89,22 +89,33 @@ export async function handleDelete(
     guild: Guild,
 ) {
     const messageId = interaction.options.getString('message_id', true)
-    const deleted = await reactionRolesService.deleteReactionRoleMessage(
-        messageId,
-        guild.id,
-    )
 
-    if (deleted) {
-        await replyEmbed(
-            interaction,
-            createSuccessEmbed('Success', 'Reaction role message deleted.'),
+    try {
+        const deleted = await reactionRolesService.deleteReactionRoleMessage(
+            messageId,
+            guild.id,
         )
-    } else {
+
+        if (deleted) {
+            await replyEmbed(
+                interaction,
+                createSuccessEmbed('Success', 'Reaction role message deleted.'),
+            )
+        } else {
+            await replyEmbed(
+                interaction,
+                createErrorEmbed(
+                    'Error',
+                    'Reaction role message not found or you do not have permission to delete it.',
+                ),
+            )
+        }
+    } catch (_error) {
         await replyEmbed(
             interaction,
             createErrorEmbed(
                 'Error',
-                'Reaction role message not found or you do not have permission to delete it.',
+                'Failed to delete reaction role message. Please try again later.',
             ),
         )
     }

--- a/packages/bot/src/functions/general/handlers/reactionroleHandlers.ts
+++ b/packages/bot/src/functions/general/handlers/reactionroleHandlers.ts
@@ -8,6 +8,7 @@ import {
 } from 'discord.js'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import { reactionRolesService } from '@lucky/shared/services'
+import { errorLog } from '@lucky/shared/utils'
 import {
     createErrorEmbed,
     createSuccessEmbed,
@@ -99,7 +100,8 @@ export async function handleDelete(
             messageId,
             guild.id,
         )
-    } catch (_error) {
+    } catch (error) {
+        errorLog({ message: 'Failed to delete reaction role message', error })
         await replyEmbed(
             interaction,
             createErrorEmbed(

--- a/packages/bot/src/functions/general/handlers/reactionroleHandlers.ts
+++ b/packages/bot/src/functions/general/handlers/reactionroleHandlers.ts
@@ -8,7 +8,10 @@ import {
 } from 'discord.js'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import { reactionRolesService } from '@lucky/shared/services'
-import { createErrorEmbed, createSuccessEmbed } from '../../../utils/general/embeds'
+import {
+    createErrorEmbed,
+    createSuccessEmbed,
+} from '../../../utils/general/embeds'
 
 function replyEmbed(
     interaction: ChatInputCommandInteraction,
@@ -90,32 +93,34 @@ export async function handleDelete(
 ) {
     const messageId = interaction.options.getString('message_id', true)
 
+    let deleted: boolean
     try {
-        const deleted = await reactionRolesService.deleteReactionRoleMessage(
+        deleted = await reactionRolesService.deleteReactionRoleMessage(
             messageId,
             guild.id,
         )
-
-        if (deleted) {
-            await replyEmbed(
-                interaction,
-                createSuccessEmbed('Success', 'Reaction role message deleted.'),
-            )
-        } else {
-            await replyEmbed(
-                interaction,
-                createErrorEmbed(
-                    'Error',
-                    'Reaction role message not found or you do not have permission to delete it.',
-                ),
-            )
-        }
     } catch (_error) {
         await replyEmbed(
             interaction,
             createErrorEmbed(
                 'Error',
                 'Failed to delete reaction role message. Please try again later.',
+            ),
+        )
+        return
+    }
+
+    if (deleted) {
+        await replyEmbed(
+            interaction,
+            createSuccessEmbed('Success', 'Reaction role message deleted.'),
+        )
+    } else {
+        await replyEmbed(
+            interaction,
+            createErrorEmbed(
+                'Error',
+                'Reaction role message not found or you do not have permission to delete it.',
             ),
         )
     }


### PR DESCRIPTION
## Summary
- Route handler catches DB errors and returns 500 instead of 404
- Bot handler wraps call in try-catch for graceful error handling
- Added tests to verify 500 response on DB errors vs 404 for not-found

## Test plan
- Backend route tests pass (22 tests)
- Bot handler tests pass (13 tests)  
- Service already handles P2025 correctly; non-P2025 errors now propagate
- Route distinguishes between "not found" (404) and DB errors (500)
- Bot handler catches errors without crashing

Fixes #1536

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 500 on database failures in the DELETE reaction-roles endpoint, keeping 404 only for not-found. The bot delete handler now logs and catches DB errors with a friendly message; fixes #1536.

- **Bug Fixes**
  - DELETE route returns 500 on DB errors via `new AppError(500, 'Failed to delete reaction role message')`; still returns 404 when not found.
  - Bot handler catches DB errors, logs them with `errorLog` from `@lucky/shared/utils`, and replies: “Failed to delete reaction role message. Please try again later.”
  - Added integration and bot tests for 500 vs 404 and graceful messaging; mocked `@lucky/shared/utils` in tests to fix an ESM import.meta error.

- **Refactors**
  - Narrowed try/catch to only the service call in the route, removing the catch-and-rethrow anti-pattern.
  - Flattened bot delete handler with an early return to reduce nesting.

<sup>Written for commit 8de2920751129d2b1722ea7c0e3c792710493d44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reaction-role message deletion handling across the API and bot to return consistent, user-friendly error responses instead of unhandled failures.
  * Backend now converts unexpected deletion errors into a clear HTTP 500 message while preserving the existing “not found” behavior.
* **Tests**
  * Added an API integration test for deletion failures returning HTTP 500 with an error payload.
  * Extended bot handler tests to cover service rejection behavior and updated test logging mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->