### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs, scope secrets, harden Renovate

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -23,10 +23,10 @@ jobs:
             YOUTUBE_DL_SKIP_DOWNLOAD: 'true'
         steps:
             - name: Checkout PR
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         name: Build — shared
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'
@@ -32,7 +32,7 @@ jobs:
             - name: Build shared package
               run: npm run build:shared
             - name: Upload shared artifact
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-build
                   path: |
@@ -45,15 +45,15 @@ jobs:
         runs-on: ubuntu-latest
         needs: build-shared
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'
             - name: Install dependencies
               run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: shared-build
                   path: packages/shared
@@ -79,14 +79,14 @@ jobs:
         runs-on: ubuntu-latest
         needs: build-shared
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: shared-build
                   path: packages/shared
@@ -101,20 +101,20 @@ jobs:
         runs-on: ubuntu-latest
         needs: build-shared
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: shared-build
                   path: packages/shared
             - name: Run backend tests
               run: npm run test --workspace=packages/backend -- --ci --coverage
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               if: always()
               with:
                   name: coverage-backend
@@ -126,14 +126,14 @@ jobs:
         runs-on: ubuntu-latest
         needs: build-shared
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: shared-build
                   path: packages/shared
@@ -141,7 +141,7 @@ jobs:
               run: npm run test --workspace=packages/bot -- --ci --coverage
             - name: Run music incident regression
               run: npm run test:music:incident
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               if: always()
               with:
                   name: coverage-bot
@@ -162,20 +162,20 @@ jobs:
             contains(github.event.pull_request.title, 'play-dl')
           )
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: shared-build
                   path: packages/shared
             - name: Run YouTube smoke test
               run: YOUTUBE_SMOKE_TEST=true npm run test --workspace=packages/bot -- --testPathPatterns="youtube.smoke" --ci --coverage
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               if: always()
               with:
                   name: coverage-bot-youtube-smoke
@@ -187,20 +187,20 @@ jobs:
         runs-on: ubuntu-latest
         needs: build-shared
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: shared-build
                   path: packages/shared
             - name: Run frontend tests
               run: npm run test --workspace=packages/frontend -- --coverage --coverage.reporter=lcov --coverage.reporter=text
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               if: always()
               with:
                   name: coverage-frontend
@@ -220,17 +220,17 @@ jobs:
                     - {service: frontend, file: Dockerfile, target: production-frontend}
                     - {service: nginx, file: Dockerfile.nginx, target: ''}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - name: Set up Docker Buildx
               id: buildx
-              uses: docker/setup-buildx-action@v4
+              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
               continue-on-error: true
             - name: Set up Docker Buildx — retry once on transient failure
               if: steps.buildx.outcome == 'failure'
-              uses: docker/setup-buildx-action@v4
+              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
             - name: Build ${{ matrix.service }}
               id: build
-              uses: docker/build-push-action@v7
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
               continue-on-error: true
               with:
                   context: .
@@ -245,7 +245,7 @@ jobs:
                       NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
             - name: Build ${{ matrix.service }} — retry once on transient failure
               if: steps.build.outcome == 'failure'
-              uses: docker/build-push-action@v7
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
               with:
                   context: .
                   file: ${{ matrix.file }}
