### PR TITLE
feat(bot): add RSS bridge service for Criativaria guides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23868,6 +23868,25 @@
                 "node": ">= 18"
             }
         },
+        "node_modules/rss-parser": {
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+            "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^2.0.3",
+                "xml2js": "^0.5.0"
+            }
+        },
+        "node_modules/rss-parser/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "license": "BSD-2-Clause",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/rxjs": {
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -23958,6 +23977,15 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
+        },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
         },
         "node_modules/saxes": {
             "version": "6.0.0",
@@ -26894,6 +26922,28 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/xml2js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -27256,6 +27306,7 @@
                 "lru-cache": "^11.5.0",
                 "play-dl": "^1.9.7",
                 "prom-client": "^15.1.3",
+                "rss-parser": "^3.13.0",
                 "ws": "^8.21.0",
                 "youtube-dl-exec": "^3.1.7",
                 "youtubei.js": "^16.0.1"

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -36,7 +36,8 @@
         "prom-client": "^15.1.3",
         "ws": "^8.21.0",
         "youtube-dl-exec": "^3.1.7",
-        "youtubei.js": "^16.0.1"
+        "youtubei.js": "^16.0.1",
+        "rss-parser": "^3.13.0"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/packages/bot/src/bot/start/initializer.ts
+++ b/packages/bot/src/bot/start/initializer.ts
@@ -29,6 +29,7 @@ import { criativariaLiveNotificationService } from '../../services/CriativariaLi
 import { stopTwitchService } from '../../twitch'
 import { stopBatchJobWorker } from '../../workers/batchJobWorker'
 import { setClient } from '../clientStore'
+import { stopRssBridgeService } from '../../services/RssBridgeService'
 import type {
     BotInitializationOptions,
     BotInitializationResult,
@@ -250,6 +251,15 @@ export class BotInitializer {
         } catch (error) {
             errorLog({
                 message: 'Error stopping batch job worker:',
+                error,
+            })
+        }
+
+        try {
+            stopRssBridgeService()
+        } catch (error) {
+            errorLog({
+                message: 'Error stopping RSS Bridge service:',
                 error,
             })
         }

--- a/packages/bot/src/handlers/clientHandler/service.ts
+++ b/packages/bot/src/handlers/clientHandler/service.ts
@@ -94,6 +94,10 @@ export async function startClient({
                 const { startTwitchService } =
                     await import('../../twitch/index.js')
                 await startTwitchService(client)
+
+                const { startRssBridgeService } =
+                    await import('../../services/RssBridgeService.js')
+                await startRssBridgeService(client)
             } catch (error) {
                 errorLog({
                     message: 'Error in ready handler:',

--- a/packages/bot/src/services/RssBridgeService.spec.ts
+++ b/packages/bot/src/services/RssBridgeService.spec.ts
@@ -1,0 +1,388 @@
+import {
+    jest,
+    describe,
+    it,
+    expect,
+    beforeEach,
+    afterEach,
+} from '@jest/globals'
+
+const parseURLMock = jest.fn()
+const debugLogMock = jest.fn()
+const errorLogMock = jest.fn()
+const infoLogMock = jest.fn()
+const featureToggleMock = jest.fn()
+const findUniqueMock = jest.fn()
+const createMock = jest.fn()
+
+jest.mock(
+    'rss-parser',
+    () =>
+        function Parser() {
+            return { parseURL: (...args: unknown[]) => parseURLMock(...args) }
+        },
+)
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: (...args: unknown[]) => debugLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
+    infoLog: (...args: unknown[]) => infoLogMock(...args),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    featureToggleService: {
+        isEnabled: (...args: unknown[]) => featureToggleMock(...args),
+    },
+}))
+
+jest.mock('@lucky/shared/utils/database/prismaClient', () => ({
+    getPrismaClient: () => ({
+        rssDiscoveredGuide: {
+            findUnique: (...args: unknown[]) => findUniqueMock(...args),
+            create: (...args: unknown[]) => createMock(...args),
+        },
+    }),
+}))
+
+import { startRssBridgeService, stopRssBridgeService } from './RssBridgeService'
+
+const makeChannel = (overrides: Record<string, unknown> = {}) => ({
+    isTextBased: () => true,
+    send: jest.fn().mockResolvedValue(undefined as never),
+    ...overrides,
+})
+
+const makeClient = (channel: unknown = makeChannel()) => ({
+    channels: {
+        fetch: jest.fn().mockResolvedValue(channel as never),
+    },
+})
+
+const makeFeedItem = (overrides: Record<string, unknown> = {}) => ({
+    title: 'Guide Title',
+    link: 'https://criativaria.com.br/guias/my-guide',
+    description: 'Short description',
+    ...overrides,
+})
+
+beforeEach(() => {
+    parseURLMock.mockReset()
+    debugLogMock.mockReset()
+    errorLogMock.mockReset()
+    infoLogMock.mockReset()
+    featureToggleMock.mockReset()
+    findUniqueMock.mockReset()
+    createMock.mockReset()
+
+    featureToggleMock.mockResolvedValue(true)
+    findUniqueMock.mockResolvedValue(null)
+    createMock.mockResolvedValue({ slug: 'my-guide', title: 'Guide Title' })
+    process.env.CRIATIVARIA_GUIDES_CHANNEL_ID = 'channel-123'
+})
+
+afterEach(() => {
+    stopRssBridgeService()
+    delete process.env.CRIATIVARIA_GUIDES_CHANNEL_ID
+})
+
+describe('startRssBridgeService', () => {
+    it('returns early when feature flag disabled', async () => {
+        featureToggleMock.mockResolvedValue(false)
+        await startRssBridgeService(makeClient() as never)
+
+        expect(parseURLMock).not.toHaveBeenCalled()
+        expect(errorLogMock).not.toHaveBeenCalled()
+        expect(infoLogMock).not.toHaveBeenCalled()
+    })
+
+    it('logs error and returns when env var missing', async () => {
+        delete process.env.CRIATIVARIA_GUIDES_CHANNEL_ID
+        await startRssBridgeService(makeClient() as never)
+
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining(
+                    'CRIATIVARIA_GUIDES_CHANNEL_ID',
+                ),
+            }),
+        )
+        expect(parseURLMock).not.toHaveBeenCalled()
+    })
+
+    it('errorLogs feed errors internally without failing startup', async () => {
+        parseURLMock.mockRejectedValue(new Error('network error') as never)
+        await startRssBridgeService(makeClient() as never)
+
+        // pollRssFeed has its own try-catch — error is swallowed there, not at startup
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'Error polling RSS feed' }),
+        )
+        // Startup succeeds despite the poll error (infoLog still fires)
+        expect(infoLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('started'),
+            }),
+        )
+    })
+
+    it('logs startup message and begins polling on happy path', async () => {
+        parseURLMock.mockResolvedValue({ items: [] } as never)
+        await startRssBridgeService(makeClient() as never)
+
+        expect(infoLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('started'),
+            }),
+        )
+        expect(parseURLMock).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('stopRssBridgeService', () => {
+    it('is a no-op when no interval is running', () => {
+        expect(() => stopRssBridgeService()).not.toThrow()
+        expect(infoLogMock).not.toHaveBeenCalled()
+    })
+
+    it('clears the interval and logs when service is running', async () => {
+        parseURLMock.mockResolvedValue({ items: [] } as never)
+        await startRssBridgeService(makeClient() as never)
+        infoLogMock.mockClear()
+
+        stopRssBridgeService()
+
+        expect(infoLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('stopped'),
+            }),
+        )
+    })
+
+    it('is a no-op when called twice', async () => {
+        parseURLMock.mockResolvedValue({ items: [] } as never)
+        await startRssBridgeService(makeClient() as never)
+        stopRssBridgeService()
+        infoLogMock.mockClear()
+
+        stopRssBridgeService()
+
+        expect(infoLogMock).not.toHaveBeenCalled()
+    })
+})
+
+describe('RSS feed polling', () => {
+    it('debugLogs and returns when feed has no items', async () => {
+        parseURLMock.mockResolvedValue({ items: [] } as never)
+        await startRssBridgeService(makeClient() as never)
+
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('No items'),
+            }),
+        )
+        expect(findUniqueMock).not.toHaveBeenCalled()
+    })
+
+    it('errorLogs when channel is not text-based', async () => {
+        const nonTextChannel = { isTextBased: () => false }
+        parseURLMock.mockResolvedValue({ items: [makeFeedItem()] } as never)
+        await startRssBridgeService(makeClient(nonTextChannel) as never)
+
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('not a text channel'),
+            }),
+        )
+        expect(findUniqueMock).not.toHaveBeenCalled()
+    })
+
+    it('errorLogs when channel lacks send method', async () => {
+        const channelNoSend = { isTextBased: () => true }
+        parseURLMock.mockResolvedValue({ items: [makeFeedItem()] } as never)
+        await startRssBridgeService(makeClient(channelNoSend) as never)
+
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('not a text channel'),
+            }),
+        )
+    })
+
+    it('debugLogs and skips items with no link', async () => {
+        parseURLMock.mockResolvedValue({
+            items: [makeFeedItem({ link: undefined })],
+        } as never)
+        await startRssBridgeService(makeClient() as never)
+
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('slug'),
+            }),
+        )
+        expect(findUniqueMock).not.toHaveBeenCalled()
+    })
+
+    it('debugLogs and skips items with unparseable link', async () => {
+        parseURLMock.mockResolvedValue({
+            items: [makeFeedItem({ link: 'not-a-url' })],
+        } as never)
+        await startRssBridgeService(makeClient() as never)
+
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('slug'),
+            }),
+        )
+        expect(findUniqueMock).not.toHaveBeenCalled()
+    })
+
+    it('debugLogs and skips items already in DB', async () => {
+        findUniqueMock.mockResolvedValue({ slug: 'my-guide' })
+        parseURLMock.mockResolvedValue({ items: [makeFeedItem()] } as never)
+        await startRssBridgeService(makeClient() as never)
+
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('already posted'),
+            }),
+        )
+        expect(createMock).not.toHaveBeenCalled()
+    })
+
+    it('creates DB record and sends Discord embed for new item', async () => {
+        const channel = makeChannel()
+        parseURLMock.mockResolvedValue({ items: [makeFeedItem()] } as never)
+        await startRssBridgeService(makeClient(channel) as never)
+
+        expect(createMock).toHaveBeenCalledWith({
+            data: { slug: 'my-guide', title: 'Guide Title' },
+        })
+        expect(channel.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.arrayContaining([
+                    expect.objectContaining({
+                        title: 'Guide Title',
+                        url: 'https://criativaria.com.br/guias/my-guide',
+                    }),
+                ]),
+            }),
+        )
+        expect(infoLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('posted'),
+            }),
+        )
+    })
+
+    it('uses content when description is absent', async () => {
+        const channel = makeChannel()
+        parseURLMock.mockResolvedValue({
+            items: [
+                makeFeedItem({
+                    description: undefined,
+                    content: 'Content text',
+                }),
+            ],
+        } as never)
+        await startRssBridgeService(makeClient(channel) as never)
+
+        expect(channel.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.arrayContaining([
+                    expect.objectContaining({ description: 'Content text' }),
+                ]),
+            }),
+        )
+    })
+
+    it('falls back to "Untitled" when item has no title', async () => {
+        const channel = makeChannel()
+        parseURLMock.mockResolvedValue({
+            items: [makeFeedItem({ title: undefined })],
+        } as never)
+        await startRssBridgeService(makeClient(channel) as never)
+
+        expect(channel.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.arrayContaining([
+                    expect.objectContaining({ title: 'Untitled' }),
+                ]),
+            }),
+        )
+    })
+
+    it('truncates description longer than 150 characters', async () => {
+        const channel = makeChannel()
+        const longDesc = 'A'.repeat(200)
+        parseURLMock.mockResolvedValue({
+            items: [makeFeedItem({ description: longDesc })],
+        } as never)
+        await startRssBridgeService(makeClient(channel) as never)
+
+        const embed = (channel.send as jest.Mock).mock.calls[0] as [
+            { embeds: { description: string }[] },
+        ]
+        const description = embed[0].embeds[0].description
+        expect(description.length).toBeLessThanOrEqual(150)
+        expect(description.endsWith('…')).toBe(true)
+    })
+
+    it('does not truncate description 150 characters or shorter', async () => {
+        const channel = makeChannel()
+        const desc = 'B'.repeat(150)
+        parseURLMock.mockResolvedValue({
+            items: [makeFeedItem({ description: desc })],
+        } as never)
+        await startRssBridgeService(makeClient(channel) as never)
+
+        const embed = (channel.send as jest.Mock).mock.calls[0] as [
+            { embeds: { description: string }[] },
+        ]
+        expect(embed[0].embeds[0].description).toBe(desc)
+    })
+
+    it('errorLogs per item when DB create fails and continues to next item', async () => {
+        const channel = makeChannel()
+        const item1 = makeFeedItem({
+            link: 'https://criativaria.com.br/guias/guide-1',
+        })
+        const item2 = makeFeedItem({
+            link: 'https://criativaria.com.br/guias/guide-2',
+            title: 'Guide 2',
+        })
+        createMock
+            .mockRejectedValueOnce(new Error('DB error') as never)
+            .mockResolvedValueOnce({ slug: 'guide-2' } as never)
+        parseURLMock.mockResolvedValue({ items: [item1, item2] } as never)
+
+        await startRssBridgeService(makeClient(channel) as never)
+
+        expect(errorLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('Failed to post'),
+            }),
+        )
+        // Second item should still be processed
+        expect(createMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('processes multiple new items in sequence', async () => {
+        const channel = makeChannel()
+        const items = [
+            makeFeedItem({
+                link: 'https://criativaria.com.br/guias/guide-a',
+                title: 'Guide A',
+            }),
+            makeFeedItem({
+                link: 'https://criativaria.com.br/guias/guide-b',
+                title: 'Guide B',
+            }),
+        ]
+        parseURLMock.mockResolvedValue({ items } as never)
+
+        await startRssBridgeService(makeClient(channel) as never)
+
+        expect(createMock).toHaveBeenCalledTimes(2)
+        expect(channel.send).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/bot/src/services/RssBridgeService.ts
+++ b/packages/bot/src/services/RssBridgeService.ts
@@ -45,7 +45,7 @@ export async function startRssBridgeService(client: Client): Promise<void> {
     } catch (err) {
         errorLog({
             message: 'RSS Bridge service failed to start (non-fatal)',
-            data: err,
+            error: err,
         })
     }
 }
@@ -117,6 +117,15 @@ async function pollRssFeed(
             )
 
             try {
+                // Persist dedup record first
+                await db.rssDiscoveredGuide.create({
+                    data: {
+                        slug,
+                        title,
+                    },
+                })
+
+                // Post to Discord after DB write succeeds
                 await channel.send({
                     embeds: [
                         {
@@ -126,14 +135,6 @@ async function pollRssFeed(
                             color: EMBED_COLOR,
                         },
                     ],
-                })
-
-                // Record the guide in database
-                await db.rssDiscoveredGuide.create({
-                    data: {
-                        slug,
-                        title,
-                    },
                 })
 
                 infoLog({

--- a/packages/bot/src/services/RssBridgeService.ts
+++ b/packages/bot/src/services/RssBridgeService.ts
@@ -1,7 +1,8 @@
 import type { Client } from 'discord.js'
 import Parser from 'rss-parser'
 import { debugLog, errorLog, infoLog } from '@lucky/shared/utils'
-import { featureToggleService, getPrismaClient } from '@lucky/shared/services'
+import { featureToggleService } from '@lucky/shared/services'
+import { getPrismaClient } from '@lucky/shared/utils/database/prismaClient'
 
 const RSS_FEED_URL = 'https://criativaria.com.br/rss.xml'
 const POLL_INTERVAL_MS = 3600000 // 1 hour
@@ -15,7 +16,7 @@ interface RssItem {
     pubDate?: string
 }
 
-let pollInterval: NodeJS.Timeout | null = null
+let pollInterval: ReturnType<typeof setInterval> | null = null
 
 export async function startRssBridgeService(client: Client): Promise<void> {
     const enabled = await featureToggleService.isEnabled('RSS_BRIDGE')
@@ -36,12 +37,9 @@ export async function startRssBridgeService(client: Client): Promise<void> {
         infoLog({ message: 'RSS Bridge service started' })
         await pollRssFeed(client, channelId)
         // Schedule polling every hour
-        pollInterval = setInterval(
-            async () => {
-                await pollRssFeed(client, channelId)
-            },
-            POLL_INTERVAL_MS,
-        )
+        pollInterval = setInterval(async () => {
+            await pollRssFeed(client, channelId)
+        }, POLL_INTERVAL_MS)
     } catch (err) {
         errorLog({
             message: 'RSS Bridge service failed to start (non-fatal)',
@@ -58,10 +56,7 @@ export function stopRssBridgeService(): void {
     }
 }
 
-async function pollRssFeed(
-    client: Client,
-    channelId: string,
-): Promise<void> {
+async function pollRssFeed(client: Client, channelId: string): Promise<void> {
     try {
         const parser = new Parser()
         const feed = await parser.parseURL(RSS_FEED_URL)
@@ -77,12 +72,16 @@ async function pollRssFeed(
         const db = getPrismaClient()
         const channel = await client.channels.fetch(channelId)
 
-        if (!channel?.isTextBased()) {
+        if (!channel?.isTextBased() || !('send' in channel)) {
             errorLog({
                 message: 'RSS Bridge channel is not a text channel',
                 data: { channelId },
             })
             return
+        }
+
+        const sendableChannel = channel as unknown as {
+            send: (options: unknown) => Promise<unknown>
         }
 
         for (const item of feed.items) {
@@ -126,7 +125,7 @@ async function pollRssFeed(
                 })
 
                 // Post to Discord after DB write succeeds
-                await channel.send({
+                await sendableChannel.send({
                     embeds: [
                         {
                             title,

--- a/packages/bot/src/services/RssBridgeService.ts
+++ b/packages/bot/src/services/RssBridgeService.ts
@@ -1,0 +1,176 @@
+import type { Client } from 'discord.js'
+import Parser from 'rss-parser'
+import { debugLog, errorLog, infoLog } from '@lucky/shared/utils'
+import { featureToggleService, getPrismaClient } from '@lucky/shared/services'
+
+const RSS_FEED_URL = 'https://criativaria.com.br/rss.xml'
+const POLL_INTERVAL_MS = 3600000 // 1 hour
+const EMBED_COLOR = 0xe879a0
+
+interface RssItem {
+    title?: string
+    link?: string
+    description?: string
+    content?: string
+    pubDate?: string
+}
+
+let pollInterval: NodeJS.Timeout | null = null
+
+export async function startRssBridgeService(client: Client): Promise<void> {
+    const enabled = await featureToggleService.isEnabled('RSS_BRIDGE')
+    if (!enabled) {
+        return
+    }
+
+    const channelId = process.env.CRIATIVARIA_GUIDES_CHANNEL_ID
+    if (!channelId) {
+        errorLog({
+            message:
+                'RSS Bridge service requires CRIATIVARIA_GUIDES_CHANNEL_ID env variable',
+        })
+        return
+    }
+
+    try {
+        infoLog({ message: 'RSS Bridge service started' })
+        await pollRssFeed(client, channelId)
+        // Schedule polling every hour
+        pollInterval = setInterval(
+            async () => {
+                await pollRssFeed(client, channelId)
+            },
+            POLL_INTERVAL_MS,
+        )
+    } catch (err) {
+        errorLog({
+            message: 'RSS Bridge service failed to start (non-fatal)',
+            data: err,
+        })
+    }
+}
+
+export function stopRssBridgeService(): void {
+    if (pollInterval) {
+        clearInterval(pollInterval)
+        pollInterval = null
+        infoLog({ message: 'RSS Bridge service stopped' })
+    }
+}
+
+async function pollRssFeed(
+    client: Client,
+    channelId: string,
+): Promise<void> {
+    try {
+        const parser = new Parser()
+        const feed = await parser.parseURL(RSS_FEED_URL)
+
+        if (!feed.items || feed.items.length === 0) {
+            debugLog({
+                message: 'No items found in RSS feed',
+                data: { feedUrl: RSS_FEED_URL },
+            })
+            return
+        }
+
+        const db = getPrismaClient()
+        const channel = await client.channels.fetch(channelId)
+
+        if (!channel?.isTextBased()) {
+            errorLog({
+                message: 'RSS Bridge channel is not a text channel',
+                data: { channelId },
+            })
+            return
+        }
+
+        for (const item of feed.items) {
+            const itemTyped = item as RssItem
+            const slug = extractSlug(itemTyped.link)
+
+            if (!slug) {
+                debugLog({
+                    message: 'Could not extract slug from RSS item',
+                    data: { link: itemTyped.link },
+                })
+                continue
+            }
+
+            // Check if we've already posted this guide
+            const existing = await db.rssDiscoveredGuide.findUnique({
+                where: { slug },
+            })
+
+            if (existing) {
+                debugLog({
+                    message: 'Guide already posted',
+                    data: { slug },
+                })
+                continue
+            }
+
+            // Post new guide to Discord
+            const title = itemTyped.title || 'Untitled'
+            const description = truncateDescription(
+                itemTyped.description || itemTyped.content || '',
+            )
+
+            try {
+                await channel.send({
+                    embeds: [
+                        {
+                            title,
+                            description,
+                            url: itemTyped.link,
+                            color: EMBED_COLOR,
+                        },
+                    ],
+                })
+
+                // Record the guide in database
+                await db.rssDiscoveredGuide.create({
+                    data: {
+                        slug,
+                        title,
+                    },
+                })
+
+                infoLog({
+                    message: 'RSS guide posted',
+                    data: { slug, title },
+                })
+            } catch (err) {
+                errorLog({
+                    message: 'Failed to post RSS guide',
+                    error: err,
+                    data: { slug, title },
+                })
+            }
+        }
+    } catch (err) {
+        errorLog({
+            message: 'Error polling RSS feed',
+            error: err,
+        })
+    }
+}
+
+function extractSlug(url?: string): string | null {
+    if (!url) return null
+
+    try {
+        const urlObj = new URL(url)
+        const pathname = urlObj.pathname
+        const segments = pathname.split('/').filter((s) => s.length > 0)
+        return segments[segments.length - 1] || null
+    } catch {
+        return null
+    }
+}
+
+function truncateDescription(text: string): string {
+    const maxLength = 150
+    if (text.length <= maxLength) return text
+    return text.slice(0, maxLength - 1) + '…'
+}

--- a/packages/shared/src/config/featureToggles.ts
+++ b/packages/shared/src/config/featureToggles.ts
@@ -117,6 +117,11 @@ const defaultToggles: Record<FeatureToggleName, FeatureToggleConfig> = {
         enabled: true,
         description: 'Enable collaborative queue mode (/playlist collaborative)',
     },
+    RSS_BRIDGE: {
+        name: 'RSS_BRIDGE',
+        enabled: true,
+        description: 'Enable RSS feed polling for Criativaria guides',
+    },
 }
 
 function parseEnvironmentToggle(

--- a/packages/shared/src/types/featureToggle.ts
+++ b/packages/shared/src/types/featureToggle.ts
@@ -21,6 +21,7 @@ export type FeatureToggleName =
     | 'ALBUM_COMMAND'
     | 'EMBED_BUILDER'
     | 'COLLABORATIVE_PLAYLIST'
+    | 'RSS_BRIDGE'
 
 export type FeatureToggleConfig = {
     name: FeatureToggleName

--- a/prisma/migrations/20260625165351_add_rss_discovered_guide/migration.sql
+++ b/prisma/migrations/20260625165351_add_rss_discovered_guide/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "rss_discovered_guides" (
+    "id" SERIAL NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "postedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "rss_discovered_guides_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rss_discovered_guides_slug_key" ON "rss_discovered_guides"("slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1169,3 +1169,14 @@ model BatchJobItem {
   @@index([jobId, attemptedAt])
   @@map("batch_job_items")
 }
+
+// RSS feed tracking for Criativaria guides. Stores slugs of guides already
+// posted to Discord to avoid duplicates.
+model RssDiscoveredGuide {
+  id       Int      @id @default(autoincrement())
+  slug     String   @unique
+  title    String
+  postedAt DateTime @default(now())
+
+  @@map("rss_discovered_guides")
+}


### PR DESCRIPTION
## Summary

Implements RSS polling service that monitors criativaria.com.br/rss.xml every hour and posts new guide entries to a Discord #guias channel. Built with deduplication via RssDiscoveredGuide Prisma model to prevent duplicate posts.

## Implementation Details

- **RssBridgeService**: Polls RSS feed every 3600000ms (1 hour), extracts guide slug from URL, checks database, posts rich embed on new guides
- **RssDiscoveredGuide model**: Tracks posted guides by slug (unique constraint) + title and timestamp
- **Feature toggle**: RSS_BRIDGE flag gates service; defaults true
- **Error handling**: All errors logged via @lucky/shared/utils, non-fatal failures don't crash bot
- **Embed styling**: Criativaria brand color (0xe879a0), description truncated to 150 chars max
- **Dependency**: Added rss-parser@^3.13.0

## Files Changed

- prisma/schema.prisma — add RssDiscoveredGuide model
- prisma/migrations/* — migration for new table
- packages/shared/src/types/featureToggle.ts — add RSS_BRIDGE to union
- packages/shared/src/config/featureToggles.ts — add RSS_BRIDGE config
- packages/bot/package.json — add rss-parser dependency
- packages/bot/src/services/RssBridgeService.ts — new service (polling, dedup, posting)
- packages/bot/src/handlers/clientHandler/service.ts — start service in ready event
- packages/bot/src/bot/start/initializer.ts — stop service in shutdown sequence

## Test Plan

- [ ] Bot starts with RSS_BRIDGE enabled (env FEATURE_RSS_BRIDGE=true)
- [ ] CRIATIVARIA_GUIDES_CHANNEL_ID env variable required; missing channel logs error gracefully
- [ ] First run polls RSS and posts all guide items to #guias
- [ ] Second run skips guides already in RssDiscoveredGuide table
- [ ] Hourly polling interval triggers correctly
- [ ] Bot shutdown cleanly stops polling interval
- [ ] Invalid feed URL, network error, or Discord send error all caught and logged without crashing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an RSS bridge that polls https://criativaria.com.br/rss.xml hourly and posts new guides to the configured Discord channel as rich embeds. Dedupes via a new Prisma model, is gated by `RSS_BRIDGE`, and includes import/type fixes plus clean startup/shutdown handling.

- **New Features**
  - `RssBridgeService` polls hourly via `rss-parser` and posts embeds (brand color, 150‑char summary).
  - Dedup via Prisma `RssDiscoveredGuide` (unique slug); record is saved before sending; errors are logged and non‑fatal.
  - Starts on client ready; stops cleanly on shutdown; adds unit tests for `RssBridgeService` (97% coverage).
  - Adds `rss-parser`; lockfile updated.

- **Migration**
  - Run the Prisma migration to create `rss_discovered_guides`.
  - Set `CRIATIVARIA_GUIDES_CHANNEL_ID` env.
  - Toggle via `RSS_BRIDGE` (enabled by default).

<sup>Written for commit 4fb464a3460112c18cefa3825909037e6e4700ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an RSS-driven update flow that can automatically share new guide posts in Discord.
  * Introduced a new feature toggle to control this behavior.

* **Bug Fixes**
  * Prevents duplicate posts by tracking previously shared guide links.
  * Improves shutdown handling so the RSS process stops cleanly.

* **Chores**
  * Added the required support for RSS feed parsing and related database storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->