### PR TITLE
fix: add missing fetch timeouts to GuildService Discord API calls

### DIFF
--- a/packages/backend/src/services/GuildService.ts
+++ b/packages/backend/src/services/GuildService.ts
@@ -143,6 +143,7 @@ class GuildService {
                     headers: {
                         Authorization: `Bot ${token}`,
                     },
+                    signal: AbortSignal.timeout(10_000),
                 },
             )
 
@@ -630,6 +631,7 @@ class GuildService {
                     headers: {
                         Authorization: `Bot ${token}`,
                     },
+                    signal: AbortSignal.timeout(10_000),
                 },
             )
 


### PR DESCRIPTION
## Summary

Two fetch calls in `GuildService.ts` were missing `AbortSignal.timeout(10_000)`, unlike every other fetch call in the file. This left them vulnerable to hung HTTP connections to the Discord API.

## Changes

- `GuildService.ts:146` — added `signal: AbortSignal.timeout(10_000)` to `fetchBotGuildIds` fetch (`/users/@me/guilds`)
- `GuildService.ts:634` — added `signal: AbortSignal.timeout(10_000)` to `getGuildTextChannelOptions` REST fallback fetch (`/guilds/{id}/channels`)

## Verification

- `tsc --noEmit` passes (no new errors — the only reported error is pre-existing on main)
- `grep` confirms 12 `AbortSignal.timeout` occurrences in GuildService.ts (was 10)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 10s timeouts to two Discord API fetches in `GuildService` to prevent hung connections and match the rest of the service.

- **Bug Fixes**
  - `fetchBotGuildIds` (`/users/@me/guilds`): added `signal: AbortSignal.timeout(10_000)`.
  - `getGuildTextChannelOptions` REST fallback (`/guilds/{id}/channels`): added `signal: AbortSignal.timeout(10_000)`.

<sup>Written for commit 6e818414873d32cdcc7e2b32704699ae2bf3f29a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added request timeouts to some Discord data fetches, helping the app fail faster and reduce hangs when Discord is slow or unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->