### PR TITLE
feat(staging): opt-in test bot for pre-merge live smoke

### DIFF
--- a/decisions/2026-07-03-staging-test-bot.md
+++ b/decisions/2026-07-03-staging-test-bot.md
@@ -1,0 +1,67 @@
+# Staging test bot for pre-merge live smoke
+
+- Status: accepted
+- Date: 2026-07-03
+
+## Context
+
+The staging stack (`docker-compose.staging.yml`) was deliberately **bot-less**:
+the dashboard reads guild data via Discord REST, so it needs no gateway bot, and
+"two bots cannot share one token."
+
+That left a gap. Lucky is mostly a **bot** — commands, message handlers,
+schedulers. None of it could be verified on a real guild before merge; only unit
+mocks. The gap bit when the destructive-interaction merge gate
+(`decisions/2026-06-21-destructive-interaction-merge-gate.md`) required a live
+on-guild smoke for a channel-cleanup PR that deletes messages, and there was no
+bot to smoke it with.
+
+## Decision
+
+Add an **opt-in, test-only** bot service to the staging stack.
+
+- It logs in with a **separate Discord app** token, `STAGING_DISCORD_TOKEN` — not
+  the production token. In `docker-compose.staging.yml` the bot's
+  `DISCORD_TOKEN` is explicitly overridden to `${STAGING_DISCORD_TOKEN:-}`,
+  which wins over the `common-app-env` production token. The empty default means
+  a missing token yields a **clean login failure, never a production login**.
+- Because it's a distinct app, it is only ever in guilds where that app was
+  invited, so it **cannot act in production guilds** (e.g. Criativaria).
+- It is **gated on the token's presence**: `scripts/deploy-staging.sh` includes
+  `bot` in the build/up set only when `STAGING_DISCORD_TOKEN` is set in
+  `.env.staging`. Merging this change with no token configured is a no-op — the
+  stack does not crash-loop.
+- It shares the isolated `lucky-staging-postgres` / `lucky-staging` network, so
+  its data never touches production.
+
+## One-time setup (operator)
+
+1. Create a **new** Discord application + bot at
+   <https://discord.com/developers/applications> (e.g. "Lucky Staging").
+2. Create or pick a **test guild** and invite the new bot to it (needs the
+   permissions the feature under test uses, e.g. Manage Messages for cleanup).
+3. On the homelab, add the token to the staging env file
+   (`/home/luk-server/lucky-staging/.env.staging`):
+   `STAGING_DISCORD_TOKEN=<the test app's token>`
+4. Re-deploy staging (label a PR `staging`, or run the deploy script). The bot
+   now comes up automatically.
+
+After that, any bot PR can be smoke-tested pre-merge: label it `staging`, wait
+for the branch bot to deploy, exercise the feature in the test guild.
+
+## Consequences
+
+- **Positive:** the destructive-interaction gate becomes a real gate for bot
+  work, not a checkbox. Every future bot feature gets pre-merge live
+  verification.
+- **Negative:** one more idle gateway connection on the shared staging stack —
+  in slight tension with the Phase-C staging auto-stop goal
+  (`adr_2026-07-02_resource_hygiene`). Mitigated: small-svc limits (128m /
+  0.25 cpu) and it only runs when a token is configured.
+
+## Revisit when
+
+- Staging moves to on-demand start/stop (Phase C) — fold the bot into the same
+  lifecycle.
+- A second test guild / multi-tenant smoke is needed — then parameterize the
+  invited guild set instead of relying on app-invite scope.

--- a/decisions/2026-07-03-staging-test-bot.md
+++ b/decisions/2026-07-03-staging-test-bot.md
@@ -56,7 +56,8 @@ for the branch bot to deploy, exercise the feature in the test guild.
   verification.
 - **Negative:** one more idle gateway connection on the shared staging stack —
   in slight tension with the Phase-C staging auto-stop goal
