### PR TITLE
fix(sonar): clear main reliability gate - s1244 and tailwind v4 fps

### DIFF
--- a/packages/bot/src/utils/music/autoplay/candidateScorer.ts
+++ b/packages/bot/src/utils/music/autoplay/candidateScorer.ts
@@ -537,7 +537,9 @@ export function calculateRecommendationScore(ctx: ScoringContext): {
         // Linear decay: penalty = max * (1 - index/window), clamped to [0, max]
         const decayFactor = Math.max(0, 1 - recentIndex / RECENCY_WINDOW_TRACKS)
         const penalty = SCORE_RECENCY_DECAY_MAX * decayFactor
-        if (penalty !== 0) {
+        // decayFactor > 0 ⟺ penalty !== 0 (MAX is a nonzero constant) —
+        // avoids float equality (S1244) with identical branch behavior
+        if (decayFactor > 0) {
             score += penalty
             signals.push('recency decay')
         }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,6 +22,13 @@ sonar.scanner.skipJreProvisioning=true
 # reviewed-safe configuration: multer caps fileSize to 8MB + files:1 + bounded
 # fields/parts, memory storage, image-only mime filter. Suppress the "make sure"
 # flag for that one route.
-sonar.issue.ignore.multicriteria=rr1
+# css:S8776/S8767 false-positives: Sonar's CSS parser predates Tailwind v4
+# at-rules (@utility/@theme) and treats their nesting as missing scoping
+# roots / misplaced declarations. Scoped to index.css only.
+sonar.issue.ignore.multicriteria=rr1,tw1,tw2
 sonar.issue.ignore.multicriteria.rr1.ruleKey=typescript:S5693
 sonar.issue.ignore.multicriteria.rr1.resourceKey=packages/backend/src/routes/roles.ts
+sonar.issue.ignore.multicriteria.tw1.ruleKey=css:S8776
+sonar.issue.ignore.multicriteria.tw1.resourceKey=packages/frontend/src/index.css
+sonar.issue.ignore.multicriteria.tw2.ruleKey=css:S8767
+sonar.issue.ignore.multicriteria.tw2.resourceKey=packages/frontend/src/index.css


### PR DESCRIPTION
Main went red after v2.28.0: SonarCloud `new_reliability_rating = C` — 8 MAJOR bugs, all pre-existing code newly captured by the new-code period (blame: 06-13/06-23). Fixes: (1) `candidateScorer.ts:540` S1244 float equality → `decayFactor > 0` (provably identical branches, autoplay-freeze-safe — no scoring behavior change; scorer suite 50/50); (2) css:S8776 ×5 + css:S8767 ×2 in `index.css` = Sonar CSS parser vs Tailwind v4 `@utility`/`@theme` nesting → targeted `multicriteria` suppressions scoped to that file only (extends the existing rr1 pattern). Closes #1670.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Sonar’s main reliability gate by fixing S1244 in the autoplay scorer and scoping Tailwind v4 CSS false positives to `index.css`. Aligns with #1670; no runtime or scoring behavior changes.

- **Bug Fixes**
  - Autoplay scorer: replace `penalty !== 0` with `decayFactor > 0` to avoid float equality (S1244) with identical logic and freeze-safe behavior.
  - Sonar config: add targeted `multicriteria` ignores for `css:S8776`/`css:S8767` on `packages/frontend/src/index.css` only, handling Tailwind v4 `@utility`/`@theme` nesting without masking other files.

<sup>Written for commit 026eb4a04e211b8e8e5c8f225a11d0d776236f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