@@ -300,22 +300,22 @@ jobs:
         env:
             SONAR_TOKEN_PRESENT: ${{ secrets.SONAR_TOKEN != '' }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
                   fetch-depth: 0
-            - uses: actions/download-artifact@v8
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: coverage-backend
                   path: packages/backend/coverage
-            - uses: actions/download-artifact@v8
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: coverage-bot
                   path: packages/bot/coverage
-            - uses: actions/download-artifact@v8
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: coverage-frontend
                   path: packages/frontend/coverage
-            - uses: actions/setup-java@v4
+            - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
               with:
                   distribution: temurin
                   java-version: '17'
@@ -368,10 +368,10 @@ jobs:
             group: ${{ github.workflow }}-security-${{ github.ref }}
             cancel-in-progress: true
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
                   cache: 'npm'

--- a/.github/workflows/deploy-frontend-cf.yml
+++ b/.github/workflows/deploy-frontend-cf.yml
@@ -18,7 +18,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # This is a root-lockfile monorepo (workspaces: packages/*). Per-package
       # lockfiles are gitignored (.gitignore: packages/*/package-lock.json), so
@@ -28,7 +28,7 @@ jobs:
       # live site froze on a pre-workflow build. Mirror the Dockerfile `build` +
       # `build-frontend` stages: root install → prisma generate → build:shared →
       # frontend build (which imports @lucky/shared and repo-root CHANGELOG.md).
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -53,7 +53,7 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: 712118840109d834d5e99925fd172432

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -79,7 +79,7 @@ jobs:
 
             - name: Comment staging URL on PR
               if: github.event_name == 'pull_request'
-              uses: actions/github-script@v7
+              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
               with:
                   script: |
                       const url = 'https://lucky-staging.lucassantana.tech';

--- a/.github/workflows/destructive-interaction-gate.yml
+++ b/.github/workflows/destructive-interaction-gate.yml
@@ -31,7 +31,7 @@ jobs:
               if: github.event_name == 'merge_group'
               run: echo "::notice::Attestation was enforced when the PR was open; nothing to re-check in the merge queue."
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               if: github.event_name == 'pull_request'
               with:
                   fetch-depth: 0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -121,7 +121,7 @@ jobs:
 
             - name: Upload Trivy SARIF
               if: always()
-              uses: github/codeql-action/upload-sarif@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
+              uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
               with:
                   sarif_file: trivy-image-${{ matrix.service }}.sarif
                   category: trivy-image-${{ matrix.service }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,21 +52,21 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - name: Log in to ghcr.io
-              uses: docker/login-action@v4
+              uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4
+              uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
             - name: Extract metadata
               id: meta
-              uses: docker/metadata-action@v6
+              uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
               with:
                   images: ${{ env.IMAGE_PREFIX }}-${{ matrix.service }}
                   tags: |
@@ -74,7 +74,7 @@ jobs:
                       type=raw,value=latest
 
             - name: Build and push
-              uses: docker/build-push-action@v7
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
               with:
                   context: .
                   file: ${{ matrix.dockerfile }}
@@ -121,7 +121,7 @@ jobs:
 
             - name: Upload Trivy SARIF
               if: always()
-              uses: github/codeql-action/upload-sarif@v4
+              uses: github/codeql-action/upload-sarif@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
               with:
                   sarif_file: trivy-image-${{ matrix.service }}.sarif
                   category: trivy-image-${{ matrix.service }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Label PR by changed files
-              uses: actions/labeler@v6
+              uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
               with:
                   sync-labels: true

--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -27,6 +27,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  persist-credentials: false
 
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:

--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -26,9 +26,9 @@ jobs:
         name: madge / packages/bot
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: '22'
 
@@ -64,7 +64,7 @@ jobs:
 
             - name: Upload madge report
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: madge-report
                   path: madge-bot.txt

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -36,6 +36,8 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
@@ -74,6 +76,8 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
       - name: Build shared package
         run: npm run build:shared
       - name: Restore Stryker incremental cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/shared/reports/stryker-incremental.json
           key: stryker-incremental-shared-${{ github.run_id }}
@@ -62,7 +62,7 @@ jobs:
           DATABASE_URL: postgresql://localhost:5432/test
       - name: Upload mutation report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mutation-report-shared
           path: packages/shared/reports/mutation
@@ -73,8 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -85,7 +85,7 @@ jobs:
       - name: Build shared package
         run: npm run build:shared
       - name: Restore Stryker incremental cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/backend/reports/stryker-incremental.json
           key: stryker-incremental-backend-${{ github.run_id }}
@@ -100,7 +100,7 @@ jobs:
           DATABASE_URL: postgresql://localhost:5432/test
       - name: Upload mutation report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mutation-report-backend
           path: packages/backend/reports/mutation

--- a/.github/workflows/path-portability.yml
+++ b/.github/workflows/path-portability.yml
@@ -14,7 +14,7 @@ jobs:
   portability:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install jq and ripgrep
         run: |
           sudo apt-get update

--- a/.github/workflows/queueresolver-canary.yml
+++ b/.github/workflows/queueresolver-canary.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -33,7 +33,7 @@ jobs:
     name: Ensure release tag + GitHub release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -46,10 +46,11 @@ permissions:
 
 jobs:
   claude-review:
-    uses: LucasSantana-Dev/.github/.github/workflows/claude-review.yml@v1
+    uses: LucasSantana-Dev/.github/.github/workflows/claude-review.yml@0e4a491c9ae4cae6859972da1813c6a581a1a082 # v1
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   danger:
-    uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@v1
-    secrets: inherit
+    uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@0e4a491c9ae4cae6859972da1813c6a581a1a082 # v1
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -52,5 +52,3 @@ jobs:
 
   danger:
     uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@0e4a491c9ae4cae6859972da1813c6a581a1a082 # v1
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           days-before-stale: 30
           days-before-close: 14

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -55,7 +55,7 @@
             ],
             "automerge": false,
             "labels": ["youtube-dep", "dependencies"],
-            "minimumReleaseAge": "3 days"
+            "minimumReleaseAge": "7 days"
         }
     ],
     "github-actions": {

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -54,7 +54,8 @@
                 "play-dl"
             ],
             "automerge": false,
