### PR TITLE
fix(ci): skip docker-build validation for non-docker-relevant PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,13 @@ jobs:
               id: filter
               run: |
                   BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                      # pull_request.base.sha is a snapshot from when the PR was
+                      # opened/synced, not the live base branch tip — diffing
+                      # against it directly can pick up unrelated commits merged
+                      # to base after that point. Use the actual merge-base.
+                      BASE_SHA=$(git merge-base "$BASE_SHA" HEAD)
+                  fi
                   CHANGED=$(git diff --name-only "$BASE_SHA" HEAD)
                   echo "Changed files:"
                   echo "$CHANGED"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,37 @@ jobs:
                   path: packages/frontend/coverage/lcov.info
                   retention-days: 1
 
+    detect-docker-changes:
+        name: Detect Docker-relevant changes
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        outputs:
+            relevant: ${{ steps.filter.outputs.relevant }}
+        steps:
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  fetch-depth: 0
+            - name: Check for Docker-relevant changes
+              id: filter
+              run: |
+                  BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+                  CHANGED=$(git diff --name-only "$BASE_SHA" HEAD)
+                  echo "Changed files:"
+                  echo "$CHANGED"
+                  # Mirrors docker-publish.yml's paths: filter, plus this
+                  # workflow file itself (so edits to the docker-build job
+                  # definition are still validated).
+                  if echo "$CHANGED" | grep -qE '^(packages/|prisma/|Dockerfile$|Dockerfile\.|nginx/|package.*\.json$|\.github/workflows/ci\.yml$)'; then
+                      echo "relevant=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "relevant=false" >> "$GITHUB_OUTPUT"
+                  fi
+
     docker-build:
         name: Build — ${{ matrix.service }}
         runs-on: ubuntu-latest
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        needs: detect-docker-changes
+        if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.detect-docker-changes.outputs.relevant == 'true'
         strategy:
             fail-fast: false
             matrix:
@@ -261,11 +288,15 @@ jobs:
     docker-build-check:
         name: Build — Docker images
         runs-on: ubuntu-latest
-        needs: docker-build
+        needs: [detect-docker-changes, docker-build]
         if: always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         steps:
             - name: Assert all builds passed
               run: |
+                  if [[ "${{ needs.detect-docker-changes.outputs.relevant }}" != "true" ]]; then
+                      echo "No Docker-relevant changes in this diff — skipping validation."
+                      exit 0
+                  fi
                   if [[ "${{ needs.docker-build.result }}" != "success" ]]; then
                       echo "Docker build result: ${{ needs.docker-build.result }}"
                       exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,10 @@ jobs:
         steps:
             - name: Assert all builds passed
               run: |
+                  if [[ "${{ needs.detect-docker-changes.result }}" != "success" ]]; then
+                      echo "Detect-docker-changes did not complete successfully: ${{ needs.detect-docker-changes.result }}"
+                      exit 1
+                  fi
                   if [[ "${{ needs.detect-docker-changes.outputs.relevant }}" != "true" ]]; then
                       echo "No Docker-relevant changes in this diff — skipping validation."
                       exit 0

