### PR TITLE
fix: auth loop between web dashboard and api subdomains

### DIFF
--- a/decisions/2026-06-27-eslint-legacy-config-cleanup.md
+++ b/decisions/2026-06-27-eslint-legacy-config-cleanup.md
@@ -1,0 +1,88 @@
+# ADR 2026-06-27 — Clean up ESLint legacy config and restore react-refresh rule
+
+**Status:** Accepted
+
+**Deciders:** Lucas Santana
+
+**Trigger:** config-drift-detect flagged legacy `.eslintrc.cjs` files that ESLint v10 already ignores; `eslint-plugin-react-refresh` rule was accidentally dropped during flat config migration
+
+## Context
+
+During the monorepo restructure (2026-01), ESLint was migrated from the legacy `.eslintrc` format to the flat config format (`eslint.config.js` / `eslint.config.mjs`). ESLint v10 (`^10.4.0`) ignores legacy `.eslintrc.*` files by default when a flat config is present. However, two stale `.eslintrc.cjs` files were left behind:
+
+### Inventory
+
+| File                                       | Location                                      | Status                                                                                |
+| ------------------------------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `packages/frontend/.eslintrc.cjs`          | packages/frontend/                            | DEAD — ESLint v10 ignores it; `package.json` scripts pass `--config eslint.config.js` |
+| `packages/frontend/frontend/.eslintrc.cjs` | Ghost directory `packages/frontend/frontend/` | DEAD — directory has zero other files; never touched since monorepo restructure       |
+
+Both files are byte-identical (`contentHash: 41721dc8`). The `packages/frontend/frontend/` directory is an artifact — presumably a monorepo restructure that left a stale copy. It contains nothing else.
+
+### The react-refresh gap
+
+The two dead `.eslintrc.cjs` files contained:
+
+```js
+'react-refresh/only-export-components': ['warn', { allowConstantExport: true }]
+```
+
+This rule is **not** present in either:
+
+- `eslint.config.js` (root)
+- `packages/frontend/eslint.config.js`
+
+Yet `eslint-plugin-react-refresh@^0.5.0` is still a devDependency in `packages/frontend/package.json`. The rule has been **un-enforced by CI and CLI linting since the flat config migration** — it only applies if a developer's editor picks up the stale `.eslintrc.cjs` by accident. The `packages/frontend/eslint.config.js` even has `'.eslintrc.cjs'` in its `ignores` array, explicitly opting out of the legacy file.
+
+**No other rules are missing.** The `@typescript-eslint/no-unused-vars` difference (error in legacy vs `off` in flat config) is intentional — flat config offloads unused-vars to TypeScript's `noUnusedLocals`.
+
+### Risk of deletion
+
+- **Safe** — all 5 lint scripts (root + 4 packages) explicitly use `-c eslint.config.js` or `--config eslint.config.js`.
+- **lint-staged** uses `-c eslint.config.js`.
+- **CI** runs `npm run lint:fix` with `--config eslint.config.js`.
+- **ESLint v10** ignores legacy config by default when flat config is present.
+- No `.vscode/settings.json` overrides reference `.eslintrc.cjs`.
+- The self-referential ignore `'.eslintrc.cjs'` in `packages/frontend/eslint.config.js` becomes obsolete.
+
+## Decision
+
+**Port the react-refresh rule to flat config, then delete the dead config files and ghost directory.**
+
+### Order of operations
+
+1. **Port `react-refresh/only-export-components` to `packages/frontend/eslint.config.js`** — restores accidentally-dropped lint coverage before removing the legacy file.
+2. **Delete `packages/frontend/.eslintrc.cjs`** — dead file, no tooling references it.
+3. **Delete `packages/frontend/frontend/` directory** — ghost directory containing only the stale config.
+4. **Remove `'.eslintrc.cjs'` from the `ignores` array in `packages/frontend/eslint.config.js`** — ignore target no longer exists.
+5. **Update `docs/FRONTEND.md` line 125** — replace `.eslintrc.cjs` reference in the file-tree diagram with `eslint.config.js`.
+6. **Verify** — `npm run lint --workspace=packages/frontend` and `npm run lint` (root) pass.
+
+### What does NOT change
+
+- Rule values, plugin versions, and lint severity — only `react-refresh/only-export-components` at `warn` is added.
+- `eslint-plugin-react-refresh` dependency stays — it was already in `packages/frontend/package.json`.
+- Root `eslint.config.js` is untouched — its rules and ignore patterns are correct.
+- All lint CI workflows are untouched.
+
+## Alternatives considered
+
+- **Delete without porting** — rejected: would permanently lose HMR-export validation for React components in the frontend. The rule existed for a reason.
+- **Keep the legacy files as "documentation"** — rejected: ESLint v10 ignores them, so they are dead code. Documentation belongs in `docs/`, not in orphaned config files.
+- **Port to root eslint.config.js instead of frontend** — rejected: `react-refresh` is UI-specific (only applies to React components). It belongs in the frontend package config.
+
+## Consequences
+
+**Positive:**
+
+- ~2 files deleted, ~1 ghost directory removed.
+- HMR export validation restored for CLI and CI linting.
+- One fewer maintenance surface for ESLint config drift.
+
+**Negative:** None identified — the port restores the previous behavior that was accidentally lost.
+
+**Neutral:** No rule strictness changes — `warn` preserved, `allowConstantExport: true` preserved.
+
+## Revisit when
+
+- Never — this is a one-time cleanup. If the react-refresh needs to be adjusted (e.g., to `error` level), that's a separate config change.

