### PR TITLE
feat(bot): extend mod-log posting, fix twitch startup silence

### DIFF
--- a/packages/bot/src/handlers/auditHandler.ts
+++ b/packages/bot/src/handlers/auditHandler.ts
@@ -10,6 +10,8 @@ import {
     type PartialGuildMember,
     type Role,
     type GuildBan,
+    type User,
+    type PartialUser,
     type DMChannel,
     type NonThreadGuildBasedChannel,
     AuditLogEvent,
@@ -20,6 +22,14 @@ import { postToModLog } from '../functions/moderation/helpers/modLogPoster.js'
 
 async function isServerLogsEnabled(guildId: string): Promise<boolean> {
     return featureToggleService.isEnabled('SERVER_LOGS', { guildId })
+}
+
+function moderatorField(executor: User | PartialUser | null | undefined) {
+    return {
+        name: 'Moderator',
+        value: executor ? `${executor.tag} (${executor.id})` : 'Unknown',
+        inline: true as const,
+    }
 }
 
 async function handleMessageDelete(
@@ -186,13 +196,7 @@ async function handleGuildBanAdd(ban: {
                         value: `${ban.user.tag} (${ban.user.id})`,
                         inline: true,
                     },
-                    {
-                        name: 'Moderator',
-                        value: banEntry?.executor
-                            ? `${banEntry.executor.tag} (${banEntry.executor.id})`
-                            : 'Unknown',
-                        inline: true,
-                    },
+                    moderatorField(banEntry?.executor),
                     {
                         name: 'Reason',
                         value: banEntry?.reason || 'No reason provided',
@@ -253,13 +257,7 @@ async function handleGuildBanRemove(ban: {
                         value: `${ban.user.tag} (${ban.user.id})`,
                         inline: true,
                     },
-                    {
-                        name: 'Moderator',
-                        value: unbanEntry?.executor
-                            ? `${unbanEntry.executor.tag} (${unbanEntry.executor.id})`
-                            : 'Unknown',
-                        inline: true,
-                    },
+                    moderatorField(unbanEntry?.executor),
                     {
                         name: 'Reason',
                         value: unbanEntry?.reason || 'No reason provided',
@@ -280,18 +278,22 @@ async function handleGuildBanRemove(ban: {
     }
 }
 
-async function handleChannelCreate(channel: GuildChannel): Promise<void> {
+async function handleChannelEvent(
+    channel: GuildChannel,
+    action: 'created' | 'deleted',
+    auditLogAction: AuditLogEvent,
+): Promise<void> {
     if (!(await isServerLogsEnabled(channel.guild.id))) return
     try {
         const auditLogs = await channel.guild
-            .fetchAuditLogs({ type: AuditLogEvent.ChannelCreate, limit: 1 })
+            .fetchAuditLogs({ type: auditLogAction, limit: 1 })
             .catch(() => null)
         const channelEntry = auditLogs?.entries.first()
 
         await serverLogService.createLog(
             channel.guild.id,
             'channel_update',
-            'Channel created',
+            `Channel ${action}`,
             {
                 channelId: channel.id,
                 channelName: channel.name,
@@ -304,80 +306,36 @@ async function handleChannelCreate(channel: GuildChannel): Promise<void> {
         )
 
         const embed = new EmbedBuilder()
-            .setColor(0x57f287)
-            .setTitle('➕ Channel Created')
+            .setColor(action === 'created' ? 0x57f287 : 0xed4245)
+            .setTitle(
+                action === 'created'
+                    ? '➕ Channel Created'
+                    : '➖ Channel Deleted',
+            )
             .addFields(
                 { name: 'Channel', value: `#${channel.name}`, inline: true },
-                {
-                    name: 'Moderator',
-                    value: channelEntry?.executor
-                        ? `${channelEntry.executor.tag} (${channelEntry.executor.id})`
-                        : 'Unknown',
-                    inline: true,
-                },
+                moderatorField(channelEntry?.executor),
             )
             .setTimestamp()
         await postToModLog(channel.guild, embed)
 
         debugLog({
-            message: `Logged channel create in ${channel.guild.name}`,
+            message: `Logged channel ${action} in ${channel.guild.name}`,
         })
     } catch (error) {
         errorLog({
-            message: 'Error logging channel create:',
+            message: `Error logging channel ${action}:`,
             error,
         })
     }
 }
 
+async function handleChannelCreate(channel: GuildChannel): Promise<void> {
+    await handleChannelEvent(channel, 'created', AuditLogEvent.ChannelCreate)
+}
+
 async function handleChannelDelete(channel: GuildChannel): Promise<void> {
-    if (!(await isServerLogsEnabled(channel.guild.id))) return
-    try {
-        const auditLogs = await channel.guild
-            .fetchAuditLogs({ type: AuditLogEvent.ChannelDelete, limit: 1 })
-            .catch(() => null)
-        const channelEntry = auditLogs?.entries.first()
-
-        await serverLogService.createLog(
-            channel.guild.id,
-            'channel_update',
-            'Channel deleted',
-            {
-                channelId: channel.id,
-                channelName: channel.name,
-                channelType: channel.type,
-            },
-            {
-                channelId: channel.id,
-                moderatorId: channelEntry?.executor?.id,
-            },
-        )
-
-        const embed = new EmbedBuilder()
-            .setColor(0xed4245)
-            .setTitle('➖ Channel Deleted')
-            .addFields(
-                { name: 'Channel', value: `#${channel.name}`, inline: true },
-                {
-                    name: 'Moderator',
-                    value: channelEntry?.executor
-                        ? `${channelEntry.executor.tag} (${channelEntry.executor.id})`
-                        : 'Unknown',
-                    inline: true,
-                },
-            )
-            .setTimestamp()
-        await postToModLog(channel.guild, embed)
-
-        debugLog({
-            message: `Logged channel delete in ${channel.guild.name}`,
-        })
-    } catch (error) {
-        errorLog({
-            message: 'Error logging channel delete:',
-            error,
-        })
-    }
+    await handleChannelEvent(channel, 'deleted', AuditLogEvent.ChannelDelete)
 }
 
 async function handleRoleEvent(
@@ -414,13 +372,7 @@ async function handleRoleEvent(
             )
             .addFields(
                 { name: 'Role', value: role.name, inline: true },
-                {
-                    name: 'Moderator',
-                    value: roleEntry?.executor
-                        ? `${roleEntry.executor.tag} (${roleEntry.executor.id})`
-                        : 'Unknown',
-                    inline: true,
-                },
+                moderatorField(roleEntry?.executor),
             )
             .setTimestamp()
         await postToModLog(role.guild, embed)

--- a/packages/bot/src/handlers/auditHandler.ts
+++ b/packages/bot/src/handlers/auditHandler.ts
@@ -1,10 +1,13 @@
 import {
     Events,
+    EmbedBuilder,
     type Client,
     type Message,
     type PartialMessage,
     type Guild,
     type GuildChannel,
+    type GuildMember,
+    type PartialGuildMember,
     type Role,
     type GuildBan,
     type DMChannel,
@@ -13,6 +16,7 @@ import {
 } from 'discord.js'
 import { serverLogService, featureToggleService } from '@lucky/shared/services'
 import { errorLog, debugLog } from '@lucky/shared/utils'
+import { postToModLog } from '../functions/moderation/helpers/modLogPoster.js'
 
 async function isServerLogsEnabled(guildId: string): Promise<boolean> {
     return featureToggleService.isEnabled('SERVER_LOGS', { guildId })
@@ -39,6 +43,29 @@ async function handleMessageDelete(
                 channelId: message.channelId,
             },
         )
+
+        const embed = new EmbedBuilder()
+            .setColor(0xed4245)
+            .setTitle('🗑️ Message Deleted')
+            .addFields(
+                {
+                    name: 'Author',
+                    value: `${message.author?.tag ?? 'Unknown'} (${message.author?.id ?? '?'})`,
+                    inline: true,
+                },
+                {
+                    name: 'Channel',
+                    value: `<#${message.channelId}>`,
+                    inline: true,
+                },
+                {
+                    name: 'Content',
+                    value:
+                        message.content?.substring(0, 1000) || '[No content]',
+                },
+            )
+            .setTimestamp()
+        await postToModLog(message.guild, embed)
 
         debugLog({
             message: `Logged message delete in ${message.guild.name}`,
@@ -77,6 +104,34 @@ async function handleMessageUpdate(
                 channelId: newMessage.channelId,
             },
         )
+
+        const embed = new EmbedBuilder()
+            .setColor(0xfee75c)
+            .setTitle('✏️ Message Edited')
+            .addFields(
+                {
+                    name: 'Author',
+                    value: `${newMessage.author?.tag ?? 'Unknown'} (${newMessage.author?.id ?? '?'})`,
+                    inline: true,
+                },
+                {
+                    name: 'Channel',
+                    value: `<#${newMessage.channelId}>`,
+                    inline: true,
+                },
+                {
+                    name: 'Before',
+                    value:
+                        oldMessage.content?.substring(0, 500) || '[No content]',
+                },
+                {
+                    name: 'After',
+                    value:
+                        newMessage.content?.substring(0, 500) || '[No content]',
+                },
+            )
+            .setTimestamp()
+        await postToModLog(newMessage.guild, embed)
 
         debugLog({
             message: `Logged message edit in ${newMessage.guild.name}`,
@@ -117,6 +172,36 @@ async function handleGuildBanAdd(ban: {
             },
         )
 
+        // Bot-issued bans (via /ban) already post to the mod-log channel with
+        // the command's reason at creation time — posting again here would
+        // duplicate it. Only post for bans made outside the bot (native
+        // Discord UI, other bots).
+        if (banEntry?.executor?.id !== guild.client.user?.id) {
+            const embed = new EmbedBuilder()
+                .setColor(0xc92a2a)
+                .setTitle('🔨 Member Banned')
+                .addFields(
+                    {
+                        name: 'User',
+                        value: `${ban.user.tag} (${ban.user.id})`,
+                        inline: true,
+                    },
+                    {
+                        name: 'Moderator',
+                        value: banEntry?.executor
+                            ? `${banEntry.executor.tag} (${banEntry.executor.id})`
+                            : 'Unknown',
+                        inline: true,
+                    },
+                    {
+                        name: 'Reason',
+                        value: banEntry?.reason || 'No reason provided',
+                    },
+                )
+                .setTimestamp()
+            await postToModLog(guild, embed)
+        }
+
         debugLog({
             message: `Logged ban in ${guild.name}`,
         })
@@ -156,6 +241,34 @@ async function handleGuildBanRemove(ban: {
             },
         )
 
+        // Bot-issued unbans (via /unban) already post to the mod-log channel
+        // at creation time — see handleGuildBanAdd for the same guard.
+        if (unbanEntry?.executor?.id !== guild.client.user?.id) {
+            const embed = new EmbedBuilder()
+                .setColor(0x51cf66)
+                .setTitle('✅ Member Unbanned')
+                .addFields(
+                    {
+                        name: 'User',
+                        value: `${ban.user.tag} (${ban.user.id})`,
+                        inline: true,
+                    },
+                    {
+                        name: 'Moderator',
+                        value: unbanEntry?.executor
+                            ? `${unbanEntry.executor.tag} (${unbanEntry.executor.id})`
+                            : 'Unknown',
+                        inline: true,
+                    },
+                    {
+                        name: 'Reason',
+                        value: unbanEntry?.reason || 'No reason provided',
+                    },
+                )
+                .setTimestamp()
+            await postToModLog(guild, embed)
+        }
+
         debugLog({
             message: `Logged unban in ${guild.name}`,
         })
@@ -190,6 +303,22 @@ async function handleChannelCreate(channel: GuildChannel): Promise<void> {
             },
         )
 
+        const embed = new EmbedBuilder()
+            .setColor(0x57f287)
+            .setTitle('➕ Channel Created')
+            .addFields(
+                { name: 'Channel', value: `#${channel.name}`, inline: true },
+                {
+                    name: 'Moderator',
+                    value: channelEntry?.executor
+                        ? `${channelEntry.executor.tag} (${channelEntry.executor.id})`
+                        : 'Unknown',
+                    inline: true,
+                },
+            )
+            .setTimestamp()
+        await postToModLog(channel.guild, embed)
+
         debugLog({
             message: `Logged channel create in ${channel.guild.name}`,
         })
@@ -223,6 +352,22 @@ async function handleChannelDelete(channel: GuildChannel): Promise<void> {
                 moderatorId: channelEntry?.executor?.id,
             },
         )
+
+        const embed = new EmbedBuilder()
+            .setColor(0xed4245)
+            .setTitle('➖ Channel Deleted')
+            .addFields(
+                { name: 'Channel', value: `#${channel.name}`, inline: true },
+                {
+                    name: 'Moderator',
+                    value: channelEntry?.executor
+                        ? `${channelEntry.executor.tag} (${channelEntry.executor.id})`
+                        : 'Unknown',
+                    inline: true,
+                },
+            )
+            .setTimestamp()
+        await postToModLog(channel.guild, embed)
 
         debugLog({
             message: `Logged channel delete in ${channel.guild.name}`,
@@ -262,6 +407,24 @@ async function handleRoleEvent(
             },
         )
 
+        const embed = new EmbedBuilder()
+            .setColor(action === 'created' ? 0x57f287 : 0xed4245)
+            .setTitle(
+                action === 'created' ? '➕ Role Created' : '➖ Role Deleted',
+            )
+            .addFields(
+                { name: 'Role', value: role.name, inline: true },
+                {
+                    name: 'Moderator',
+                    value: roleEntry?.executor
+                        ? `${roleEntry.executor.tag} (${roleEntry.executor.id})`
+                        : 'Unknown',
+                    inline: true,
+                },
+            )
+            .setTimestamp()
+        await postToModLog(role.guild, embed)
+
         debugLog({
             message: `Logged role ${action} in ${role.guild.name}`,
         })
@@ -279,6 +442,97 @@ async function handleRoleCreate(role: Role): Promise<void> {
 
 async function handleRoleDelete(role: Role): Promise<void> {
     await handleRoleEvent(role, 'deleted', AuditLogEvent.RoleDelete)
+}
+
+async function handleGuildMemberAdd(member: GuildMember): Promise<void> {
+    if (!(await isServerLogsEnabled(member.guild.id))) return
+    try {
+        await serverLogService.createLog(
+            member.guild.id,
+            'member_join',
+            'Member joined',
+            {
+                username: member.user.tag,
+                accountCreated: member.user.createdAt.toISOString(),
+            },
+            { userId: member.user.id },
+        )
+
+        const embed = new EmbedBuilder()
+            .setColor(0x57f287)
+            .setTitle('📥 Member Joined')
+            .addFields(
+                {
+                    name: 'User',
+                    value: `${member.user.tag} (${member.user.id})`,
+                    inline: true,
+                },
+                {
+                    name: 'Account Created',
+                    value: `<t:${Math.floor(member.user.createdAt.getTime() / 1000)}:R>`,
+                    inline: true,
+                },
+            )
+            .setTimestamp()
+        await postToModLog(member.guild, embed)
+
+        debugLog({
+            message: `Logged member join in ${member.guild.name}`,
+        })
+    } catch (error) {
+        errorLog({
+            message: 'Error logging member join:',
+            error,
+        })
+    }
+}
+
+async function handleGuildMemberRemove(
+    member: GuildMember | PartialGuildMember,
+): Promise<void> {
+    if (!(await isServerLogsEnabled(member.guild.id))) return
+    try {
+        const roleNames = member.roles.cache
+            .filter((role) => role.name !== '@everyone')
+            .map((role) => role.name)
+
+        await serverLogService.createLog(
+            member.guild.id,
+            'member_leave',
+            'Member left',
+            {
+                username: member.user.tag,
+                roles: roleNames,
+            },
+            { userId: member.user.id },
+        )
+
+        const embed = new EmbedBuilder()
+            .setColor(0xed4245)
+            .setTitle('📤 Member Left')
+            .addFields(
+                {
+                    name: 'User',
+                    value: `${member.user.tag} (${member.user.id})`,
+                    inline: true,
+                },
+                {
+                    name: 'Roles',
+                    value: roleNames.length > 0 ? roleNames.join(', ') : 'None',
+                },
+            )
+            .setTimestamp()
+        await postToModLog(member.guild, embed)
+
+        debugLog({
+            message: `Logged member leave in ${member.guild.name}`,
+        })
+    } catch (error) {
+        errorLog({
+            message: 'Error logging member leave:',
+            error,
+        })
+    }
 }
 
 export function handleAuditEvents(client: Client): void {
@@ -388,4 +642,29 @@ export function handleAuditEvents(client: Client): void {
             })
         }
     })
+
+    client.on(Events.GuildMemberAdd, async (member: GuildMember) => {
+        try {
+            await handleGuildMemberAdd(member)
+        } catch (error) {
+            errorLog({
+                message: 'Error in member add handler:',
+                error,
+            })
+        }
+    })
+
+    client.on(
+        Events.GuildMemberRemove,
+        async (member: GuildMember | PartialGuildMember) => {
+            try {
+                await handleGuildMemberRemove(member)
+            } catch (error) {
+                errorLog({
+                    message: 'Error in member remove handler:',
+                    error,
+                })
+            }
+        },
+    )
 }

--- a/packages/bot/src/handlers/auditHandler.ts
+++ b/packages/bot/src/handlers/auditHandler.ts
@@ -186,7 +186,10 @@ async function handleGuildBanAdd(ban: {
         // the command's reason at creation time — posting again here would
         // duplicate it. Only post for bans made outside the bot (native
         // Discord UI, other bots).
-        if (banEntry?.executor?.id !== guild.client.user?.id) {
+        if (
+            banEntry?.executor &&
+            banEntry.executor.id !== guild.client.user?.id
+        ) {
             const embed = new EmbedBuilder()
                 .setColor(0xc92a2a)
                 .setTitle('🔨 Member Banned')
@@ -247,7 +250,10 @@ async function handleGuildBanRemove(ban: {
 
         // Bot-issued unbans (via /unban) already post to the mod-log channel
         // at creation time — see handleGuildBanAdd for the same guard.
-        if (unbanEntry?.executor?.id !== guild.client.user?.id) {
+        if (
+            unbanEntry?.executor &&
+            unbanEntry.executor.id !== guild.client.user?.id
+        ) {
             const embed = new EmbedBuilder()
                 .setColor(0x51cf66)
                 .setTitle('✅ Member Unbanned')
@@ -470,7 +476,10 @@ async function handleGuildMemberRemove(
                 },
                 {
                     name: 'Roles',
-                    value: roleNames.length > 0 ? roleNames.join(', ') : 'None',
+                    value:
+                        roleNames.length > 0
+                            ? roleNames.join(', ').slice(0, 1024)
+                            : 'None',
                 },
             )
             .setTimestamp()

--- a/packages/bot/src/twitch/index.spec.ts
+++ b/packages/bot/src/twitch/index.spec.ts
@@ -3,6 +3,14 @@ import type { Client } from 'discord.js'
 
 const mockIsEnabled = jest.fn<() => Promise<boolean>>()
 const mockIsConfigured = jest.fn<() => boolean>()
+const mockGetTwitchEnv = jest.fn<
+    () => {
+        clientId: string
+        clientSecret: string
+        accessToken: string | undefined
+        refreshToken: string | undefined
+    }
+>()
 const mockStart = jest.fn<(c: Client) => Promise<void>>()
 const mockStop = jest.fn<() => void>()
 const mockRefresh = jest.fn<() => Promise<void>>()
@@ -10,9 +18,11 @@ const mockConnect = jest.fn<() => Promise<void>>()
 const mockDisconnect = jest.fn<() => Promise<void>>()
 const mockSubscribe = jest.fn<(h: () => Promise<void>) => Promise<void>>()
 const mockIsHealthy = jest.fn<() => boolean>()
+const mockWarnLog = jest.fn()
 
 jest.mock('@lucky/shared/utils', () => ({
     infoLog: jest.fn(),
+    warnLog: (...args: unknown[]) => mockWarnLog(...args),
 }))
 
 jest.mock('@lucky/shared/services', () => ({
@@ -27,6 +37,7 @@ jest.mock('@lucky/shared/services', () => ({
 
 jest.mock('./token', () => ({
     isTwitchConfigured: () => mockIsConfigured(),
+    getTwitchEnv: () => mockGetTwitchEnv(),
 }))
 
 jest.mock('./eventsubClient', () => ({
@@ -50,6 +61,12 @@ describe('twitch/index', () => {
         jest.clearAllMocks()
         mockIsEnabled.mockResolvedValue(true)
         mockIsConfigured.mockReturnValue(true)
+        mockGetTwitchEnv.mockReturnValue({
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            accessToken: 'access-token',
+            refreshToken: undefined,
+        })
         mockStart.mockResolvedValue(undefined)
         mockConnect.mockResolvedValue(undefined)
         mockSubscribe.mockResolvedValue(undefined)
@@ -74,6 +91,26 @@ describe('twitch/index', () => {
 
             expect(mockStart).not.toHaveBeenCalled()
             expect(mockConnect).not.toHaveBeenCalled()
+        })
+
+        it('warns which env var(s) are missing when misconfigured', async () => {
+            mockIsConfigured.mockReturnValue(false)
+            mockGetTwitchEnv.mockReturnValue({
+                clientId: 'client-id',
+                clientSecret: '',
+                accessToken: undefined,
+                refreshToken: undefined,
+            })
+
+            await startTwitchService(client)
+
+            expect(mockWarnLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'TWITCH_CLIENT_SECRET, TWITCH_ACCESS_TOKEN',
+                    ),
+                }),
+            )
         })
 
         it('starts EventSub and subscribes to refresh when healthy', async () => {

--- a/packages/bot/src/twitch/index.ts
+++ b/packages/bot/src/twitch/index.ts
@@ -1,15 +1,27 @@
 import type { Client } from 'discord.js'
-import { infoLog } from '@lucky/shared/utils'
+import { infoLog, warnLog } from '@lucky/shared/utils'
 import {
     featureToggleService,
     twitchControlService,
 } from '@lucky/shared/services'
-import { isTwitchConfigured } from './token'
+import { isTwitchConfigured, getTwitchEnv } from './token'
 import { twitchEventSubClient } from './eventsubClient'
 
 export async function startTwitchService(client: Client): Promise<void> {
     const enabled = await featureToggleService.isEnabled('TWITCH_NOTIFICATIONS')
-    if (!enabled || !isTwitchConfigured()) {
+    if (!enabled) {
+        return
+    }
+    if (!isTwitchConfigured()) {
+        const { clientId, clientSecret, accessToken } = getTwitchEnv()
+        const missing = [
+            !clientId && 'TWITCH_CLIENT_ID',
+            !clientSecret && 'TWITCH_CLIENT_SECRET',
+            !accessToken && 'TWITCH_ACCESS_TOKEN',
+        ].filter((name): name is string => Boolean(name))
+        warnLog({
+            message: `Twitch EventSub: not starting, missing env var(s): ${missing.join(', ')}`,
+        })
         return
     }
     try {


### PR DESCRIPTION
## Summary
- Fixes #1695: `startTwitchService()` no longer returns silently when Twitch is enabled-but-misconfigured — logs which env var(s) (`TWITCH_CLIENT_ID`/`TWITCH_CLIENT_SECRET`/`TWITCH_ACCESS_TOKEN`) are missing via `warnLog`. This was the root cause of a ~24h undetected Twitch notification outage (2026-07-02).
- Fixes #1697: extends the mod-log channel posting from #1696 to the rest of `auditHandler.ts`'s events — message delete/edit, channel create/delete, role create/delete, and external (non-bot) bans/unbans — gated on the `SERVER_LOGS` toggle. Also adds `GuildMemberAdd`/`GuildMemberRemove` handlers, since `ServerLogService.logMemberJoin`/`logMemberLeave` were exported but never called anywhere.
- Bot-issued bans/unbans (via `/ban`, `/unban`) are explicitly skipped in the audit-log-driven ban listener to avoid double-posting, since those commands already post their case embed at creation time (see code comment for the guard).

## Test plan
- [x] `tsc --noEmit` clean (bot + shared)
- [x] `eslint` clean on touched files
- [ ] Manual: delete/edit a message, create/delete a channel or role, and have someone join/leave Criativaria — confirm each lands in `#logs`
- [ ] Manual: ban via `/ban` (should post once) vs. ban via Discord's native UI (should also post, attributed to the actual moderator)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend mod-log coverage to messages, channels, roles, external bans/unbans, and member join/leave (behind `SERVER_LOGS`), and add Twitch startup warnings for missing env vars. Dedup embeds and tighten ban/unban guard; fixes #1695 and #1697.

- **New Features**
  - Post to the mod-log for message delete/edit, channel/role create/delete, and external (non-bot) bans/unbans.
  - Add join/leave handlers; post to mod-log and server logs.

- **Bug Fixes**
  - `startTwitchService()` now `warnLog`s missing `TWITCH_CLIENT_ID`/`TWITCH_CLIENT_SECRET`/`TWITCH_ACCESS_TOKEN` when enabled but misconfigured, with unit tests.
  - Require a known audit executor before posting ban/unban to avoid duplicates; cap the member-leave Roles field to Discord’s 1024-char limit.

<sup>Written for commit 3c436252d37472ac9f32d1d25affd9ff9c5a5c1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

