### PR TITLE
fix(bot): collect /vaga descricao via modal, not a single-line option

### DIFF
--- a/packages/bot/src/functions/general/commands/vaga.spec.ts
+++ b/packages/bot/src/functions/general/commands/vaga.spec.ts
@@ -91,6 +91,7 @@ function makeInteraction(
         editReply: jest.fn(),
     }
     const interaction = {
+        id: 'interaction-1',
         user: { id: 'u1', tag: 'mod#1' },
         guild: {
             id: 'g1',
@@ -246,5 +247,41 @@ describe('/vaga command', () => {
             client: {} as never,
         })
         expect(send).not.toHaveBeenCalled()
+    })
+
+    it('scopes the modal filter to this invocation, rejecting a stale/concurrent submission (regression for cross-invocation mixing)', async () => {
+        const { interaction } = makeInteraction(base, {
+            customId: 'vaga_cancel',
+        })
+        await vaga.execute({
+            interaction: interaction as never,
+            client: {} as never,
+        })
+        const [{ filter }] = interaction.awaitModalSubmit.mock.calls[0] as [
+            {
+                filter: (i: {
+                    user: { id: string }
+                    customId: string
+                }) => boolean
+            },
+        ]
+        const thisCustomId = `vaga_descricao_${interaction.id}`
+
+        // Same user, this invocation's modal — accepted.
+        expect(filter({ user: { id: 'u1' }, customId: thisCustomId })).toBe(
+            true,
+        )
+        // Same user, a DIFFERENT (e.g. earlier, still-open) /vaga
+        // invocation's modal — must be rejected, not mixed in.
+        expect(
+            filter({
+                user: { id: 'u1' },
+                customId: 'vaga_descricao_some-other-interaction',
+            }),
+        ).toBe(false)
+        // Different user entirely — rejected.
+        expect(filter({ user: { id: 'u2' }, customId: thisCustomId })).toBe(
+            false,
+        )
     })
 })

--- a/packages/bot/src/functions/general/commands/vaga.spec.ts
+++ b/packages/bot/src/functions/general/commands/vaga.spec.ts
@@ -78,7 +78,18 @@ function makeInteraction(
                 : Promise.reject(new Error('timeout')),
         ),
     }