--- a/decisions/2026-06-27-standardize-test-runner-vitest.md
+++ b/decisions/2026-06-27-standardize-test-runner-vitest.md
@@ -1,0 +1,114 @@
+# ADR 2026-06-27 — Standardize test runner: migrate Jest tests to Vitest
+
+**Status:** Accepted
+
+**Deciders:** Lucas Santana
+
+**Trigger:** config-drift-detect flagged mixed Jest/Vitest usage across packages; `sonar.check` requires consistent coverage reporting
+
+**Related:** `decisions/2026-05-09-bot-test-suite-cleanup-strategy.md`
+
+## Context
+
+The Lucky monorepo has four packages with tests:
+
+| Package  | Current runner | Test files | `jest.*` patterns                                                                                            | Status       |
+| -------- | -------------- | ---------- | ------------------------------------------------------------------------------------------------------------ | ------------ |
+| shared   | Jest           | ~295       | 527 `jest.fn()`, 64 `jest.mock()`, ~15 `jest.spyOn()`, ~19 `jest.useFakeTimers()`, ~3 `jest.requireActual()` | To migrate   |
+| backend  | Jest           | ~390       | 0 patterns found (uses Prisma/testcontainers) — likely uses native mocks                                     | To migrate   |
+| bot      | Jest           | ~202       | 2,273 `jest.fn()`, 581 `jest.mock()`, ~15 `jest.spyOn()`                                                     | To migrate   |
+| frontend | Vitest ✅      | ~254       | 0 patterns — already clean                                                                                   | Already done |
+
+**Total:** ~1,141 test files, of which ~887 are on Jest.
+
+The initial assessment estimated ~90 Jest tests — this was off by ~10x because it did not account for `packages/shared` and `packages/bot`, and underestimated `packages/backend`.
+
+### Why standardize
+
+1. **Mixed-runner friction:** Developers need to remember which runner each package uses. Configs (`jest.config.cjs` vs `vitest.config.ts`), transform setup (`ts-jest` vs `esbuild`), and global APIs (`jest.fn()` vs `vi.fn()`) differ.
+2. **SonarCloud consistency:** Sonar requires a single coverage reporter format. Vitest's `@vitest/coverage-v8` produces standard `lcov` Sonar consumes natively; Jest's `jest-sonar-reporter` is a separate plugin that can drift.
+3. **Dependency reduction:** Removing `jest`, `ts-jest`, `@types/jest`, `jest-mock-extended`, and `@stryker-mutator/jest-runner` reduces `node_modules` weight and lockfile complexity.
+4. **Speed:** Vitest's esbuild-based transform is measurably faster than `ts-jest` for the same test suite (typical 30–50% reduction).
+5. **Feature parity:** Vitest covers the Jest API surface we use (`jest.fn()`, `jest.mock()`, `jest.spyOn()`, `jest.useFakeTimers()`, `test.each`, snapshot testing). The one API difference — `jest.requireActual()` → `vi.importActual()` (sync → promise) — is manageable at ~3 occurrences.
+
+### Migration concerns identified
+
+- **jest-mock-extended** (used in `packages/shared` and `packages/bot`) → `vitest-mock-extended`. API is identical (`mockDeep`, `mock`, `MockProxy`).
+- **Stryker mutation testing** (`packages/shared/stryker.conf.json`, `packages/backend/stryker.conf.json`) uses `"testRunner": "jest"` → must switch to `@stryker-mutator/vitest-runner`.
+- **discord.js mocks** (bot): extensive `jest.mock('discord.js', ...)` with manual `__mocks__` dirs. Vitest `vi.mock` handles hoisting similarly but path alias resolution (`@lucky/shared`) needs explicit `resolve.alias` in config.
+- **jest.requireActual** (sync) → `vi.importActual` (async): ~3 occurrences, minor refactor needed.
+- **Backend test patterns:** 390 test files with 0 `jest.*` — likely using Prisma/testcontainers with minimal mocking. Low migration risk.
+
+## Decision
+
+**Migrate all Jest tests to Vitest in two phases.**
+
+### Phase 1: `packages/shared` (safe boundary)
+
+Rationale: shared has no discord.js, no Prisma/testcontainers, uses standard Jest patterns. Lowest blast radius. Serves as proof of concept.
+
+Steps:
+
+1. Add `vitest` + `@vitest/coverage-v8` + `vitest-mock-extended` as devDependencies.
+2. Create `vitest.config.ts` with `globals: true`.
+3. Codemod `jest.fn/mock/spyOn/useFakeTimers` → `vi.fn/mock/spyOn/useFakeTimers`.
+4. Codemod `jest.requireActual` → `vi.importActual` (async wrapping).
+5. Replace `jest-mock-extended` → `vitest-mock-extended` imports.
+6. Remove `jest`, `ts-jest`, `@types/jest`, `jest-mock-extended`.
+7. Switch Stryker config from `jest-runner` to `vitest-runner`.
+8. Verify: `vitest run` passes, coverage reports, Stryker works.
+
+### Phase 2: `packages/backend` + `packages/bot` (parallel)
+
+Rationale: Both depend on shared, so they benefit from Phase 1 proving the config pattern. Can run in parallel worktrees.
+
+Steps (per package):
+
+1. Same dependency swap as Phase 1.
+2. Config with `globals: true` + `testTimeout` (for Prisma/testcontainers in backend).
+3. Codemod jest → vi patterns.
+4. For backend: ensure Prisma/testcontainers `beforeAll` / `afterAll` hooks work in Vitest's threading model. Set `pool: 'forks'` if needed.
+5. For bot: handle `discord.js` mock hoisting and `@lucky/shared` path aliases in config.
+6. Switch Stryker config.
+7. Remove legacy configs.
+8. Verify.
+
+### Risk mitigation
+
+- **Both runners coexist during migration** — no CI breakage. The root `package.json` scripts can be updated per-package as each phase lands. Jest configs stay until the phase is verified.
+- **Fallback:** If a package's tests cannot migrate cleanly, the Jest config stays for that package and it gets documented as "still on Jest — blocked by [reason]." The ADR is then updated. This applies primarily to `packages/bot` if discord.js mock hoisting proves intractable.
+
+## Alternatives considered
+
+- **Standardize on Jest** — rejected: frontend already on Vite+Vitest; would require migrating frontend back to Jest, losing esbuild speed and adding `ts-jest` back.
+- **Only migrate frontend (already done), leave others on Jest** — rejected: mixed-runner friction persists; SonarCloud coverage reporter inconsistency; missed dep reduction (~9 packages).
+- **Gradual per-file migration** — rejected: creates a half-migrated state where developers need both `jest` and `vi` globals in mind simultaneously. Package-level phases are coarse enough for safety but clean enough for CI.
+- **Do nothing** — rejected: config-drift surface grows over time; already flagged by monitoring.
+
+## Consequences
+
+**Positive:**
+
+- Single test runner across all packages.
+- ~9 npm dependencies removed (jest, ts-jest, @types/jest ×3, jest-mock-extended ×2, @stryker-mutator/jest-runner ×2).
+- Faster test execution via esbuild transform.
+- SonarCloud coverage from a single reporter.
+- Config consolidation: one `vitest.config.ts` pattern per package vs `jest.config.cjs` + `ts-jest` + `babel` configs.
+
+**Negative:**
+
+- ~4–8 hours of codemod / config work (agent-assisted).
+- Stryker configs need updating per package.
+- `jest.requireActual` → `vi.importActual` introduces async changes in ~3 files.
+- bot tests (~2,273 `jest.fn()` calls) will generate the largest diff.
+
+**Neutral:**
+
+- No test behavior change — codemod is mechanical.
+- Snapshot format differences between Jest and Vitest are minimal (Vitest snapshots are compatible with Jest format).
+
+## Revisit when
+
+- **Phase 1 (shared) is complete and verified** — proceed to Phase 2.
+- **If Phase 1 unearths an unexpected Vitest limitation** — re-scope: document the limitation in this ADR and keep Jest for affected packages.
+- **Phase 2 bot migration blocked by discord.js mock hoisting** — open a tracking issue, keep bot on Jest documented, and route future bot PRs to the Jest workflow explicitly.

