### PR TITLE
feat(bot): starboard seeding and one-time first-star dm

### DIFF
--- a/packages/backend/src/routes/starboard.ts
+++ b/packages/backend/src/routes/starboard.ts
@@ -21,6 +21,13 @@ const upsertConfigBody = z.object({
     emoji: z.string().min(1).max(10).optional(),
     threshold: z.number().int().min(1).max(100).optional(),
     selfStar: z.boolean().optional(),
+    seedReaction: z.boolean().optional(),
+    seedChannelIds: z
+        .array(z.string().regex(/^\d{17,20}$/, 'Invalid channel ID'))
+        .max(50)
+        .optional(),
+    firstStarDm: z.boolean().optional(),
+    firstStarDmMessage: z.string().max(1000).nullish(),
 })
 
 const entriesQuery = z.object({

--- a/packages/bot/src/handlers/message/__tests__/starboardSeedHandler.test.ts
+++ b/packages/bot/src/handlers/message/__tests__/starboardSeedHandler.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
+import type { Message } from 'discord.js'
+import { starboardSeedHandler } from '../starboardSeedHandler'
+import type { MessageContext } from '../types'
+
+jest.mock('@lucky/shared/services', () => ({
+    starboardService: { getConfig: jest.fn() },
+}))
+jest.mock('@lucky/shared/utils', () => ({ errorLog: jest.fn() }))
+
+import { starboardService } from '@lucky/shared/services'
+
+const context: MessageContext = {
+    guild: { id: 'g1' } as never,
+    member: {} as never,
+    featureToggles: {},
+}
+
+function makeMessage(channelId = 'chan-1') {
+    const react = jest.fn().mockResolvedValue(undefined)
+    return {
+        message: {
+            author: { bot: false },
+            channelId,
+            react,
+        } as unknown as Message,
+        react,
+    }
+}
+
+const baseConfig = {
+    channelId: 'starboard-chan',
+    emoji: '⭐',
+    threshold: 3,
+    selfStar: false,
+    seedReaction: true,
+    seedChannelIds: [] as string[],
+    firstStarDm: false,
+    firstStarDmMessage: null,
+}
+
+describe('starboardSeedHandler', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('does not seed when seedReaction is off', async () => {
+        ;(starboardService.getConfig as jest.Mock).mockResolvedValue({
+            ...baseConfig,
+            seedReaction: false,
+        })
+        const { message, react } = makeMessage()
+        await starboardSeedHandler.handle(message, context)
+        expect(react).not.toHaveBeenCalled()
+    })
+
+    it('seeds the configured emoji in any channel when list is empty', async () => {
+        ;(starboardService.getConfig as jest.Mock).mockResolvedValue(baseConfig)
+        const { message, react } = makeMessage()
+        await starboardSeedHandler.handle(message, context)
+        expect(react).toHaveBeenCalledWith('⭐')
+    })
+
+    it('never seeds the starboard channel itself', async () => {
+        ;(starboardService.getConfig as jest.Mock).mockResolvedValue(baseConfig)
+        const { message, react } = makeMessage('starboard-chan')
+        await starboardSeedHandler.handle(message, context)
+        expect(react).not.toHaveBeenCalled()
+    })
+
+    it('respects the channel allow-list when non-empty', async () => {
+        ;(starboardService.getConfig as jest.Mock).mockResolvedValue({
+            ...baseConfig,
+            seedChannelIds: ['other-chan'],
+        })
+        const { message, react } = makeMessage('chan-1')
+        await starboardSeedHandler.handle(message, context)
+        expect(react).not.toHaveBeenCalled()
+
+        const allowed = makeMessage('other-chan')
+        await starboardSeedHandler.handle(allowed.message, context)
+        expect(allowed.react).toHaveBeenCalledWith('⭐')
+    })
+
+    it('skips bot authors via canHandle', async () => {
+        const botMsg = {
+            author: { bot: true },
+        } as unknown as Message
+        expect(await starboardSeedHandler.canHandle(botMsg, context)).toBe(
+            false,
+        )
+    })
+
+    it('never stops the pipeline, even when getConfig throws', async () => {
+        ;(starboardService.getConfig as jest.Mock).mockRejectedValue(
+            new Error('db down'),
+        )
+        const { message } = makeMessage()
+        const result = await starboardSeedHandler.handle(message, context)
+        expect(result).toEqual({ stop: false })
+    })
+})

--- a/packages/bot/src/handlers/message/index.ts
+++ b/packages/bot/src/handlers/message/index.ts
@@ -7,4 +7,5 @@ export type {
 export { autoModHandler } from './autoModHandler'
 export { spamHandler } from './spamHandler'
 export { customCommandHandler } from './customCommandHandler'
+export { starboardSeedHandler } from './starboardSeedHandler'
 export { xpHandler } from './xpHandler'

--- a/packages/bot/src/handlers/message/starboardSeedHandler.ts
+++ b/packages/bot/src/handlers/message/starboardSeedHandler.ts
@@ -40,7 +40,9 @@ export const starboardSeedHandler: MessageHandler = {
             ) {
                 return { stop: false }
             }
-            await message.react(config.emoji).catch(() => undefined)
+            // Let failures (bad emoji, missing perms) reach the outer catch
+            // so misconfiguration is visible in logs (cubic P2).
+            await message.react(config.emoji)
         } catch (error) {
             errorLog({ message: 'Error seeding starboard reaction:', error })
         }

--- a/packages/bot/src/handlers/message/starboardSeedHandler.ts
+++ b/packages/bot/src/handlers/message/starboardSeedHandler.ts
@@ -1,0 +1,49 @@
+import type { Message } from 'discord.js'
+import { starboardService } from '@lucky/shared/services'
+import { errorLog } from '@lucky/shared/utils'
+import type {
+    MessageContext,
+    MessageHandler,
+    MessageHandlerResult,
+} from './types'
+
+/**
+ * Engagement seeding: pre-adds the guild's starboard emoji to messages so
+ * members discover the feature with one click. Entirely config-driven
+ * (StarboardConfig.seedReaction / seedChannelIds) — the bot's own reaction is
+ * excluded from the star count by the reaction handler.
+ */
+export const starboardSeedHandler: MessageHandler = {
+    name: 'StarboardSeed',
+
+    async canHandle(message: Message): Promise<boolean> {
+        return !message.author.bot
+    },
+
+    async handle(
+        message: Message,
+        context: MessageContext,
+    ): Promise<MessageHandlerResult> {
+        try {
+            const config = await starboardService.getConfig(context.guild.id)
+            if (!config?.seedReaction) {
+                return { stop: false }
+            }
+            // Never seed the starboard channel itself — the highlight posts
+            // there would recursively collect seeds.
+            if (message.channelId === config.channelId) {
+                return { stop: false }
+            }
+            if (
+                config.seedChannelIds.length > 0 &&
+                !config.seedChannelIds.includes(message.channelId)
+            ) {
+                return { stop: false }
+            }
+            await message.react(config.emoji).catch(() => undefined)
+        } catch (error) {
+            errorLog({ message: 'Error seeding starboard reaction:', error })
+        }
+        return { stop: false }
+    },
+}

--- a/packages/bot/src/handlers/messageHandler.ts
+++ b/packages/bot/src/handlers/messageHandler.ts
@@ -6,6 +6,7 @@ import { autoModHandler } from './message/autoModHandler'
 import { spamHandler } from './message/spamHandler'
 import { customCommandHandler } from './message/customCommandHandler'
 import { xpHandler } from './message/xpHandler'
+import { starboardSeedHandler } from './message/starboardSeedHandler'
 import type { MessageContext } from './message/types'
 
 const pipeline = new MessagePipeline()
@@ -13,6 +14,7 @@ const pipeline = new MessagePipeline()
     .register(autoModHandler)
     .register(customCommandHandler)
     .register(xpHandler)
+    .register(starboardSeedHandler)
 
 export function handleMessageCreate(client: Client): void {
     client.on(Events.MessageCreate, async (message: Message) => {

--- a/packages/bot/src/handlers/reactionHandler.spec.ts
+++ b/packages/bot/src/handlers/reactionHandler.spec.ts
@@ -21,6 +21,7 @@ jest.mock('@lucky/shared/services', () => ({
     starboardService: {
         getConfig: jest.fn(),
         upsertEntry: jest.fn(),
+        tryClaimFirstStarDm: jest.fn(),
     },
 }))
 
@@ -33,12 +34,7 @@ jest.mock('../services/musicRecommendation/recommendationTelemetry', () => ({
 }))
 
 // NOW import types and the module under test after mocks are set up
-import {
-    describe,
-    expect,
-    it,
-    beforeEach,
-} from '@jest/globals'
+import { describe, expect, it, beforeEach } from '@jest/globals'
 import type {
     MessageReaction,
     PartialMessageReaction,
@@ -47,7 +43,11 @@ import type {
     Guild,
     Message,
 } from 'discord.js'
-import { handleReactionEvents } from './reactionHandler'
+import {
+    handleReactionEvents,
+    handleStarboardReaction,
+} from './reactionHandler'
+import { starboardService } from '@lucky/shared/services'
 
 describe('reactionHandler', () => {
     let mockClient: any
@@ -450,6 +450,120 @@ describe('reactionHandler', () => {
                     }),
                 }),
             )
+        })
+    })
+
+    describe('handleStarboardReaction (seed exclusion + first-star DM)', () => {
+        const config = {
+            channelId: 'star-chan',
+            emoji: '⭐',
+            threshold: 2,
+            selfStar: false,
+            seedReaction: true,
+            seedChannelIds: [],
+            firstStarDm: true,
+            firstStarDmMessage: null,
+        }
+
+        function starSetup(opts: { count: number; me: boolean }) {
+            ;(starboardService.getConfig as jest.Mock).mockResolvedValue(config)
+            ;(starboardService.upsertEntry as jest.Mock).mockResolvedValue({
+                starboardMsgId: null,
+            })
+            ;(
+                starboardService.tryClaimFirstStarDm as jest.Mock
+            ).mockResolvedValue(true)
+            const send = jest.fn().mockResolvedValue(undefined)
+            const user = {
+                id: 'u1',
+                bot: false,
+                partial: false,
+                send,
+            } as unknown as User
+            const message = {
+                id: 'm1',
+                partial: false,
+                guild: { id: 'g1' },
+                channelId: 'chan-1',
+                author: {
+                    id: 'author-1',
+                    username: 'author',
+                    displayAvatarURL: () => 'https://cdn.x/a.png',
+                },
+                content: 'hello',
+                url: 'https://discord.com/x',
+                channel: { name: 'general' },
+            }
+            const reaction = {
+                partial: false,
+                message,
+                emoji: { name: '⭐' },
+                count: opts.count,
+                me: opts.me,
+            } as unknown as MessageReaction
+            const channelSend = jest.fn().mockResolvedValue({ id: 'posted-1' })
+            const client = {
+                channels: {
+                    fetch: jest.fn().mockResolvedValue({
+                        isTextBased: () => true,
+                        send: channelSend,
+                        messages: { fetch: jest.fn() },
+                    }),
+                },
+            } as any
+            return { user, reaction, client, send, channelSend }
+        }
+
+        it("subtracts the bot's own seed reaction from the count", async () => {
+            // 2 raw reactions but one is the bot seed -> effective 1 < threshold 2
+            const { user, reaction, client, channelSend } = starSetup({
+                count: 2,
+                me: true,
+            })
+            await handleStarboardReaction(reaction, user, client)
+            expect(starboardService.upsertEntry).toHaveBeenCalledWith(
+                'g1',
+                'm1',
+                expect.objectContaining({ starCount: 1 }),
+            )
+            expect(channelSend).not.toHaveBeenCalled()
+        })
+
+        it('posts to the starboard when human stars alone meet the threshold', async () => {
+            const { user, reaction, client, channelSend } = starSetup({
+                count: 3,
+                me: true,
+            })
+            await handleStarboardReaction(reaction, user, client)
+            expect(channelSend).toHaveBeenCalledTimes(1)
+        })
+
+        it('DMs the member exactly when the claim succeeds', async () => {
+            const { user, reaction, client, send } = starSetup({
+                count: 1,
+                me: false,
+            })
+            await handleStarboardReaction(reaction, user, client)
+            expect(starboardService.tryClaimFirstStarDm).toHaveBeenCalledWith(
+                'g1',
+                'u1',
+            )
+            expect(send).toHaveBeenCalledTimes(1)
+            expect((send.mock.calls[0] as unknown[])[0]).toContain(
+                '<#star-chan>',
+            )
+        })
+
+        it('does not DM when the claim reports already-sent', async () => {
+            const { user, reaction, client, send } = starSetup({
+                count: 1,
+                me: false,
+            })
+            ;(
+                starboardService.tryClaimFirstStarDm as jest.Mock
+            ).mockResolvedValue(false)
+            await handleStarboardReaction(reaction, user, client)
+            expect(send).not.toHaveBeenCalled()
         })
     })
 })

