### PR TITLE
fix(schema): add unique guild+thread constraint to GuildForumThread

### DIFF
--- a/prisma/migrations/20260625120000_add_unique_guild_thread_to_forum_thread/migration.sql
+++ b/prisma/migrations/20260625120000_add_unique_guild_thread_to_forum_thread/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "GuildForumThread_guildId_threadId_key" ON "guild_forum_threads"("guildId", "threadId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1101,6 +1101,7 @@ model GuildForumThread {
   updatedAt DateTime @updatedAt
 
   @@unique([guildId, slug])
+  @@unique([guildId, threadId])
   @@index([guildId])
   @@map("guild_forum_threads")
 }


### PR DESCRIPTION
## Summary

- Adds `@@unique([guildId, threadId])` to `GuildForumThread` model
- Creates manual migration `20260625120000_add_unique_guild_thread_to_forum_thread`
- Prevents duplicate threadId entries per guild in `guild_forum_threads` table

Closes #1534

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unique constraint on (guildId, threadId) to the `GuildForumThread` model to prevent duplicate forum threads per guild. Includes a migration that creates a unique index on `guild_forum_threads`.

- **Migration**
  - Run `prisma migrate deploy` (or `prisma migrate dev` locally) to apply `20260625120000_add_unique_guild_thread_to_forum_thread`.
  - Remove or merge any existing duplicates before running the migration.

<sup>Written for commit eae52402672c3c73b75f2779f0e30a02b2d46c24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