--- a/packages/backend/src/middleware/session.ts
+++ b/packages/backend/src/middleware/session.ts
@@ -190,7 +190,7 @@ export function setupSessionMiddleware(app: Express): void {
             cookie: {
                 secure: isProduction,
                 httpOnly: true,
-                sameSite: 'lax',
+                sameSite: isProduction ? 'none' : 'lax',
                 maxAge: 7 * 24 * 60 * 60 * 1000,
                 path: '/',
             },

--- a/packages/backend/tests/integration/routes/auth.test.ts
+++ b/packages/backend/tests/integration/routes/auth.test.ts
@@ -154,7 +154,7 @@ describe('Auth Routes Integration', () => {
                         (cookie) =>
                             cookie.includes('sessionId=') &&
                             cookie.includes('Secure') &&
-                            cookie.includes('SameSite=Lax'),
+                            cookie.includes('SameSite=None'),
                     ),
                 ).toBe(true)
             } finally {
@@ -232,7 +232,7 @@ describe('Auth Routes Integration', () => {
             const cookies = response.headers['set-cookie'] ?? []
             expect(cookies.join(';')).toContain('Secure')
             expect(cookies.join(';')).toContain('HttpOnly')
-            expect(cookies.join(';')).toContain('SameSite=Lax')
+            expect(cookies.join(';')).toContain('SameSite=None')
 
             process.env.NODE_ENV = originalNodeEnv
             if (originalRedirectUri) {
@@ -428,7 +428,9 @@ describe('Auth Routes Integration', () => {
                 .query({ code: MOCK_AUTH_CODE, state: MOCK_OAUTH_STATE })
                 .expect(302)
 
-            expect(response.headers.location).toContain('error=auth_failed&message=invalid_state')
+            expect(response.headers.location).toContain(
+                'error=auth_failed&message=invalid_state',
+            )
         })
 
         test('should clean up state after successful validation', async () => {

--- a/packages/backend/tests/unit/middleware/session.test.ts
+++ b/packages/backend/tests/unit/middleware/session.test.ts
@@ -103,4 +103,44 @@ describe('Session Middleware', () => {
 
         process.env.NODE_ENV = originalEnv
     })
+
+    test('should use sameSite: none in production for cross-subdomain credentials', async () => {
+        const { setupSessionMiddleware } =
+            await import('../../../src/middleware/session')
+        const originalEnv = process.env.NODE_ENV
+        process.env.NODE_ENV = 'production'
+
+        expect(() => {
+            setupSessionMiddleware(app)
+        }).not.toThrow()
+
+        // sameSite: 'none' + secure: true ensures the session cookie is sent
+        // on credentialed JS fetches between subdomains (lucky.* → lucky-api.*)
+        const source = readFileSync(
+            resolve(__dirname, '../../../src/middleware/session.ts'),
+            'utf8',
+        )
+        expect(source).toContain("sameSite: isProduction ? 'none' : 'lax'")
+
+        process.env.NODE_ENV = originalEnv
+    })
+
+    test('should use sameSite: lax in development', async () => {
+        const { setupSessionMiddleware } =
+            await import('../../../src/middleware/session')
+        const originalEnv = process.env.NODE_ENV
+        process.env.NODE_ENV = 'development'
+
+        expect(() => {
+            setupSessionMiddleware(app)
+        }).not.toThrow()
+
+        const source = readFileSync(
+            resolve(__dirname, '../../../src/middleware/session.ts'),
+            'utf8',
+        )
+        expect(source).toContain("sameSite: isProduction ? 'none' : 'lax'")
+
+        process.env.NODE_ENV = originalEnv
+    })
 })

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -109,9 +109,18 @@ apiClient.interceptors.response.use(
             typeof globalThis !== 'undefined' &&
             'window' in globalThis
         ) {
-            globalThis.window.location.assign(
-                `${NORMALIZED_API_BASE}/auth/discord`,
+            const lastRedirect = parseInt(
+                sessionStorage.getItem('auth_redirect_ts') || '0',
+                10,
             )
+            const now = Date.now()
+            // 30s cooldown: if we redirected recently (OAuth loop), break it
+            if (now - lastRedirect > 30_000) {
+                sessionStorage.setItem('auth_redirect_ts', String(now))
+                globalThis.window.location.assign(
+                    `${NORMALIZED_API_BASE}/auth/discord`,
+                )
+            }
         }
 
         return Promise.reject(new ApiError(status, message, data?.details))


### PR DESCRIPTION
## Description

Hotfix for production auth loop: web dashboard redirects to OAuth and returns to landing page in an infinite loop.

**Root cause:** Session cookie uses `SameSite=Lax`, which browsers don't send on credentialed JS `fetch()` between subdomains (`lucky.lucassantana.tech` → `lucky-api.lucassantana.tech`) in certain conditions (ITP, Lax enforcement edge cases). After OAuth redirects back to the frontend, the SPA's `checkAuth()` fetch doesn't carry the session cookie, so the user appears unauthenticated and ends up back on the landing page.

**Fix (two layers):**

1. **session.ts** — Set `sameSite: 'none'` in production (with existing `secure: true` as required by the spec). In development, keep `sameSite: 'lax'` for localhost compat. This ensures the cookie is consistently sent on credentialed cross-subdomain requests.

2. **api.ts** — Add a 30s `sessionStorage` cooldown to the 401 redirect interceptor. If a redirect was already attempted within the last 30 seconds, don't redirect again. This breaks the infinite loop as a safety net.

## Checklist

- [x] Tests pass locally (pre-existing `@lucky/shared/utils` resolution issue in jest — same 6 failures on clean `main`)
- [ ] CHANGELOG.md updated (if user-facing)
- [x] TypeScript builds cleanly (both backend + frontend)

## Destructive / irreversible interaction (Tier A)

**Skip — no irreversible Discord action added.**

## Feature-removal sweep

**Skip — no feature removed.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the production OAuth redirect loop between the dashboard and API by sending the session cookie across subdomains and adding a 30s redirect cooldown. Also adds ADRs documenting ESLint legacy config cleanup and standardizing tests on Vitest.

- **Bug Fixes**
  - `packages/backend`: Set session cookie `sameSite` to `'none'` in production (keeps `secure: true`); `'lax'` in development.
  - `packages/frontend`: Add a 30s `sessionStorage` cooldown in the 401 interceptor before redirecting to `${NORMALIZED_API_BASE}/auth/discord`.
  - `packages/backend`: Update integration tests to expect `SameSite=None` in production and add unit tests to lock the `sameSite` toggle.

<sup>Written for commit 5861675f2968c1e21d7c0660de96687db3db2d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted session cookie `SameSite` for production so it uses `None` (instead of `Lax`).
  * Prevented repeated OAuth/Discord redirect loops by adding a short cooldown between redirect attempts.
* **Documentation**
  * Updated frontend lint setup guidance to match the current configuration.
  * Added project notes for standardizing the test runner to Vitest.
* **Tests**
  * Expanded unit and integration coverage for the production/dev session cookie `SameSite` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->