-            "labels": ["youtube-dep", "dependencies"]
+            "labels": ["youtube-dep", "dependencies"],
+            "minimumReleaseAge": "3 days"
         }
     ],
     "github-actions": {


### PR DESCRIPTION
## Summary
- Pins 18 unique GitHub Actions (across 14 workflow files) from mutable tags (`@v4`) to full commit SHAs, with version comments preserved — closes 67 `github-actions-mutable-action-tag` code-scanning alerts.
- Replaces `secrets: inherit` in `review-tools.yml`'s reusable workflow call with an explicit, minimal secret list (`ANTHROPIC_API_KEY` only) — closes the `secrets-inherit` alert.
- Adds `minimumReleaseAge: "3 days"` to `.renovaterc.json`'s YouTube-adjacent package rule — closes the `renovate-missing-minimum-release-age` alert (supply-chain hardening: requires a package to be published for a minimum period before Renovate proposes it).

## Test plan
- [x] All 21 workflow files validated as parseable YAML
- [x] `.renovaterc.json` validated as parseable JSON
- [x] No remaining mutable `@vN` tags in `.github/workflows/`
- [x] Every pinned SHA resolved and cross-checked against the tag it replaces (0/18 failures)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins all GitHub Actions to exact commit SHAs, scopes reusable workflow secrets to least privilege, sets `persist-credentials: false` on read‑only jobs, enforces a 7‑day minimum release age in Renovate, and fixes a review-tools validation error. Resolves 67 mutable-action-tag alerts, the `secrets-inherit` alert, and adds a safeguard for YouTube‑adjacent updates.

- **Refactors**
  - Pinned all Actions across 14 workflows to full SHAs with version comments (no remaining `@vN` tags), covering core build/test, Docker actions, `cloudflare/wrangler-action`, `github/codeql-action/upload-sarif` (commit, not tag), and utilities like `actions/github-script`, `actions/labeler`, `actions/stale`, `actions/cache`, `actions/upload-artifact`/`download-artifact`, and `actions/setup-java`.
  - Replaced `secrets: inherit` in `review-tools.yml` with an explicit `ANTHROPIC_API_KEY`; pinned reusable workflows under `LucasSantana-Dev/.github` to commit SHAs; set `actions/checkout` `persist-credentials: false` in read‑only/test jobs.

- **Bug Fixes**
  - Dropped an undeclared secret from the `danger` reusable-workflow call to match its interface, fixing a startup validation error that blocked the Review Tools workflow.

<sup>Written for commit 6319274959d33da8894f36a0da458e105087517e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned multiple GitHub Actions and Docker-related workflow steps to fixed commit SHAs for more consistent and secure automation.
  * Updated CI, deployment, and review workflows to use pinned action references instead of floating version tags.
  * Adjusted dependency update rules to add a **7-day minimum release age** for selected YouTube-adjacent package updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->