-    const reply = jest.fn(() => Promise.resolve(message))
+    // descricao is now collected via a modal (paragraph text input), not a
+    // plain string option — the modal submission is its own interaction
+    // that owns the reply/editReply for the preview + button flow.
+    const modalReply = jest.fn(() => Promise.resolve(message))
+    const modalSubmit = {
+        user: { id: 'u1' },
+        fields: {
+            getTextInputValue: (name: string) => opts[name] ?? '',
+        },
+        reply: modalReply,
+        editReply: jest.fn(),
+    }
     const interaction = {
         user: { id: 'u1', tag: 'mod#1' },
         guild: {
@@ -98,10 +109,19 @@ function makeInteraction(
         options: {
             getString: (name: string) => opts[name] ?? null,
         },
-        reply,
+        showModal: jest.fn(),
+        awaitModalSubmit: jest.fn(() => Promise.resolve(modalSubmit)),
+        reply: jest.fn(),
         editReply: jest.fn(),
     }
-    return { interaction, reply, send, update, message }
+    return {
+        interaction,
+        reply: modalReply,
+        send,
+        update,
+        message,
+        modalSubmit,
+    }
 }
 
 describe('/vaga command', () => {
@@ -179,6 +199,48 @@ describe('/vaga command', () => {
         const { interaction, send } = makeInteraction(base, {
             customId: 'vaga_cancel',
         })
+        await vaga.execute({
+            interaction: interaction as never,
+            client: {} as never,
+        })
+        expect(send).not.toHaveBeenCalled()
+    })
+
+    it('shows a modal for descricao before doing any lookups', async () => {
+        const { interaction } = makeInteraction(base, {
+            customId: 'vaga_cancel',
+        })
+        await vaga.execute({
+            interaction: interaction as never,
+            client: {} as never,
+        })
+        expect(interaction.showModal).toHaveBeenCalledTimes(1)
+        expect(interaction.awaitModalSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    it('preserves real line breaks from the modal in the published message', async () => {
+        const multiline = {
+            ...base,
+            descricao: '- Requisito um\n- Requisito dois\n- Requisito três',
+        }
+        const { interaction, send } = makeInteraction(multiline, {
+            customId: 'vaga_publish',
+        })
+        await vaga.execute({
+            interaction: interaction as never,
+            client: {} as never,
+        })
+        const sent = send.mock.calls[0][0] as { content: string }
+        expect(sent.content).toContain(
+            '- Requisito um\n- Requisito dois\n- Requisito três',
+        )
+    })
+
+    it('does nothing further when the modal submission times out', async () => {
+        const { interaction, send } = makeInteraction(base)
+        interaction.awaitModalSubmit = jest.fn(() =>
+            Promise.reject(new Error('time')),
+        )
         await vaga.execute({
             interaction: interaction as never,
             client: {} as never,

--- a/packages/bot/src/functions/general/commands/vaga.ts
+++ b/packages/bot/src/functions/general/commands/vaga.ts
@@ -53,9 +53,9 @@ function buildVagaMessage(
 // requirements list into one collapses it onto one line (browsers flatten
 // <li> newlines into spaces on copy). A modal's paragraph text input is the
 // only way to actually accept real line breaks here.
-function buildDescricaoModal(): ModalBuilder {
+function buildDescricaoModal(customId: string): ModalBuilder {
     return new ModalBuilder()
-        .setCustomId('vaga_descricao')
+        .setCustomId(customId)
         .setTitle('Descrição da vaga')
         .addComponents(
             new ActionRowBuilder<TextInputBuilder>().addComponents(
@@ -70,10 +70,16 @@ function buildDescricaoModal(): ModalBuilder {
 }
 
 async function collectDescricao(chat: ChatInputCommandInteraction) {
-    await chat.showModal(buildDescricaoModal())
+    // Scoped to this invocation's own interaction id — without it, a second
+    // /vaga run by the same user before the first one's modal is submitted
+    // could resolve THIS awaitModalSubmit with the OTHER invocation's
+    // descrição, mixing it with this call's título/url/modalidade.
+    const customId = `vaga_descricao_${chat.id}`
+    await chat.showModal(buildDescricaoModal(customId))
     try {
         return await chat.awaitModalSubmit({
-            filter: (i) => i.user.id === chat.user.id,
+            filter: (i) =>
+                i.user.id === chat.user.id && i.customId === customId,
             time: 5 * 60 * 1000,
         })
     } catch {

--- a/packages/bot/src/functions/general/commands/vaga.ts
+++ b/packages/bot/src/functions/general/commands/vaga.ts
@@ -6,6 +6,9 @@ import {
     ButtonStyle,
     ComponentType,
     ChannelType,
+    ModalBuilder,
+    TextInputBuilder,
+    TextInputStyle,
     type ChatInputCommandInteraction,
     type GuildBasedChannel,
 } from 'discord.js'
@@ -46,6 +49,40 @@ function buildVagaMessage(
     return parts.join('\n\n')
 }
 
+// Discord's plain string options are single-line inputs — pasting a bulleted
+// requirements list into one collapses it onto one line (browsers flatten
+// <li> newlines into spaces on copy). A modal's paragraph text input is the
+// only way to actually accept real line breaks here.
+function buildDescricaoModal(): ModalBuilder {
+    return new ModalBuilder()
+        .setCustomId('vaga_descricao')
+        .setTitle('Descrição da vaga')
+        .addComponents(
+            new ActionRowBuilder<TextInputBuilder>().addComponents(
+                new TextInputBuilder()
+                    .setCustomId('descricao')
+                    .setLabel('Descrição / requisitos')
+                    .setStyle(TextInputStyle.Paragraph)
+                    .setRequired(true)
+                    .setMaxLength(1800),
+            ),
+        )
+}
+
+async function collectDescricao(chat: ChatInputCommandInteraction) {
+    await chat.showModal(buildDescricaoModal())
+    try {
+        return await chat.awaitModalSubmit({
+            filter: (i) => i.user.id === chat.user.id,
+            time: 5 * 60 * 1000,
+        })
+    } catch {
+        // No follow-up possible — the original interaction was only
+        // acknowledged by showModal(), which leaves nothing to edit.
+        return null
+    }
+}
+
 export default new Command({
     data: new SlashCommandBuilder()
         .setName('vaga')
@@ -57,12 +94,6 @@ export default new Command({
             o
                 .setName('titulo')
                 .setDescription('Título da vaga')
-                .setRequired(true),
-        )
-        .addStringOption((o) =>
-            o
-                .setName('descricao')
-                .setDescription('Descrição / requisitos da vaga')
                 .setRequired(true),
         )
         .addStringOption((o) =>
@@ -104,7 +135,6 @@ export default new Command({
         }
 
         const titulo = chat.options.getString('titulo', true)
-        const descricao = chat.options.getString('descricao', true)
         const url = chat.options.getString('url', true)
         const modalidadeVal = chat.options.getString('modalidade')
         const senioridadeVal = chat.options.getString('senioridade')
@@ -112,6 +142,10 @@ export default new Command({
         const modalidade = modalidadeVal
             ? MODALIDADE[modalidadeVal as keyof typeof MODALIDADE]
             : null
+
+        const modalSubmit = await collectDescricao(chat)
+        if (!modalSubmit) return
+        const descricao = modalSubmit.fields.getTextInputValue('descricao')
 
         const prisma = getPrismaClient()
         const messages = await prisma.reactionRoleMessage.findMany({
@@ -152,7 +186,7 @@ export default new Command({
         // Discord rejects message content over 2000 chars — fail early with a
         // clear message instead of a runtime API error at publish time.
         if (preview.length > 2000) {
-            await chat.reply({
+            await modalSubmit.reply({
                 content: `⚠️ A vaga ficou muito longa (${preview.length}/2000 caracteres). Encurte a descrição.`,
                 ephemeral: true,
             })
@@ -171,7 +205,7 @@ export default new Command({
         )
 
         const tagList = tags.map((t) => t.label).join(', ') || '(nenhum)'
-        const message = await chat.reply({
+        const message = await modalSubmit.reply({
             content: `**Prévia da vaga** (cargos marcados: ${tagList})\n\n${preview}`,
             components: [row],
             ephemeral: true,
@@ -186,7 +220,7 @@ export default new Command({
                 time: 5 * 60 * 1000,
             })
         } catch {
-            await chat.editReply({
+            await modalSubmit.editReply({
                 content: '⏱️ Tempo esgotado — vaga não publicada.',
                 components: [],
             })


### PR DESCRIPTION
## Problem
`/vaga`'s published requirements list was coming out as one run-on paragraph instead of a bullet list, e.g.:

> - Requisito A. - Requisito B. - Requisito C.

## Root cause
`descricao` was a plain Discord slash-command string option — a single-line input. Discord doesn't support real newlines there. Whoever ran `/vaga` almost certainly pasted the requirements from a job-board page, and browsers flatten `<li>` list items into one line with spaces when you copy them. The bot itself was passing the string straight through — nothing to fix in the formatting logic, the input channel just couldn't carry multi-line text.

## Fix
`descricao` is now collected via a Modal with a paragraph-style text input (`TextInputStyle.Paragraph`), which does support real line breaks. Flow: `/vaga titulo:... url:... modalidade:... senioridade:...` → modal popup for descrição → existing preview/confirm/publish flow continues unchanged.

## Test plan
- [x] 3 new tests: modal shown before any lookups, real line breaks preserved end-to-end in the published message, timeout on modal submission does nothing further
- [x] All 4 existing tests updated for the new modal-based interaction shape, still passing
- [x] `npx jest src/functions/general/commands/vaga.spec.ts` — 7/7 passing
- [x] Full bot package suite — 2851/2852 passing (1 pre-existing skip, unrelated)
- [x] `tsc --noEmit` clean (full monorepo typecheck via pre-commit hook)
- [x] `eslint` clean (pre-existing complexity warning on `execute`, 17→18, not newly introduced — already over budget before this change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes /vaga so the job description is collected via a modal with a paragraph field, preserving real line breaks. Published posts now render bullet lists correctly and avoid mixing fields across concurrent runs.

- **Bug Fixes**
  - Collect `descricao` via a modal (`TextInputStyle.Paragraph`) instead of a single-line option.
  - Keep the preview/confirm/publish flow; replies now come from the modal submission interaction.
  - Scope the modal to the current invocation using a unique `customId` and filter on user + `customId`, rejecting stale/concurrent submissions.
  - Handle modal submit timeout gracefully (no follow-ups if the user doesn’t submit).
  - Validate preview length and show an error if it exceeds 2000 characters.

<sup>Written for commit a5dbe9bb30775b3776f322b04c9203b6bca1696f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/vaga` command now collects the “Descrição / requisitos” field through a modal, making it easier to enter longer text.
  * Multiline descriptions are preserved as typed in the preview and published message.

* **Bug Fixes**
  * Added safer handling when the description step times out, preventing an incomplete post from being published.
  * Improved the preview flow so publishing and cancel actions continue to work smoothly after submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->