--- a/decisions/2026-07-08-ci-docker-build-paths-filter-phased-speedup.md
+++ b/decisions/2026-07-08-ci-docker-build-paths-filter-phased-speedup.md
@@ -1,0 +1,128 @@
+# ADR 2026-07-08 — CI speedup: paths-filter docker-build first, cache diagnostic before architecture change
+
+**Status:** Accepted (Phase 1 shipped; Phase 2 pending)
+**Deciders:** Lucas Santana (via 4-lens debate: feasibility, production-safety, pragmatism, architecture; synthesis by Fable)
+**Related:** PR #1711 (Phase 1 implementation), `.github/workflows/ci.yml`, `.github/workflows/docker-publish.yml`
+**Trigger:** operator request "CI/CD takes way too long" (2026-07-08).
+
+## Context
+
+Measured across 8 recent PR runs: total CI wall-clock ~5-11 min. Critical-path breakdown of
+one representative run (id 28978740134, 644s total):
+
+- `build-shared`: 48s
+- `docker-build` matrix (4 services, no `needs:` on `build-shared`, starts after a ~48s
+  runner-queue gap): **`Build — bot` 419s — the single largest job, and the critical path.**
+  `Build — backend` 356s, `Build — frontend` 260s, `Build — nginx` 16s.
+- `Checks` (lint+typecheck+build): 175s, parallel with docker-build.
+- `Test — *`: 85-127s each, parallel.
+- `SonarCloud Scan`: 83s.
+
+`docker-build` runs the full multi-stage `docker/build-push-action` build of each
+production image (`push: false`, pure PR-time validation — never publishes), using
+`cache-from/cache-to: type=gha`. The bot image needs `@discordjs/opus`, which has no
+prebuilt binary for the current Node/Alpine ABI and source-compiles via node-gyp — a known,
+deliberate, documented tradeoff in the Dockerfile already.
+
+It ran **unconditionally on every `pull_request`/`merge_group` event, with no `paths:`
+filter** — unlike `docker-publish.yml` (the workflow that builds and pushes the *real*
+release images), which already gates on one:
+
+```yaml
+paths:
+  - 'packages/**'
+  - 'prisma/**'
+  - 'Dockerfile'
+  - 'Dockerfile.*'
+  - 'nginx/**'
+  - 'package*.json'
+  - '.github/workflows/docker-publish.yml'
+```
+
+Root-cause hypothesis for the 400s+ duration (not yet confirmed): `cache-from/cache-to:
+type=gha` may not be landing cache hits on the expensive `npm ci` + native-compile layer,
+forcing a cold native rebuild of `@discordjs/opus` on every run regardless of whether
+`package-lock.json` changed.
+
+## Decision
+
+**A 4-lens debate converged unanimously on a phased approach — ship the safe, high-value
+win now; don't commit to a bigger architecture change (pre-built base image, cache-backend
+switch) without data.**
+
+**Phase 1 — shipped (PR #1711):** add a `detect-docker-changes` job to `ci.yml` that diffs
+the PR against its base and mirrors `docker-publish.yml`'s existing paths list (plus
+`ci.yml` itself, so edits to the `docker-build` job definition stay validated). Gates
+`docker-build`'s `if:` on the result. `docker-build-check` (the required branch-protection
+status check, `"Build — Docker images"`) still *always* runs and explicitly reports
+success/skip/fail, so the required check never goes missing — it reports fast instead of
+waiting on a build that couldn't have been affected by the diff.
+
+**Phase 2 — pending, not yet started:** root-cause the cache-effectiveness question before
+deciding between fixing the cache config (cheaper) vs. a pre-built "deps" base image with
+natives pre-compiled (bigger, more durable, more complex):
+
+1. Two-scenario diagnostic: inspect Buildx logs for the `npm-mount` cache layer on (a) a
+   recent PR that touched `Dockerfile` only (no lockfile change — should show `CACHED` if
+   the cache mechanism works at all) and (b) a recent PR that bumped `package-lock.json`
+   (expected cache miss either way — isolates whether the 400s is legitimate compile cost
+   or a cache misconfiguration bug).
+2. In parallel: measure `docker-publish.yml`'s catch rate over the last ~100 merged PRs —
+   how often does the post-merge real build catch a break `ci.yml`'s `docker-build` missed?
+   This bounds how safe a cheaper PR-time validation (build stage only, or a reduced
+   matrix) would be, independent of the cache question.
+3. Decision fork on the data: cache hit on scenario (a) → the 400s is real compile cost,
+   escalate to a pre-built base image only if the ROI over 6-12 months justifies the added
+   complexity. Cache miss on scenario (a) → fix the cache config/backend directly, cheaper
+   than a base-image rearchitecture.
+
+## Alternatives considered
+
+- **Fix the GHA cache miss directly, first (skip the paths filter).** Rejected as the
+  *first* move: unconfirmed root cause, and even if fixed, PRs that DO touch Docker-relevant
+  paths still pay the compile cost on every push within that PR — the paths filter is
+  strictly complementary, not a substitute, and is zero-risk to ship immediately while the
+  cache question is still being diagnosed.
+- **Pre-built deps base image immediately (Option C).** Rejected as a first move: real
+  architecture change, meaningful complexity (refresh-on-lockfile-change pipeline,
+  additional registry surface), and the debate's feasibility lens flagged it as premature
+  before confirming the cache hypothesis — building this without knowing whether it's a
+  cache-config bug or genuine compile cost risks solving the wrong problem.
+- **Downgrade PR-time validation immediately (Option D — build-stage only, or reduced
+  matrix).** Rejected as a first move, not rejected outright: the production-safety lens
+  argued this shifts real regression risk to post-merge without first measuring how often
+  `docker-publish.yml` actually catches something `ci.yml` would have missed. Deferred to
+  Phase 2's parallel measurement — if divergence is low (<2%), this becomes an acceptable
+  fallback; if not, full validation stays.
+- **Make `docker-build` advisory/non-blocking instead of required (Option E).** Rejected
+  outright by all 4 lenses — defers the wait-time friction rather than solving it, and
+  removes a real safety signal for zero speed benefit (the job still runs and takes the
+  same wall-clock time; only its blocking status changes).
+
+## Consequences
+
+**Positive:** PRs that touch only docs, unrelated workflow files, or config (e.g. Renovate
+config, `.env.example`) skip ~5-8 min of unnecessary Docker validation entirely, with zero
+regression risk (the required check still always reports). No architecture change risked
+on an unconfirmed hypothesis.
+
+**Negative:** PRs that genuinely touch Docker-relevant paths (the majority of real app-code
+and dependency PRs, per this session's own 6 PRs — all 6 were correctly classified
+`RELEVANT`) see no speedup yet from Phase 1 alone; the actual 419s bottleneck is
+untouched until Phase 2 lands a fix.
+
+**Neutral:** `docker-publish.yml` (the real release build) is unaffected — it already had
+its own, separate paths filter.
+
+## Revisit when
+
+- **Phase 2 diagnostic completes** — re-open this ADR (or a follow-up) with the cache
+  hit/miss data and commit to fixing the cache config vs. building the pre-built base image.
+- **`docker-publish.yml` catch-rate measurement shows >5% divergence** from `ci.yml`'s
+  `docker-build` — keep full validation, deprioritize Option D entirely.
+- **`docker-publish.yml` catch-rate measurement shows <2% divergence** — Option D (cheaper
+  PR-time validation) becomes a live option worth prototyping.
+- **The `detect-docker-changes` paths list drifts out of sync with `docker-publish.yml`'s** —
+  if one gets updated without the other, re-align them (they're currently duplicated by
+  hand, not shared — a future refactor could extract a reusable composite action or
+  `paths-filter` config if this becomes a maintenance burden).


