### PR TITLE
fix(bot): process threadcreate regardless of newlycreated flag

### DIFF
--- a/packages/bot/src/handlers/forumThreadHandler.spec.ts
+++ b/packages/bot/src/handlers/forumThreadHandler.spec.ts
@@ -191,4 +191,32 @@ describe('handleForumThreadCreate', () => {
             expect.any(Function),
         )
     })
+
+    it('processes threads even when newlyCreated is false (cache miss / bot restart)', async () => {
+        let capturedHandler: ((thread: unknown) => void) | undefined
+        const onMock = jest.fn((event, handler) => {
+            capturedHandler = handler
+        })
+        mockUpsert.mockResolvedValue({})
+        mockGetPrismaClient.mockReturnValue({
+            guildForumThread: { upsert: mockUpsert },
+        })
+
+        handleForumThreadCreate({ on: onMock } as never)
+
+        const thread = {
+            guildId: '895505900016631839',
+            id: 'THREAD_456',
+            name: 'Guide Thread',
+            parent: { type: ChannelType.GuildForum },
+            client: { user: { id: 'BOT_ID' } },
+            fetchStarterMessage: jest.fn().mockResolvedValue({
+                content: '<!-- official:v1:my-guide -->',
+                author: { id: 'BOT_ID' },
+            }),
+        }
+
+        await capturedHandler!(thread)
+        expect(mockUpsert).toHaveBeenCalled()
+    })
 })

--- a/packages/bot/src/handlers/forumThreadHandler.ts
+++ b/packages/bot/src/handlers/forumThreadHandler.ts
@@ -64,8 +64,7 @@ export async function processForumThread(
 }
 
 export function handleForumThreadCreate(client: Client): void {
-    client.on(Events.ThreadCreate, (thread, newlyCreated) => {
-        if (!newlyCreated) return
+    client.on(Events.ThreadCreate, (thread) => {
         processForumThread(thread).catch((error) => {
             errorLog({
                 message: 'unhandled error in forumThreadHandler:',


### PR DESCRIPTION
## Summary
- Removes `if (!newlyCreated) return` gate from `handleForumThreadCreate`
- Discord sets `newlyCreated=false` for threads the bot encounters on restart or cache miss — the guard was silently dropping valid forum thread events in those cases
- `processForumThread` is idempotent (upsert by `guildId_slug`) so processing twice is safe
- Bot-authorship check (from #1599) already guards against processing unofficial threads

## Test plan
- Added test: handler invokes `processForumThread` even when the `newlyCreated` parameter is absent/false
- All 14 `forumThreadHandler` tests pass

Closes #1535

Depends on #1599 (base branch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Process forum thread create events even when Discord sends newlyCreated=false. This prevents skipped official threads after bot restarts or cache misses.

- **Bug Fixes**
  - Removed the `newlyCreated` gate in `handleForumThreadCreate`; all `ThreadCreate` events are processed.
  - Safe to run twice: `processForumThread` upserts by `guildId_slug` and keeps the bot-authorship check from #1599.
  - Added a test asserting processing when `newlyCreated` is false; all `forumThreadHandler` tests pass.
  - Closes #1535.

<sup>Written for commit c6a1c4f3f41e2d8f6d66b22ea49476eb15b18386. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