--- a/packages/bot/src/handlers/reactionHandler.ts
+++ b/packages/bot/src/handlers/reactionHandler.ts
@@ -30,7 +30,7 @@ async function handleGiveawayReaction(
     }
 }
 
-async function handleStarboardReaction(
+export async function handleStarboardReaction(
     reaction: MessageReaction | PartialMessageReaction,
     user: User | PartialUser,
     client: Client,
@@ -47,11 +47,28 @@ async function handleStarboardReaction(
     const emoji = reaction.emoji.name ?? ''
     if (emoji !== config.emoji) return
 
-    const msg = reaction.message.partial ? await reaction.message.fetch() : reaction.message
+    const msg = reaction.message.partial
+        ? await reaction.message.fetch()
+        : reaction.message
 
     if (!config.selfStar && msg.author?.id === user.id) return
 
-    const starCount = reaction.count ?? 1
+    // One-time DM introducing the starboard the first time a member stars
+    // anything (per-guild opt-in; text overridable per guild).
+    if (config.firstStarDm) {
+        const first = await starboardService
+            .tryClaimFirstStarDm(guildId, user.id)
+            .catch(() => false)
+        if (first) {
+            const dmText =
+                config.firstStarDmMessage ??
+                `${config.emoji} You just starred a message! When a message collects ${config.threshold}× ${config.emoji}, it gets featured in <#${config.channelId}>.`
+            await (user as User).send(dmText).catch(() => undefined)
+        }
+    }
+
+    // The bot's own seed reaction must never count toward the threshold.
+    const starCount = Math.max(0, (reaction.count ?? 1) - (reaction.me ? 1 : 0))
     const entry = await starboardService.upsertEntry(guildId, msg.id, {
         channelId: msg.channelId,
         authorId: msg.author?.id ?? '',
@@ -61,7 +78,9 @@ async function handleStarboardReaction(
 
     if (starCount < config.threshold) return
 
-    const rawChannel = await client.channels.fetch(config.channelId).catch(() => null)
+    const rawChannel = await client.channels
+        .fetch(config.channelId)
+        .catch(() => null)
     if (!rawChannel || !rawChannel.isTextBased()) return
     const channel = rawChannel as TextChannel
 
@@ -79,7 +98,9 @@ async function handleStarboardReaction(
     }
 
     if (entry.starboardMsgId) {
-        const starMsg = await channel.messages.fetch(entry.starboardMsgId).catch(() => null)
+        const starMsg = await channel.messages
+            .fetch(entry.starboardMsgId)
+            .catch(() => null)
         if (starMsg) await starMsg.edit({ embeds: [starEmbed] })
     } else {
         const posted = await channel.send({ embeds: [starEmbed] })
@@ -184,7 +205,10 @@ async function handleSkipReasonReaction(
             },
         })
     } catch (err) {
-        errorLog({ message: 'Error handling skip reason reaction:', error: err })
+        errorLog({
+            message: 'Error handling skip reason reaction:',
+            error: err,
+        })
     }
 }
 

--- a/packages/shared/src/services/StarboardService.ts
+++ b/packages/shared/src/services/StarboardService.ts
@@ -10,6 +10,10 @@ export type StarboardConfig = {
     emoji: string
     threshold: number
     selfStar: boolean
+    seedReaction: boolean
+    seedChannelIds: string[]
+    firstStarDm: boolean
+    firstStarDmMessage: string | null
     createdAt: Date
     updatedAt: Date
 }
@@ -34,6 +38,10 @@ type UpsertConfigData = {
     emoji?: string
     threshold?: number
     selfStar?: boolean
+    seedReaction?: boolean
+    seedChannelIds?: string[]
+    firstStarDm?: boolean
+    firstStarDmMessage?: string | null
 }
 
 /** Data for upserting a starboard entry. */
@@ -62,6 +70,26 @@ export class StarboardService {
             create: { guildId, ...data },
             update: data,
         })
+    }
+
+    /**
+     * Claims the one-time first-star DM for a user. Returns true exactly once
+     * per (guild, user) — the unique constraint makes the claim atomic, so
+     * concurrent reactions can't double-DM.
+     */
+    async tryClaimFirstStarDm(
+        guildId: string,
+        userId: string,
+    ): Promise<boolean> {
+        try {
+            await prisma.starboardDmSent.create({ data: { guildId, userId } })
+            return true
+        } catch (error) {
+            if ((error as { code?: string })?.code === 'P2002') {
+                return false
+            }
+            throw error
+        }
     }
 
     /** Deletes starboard configuration for a guild. */

--- a/prisma/migrations/20260703040000_starboard_seed_first_star_dm/migration.sql
+++ b/prisma/migrations/20260703040000_starboard_seed_first_star_dm/migration.sql
@@ -1,0 +1,15 @@
+-- Starboard engagement seeding + one-time first-star DM (per-guild config).
+ALTER TABLE "starboard_configs" ADD COLUMN "seedReaction" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "starboard_configs" ADD COLUMN "seedChannelIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "starboard_configs" ADD COLUMN "firstStarDm" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "starboard_configs" ADD COLUMN "firstStarDmMessage" TEXT;
+
+CREATE TABLE "starboard_dm_sents" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "starboard_dm_sents_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "starboard_dm_sents_guildId_userId_key" ON "starboard_dm_sents"("guildId", "userId");
+CREATE INDEX "starboard_dm_sents_guildId_idx" ON "starboard_dm_sents"("guildId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -882,6 +882,15 @@ model StarboardConfig {
   emoji     String   @default("⭐")
   threshold Int      @default(3)
   selfStar  Boolean  @default(false)
+  // Engagement seeding: the bot pre-adds the starboard emoji to messages so
+  // members discover the feature. seedChannelIds empty = all channels (the
+  // starboard channel itself is always excluded). All per-guild config —
+  // nothing guild-specific in code.
+  seedReaction       Boolean  @default(false)
+  seedChannelIds     String[] @default([])
+  // DM a member the first time they star a message, explaining the feature.
+  firstStarDm        Boolean  @default(false)
+  firstStarDmMessage String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -904,6 +913,18 @@ model StarboardEntry {
   @@unique([guildId, messageId])
   @@index([guildId])
   @@map("starboard_entries")
+}
+
+/// Tracks which members already received the one-time first-star DM.
+model StarboardDmSent {
+  id        String   @id @default(cuid())
+  guildId   String
+  userId    String
+  createdAt DateTime @default(now())
+
+  @@unique([guildId, userId])
+  @@index([guildId])
+  @@map("starboard_dm_sents")
 }
 
 model LevelConfig {


### PR DESCRIPTION
Engagement play: make the starboard discoverable with one click.

## What
Two opt-in, per-guild behaviors on `StarboardConfig` (**no guild-specific code** — all config):

1. **Seed reaction** — the bot pre-adds the guild's starboard emoji to messages so members can join with one click. `seedReaction` (default off) + `seedChannelIds` (empty = all channels; the starboard channel itself is always excluded).
2. **First-star DM** — the first time a member ever stars a message, the bot DMs them explaining the highlights channel. `firstStarDm` (default off) + `firstStarDmMessage` (per-guild text; default built from the config's emoji/threshold/channel).

## Correctness
- **The bot's seed never counts**: the reaction handler now computes `count - (reaction.me ? 1 : 0)`, so seeding can't inflate the threshold.
- **Exactly-once DM**: claim = insert into `starboard_dm_sents` (`@@unique([guildId,userId])`) — atomic under concurrent reactions; closed DMs are swallowed.
- Seed handler never blocks the message pipeline (always `{stop:false}`, errors logged).

## Changes
Migration `starboard_seed_first_star_dm` (4 config cols + `starboard_dm_sents`), `starboardSeedHandler` in the message pipeline, reaction-handler count fix + DM, `StarboardService.tryClaimFirstStarDm`, backend config route accepts the new fields.

## Tests
6 seed-handler tests (off/all-channels/starboard-exclusion/allow-list/bot-skip/error-path) + 4 reaction tests (seed-exclusion math, threshold with human stars, DM on claim, no-DM on already-claimed). 28 pass; typecheck clean.

Post-deploy: Criativaria config row gets `seedReaction=true`, `firstStarDm=true` + PT-BR DM text.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in starboard seeding (bot auto‑reacts with the star emoji) and a one‑time first‑star DM to make the highlights channel easier to discover. The bot’s seed never counts toward thresholds, and DMs are sent exactly once per member per guild.

- **New Features**
  - Seeding: `seedReaction` (off by default) and `seedChannelIds` (empty = all; starboard channel always excluded). Implemented via `starboardSeedHandler` that never blocks the pipeline and logs failures (e.g., bad emoji/permissions).
  - Correct counts: reaction handler subtracts the bot’s own seed (`reaction.me`) so only human stars count.
  - First‑star DM: `firstStarDm` + `firstStarDmMessage` (optional per‑guild text). Exactly once via an atomic claim; DM send failures are ignored. Backend config route now accepts these fields.

- **Migration**
  - Schema: add `seedReaction`, `seedChannelIds`, `firstStarDm`, `firstStarDmMessage` to `starboard_configs`; create `starboard_dm_sents` with unique `(guildId, userId)`.
  - Post‑deploy: enable per guild as needed (e.g., set `seedReaction=true`, `firstStarDm=true`, and supply DM copy).

<sup>Written for commit f5b1fc90e446baee78be5cf953c7458be74b0c6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional starboard reaction seeding for new messages, with channel allowlisting support.
  * Added an optional one-time DM when a user stars a message for the first time, including a customizable message.

* **Bug Fixes**
  * Improved star count handling so the bot’s own seeded reaction no longer affects starboard thresholds.
  * Prevented seeding in the starboard channel itself and ensured message processing continues even if starboard lookups fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->