### PR DESCRIPTION
## Summary

`docker-build` (the 4-service Docker image matrix in `ci.yml`) is the critical-path bottleneck of the whole CI run — measured at 419s for the bot image alone (of a ~644s total run), dominated by `@discordjs/opus`'s native compile (node-gyp/C toolchain, no prebuilt binary for the current ABI). It runs unconditionally on every `pull_request`/`merge_group` event, with no `paths:` filter — unlike `docker-publish.yml` (the workflow that builds and pushes the *real* release images), which already gates on one.

Adds a `detect-docker-changes` job that diffs the PR against its base and mirrors `docker-publish.yml`'s existing filter (`packages/**`, `prisma/**`, `Dockerfile*`, `nginx/**`, `package*.json`) — plus `ci.yml` itself, so edits to the `docker-build` job definition stay validated. `docker-build-check` (the required branch-protection status check, `"Build — Docker images"`) still *always* runs and explicitly reports success when skipped, so a required check never goes missing/pending — it just reports fast instead of waiting on a build that couldn't have been affected.

This came out of a 4-lens debate (feasibility / production-safety / pragmatism / architecture) on how to speed up CI — full synthesis available on request. This is Phase 1 (the converged, zero-risk win). Phase 2 is a follow-up: root-causing whether `cache-from/cache-to: type=gha` is actually landing cache hits on the expensive native-compile layer for PRs that *do* touch Docker-relevant paths — that's independent of this change and still TBD.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [x] `actionlint .github/workflows/ci.yml` — 0 issues
- [x] Verified detection logic against the actual file lists of 5 recently-merged/open PRs in this repo (all 5 correctly classified `RELEVANT` — they all touch `packages/`, `Dockerfile`, `package.json`, or `ci.yml` itself) and 2 synthetic docs-only / `.env.example`-only diffs (both correctly classified `SKIP`)
- [ ] Live CI run on this PR itself will be the first real end-to-end validation (this PR touches only `ci.yml`, which the filter explicitly always treats as relevant, so `docker-build` will still run here — by design, since I'm changing the job that gates it)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the 4-image `docker-build` matrix for PRs without Docker-relevant changes to cut CI time. The required check now skips only after successful detection and uses the merge-base to avoid false positives.

- **Refactors**
  - Added `detect-docker-changes` that diffs PRs against the merge-base and mirrors `docker-publish.yml` filters: `packages/**`, `prisma/**`, `Dockerfile*`, `nginx/**`, `package*.json`, plus `.github/workflows/ci.yml`.
  - Run `docker-build` only on `pull_request`/`merge_group` when relevant; keep `docker-build-check` always on with an early success when irrelevant.
  - Added ADR: `decisions/2026-07-08-ci-docker-build-paths-filter-phased-speedup.md`.

- **Bug Fixes**
  - `docker-build-check` now verifies `detect-docker-changes` completed successfully and fails if it didn’t, preventing false “skip” passes.

<sup>Written for commit 455e89527cc23cce9430ddd813e73f7630f4909f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI efficiency by running Docker-related build checks only when Docker-impacting files change.
  * Added change detection so unrelated updates skip expensive Docker jobs.
  * Preserved Docker validation while allowing it to complete quickly when no relevant changes are present.
* **Documentation**
  * Added an architecture decision record outlining the CI Docker build-speedup plan, including a phased rollout and future follow-up criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->