-  (`adr_2026-07-02_resource_hygiene`). Mitigated: small-svc limits (128m /
+  (`decisions/2026-07-02-resource-hygiene-alert-calibration-first.md`).
+  Mitigated: small-svc limits (128m /
   0.25 cpu) and it only runs when a token is configured.
 
 ## Revisit when

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -2,8 +2,11 @@
 # verifying frontend/dashboard changes on a real branch before they reach prod.
 #
 # Differences vs docker-compose.yml (production):
-#   - NO bot service (the dashboard reads guild data via Discord REST; it does
-#     not need a running gateway bot — and two bots cannot share one token).
+#   - The bot service is TEST-ONLY and OPT-IN: it uses a SEPARATE Discord app
+#     token (STAGING_DISCORD_TOKEN) and is started by scripts/deploy-staging.sh
+#     only when that token is set, so it can never share the production token or
+#     act in production guilds. Its purpose is pre-merge live smoke of bot
+#     features (e.g. the destructive-interaction gate).
 #   - NO webhook / cloudflared services (staging reuses the PRODUCTION tunnel;
 #     an ingress rule in config-lucky.yml routes lucky-staging.* → this nginx's
 #     published host port 8093).
@@ -128,6 +131,47 @@ services:
             DEVELOPER_USER_IDS: ${DEVELOPER_USER_IDS:-}
             WEBAPP_FRONTEND_URL: ${WEBAPP_FRONTEND_URL:-}
             WEBAPP_BACKEND_URL: ${WEBAPP_BACKEND_URL:-}
+        networks:
+            - lucky-staging-network
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "10m"
+                max-file: "3"
+                tag: "{{.Name}}"
+
+    # TEST-ONLY gateway bot for pre-merge live smoke of bot features. It logs in
+    # with STAGING_DISCORD_TOKEN — a SEPARATE Discord app — so it only acts in
+    # guilds where that test app is invited and can NEVER touch production
+    # guilds. DISCORD_TOKEN is overridden below (empty default) so it never
+    # falls back to the common-app-env production token: a missing
+    # STAGING_DISCORD_TOKEN yields a clean login failure, not a prod login.
+    # Started only when the token is present (see scripts/deploy-staging.sh).
+    bot:
+        <<: *small-svc
+        image: ${IMAGE_PREFIX:-ghcr.io/lucassantana-dev/lucky}-bot:${IMAGE_TAG:-staging}
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: production-bot
+            args:
+                SERVICE: bot
+                NODE_ENV: production
+        container_name: lucky-staging-bot
+        env_file:
+            - .env.staging
+        depends_on:
+            postgres:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+        environment:
+            <<: *common-app-env
+            # Override the production token from common-app-env with the
+            # test-app token; empty default = clean login failure, never prod.
+            DISCORD_TOKEN: ${STAGING_DISCORD_TOKEN:-}
+            SENTRY_SERVICE_NAME: ${SENTRY_SERVICE_NAME:-bot}
+            BOT_NAME: ${BOT_NAME:-Lucky-Staging}
         networks:
             - lucky-staging-network
         logging:

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -78,9 +78,21 @@ git checkout --quiet --force --detach "$RESOLVED_SHA"
 log "Checked out $DEPLOY_REF -> ${RESOLVED_SHA:0:7}"
 export IMAGE_TAG="staging-${RESOLVED_SHA:0:7}"
 
+# --- test bot gating -----------------------------------------------------------
+# The staging bot is opt-in: only build/run it when a dedicated test-app token
+# is configured, so this stack never crash-loops on a missing token and never
+# logs in with the production token. Grep runs on the homelab at deploy time.
+SERVICES="backend frontend nginx"
+if grep -qE '^STAGING_DISCORD_TOKEN=.+' "$STAGING_DIR/$ENV_FILE" 2>/dev/null; then
+    SERVICES="$SERVICES bot"
+    log "STAGING_DISCORD_TOKEN present — including the test bot."
+else
+    log "STAGING_DISCORD_TOKEN absent — skipping the test bot (set it in $ENV_FILE to enable)."
+fi
+
 # --- build (locally; CI only builds main images) -------------------------------
-log "Building staging images (backend, frontend, nginx)..."
-if ! dc build backend frontend nginx; then
+log "Building staging images ($SERVICES)..."
+if ! dc build $SERVICES; then
     log "ERROR: BUILD_FAILED"
     exit 1
 fi
@@ -103,8 +115,8 @@ if ! dc run --rm --no-deps backend \
 fi
 
 # --- roll out ------------------------------------------------------------------
-log "Rolling out staging services..."
-dc up -d --remove-orphans backend frontend nginx
+log "Rolling out staging services ($SERVICES)..."
+dc up -d --remove-orphans $SERVICES
 
 # Routing is via the published HOST PORT: the production cloudflared tunnel's
 # remote ingress routes lucky-staging.* -> http://100.95.204.103:8093 (this nginx's

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -88,6 +88,10 @@ if grep -qE '^STAGING_DISCORD_TOKEN=.+' "$STAGING_DIR/$ENV_FILE" 2>/dev/null; th
     log "STAGING_DISCORD_TOKEN present — including the test bot."
 else
     log "STAGING_DISCORD_TOKEN absent — skipping the test bot (set it in $ENV_FILE to enable)."
+    # Omitting `bot` from the up set does NOT stop an already-running one
+    # (--remove-orphans only removes services absent from the compose file),
+    # so explicitly tear it down when the token has been removed.
+    dc rm -sf bot 2>/dev/null || true
 fi
 
 # --- build (locally; CI only builds main images) -------------------------------


### PR DESCRIPTION
## What

Adds a **test-only, opt-in** gateway bot to the staging stack so bot features can be smoke-tested on a real guild before merge.

## Why

Staging was deliberately bot-less (dashboard reads Discord via REST). But Lucky is mostly a bot, and the destructive-interaction merge gate requires a live on-guild smoke — impossible with no bot. First case: channel-cleanup #1687 (deletes messages).

## Safety

- Uses a **separate** Discord app token `STAGING_DISCORD_TOKEN`, explicitly overriding the `common-app-env` production token; empty default ⇒ **clean login failure, never a prod login**.
- Distinct app ⇒ only in invited (test) guilds ⇒ **cannot touch production guilds**.
- **Gated on token presence**: `scripts/deploy-staging.sh` includes `bot` only when `STAGING_DISCORD_TOKEN` is set. Merging with no token = no-op, no crash-loop.
- Shares isolated `lucky-staging-postgres` — no prod data.

## Operator setup (one-time)

See `decisions/2026-07-03-staging-test-bot.md`: create a new Discord app, invite to a test guild, add `STAGING_DISCORD_TOKEN` to `/home/luk-server/lucky-staging/.env.staging`, redeploy.

## Test

- `docker compose config` structural validation: bot service present, `DISCORD_TOKEN` resolves to `${STAGING_DISCORD_TOKEN:-}` (override wins the anchor merge).
- `bash -n scripts/deploy-staging.sh` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in, test-only gateway bot to the staging stack to live smoke-test bot features before merge without touching production. It runs only when `STAGING_DISCORD_TOKEN` is set and is auto-removed if the token is later removed.

- **New Features**
  - Added `bot` service in `docker-compose.staging.yml` with `DISCORD_TOKEN=${STAGING_DISCORD_TOKEN:-}`; isolated to staging DB/network.
  - Gated `scripts/deploy-staging.sh` so `bot` builds/rolls out only when `STAGING_DISCORD_TOKEN` exists; tears down `bot` when the token is absent.
  - Added operator notes in `decisions/2026-07-03-staging-test-bot.md` and fixed an ADR link reference.

- **Migration**
  - Create a new Discord app/bot and invite it to a test guild.
  - Set `STAGING_DISCORD_TOKEN` in `/home/luk-server/lucky-staging/.env.staging`.
  - Redeploy staging.

<sup>Written for commit 7e0e707d56f27fee045d12304f5cc82f6b3386fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

