### PR TITLE
fix(batch): resolve circular dep + lint errors blocking CI on #1564

### DIFF
--- a/packages/bot/src/bot/clientStore.ts
+++ b/packages/bot/src/bot/clientStore.ts
@@ -1,0 +1,11 @@
+import type { CustomClient } from '../types'
+
+let _client: CustomClient | null = null
+
+export function setClient(client: CustomClient): void {
+    _client = client
+}
+
+export function getStoredClient(): CustomClient | null {
+    return _client
+}

--- a/packages/bot/src/bot/start/initializer.ts
+++ b/packages/bot/src/bot/start/initializer.ts
@@ -27,6 +27,7 @@ import { aiDevToolkitService } from '../../services/AiDevToolkitService'
 import { dependencyCheckService } from '../../services/DependencyCheckService'
 import { stopTwitchService } from '../../twitch'
 import { stopBatchJobWorker } from '../../workers/batchJobWorker'
+import { setClient } from '../clientStore'
 import type {
     BotInitializationOptions,
     BotInitializationResult,
@@ -62,6 +63,7 @@ export class BotInitializer {
     private async createDiscordClient(): Promise<void> {
         try {
             this.client = await createClient()
+            setClient(this.client)
         } catch (error) {
             errorLog({ message: 'Failed to create Discord client', error })
             throw new ConfigurationError('Failed to create Discord client')

--- a/packages/bot/src/functions/moderation/batch/channelMoveExecutor.ts
+++ b/packages/bot/src/functions/moderation/batch/channelMoveExecutor.ts
@@ -8,6 +8,7 @@ import {
 import {
     type BatchJobExecutor,
     type BatchProgress,
+    type ScopeConfig,
     matchesScope,
     batchJobService,
 } from '@lucky/shared/services/batch'
@@ -19,6 +20,7 @@ import {
     getUploadLimit,
 } from '../../../handlers/moveMessageHandler'
 import type { CustomClient } from '../../../types'
+import { getStoredClient } from '../../../bot/clientStore'
 
 /**
  * Executor for batch channel move operations.
@@ -49,8 +51,7 @@ export class ChannelMoveBatchExecutor implements BatchJobExecutor {
         },
         onProgress: (progress: BatchProgress) => Promise<void>,
     ): Promise<Record<string, unknown>> {
-        const { getClient } = await import('../../../bot/start')
-        const client = getClient() as CustomClient | null
+        const client = getStoredClient() as CustomClient | null
         if (!client) {
             throw new Error('Discord client not available')
         }
@@ -116,7 +117,7 @@ export class ChannelMoveBatchExecutor implements BatchJobExecutor {
             throw new Error(`Batch job not found: ${jobId}`)
         }
 
-        const scope = dbJob.scope as Record<string, unknown>
+        const scope = dbJob.scope as unknown as ScopeConfig
         let cursor = dbJob.nextCursor || undefined
         let processed = 0
         let failed = 0
@@ -175,7 +176,7 @@ export class ChannelMoveBatchExecutor implements BatchJobExecutor {
                         createdAt: message.createdAt,
                         index: messageIndex,
                     },
-                    scope as any,
+                    scope as ScopeConfig,
                 )
 
                 if (!matchesScopeResult) {

--- a/packages/bot/src/functions/moderation/commands/bulkMoveMessages.ts
+++ b/packages/bot/src/functions/moderation/commands/bulkMoveMessages.ts
@@ -12,7 +12,7 @@ import {
     checkBatchPermissions,
     matchesScope,
 } from '@lucky/shared/services/batch'
-import type { BatchJobType } from '@lucky/shared/services/batch'
+import type { BatchJobType, ScopeConfig } from '@lucky/shared/services/batch'
 import { enqueueBatchJob } from '../../../utils/batch/batchQueue'
 import { showBatchConfirmation } from '../../../utils/batch/confirmationGate'
 import { infoLog, errorLog } from '@lucky/shared/utils'
@@ -272,7 +272,7 @@ export default new Command({
                     {
                         type: scopeType,
                         config: scopeConfig,
-                    } as any,
+                    } as ScopeConfig,
                 )
                 if (matches) sampleMatched++
                 messageIndex++

--- a/packages/bot/src/workers/batchJobWorker.ts
+++ b/packages/bot/src/workers/batchJobWorker.ts
@@ -4,6 +4,8 @@
  */
 
 import { Worker, type Job } from 'bullmq'
+
+type BatchJobData = { jobId: string }
 import { redisClient } from '@lucky/shared/services'
 import { batchJobService } from '@lucky/shared/services/batch'
 import type { BatchProgress, BatchJobType } from '@lucky/shared/services/batch'
@@ -11,7 +13,7 @@ import { errorLog, infoLog, debugLog } from '@lucky/shared/utils'
 import { getExecutor, registerExecutor } from './executorRegistry'
 
 const QUEUE_NAME = 'batch-jobs'
-let worker: Worker | null = null
+let worker: Worker<BatchJobData> | null = null
 
 /**
  * Progress callback that checkpoints to the database and publishes to Redis.
@@ -59,8 +61,8 @@ async function onProgress(
  * Processes a single batch job.
  * Loads the job from the database, resolves the executor, and runs it.
  */
-async function processBatchJob(job: Job): Promise<Record<string, unknown>> {
-    const jobId = job.data.jobId as string
+async function processBatchJob(job: Job<BatchJobData>): Promise<Record<string, unknown>> {
+    const jobId = job.data.jobId
 
     try {
         debugLog({

--- a/packages/shared/src/services/batch/BatchJobService.ts
+++ b/packages/shared/src/services/batch/BatchJobService.ts
@@ -28,9 +28,9 @@ export class BatchJobService {
                 initiatedBy: input.initiatedBy,
                 sourceChannelId: input.sourceChannelId,
                 targetChannelId: input.targetChannelId,
-                scope: JSON.parse(JSON.stringify(input.scope)),
+                scope: JSON.parse(JSON.stringify(input.scope)) as ScopeConfig,
                 options: input.options
-                    ? JSON.parse(JSON.stringify(input.options))
+                    ? (JSON.parse(JSON.stringify(input.options)) as Record<string, unknown>)
                     : null,
                 totalItems: input.totalItems,
                 estimatedMinutes: input.estimatedMinutes,
@@ -194,7 +194,7 @@ export class BatchJobService {
                 status: input.status,
                 error: input.error,
                 resultMetadata: input.resultMetadata
-                    ? JSON.parse(JSON.stringify(input.resultMetadata))
+                    ? (JSON.parse(JSON.stringify(input.resultMetadata)) as Record<string, unknown>)
                     : null,
                 attemptedAt: new Date(),
             },
@@ -209,7 +209,7 @@ export class BatchJobService {
         return await prisma.batchJob.update({
             where: { id: jobId },
             data: {
-                summary: JSON.parse(JSON.stringify(summary)),
+                summary: JSON.parse(JSON.stringify(summary)) as Record<string, unknown>,
             },
         })
     }


### PR DESCRIPTION
## Summary

Fixes the 3 CI blockers on PR #1564 (`feat/batch-operations`):

**Circular dependency (madge)**
- Introduced `clientStore.ts` — a lightweight singleton that holds the Discord client reference
- `BotInitializer.createDiscordClient()` calls `setClient()` after creating the client
- `ChannelMoveBatchExecutor.execute()` now calls `getStoredClient()` from `clientStore` instead of dynamically importing from `bot/start`
- Result: `start.ts → … → batchJobWorker → channelMoveExecutor → start.ts` cycle is broken; only the pre-existing baseline cycle remains

**ESLint `any` errors (6 errors across 4 files)**
- `channelMoveExecutor.ts` — `scope as any` → `scope as ScopeConfig`; import `ScopeConfig` type
- `bulkMoveMessages.ts` — `{ type, config } as any` → `as ScopeConfig`; import `ScopeConfig` type
- `batchJobWorker.ts` — typed `Job` generic: `Job<BatchJobData>` to fix `no-unsafe-member-access` on `.jobId`
- `BatchJobService.ts` — cast `JSON.parse(...)` results to proper types to fix `no-unsafe-assignment`

**Still requires manual action from operator:**
- Destructive Interaction Gate: run `/bulk-move-messages` on a test guild (happy path + cancellation path), then tick `- [x] Live smoke performed` in the PR #1564 body.

Closes the fixable CI blockers on #1564. Does not address SonarCloud coverage (needs investigation after lint/madge pass).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a circular dependency and ESLint errors blocking CI for batch operations. Adds a small `clientStore` and type-safe updates to stabilize the batch worker and executor.

- **Bug Fixes**
  - Broke the `madge`-reported cycle by adding `packages/bot/src/bot/clientStore.ts`; `BotInitializer.createDiscordClient()` calls `setClient()`, and `ChannelMoveBatchExecutor` uses `getStoredClient()` instead of a dynamic import.
  - Replaced `any` casts with `ScopeConfig` from `@lucky/shared/services/batch` in `channelMoveExecutor.ts` and `bulkMoveMessages.ts`.
  - Typed `bullmq` `Job` as `Job<BatchJobData>` in `batchJobWorker.ts` and accessed `job.data.jobId` safely.
  - Cast results of `JSON.parse(...)` in `BatchJobService` to typed objects to satisfy `no-unsafe-*` ESLint rules.

<sup>Written for commit f35e2cf30997e517d18764071fa4624b3b4a9c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

