### PR TITLE
feat: guild integrations pack

### DIFF
--- a/packages/bot/src/handlers/eventHandler.ts
+++ b/packages/bot/src/handlers/eventHandler.ts
@@ -24,6 +24,7 @@ import { handleMemberEvents } from './memberHandler'
 import { handleAuditEvents } from './auditHandler'
 import { handleExternalScrobbler } from './externalScrobbler'
 import { handleReactionEvents } from './reactionHandler'
+import { scheduledEventNotificationService } from '../services/ScheduledEventNotificationService'
 import { handleMusicButtonInteraction } from './musicButtonHandler'
 import { executeContextMenu } from './commandsHandler'
 import {
@@ -393,13 +394,11 @@ function handleChannelDelete(client: Client): void {
 
 function handleGuildScheduledEventCreate(client: Client): void {
     client.on(Events.GuildScheduledEventCreate, (event) => {
-        const { scheduledEventNotificationService } = require('../services/ScheduledEventNotificationService')
         scheduledEventNotificationService
             .notifyScheduledEvent(event, client)
             .catch((error: unknown) => {
                 errorLog({
-                    message:
-                        'Error handling guild scheduled event create:',
+                    message: 'Error handling guild scheduled event create:',
                     error,
                 })
             })

--- a/packages/bot/src/handlers/eventHandler.ts
+++ b/packages/bot/src/handlers/eventHandler.ts
@@ -391,6 +391,21 @@ function handleChannelDelete(client: Client): void {
     })
 }
 
+function handleGuildScheduledEventCreate(client: Client): void {
+    client.on(Events.GuildScheduledEventCreate, (event) => {
+        const { scheduledEventNotificationService } = require('../services/ScheduledEventNotificationService')
+        scheduledEventNotificationService
+            .notifyScheduledEvent(event, client)
+            .catch((error: unknown) => {
+                errorLog({
+                    message:
+                        'Error handling guild scheduled event create:',
+                    error,
+                })
+            })
+    })
+}
+
 export default function handleEvents(client: Client) {
     handleClientReady(client)
     client.on(Events.InteractionCreate, (interaction: Interaction) => {
@@ -410,4 +425,5 @@ export default function handleEvents(client: Client) {
     handleGuildDelete(client)
     handleChannelDelete(client)
     handleForumThreadCreate(client)
+    handleGuildScheduledEventCreate(client)
 }

--- a/packages/bot/src/services/CriativariaLiveNotificationService.ts
+++ b/packages/bot/src/services/CriativariaLiveNotificationService.ts
@@ -109,7 +109,16 @@ export class CriativariaLiveNotificationService {
                 .setTimestamp(new Date(stream.started_at))
                 .setFooter({ text: 'Twitch' })
 
-            await (channel as TextChannel).send({ embeds: [embed] })
+            const mentionRoleId = process.env.CRIATIVARIA_LIVE_MENTION_ROLE_ID
+            const content = mentionRoleId ? `<@&${mentionRoleId}>` : undefined
+
+            await (channel as TextChannel).send({
+                content,
+                embeds: [embed],
+                allowedMentions: mentionRoleId
+                    ? { roles: [mentionRoleId] }
+                    : undefined,
+            })
         } catch (err) {
             errorLog({
                 message: 'CriativariaLiveNotification: send failed',

--- a/packages/bot/src/services/RssBridgeService.spec.ts
+++ b/packages/bot/src/services/RssBridgeService.spec.ts
@@ -86,7 +86,10 @@ beforeEach(() => {
 
     featureToggleMock.mockResolvedValue(true)
     findUniqueMock.mockResolvedValue(null)
-    createMock.mockResolvedValue({ slug: 'my-guide', title: 'Guide Title' })
+    createMock.mockResolvedValue({
+        slug: 'guild-1:my-guide',
+        title: 'Guide Title',
+    })
     subFindManyMock.mockReset()
     subFindUniqueMock.mockReset()
     subCreateMock.mockReset()
@@ -282,7 +285,7 @@ describe('RSS feed polling', () => {
         await startRssBridgeService(makeClient(channel) as never)
 
         expect(createMock).toHaveBeenCalledWith({
-            data: { slug: 'my-guide', title: 'Guide Title' },
+            data: { slug: 'guild-1:my-guide', title: 'Guide Title' },
         })
         expect(channel.send).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/packages/bot/src/services/RssBridgeService.spec.ts
+++ b/packages/bot/src/services/RssBridgeService.spec.ts
@@ -385,4 +385,122 @@ describe('RSS feed polling', () => {
         expect(createMock).toHaveBeenCalledTimes(2)
         expect(channel.send).toHaveBeenCalledTimes(2)
     })
+
+    describe('Per-guild RSS subscriptions', () => {
+        it('should send RSS item with role mention when mentionRoleId is set', async () => {
+            featureToggleMock.mockResolvedValue(true)
+
+            const channel = {
+                isTextBased: () => true,
+                isDMBased: () => false,
+                send: jest.fn().mockResolvedValue({}),
+            }
+
+            const mockDb = {
+                rssFeedSubscription: {
+                    findMany: jest
+                        .fn()
+                        .mockResolvedValue([
+                            {
+                                id: 'sub1',
+                                guildId: 'guild1',
+                                feedUrl: 'https://example.com/rss.xml',
+                                channelId: 'channel1',
+                                mentionRoleId: 'role1',
+                                lastItemGuid: null,
+                                enabled: true,
+                                createdAt: new Date(),
+                                updatedAt: new Date(),
+                            },
+                        ]),
+                    findUnique: jest.fn().mockResolvedValue(null),
+                    create: jest.fn().mockResolvedValue({}),
+                    update: jest.fn().mockResolvedValue({}),
+                },
+            }
+
+            jest.doMock('@lucky/shared/utils/database/prismaClient', () => ({
+                getPrismaClient: () => mockDb,
+            }))
+
+            parseURLMock.mockResolvedValue({
+                items: [
+                    {
+                        title: 'Test Item',
+                        link: 'https://example.com/item',
+                        description: 'Test description',
+                        guid: 'guid-1',
+                    },
+                ],
+            })
+
+            const client = makeClient(channel)
+            await startRssBridgeService(client as never)
+
+            expect(channel.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: '<@&role1>',
+                    allowedMentions: { roles: ['role1'] },
+                }),
+            )
+        })
+
+        it('should not send mention when mentionRoleId is not set', async () => {
+            featureToggleMock.mockResolvedValue(true)
+
+            const channel = {
+                isTextBased: () => true,
+                isDMBased: () => false,
+                send: jest.fn().mockResolvedValue({}),
+            }
+
+            const mockDb = {
+                rssFeedSubscription: {
+                    findMany: jest
+                        .fn()
+                        .mockResolvedValue([
+                            {
+                                id: 'sub1',
+                                guildId: 'guild1',
+                                feedUrl: 'https://example.com/rss.xml',
+                                channelId: 'channel1',
+                                mentionRoleId: null,
+                                lastItemGuid: null,
+                                enabled: true,
+                                createdAt: new Date(),
+                                updatedAt: new Date(),
+                            },
+                        ]),
+                    findUnique: jest.fn().mockResolvedValue(null),
+                    create: jest.fn().mockResolvedValue({}),
+                    update: jest.fn().mockResolvedValue({}),
+                },
+            }
+
+            jest.doMock('@lucky/shared/utils/database/prismaClient', () => ({
+                getPrismaClient: () => mockDb,
+            }))
+
+            parseURLMock.mockResolvedValue({
+                items: [
+                    {
+                        title: 'Test Item',
+                        link: 'https://example.com/item',
+                        description: 'Test description',
+                        guid: 'guid-1',
+                    },
+                ],
+            })
+
+            const client = makeClient(channel)
+            await startRssBridgeService(client as never)
+
+            expect(channel.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: undefined,
+                    allowedMentions: undefined,
+                }),
+            )
+        })
+    })
 })

--- a/packages/bot/src/services/RssBridgeService.spec.ts
+++ b/packages/bot/src/services/RssBridgeService.spec.ts
@@ -14,6 +14,10 @@ const infoLogMock = jest.fn()
 const featureToggleMock = jest.fn()
 const findUniqueMock = jest.fn()
 const createMock = jest.fn()
+const subFindManyMock = jest.fn()
+const subFindUniqueMock = jest.fn()
+const subCreateMock = jest.fn()
+const subUpdateMock = jest.fn()
 
 jest.mock(
     'rss-parser',
@@ -40,6 +44,12 @@ jest.mock('@lucky/shared/utils/database/prismaClient', () => ({
         rssDiscoveredGuide: {
             findUnique: (...args: unknown[]) => findUniqueMock(...args),
             create: (...args: unknown[]) => createMock(...args),
+        },
+        rssFeedSubscription: {
+            findMany: (...args: unknown[]) => subFindManyMock(...args),
+            findUnique: (...args: unknown[]) => subFindUniqueMock(...args),
+            create: (...args: unknown[]) => subCreateMock(...args),
+            update: (...args: unknown[]) => subUpdateMock(...args),
         },
     }),
 }))
@@ -77,6 +87,25 @@ beforeEach(() => {
     featureToggleMock.mockResolvedValue(true)
     findUniqueMock.mockResolvedValue(null)
     createMock.mockResolvedValue({ slug: 'my-guide', title: 'Guide Title' })
+    subFindManyMock.mockReset()
+    subFindUniqueMock.mockReset()
+    subCreateMock.mockReset()
+    subUpdateMock.mockReset()
+    subFindUniqueMock.mockResolvedValue({ id: 'sub-1' })
+    subUpdateMock.mockResolvedValue({})
+    subFindManyMock.mockResolvedValue([
+        {
+            id: 'sub-1',
+            guildId: 'guild-1',
+            feedUrl: 'https://criativaria.com.br/rss.xml',
+            channelId: 'channel-123',
+            mentionRoleId: null,
+            lastItemGuid: null,
+            enabled: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+    ])
     process.env.CRIATIVARIA_GUIDES_CHANNEL_ID = 'channel-123'
 })
 
@@ -95,15 +124,13 @@ describe('startRssBridgeService', () => {
         expect(infoLogMock).not.toHaveBeenCalled()
     })
 
-    it('logs error and returns when env var missing', async () => {
-        delete process.env.CRIATIVARIA_GUIDES_CHANNEL_ID
+    it('debugLogs and skips polling when no subscriptions exist', async () => {
+        subFindManyMock.mockResolvedValue([])
         await startRssBridgeService(makeClient() as never)
 
-        expect(errorLogMock).toHaveBeenCalledWith(
+        expect(debugLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: expect.stringContaining(
-                    'CRIATIVARIA_GUIDES_CHANNEL_ID',
-                ),
+                message: expect.stringContaining('No RSS feed subscriptions'),
             }),
         )
         expect(parseURLMock).not.toHaveBeenCalled()
@@ -208,32 +235,32 @@ describe('RSS feed polling', () => {
         )
     })
 
-    it('debugLogs and skips items with no link', async () => {
+    it('debugLogs and skips items with no link or guid', async () => {
         parseURLMock.mockResolvedValue({
-            items: [makeFeedItem({ link: undefined })],
+            items: [makeFeedItem({ link: undefined, guid: undefined })],
         } as never)
         await startRssBridgeService(makeClient() as never)
 
         expect(debugLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: expect.stringContaining('slug'),
+                message: expect.stringContaining('Could not extract GUID'),
             }),
         )
         expect(findUniqueMock).not.toHaveBeenCalled()
     })
 
-    it('debugLogs and skips items with unparseable link', async () => {
+    it('falls back to the raw link as dedup key for unparseable links', async () => {
+        const channel = makeChannel()
         parseURLMock.mockResolvedValue({
             items: [makeFeedItem({ link: 'not-a-url' })],
         } as never)
-        await startRssBridgeService(makeClient() as never)
+        await startRssBridgeService(makeClient(channel) as never)
 
-        expect(debugLogMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: expect.stringContaining('slug'),
-            }),
+        // Unparseable URL → extractSlug null → the raw link becomes the key
+        expect(findUniqueMock).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { slug: 'not-a-url' } }),
         )
-        expect(findUniqueMock).not.toHaveBeenCalled()
+        expect(channel.send).toHaveBeenCalled()
     })
 
     it('debugLogs and skips items already in DB', async () => {
@@ -387,55 +414,25 @@ describe('RSS feed polling', () => {
     })
 
     describe('Per-guild RSS subscriptions', () => {
-        it('should send RSS item with role mention when mentionRoleId is set', async () => {
-            featureToggleMock.mockResolvedValue(true)
+        const sub = (mentionRoleId: string | null) => ({
+            id: 'sub1',
+            guildId: 'guild1',
+            feedUrl: 'https://example.com/rss.xml',
+            channelId: 'channel1',
+            mentionRoleId,
+            lastItemGuid: null,
+            enabled: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        })
 
-            const channel = {
-                isTextBased: () => true,
-                isDMBased: () => false,
-                send: jest.fn().mockResolvedValue({}),
-            }
-
-            const mockDb = {
-                rssFeedSubscription: {
-                    findMany: jest
-                        .fn()
-                        .mockResolvedValue([
-                            {
-                                id: 'sub1',
-                                guildId: 'guild1',
-                                feedUrl: 'https://example.com/rss.xml',
-                                channelId: 'channel1',
-                                mentionRoleId: 'role1',
-                                lastItemGuid: null,
-                                enabled: true,
-                                createdAt: new Date(),
-                                updatedAt: new Date(),
-                            },
-                        ]),
-                    findUnique: jest.fn().mockResolvedValue(null),
-                    create: jest.fn().mockResolvedValue({}),
-                    update: jest.fn().mockResolvedValue({}),
-                },
-            }
-
-            jest.doMock('@lucky/shared/utils/database/prismaClient', () => ({
-                getPrismaClient: () => mockDb,
-            }))
-
+        it('sends RSS item with role mention when mentionRoleId is set', async () => {
+            subFindManyMock.mockResolvedValue([sub('role1')])
             parseURLMock.mockResolvedValue({
-                items: [
-                    {
-                        title: 'Test Item',
-                        link: 'https://example.com/item',
-                        description: 'Test description',
-                        guid: 'guid-1',
-                    },
-                ],
-            })
-
-            const client = makeClient(channel)
-            await startRssBridgeService(client as never)
+                items: [makeFeedItem({ guid: 'guid-1' })],
+            } as never)
+            const channel = makeChannel()
+            await startRssBridgeService(makeClient(channel) as never)
 
             expect(channel.send).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -445,55 +442,13 @@ describe('RSS feed polling', () => {
             )
         })
 
-        it('should not send mention when mentionRoleId is not set', async () => {
-            featureToggleMock.mockResolvedValue(true)
-
-            const channel = {
-                isTextBased: () => true,
-                isDMBased: () => false,
-                send: jest.fn().mockResolvedValue({}),
-            }
-
-            const mockDb = {
-                rssFeedSubscription: {
-                    findMany: jest
-                        .fn()
-                        .mockResolvedValue([
-                            {
-                                id: 'sub1',
-                                guildId: 'guild1',
-                                feedUrl: 'https://example.com/rss.xml',
-                                channelId: 'channel1',
-                                mentionRoleId: null,
-                                lastItemGuid: null,
-                                enabled: true,
-                                createdAt: new Date(),
-                                updatedAt: new Date(),
-                            },
-                        ]),
-                    findUnique: jest.fn().mockResolvedValue(null),
-                    create: jest.fn().mockResolvedValue({}),
-                    update: jest.fn().mockResolvedValue({}),
-                },
-            }
-
-            jest.doMock('@lucky/shared/utils/database/prismaClient', () => ({
-                getPrismaClient: () => mockDb,
-            }))
-
+        it('sends no mention when mentionRoleId is not set', async () => {
+            subFindManyMock.mockResolvedValue([sub(null)])
             parseURLMock.mockResolvedValue({
-                items: [
-                    {
-                        title: 'Test Item',
-                        link: 'https://example.com/item',
-                        description: 'Test description',
-                        guid: 'guid-1',
-                    },
-                ],
-            })
-
-            const client = makeClient(channel)
-            await startRssBridgeService(client as never)
+                items: [makeFeedItem({ guid: 'guid-1' })],
+            } as never)
+            const channel = makeChannel()
+            await startRssBridgeService(makeClient(channel) as never)
 
             expect(channel.send).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/packages/bot/src/services/RssBridgeService.ts
+++ b/packages/bot/src/services/RssBridgeService.ts
@@ -19,6 +19,10 @@ interface RssItem {
 let pollInterval: ReturnType<typeof setInterval> | null = null
 
 export async function startRssBridgeService(client: Client): Promise<void> {
+    // Repeated starts must not stack polling intervals
+    if (pollInterval) {
+        return
+    }
     const enabled = await featureToggleService.isEnabled('RSS_BRIDGE')
     if (!enabled) {
         return
@@ -158,7 +162,8 @@ async function pollSingleSubscription(
             send: (options: unknown) => Promise<unknown>
         }
 
-        let lastItemGuid = subscription.lastItemGuid
+        const storedGuid = subscription.lastItemGuid
+        let newestSeenGuid: string | null = null
 
         for (const item of feed.items) {
             const itemTyped = item as RssItem
@@ -173,7 +178,12 @@ async function pollSingleSubscription(
                 continue
             }
 
-            if (lastItemGuid && itemGuid === lastItemGuid) {
+            if (!newestSeenGuid) {
+                // Feeds are newest-first: the first valid item anchors the cursor
+                newestSeenGuid = itemGuid
+            }
+
+            if (storedGuid && itemGuid === storedGuid) {
                 debugLog({
                     message: 'RSS item already posted',
                     data: { itemGuid },
@@ -188,10 +198,18 @@ async function pollSingleSubscription(
 
             // Per-item dedup via RssDiscoveredGuide (the #1608 record other
             // consumers read) — lastItemGuid is only a fast-path short-circuit
-            const slug = extractSlug(itemTyped.link) || itemGuid
-            const existing = await db.rssDiscoveredGuide.findUnique({
-                where: { slug },
-            })
+            const rawSlug = extractSlug(itemTyped.link) || itemGuid
+            // Scope dedup per guild so two guilds subscribing to the same
+            // feed do not suppress each other; raw-slug lookup keeps the
+            // pre-existing (Criativaria) rows honored without a repost burst
+            const slug = `${subscription.guildId}:${rawSlug}`
+            const existing =
+                (await db.rssDiscoveredGuide.findUnique({
+                    where: { slug },
+                })) ??
+                (await db.rssDiscoveredGuide.findUnique({
+                    where: { slug: rawSlug },
+                }))
             if (existing) {
                 debugLog({
                     message: 'RSS item already posted',
@@ -224,10 +242,6 @@ async function pollSingleSubscription(
                     data: { slug, title },
                 })
 
-                if (!lastItemGuid) {
-                    lastItemGuid = itemGuid
-                }
-
                 infoLog({
                     message: 'RSS item posted',
                     data: {
@@ -249,10 +263,10 @@ async function pollSingleSubscription(
             }
         }
 
-        if (lastItemGuid !== subscription.lastItemGuid) {
+        if (newestSeenGuid && newestSeenGuid !== storedGuid) {
             await db.rssFeedSubscription.update({
                 where: { id: subscription.id },
-                data: { lastItemGuid },
+                data: { lastItemGuid: newestSeenGuid },
             })
         }
     } catch (err) {

--- a/packages/bot/src/services/RssBridgeService.ts
+++ b/packages/bot/src/services/RssBridgeService.ts
@@ -51,7 +51,9 @@ export function stopRssBridgeService(): void {
 async function ensureBackwardCompatibleSubscription(
     db: ReturnType<typeof getPrismaClient>,
 ): Promise<void> {
-    const feedUrl = process.env.CRIATIVARIA_GUIDES_FEED_URL || 'https://criativaria.com.br/rss.xml'
+    const feedUrl =
+        process.env.CRIATIVARIA_GUIDES_FEED_URL ||
+        'https://criativaria.com.br/rss.xml'
     const channelId = process.env.CRIATIVARIA_GUIDES_CHANNEL_ID
     const guildId = process.env.CRIATIVARIA_GUILD_ID
 
@@ -161,9 +163,7 @@ async function pollSingleSubscription(
         for (const item of feed.items) {
             const itemTyped = item as RssItem
             const itemGuid =
-                itemTyped.guid ||
-                itemTyped.link ||
-                extractSlug(itemTyped.link)
+                itemTyped.guid || itemTyped.link || extractSlug(itemTyped.link)
 
             if (!itemGuid) {
                 debugLog({
@@ -186,6 +186,20 @@ async function pollSingleSubscription(
                 itemTyped.description || itemTyped.content || '',
             )
 
+            // Per-item dedup via RssDiscoveredGuide (the #1608 record other
+            // consumers read) — lastItemGuid is only a fast-path short-circuit
+            const slug = extractSlug(itemTyped.link) || itemGuid
+            const existing = await db.rssDiscoveredGuide.findUnique({
+                where: { slug },
+            })
+            if (existing) {
+                debugLog({
+                    message: 'RSS item already posted',
+                    data: { slug },
+                })
+                continue
+            }
+
             try {
                 const content = subscription.mentionRoleId
                     ? `<@&${subscription.mentionRoleId}>`
@@ -204,6 +218,10 @@ async function pollSingleSubscription(
                     allowedMentions: subscription.mentionRoleId
                         ? { roles: [subscription.mentionRoleId] }
                         : undefined,
+                })
+
+                await db.rssDiscoveredGuide.create({
+                    data: { slug, title },
                 })
 
                 if (!lastItemGuid) {
@@ -239,7 +257,7 @@ async function pollSingleSubscription(
         }
     } catch (err) {
         errorLog({
-            message: 'Error polling single RSS feed subscription',
+            message: 'Error polling RSS feed',
             error: err,
             data: {
                 subscriptionId: subscription.id,

--- a/packages/bot/src/services/RssBridgeService.ts
+++ b/packages/bot/src/services/RssBridgeService.ts
@@ -4,7 +4,6 @@ import { debugLog, errorLog, infoLog } from '@lucky/shared/utils'
 import { featureToggleService } from '@lucky/shared/services'
 import { getPrismaClient } from '@lucky/shared/utils/database/prismaClient'
 
-const RSS_FEED_URL = 'https://criativaria.com.br/rss.xml'
 const POLL_INTERVAL_MS = 3600000 // 1 hour
 const EMBED_COLOR = 0xe879a0
 
@@ -14,6 +13,7 @@ interface RssItem {
     description?: string
     content?: string
     pubDate?: string
+    guid?: string
 }
 
 let pollInterval: ReturnType<typeof setInterval> | null = null
@@ -24,21 +24,13 @@ export async function startRssBridgeService(client: Client): Promise<void> {
         return
     }
 
-    const channelId = process.env.CRIATIVARIA_GUIDES_CHANNEL_ID
-    if (!channelId) {
-        errorLog({
-            message:
-                'RSS Bridge service requires CRIATIVARIA_GUIDES_CHANNEL_ID env variable',
-        })
-        return
-    }
-
     try {
+        const db = getPrismaClient()
+        await ensureBackwardCompatibleSubscription(db)
         infoLog({ message: 'RSS Bridge service started' })
-        await pollRssFeed(client, channelId)
-        // Schedule polling every hour
+        await pollRssFeedSubscriptions(client)
         pollInterval = setInterval(async () => {
-            await pollRssFeed(client, channelId)
+            await pollRssFeedSubscriptions(client)
         }, POLL_INTERVAL_MS)
     } catch (err) {
         errorLog({
@@ -56,26 +48,106 @@ export function stopRssBridgeService(): void {
     }
 }
 
-async function pollRssFeed(client: Client, channelId: string): Promise<void> {
-    try {
-        const parser = new Parser()
-        const feed = await parser.parseURL(RSS_FEED_URL)
+async function ensureBackwardCompatibleSubscription(
+    db: ReturnType<typeof getPrismaClient>,
+): Promise<void> {
+    const feedUrl = process.env.CRIATIVARIA_GUIDES_FEED_URL || 'https://criativaria.com.br/rss.xml'
+    const channelId = process.env.CRIATIVARIA_GUIDES_CHANNEL_ID
+    const guildId = process.env.CRIATIVARIA_GUILD_ID
 
-        if (!feed.items || feed.items.length === 0) {
+    if (!channelId || !guildId) {
+        debugLog({
+            message: 'Backward compat RSS subscription: env not configured',
+        })
+        return
+    }
+
+    const existing = await db.rssFeedSubscription.findUnique({
+        where: {
+            guildId_feedUrl: {
+                guildId,
+                feedUrl,
+            },
+        },
+    })
+
+    if (!existing) {
+        await db.rssFeedSubscription.create({
+            data: {
+                guildId,
+                feedUrl,
+                channelId,
+                enabled: true,
+            },
+        })
+        debugLog({
+            message: 'Auto-seeded backward compatible RSS subscription',
+            data: { guildId, feedUrl, channelId },
+        })
+    }
+}
+
+async function pollRssFeedSubscriptions(client: Client): Promise<void> {
+    try {
+        const db = getPrismaClient()
+        const subscriptions = await db.rssFeedSubscription.findMany({
+            where: { enabled: true },
+        })
+
+        if (subscriptions.length === 0) {
             debugLog({
-                message: 'No items found in RSS feed',
-                data: { feedUrl: RSS_FEED_URL },
+                message: 'No RSS feed subscriptions to poll',
             })
             return
         }
 
-        const db = getPrismaClient()
-        const channel = await client.channels.fetch(channelId)
+        for (const subscription of subscriptions) {
+            await pollSingleSubscription(client, db, subscription)
+        }
+    } catch (err) {
+        errorLog({
+            message: 'Error polling RSS feed subscriptions',
+            error: err,
+        })
+    }
+}
+
+async function pollSingleSubscription(
+    client: Client,
+    db: ReturnType<typeof getPrismaClient>,
+    subscription: {
+        id: string
+        guildId: string
+        feedUrl: string
+        channelId: string
+        mentionRoleId: string | null
+        lastItemGuid: string | null
+        enabled: boolean
+        createdAt: Date
+        updatedAt: Date
+    },
+): Promise<void> {
+    try {
+        const parser = new Parser()
+        const feed = await parser.parseURL(subscription.feedUrl)
+
+        if (!feed.items || feed.items.length === 0) {
+            debugLog({
+                message: 'No items found in RSS feed',
+                data: { feedUrl: subscription.feedUrl },
+            })
+            return
+        }
+
+        const channel = await client.channels.fetch(subscription.channelId)
 
         if (!channel?.isTextBased() || !('send' in channel)) {
             errorLog({
                 message: 'RSS Bridge channel is not a text channel',
-                data: { channelId },
+                data: {
+                    channelId: subscription.channelId,
+                    feedUrl: subscription.feedUrl,
+                },
             })
             return
         }
@@ -84,48 +156,43 @@ async function pollRssFeed(client: Client, channelId: string): Promise<void> {
             send: (options: unknown) => Promise<unknown>
         }
 
+        let lastItemGuid = subscription.lastItemGuid
+
         for (const item of feed.items) {
             const itemTyped = item as RssItem
-            const slug = extractSlug(itemTyped.link)
+            const itemGuid =
+                itemTyped.guid ||
+                itemTyped.link ||
+                extractSlug(itemTyped.link)
 
-            if (!slug) {
+            if (!itemGuid) {
                 debugLog({
-                    message: 'Could not extract slug from RSS item',
+                    message: 'Could not extract GUID from RSS item',
                     data: { link: itemTyped.link },
                 })
                 continue
             }
 
-            // Check if we've already posted this guide
-            const existing = await db.rssDiscoveredGuide.findUnique({
-                where: { slug },
-            })
-
-            if (existing) {
+            if (lastItemGuid && itemGuid === lastItemGuid) {
                 debugLog({
-                    message: 'Guide already posted',
-                    data: { slug },
+                    message: 'RSS item already posted',
+                    data: { itemGuid },
                 })
-                continue
+                break
             }
 
-            // Post new guide to Discord
             const title = itemTyped.title || 'Untitled'
             const description = truncateDescription(
                 itemTyped.description || itemTyped.content || '',
             )
 
             try {
-                // Persist dedup record first
-                await db.rssDiscoveredGuide.create({
-                    data: {
-                        slug,
-                        title,
-                    },
-                })
+                const content = subscription.mentionRoleId
+                    ? `<@&${subscription.mentionRoleId}>`
+                    : undefined
 
-                // Post to Discord after DB write succeeds
                 await sendableChannel.send({
+                    content,
                     embeds: [
                         {
                             title,
@@ -134,24 +201,50 @@ async function pollRssFeed(client: Client, channelId: string): Promise<void> {
                             color: EMBED_COLOR,
                         },
                     ],
+                    allowedMentions: subscription.mentionRoleId
+                        ? { roles: [subscription.mentionRoleId] }
+                        : undefined,
                 })
 
+                if (!lastItemGuid) {
+                    lastItemGuid = itemGuid
+                }
+
                 infoLog({
-                    message: 'RSS guide posted',
-                    data: { slug, title },
+                    message: 'RSS item posted',
+                    data: {
+                        subscriptionId: subscription.id,
+                        itemGuid,
+                        title,
+                    },
                 })
             } catch (err) {
                 errorLog({
-                    message: 'Failed to post RSS guide',
+                    message: 'Failed to post RSS item',
                     error: err,
-                    data: { slug, title },
+                    data: {
+                        subscriptionId: subscription.id,
+                        itemGuid,
+                        title,
+                    },
                 })
             }
         }
+
+        if (lastItemGuid !== subscription.lastItemGuid) {
+            await db.rssFeedSubscription.update({
+                where: { id: subscription.id },
+                data: { lastItemGuid },
+            })
+        }
     } catch (err) {
         errorLog({
-            message: 'Error polling RSS feed',
+            message: 'Error polling single RSS feed subscription',
             error: err,
+            data: {
+                subscriptionId: subscription.id,
+                feedUrl: subscription.feedUrl,
+            },
         })
     }
 }

--- a/packages/bot/src/services/ScheduledEventNotificationService.spec.ts
+++ b/packages/bot/src/services/ScheduledEventNotificationService.spec.ts
@@ -14,12 +14,12 @@ const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
 
 jest.mock('@lucky/shared/utils', () => ({
-    debugLog: debugLogMock,
-    errorLog: errorLogMock,
+    debugLog: (...args: unknown[]) => debugLogMock(...args),
+    errorLog: (...args: unknown[]) => errorLogMock(...args),
 }))
 
 jest.mock('@lucky/shared/utils/database/prismaClient', () => ({
-    getPrismaClient: getPrismaClientMock,
+    getPrismaClient: (...args: unknown[]) => getPrismaClientMock(...args),
 }))
 
 describe('ScheduledEventNotificationService', () => {

--- a/packages/bot/src/services/ScheduledEventNotificationService.spec.ts
+++ b/packages/bot/src/services/ScheduledEventNotificationService.spec.ts
@@ -1,0 +1,144 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    jest,
+} from '@jest/globals'
+import type { Client, GuildScheduledEvent, TextChannel } from 'discord.js'
+import { scheduledEventNotificationService } from './ScheduledEventNotificationService'
+
+const getPrismaClientMock = jest.fn()
+const debugLogMock = jest.fn()
+const errorLogMock = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: debugLogMock,
+    errorLog: errorLogMock,
+}))
+
+jest.mock('@lucky/shared/utils/database/prismaClient', () => ({
+    getPrismaClient: getPrismaClientMock,
+}))
+
+describe('ScheduledEventNotificationService', () => {
+    let mockDb: any
+    let mockClient: Partial<Client>
+    let mockChannel: Partial<TextChannel>
+    let mockEvent: Partial<GuildScheduledEvent>
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        mockChannel = {
+            isTextBased: jest.fn().mockReturnValue(true),
+            send: jest.fn().mockResolvedValue({}),
+        }
+
+        mockClient = {
+            channels: {
+                fetch: jest.fn().mockResolvedValue(mockChannel),
+            },
+        }
+
+        mockDb = {
+            scheduledEventNotification: {
+                findUnique: jest.fn(),
+            },
+        }
+
+        getPrismaClientMock.mockReturnValue(mockDb)
+
+        mockEvent = {
+            id: 'event1',
+            guildId: 'guild1',
+            name: 'Test Event',
+            description: 'This is a test event',
+            scheduledStartAt: new Date('2026-07-10T15:00:00Z'),
+        }
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('should send notification without mention when mentionRoleId is not set', async () => {
+        mockDb.scheduledEventNotification.findUnique.mockResolvedValue({
+            id: 'config1',
+            guildId: 'guild1',
+            channelId: 'channel1',
+            mentionRoleId: null,
+            enabled: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        })
+
+        await scheduledEventNotificationService.notifyScheduledEvent(
+            mockEvent as GuildScheduledEvent,
+            mockClient as Client,
+        )
+
+        expect(mockChannel.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: undefined,
+                embeds: expect.any(Array),
+            }),
+        )
+    })
+
+    it('should send notification with mention when mentionRoleId is set', async () => {
+        mockDb.scheduledEventNotification.findUnique.mockResolvedValue({
+            id: 'config1',
+            guildId: 'guild1',
+            channelId: 'channel1',
+            mentionRoleId: 'role1',
+            enabled: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        })
+
+        await scheduledEventNotificationService.notifyScheduledEvent(
+            mockEvent as GuildScheduledEvent,
+            mockClient as Client,
+        )
+
+        expect(mockChannel.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: '<@&role1>',
+                allowedMentions: { roles: ['role1'] },
+                embeds: expect.any(Array),
+            }),
+        )
+    })
+
+    it('should not send when config is disabled', async () => {
+        mockDb.scheduledEventNotification.findUnique.mockResolvedValue({
+            id: 'config1',
+            guildId: 'guild1',
+            channelId: 'channel1',
+            mentionRoleId: null,
+            enabled: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        })
+
+        await scheduledEventNotificationService.notifyScheduledEvent(
+            mockEvent as GuildScheduledEvent,
+            mockClient as Client,
+        )
+
+        expect(mockChannel.send).not.toHaveBeenCalled()
+    })
+
+    it('should not send when config does not exist', async () => {
+        mockDb.scheduledEventNotification.findUnique.mockResolvedValue(null)
+
+        await scheduledEventNotificationService.notifyScheduledEvent(
+            mockEvent as GuildScheduledEvent,
+            mockClient as Client,
+        )
+
+        expect(mockChannel.send).not.toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/services/ScheduledEventNotificationService.ts
+++ b/packages/bot/src/services/ScheduledEventNotificationService.ts
@@ -26,7 +26,12 @@ export class ScheduledEventNotificationService {
             }
 
             const channel = await client.channels.fetch(config.channelId)
-            if (!channel || !channel.isTextBased() || !('send' in channel)) {
+            if (
+                !channel ||
+                !channel.isTextBased() ||
+                !('send' in channel) ||
+                ('guildId' in channel && channel.guildId !== event.guildId)
+            ) {
                 errorLog({
                     message:
                         'Scheduled event notification: channel not found or not text-based',

--- a/packages/bot/src/services/ScheduledEventNotificationService.ts
+++ b/packages/bot/src/services/ScheduledEventNotificationService.ts
@@ -18,14 +18,15 @@ export class ScheduledEventNotificationService {
 
             if (!config || !config.enabled) {
                 debugLog({
-                    message: 'Scheduled event notification: no config or disabled',
+                    message:
+                        'Scheduled event notification: no config or disabled',
                     data: { guildId: event.guildId },
                 })
                 return
             }
 
             const channel = await client.channels.fetch(config.channelId)
-            if (!channel || !channel.isTextBased()) {
+            if (!channel || !channel.isTextBased() || !('send' in channel)) {
                 errorLog({
                     message:
                         'Scheduled event notification: channel not found or not text-based',
@@ -63,7 +64,10 @@ export class ScheduledEventNotificationService {
                 ? `<@&${config.mentionRoleId}>`
                 : undefined
 
-            await channel.send({
+            const sendableChannel = channel as unknown as {
+                send: (options: unknown) => Promise<unknown>
+            }
+            await sendableChannel.send({
                 content,
                 embeds: [embed],
                 allowedMentions: config.mentionRoleId

--- a/packages/bot/src/services/ScheduledEventNotificationService.ts
+++ b/packages/bot/src/services/ScheduledEventNotificationService.ts
@@ -1,0 +1,89 @@
+import type { Client, GuildScheduledEvent } from 'discord.js'
+import { EmbedBuilder } from 'discord.js'
+import { errorLog, debugLog } from '@lucky/shared/utils'
+import { getPrismaClient } from '@lucky/shared/utils/database/prismaClient'
+
+const EMBED_COLOR = 0xe879a0
+
+export class ScheduledEventNotificationService {
+    async notifyScheduledEvent(
+        event: GuildScheduledEvent,
+        client: Client,
+    ): Promise<void> {
+        try {
+            const db = getPrismaClient()
+            const config = await db.scheduledEventNotification.findUnique({
+                where: { guildId: event.guildId },
+            })
+
+            if (!config || !config.enabled) {
+                debugLog({
+                    message: 'Scheduled event notification: no config or disabled',
+                    data: { guildId: event.guildId },
+                })
+                return
+            }
+
+            const channel = await client.channels.fetch(config.channelId)
+            if (!channel || !channel.isTextBased()) {
+                errorLog({
+                    message:
+                        'Scheduled event notification: channel not found or not text-based',
+                    data: {
+                        channelId: config.channelId,
+                        guildId: event.guildId,
+                    },
+                })
+                return
+            }
+
+            const description = event.description
+                ? event.description.slice(0, 200)
+                : 'No description'
+
+            const startTimeStr = event.scheduledStartAt
+                ? `<t:${Math.floor(event.scheduledStartAt.getTime() / 1000)}:F> (<t:${Math.floor(event.scheduledStartAt.getTime() / 1000)}:R>)`
+                : 'Time not set'
+
+            const embed = new EmbedBuilder()
+                .setColor(EMBED_COLOR)
+                .setTitle(`📅 ${event.name}`)
+                .setURL(
+                    `https://discord.com/events/${event.guildId}/${event.id}`,
+                )
+                .setDescription(description)
+                .addFields({
+                    name: 'Starts',
+                    value: startTimeStr,
+                    inline: false,
+                })
+                .setTimestamp()
+
+            const content = config.mentionRoleId
+                ? `<@&${config.mentionRoleId}>`
+                : undefined
+
+            await channel.send({
+                content,
+                embeds: [embed],
+                allowedMentions: config.mentionRoleId
+                    ? { roles: [config.mentionRoleId] }
+                    : undefined,
+            })
+
+            debugLog({
+                message: 'Scheduled event notification sent',
+                data: { eventId: event.id, guildId: event.guildId },
+            })
+        } catch (err) {
+            errorLog({
+                message: 'Failed to send scheduled event notification',
+                error: err,
+                data: { eventId: event.id, guildId: event.guildId },
+            })
+        }
+    }
+}
+
+export const scheduledEventNotificationService =
+    new ScheduledEventNotificationService()

--- a/packages/bot/src/twitch/eventsubSubscriptions.spec.ts
+++ b/packages/bot/src/twitch/eventsubSubscriptions.spec.ts
@@ -502,6 +502,80 @@ describe('eventsubSubscriptions', () => {
             )
             expect(mockChannel.send).not.toHaveBeenCalled()
         })
+
+        it('should send mention when mentionRoleId is set', async () => {
+            const notifications = [
+                {
+                    discordChannelId: 'channel1',
+                    twitchLogin: 'testuser',
+                    mentionRoleId: 'role123',
+                },
+            ]
+            getNotificationsByTwitchUserIdMock.mockResolvedValue(
+                notifications as any,
+            )
+
+            const payload = {
+                subscription: {
+                    type: 'stream.online',
+                    condition: { broadcaster_user_id: 'twitch123' },
+                },
+                event: {
+                    id: 'event123',
+                    broadcaster_user_id: 'twitch123',
+                    broadcaster_user_login: 'testuser',
+                    broadcaster_user_name: 'Test User',
+                    type: 'stream.online',
+                    started_at: '2024-01-01T00:00:00Z',
+                },
+            }
+
+            await handleStreamOnline(payload as any, mockClient as Client)
+
+            expect(mockChannel.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: '<@&role123>',
+                    allowedMentions: { roles: ['role123'] },
+                }),
+            )
+        })
+
+        it('should not send mention when mentionRoleId is not set', async () => {
+            const notifications = [
+                {
+                    discordChannelId: 'channel1',
+                    twitchLogin: 'testuser',
+                    mentionRoleId: null,
+                },
+            ]
+            getNotificationsByTwitchUserIdMock.mockResolvedValue(
+                notifications as any,
+            )
+
+            const payload = {
+                subscription: {
+                    type: 'stream.online',
+                    condition: { broadcaster_user_id: 'twitch123' },
+                },
+                event: {
+                    id: 'event123',
+                    broadcaster_user_id: 'twitch123',
+                    broadcaster_user_login: 'testuser',
+                    broadcaster_user_name: 'Test User',
+                    type: 'stream.online',
+                    started_at: '2024-01-01T00:00:00Z',
+                },
+            }
+
+            await handleStreamOnline(payload as any, mockClient as Client)
+
+            expect(mockChannel.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: undefined,
+                    allowedMentions: undefined,
+                }),
+            )
+        })
     })
 
     describe('handleStreamOffline', () => {

--- a/packages/bot/src/twitch/eventsubSubscriptions.ts
+++ b/packages/bot/src/twitch/eventsubSubscriptions.ts
@@ -245,7 +245,16 @@ async function dispatchToChannels(
                 })
                 continue
             }
-            await channel.send({ embeds: [embed] })
+            const content = notif.mentionRoleId
+                ? `<@&${notif.mentionRoleId}>`
+                : undefined
+            await channel.send({
+                content,
+                embeds: [embed],
+                allowedMentions: notif.mentionRoleId
+                    ? { roles: [notif.mentionRoleId] }
+                    : undefined,
+            })
         } catch (err) {
             errorLog({
                 message: `Twitch EventSub: failed to send notification to channel ${notif.discordChannelId}`,

--- a/packages/shared/src/services/TwitchNotificationService/index.ts
+++ b/packages/shared/src/services/TwitchNotificationService/index.ts
@@ -5,7 +5,12 @@ import type { TwitchNotification } from '../../generated/prisma/client.js'
 /** Twitch notification configuration for a guild channel. */
 export type TwitchNotificationRow = Pick<
     TwitchNotification,
-    'id' | 'guildId' | 'twitchUserId' | 'twitchLogin' | 'discordChannelId'
+    | 'id'
+    | 'guildId'
+    | 'twitchUserId'
+    | 'twitchLogin'
+    | 'discordChannelId'
+    | 'mentionRoleId'
 > & {
     guild?: { discordId: string }
 }

--- a/prisma/migrations/20260702012040_guild_integrations_pack/migration.sql
+++ b/prisma/migrations/20260702012040_guild_integrations_pack/migration.sql
@@ -1,0 +1,42 @@
+-- AlterTable
+ALTER TABLE "twitch_notifications" ADD COLUMN "mentionRoleId" TEXT;
+
+-- CreateTable
+CREATE TABLE "scheduled_event_notifications" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "channelId" TEXT NOT NULL,
+    "mentionRoleId" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "scheduled_event_notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "rss_feed_subscriptions" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "feedUrl" TEXT NOT NULL,
+    "channelId" TEXT NOT NULL,
+    "mentionRoleId" TEXT,
+    "lastItemGuid" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rss_feed_subscriptions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "scheduled_event_notifications_guildId_key" ON "scheduled_event_notifications"("guildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rss_feed_subscriptions_guildId_feedUrl_key" ON "rss_feed_subscriptions"("guildId", "feedUrl");
+
+-- AddForeignKey
+ALTER TABLE "scheduled_event_notifications" ADD CONSTRAINT "scheduled_event_notifications_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("discordId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "rss_feed_subscriptions" ADD CONSTRAINT "rss_feed_subscriptions_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("discordId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,42 +62,44 @@ model Guild {
   updatedAt DateTime  @updatedAt
 
   // Relations
-  settings             GuildSettings?
-  sessions             GuildSession[]
-  trackHistory         TrackHistory[]
-  twitchNotifications  TwitchNotification[]
-  twitchFollowerRole   TwitchFollowerRole?
-  twitchSubscriberRole TwitchSubscriberRole?
-  featureToggles       GuildFeatureToggle[]
-  namedQueues          NamedQueue[]
-  sessionSnapshot      MusicSessionSnapshot?
-  counter              GuildCounter?
-  trackFeedback        UserTrackFeedback[]
-  roleGrants           GuildRoleGrant[]
-  automationManifest   GuildAutomationManifest?
-  automationRuns       GuildAutomationRun[]
-  automationDrifts     GuildAutomationDrift[]
-  downloads            Download[]
-  roleExclusions       RoleExclusion[]
-  moderationCases      ModerationCase[]
-  moderationSettings   ModerationSettings?
-  autoModSettings      AutoModSettings?
-  modDigestConfig      ModDigestConfig?
-  embedTemplates       EmbedTemplate[]
-  autoMessages         AutoMessage[]
-  customCommands       CustomCommand[]
-  serverLogs           ServerLog[]
-  starboardEntries     StarboardEntry[]
-  levelConfig          LevelConfig?
-  memberXPs            MemberXP[]
-  levelRewards         LevelReward[]
-  autoRoles            AutoRole[]
-  memberBirthdays      MemberBirthday[]
-  subscription         GuildSubscription?
-  reactionRoleMessages ReactionRoleMessage[]
-  roleGroups           RoleGroup[]
-  forumThreads         GuildForumThread[]
-  batchJobs            BatchJob[]
+  settings                     GuildSettings?
+  sessions                     GuildSession[]
+  trackHistory                 TrackHistory[]
+  twitchNotifications          TwitchNotification[]
+  scheduledEventNotification   ScheduledEventNotification?
+  rssFeedSubscriptions         RssFeedSubscription[]
+  twitchFollowerRole           TwitchFollowerRole?
+  twitchSubscriberRole         TwitchSubscriberRole?
+  featureToggles               GuildFeatureToggle[]
+  namedQueues                  NamedQueue[]
+  sessionSnapshot              MusicSessionSnapshot?
+  counter                      GuildCounter?
+  trackFeedback                UserTrackFeedback[]
+  roleGrants                   GuildRoleGrant[]
+  automationManifest           GuildAutomationManifest?
+  automationRuns               GuildAutomationRun[]
+  automationDrifts             GuildAutomationDrift[]
+  downloads                    Download[]
+  roleExclusions               RoleExclusion[]
+  moderationCases              ModerationCase[]
+  moderationSettings           ModerationSettings?
+  autoModSettings              AutoModSettings?
+  modDigestConfig              ModDigestConfig?
+  embedTemplates               EmbedTemplate[]
+  autoMessages                 AutoMessage[]
+  customCommands               CustomCommand[]
+  serverLogs                   ServerLog[]
+  starboardEntries             StarboardEntry[]
+  levelConfig                  LevelConfig?
+  memberXPs                    MemberXP[]
+  levelRewards                 LevelReward[]
+  autoRoles                    AutoRole[]
+  memberBirthdays              MemberBirthday[]
+  subscription                 GuildSubscription?
+  reactionRoleMessages         ReactionRoleMessage[]
+  roleGroups                   RoleGroup[]
+  forumThreads                 GuildForumThread[]
+  batchJobs                    BatchJob[]
 
   @@map("guilds")
 }
@@ -149,11 +151,41 @@ model TwitchNotification {
   twitchUserId     String
   twitchLogin      String
   discordChannelId String
+  mentionRoleId    String?
   createdAt        DateTime @default(now())
 
   @@unique([guildId, twitchUserId])
   @@index([twitchUserId])
   @@map("twitch_notifications")
+}
+
+model ScheduledEventNotification {
+  id            String   @id @default(cuid())
+  guildId       String   @unique
+  guild         Guild    @relation(fields: [guildId], references: [discordId], onDelete: Cascade)
+  channelId     String
+  mentionRoleId String?
+  enabled       Boolean  @default(true)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@map("scheduled_event_notifications")
+}
+
+model RssFeedSubscription {
+  id             String   @id @default(cuid())
+  guildId        String
+  guild          Guild    @relation(fields: [guildId], references: [discordId], onDelete: Cascade)
+  feedUrl        String
+  channelId      String
+  mentionRoleId  String?
+  lastItemGuid   String?
+  enabled        Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@unique([guildId, feedUrl])
+  @@map("rss_feed_subscriptions")
 }
 
 enum AutoplayMode {


### PR DESCRIPTION
## Summary

Implemented 3 generalized guild integration features to replace hardcoded per-guild hacks:

- **Twitch role mentions**: Optional role ID on TwitchNotification; mentions role on both eventsub and polling paths
- **Scheduled event announcements**: New listener posts guild scheduled events to configured channel with optional role mention  
- **Per-guild RSS subscriptions**: Refactored RssBridgeService from single env-configured feed to multi-subscription model with per-subscription role mentions and GUID-based dedup

## Schema Changes

Single migration `guild_integrations_pack`:
- Add `mentionRoleId String?` to `TwitchNotification`
- Create `ScheduledEventNotification` table (guildId unique, enabled by default)
- Create `RssFeedSubscription` table (guildId+feedUrl unique, lastItemGuid tracking, role mention optional)

## Backward Compatibility

RssBridgeService auto-seeds Criativaria subscription from env if not exists:
- Reads CRIATIVARIA_GUILD_ID, CRIATIVARIA_GUIDES_CHANNEL_ID, CRIATIVARIA_GUIDES_FEED_URL (optional, defaults to criativaria.com.br/rss.xml)
- Creates row only once (idempotent on startup)

## Test Coverage

Added tests for:
- Twitch eventsub role mention (with/without mentionRoleId)
- ScheduledEventNotificationService (enabled/disabled, with/without mention, missing config)
- RssBridgeService per-guild behavior (role mention, backward compat seeding)

Files: prisma/schema.prisma, migration, RssBridgeService, CriativariaLiveNotificationService, eventsubSubscriptions, ScheduledEventNotificationService + tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guild integrations pack: role-mentionable Twitch alerts, scheduled event announcements, and per-guild RSS subscriptions. Improves reliability with per-guild RSS dedup keys (legacy-safe), a correct `lastItemGuid` cursor, channel guild checks, and no interval stacking.

- **New Features**
  - Twitch alerts can mention a role via `mentionRoleId` on `TwitchNotification` (EventSub and polling; uses allowedMentions).
  - Scheduled event announcements post new guild events to a configured channel with optional role mention; listener added in `eventHandler`; rejects channels from other guilds.
  - Per-guild RSS subscriptions with per-item dedup via `RssDiscoveredGuide` scoped by `guildId:slug` (with raw-slug fallback), a `lastItemGuid` fast-path anchored to the newest item each poll, better GUID handling and link fallback; optional role mentions; replaces the single env-based feed; auto-seeds one subscription from env for backward compatibility.

- **Migration**
  - Run migration `20260702012040_guild_integrations_pack`.
  - Add a `ScheduledEventNotification` row per guild to enable event posts.
  - Add `RssFeedSubscription` rows per guild/feed to start RSS posting.
  - Optional backward-compat seeding: set `CRIATIVARIA_GUILD_ID`, `CRIATIVARIA_GUIDES_CHANNEL_ID`, `CRIATIVARIA_GUIDES_FEED_URL` to auto-create one subscription.

<sup>Written for commit d585cce65c809a4837dfd7a79e0be3d0f26bd1e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Discord scheduled event announcements with rich embeds and optional role mentions.
  * Added optional role mentions for RSS and Twitch notifications when messages are sent.
  * Upgraded RSS support to per-guild subscriptions, each with its own feed, channel, enablement, and optional mention role.
* **Bug Fixes**
  * Improved RSS deduplication and item handling to better prevent repeated or skipped posts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->