### PR TITLE
refactor(backend): extract named constant for zero-permissions literal

### DIFF
--- a/packages/backend/src/services/GuildService.ts
+++ b/packages/backend/src/services/GuildService.ts
@@ -6,6 +6,8 @@ let botClient: Client | null = null
 const DISCORD_API_BASE_URL = 'https://discord.com/api/v10'
 const BOT_GUILD_CACHE_TTL_MS = 60_000
 const GUILD_METRICS_CACHE_TTL_MS = 30_000
+// Discord permission bitfield literal representing zero permissions granted
+const NO_PERMISSIONS = '0'
 
 interface GuildMetrics {
     memberCount: number | null
@@ -839,7 +841,7 @@ class GuildService {
             name: guild.name,
             icon: guild.icon,
             owner: false,
-            permissions: '0',
+            permissions: NO_PERMISSIONS,
             features: guild.features,
             hasBot,
             botInviteUrl,
@@ -945,7 +947,7 @@ class GuildService {
                     color: role.color ?? 0,
                     hoist: role.hoist ?? false,
                     mentionable: role.mentionable ?? false,
-                    permissions: role.permissions ?? '0',
+                    permissions: role.permissions ?? NO_PERMISSIONS,
                     position: role.position ?? 0,
                     managed: role.managed ?? false,
                 }))
@@ -1027,7 +1029,7 @@ class GuildService {
                 color: payload.color ?? 0,
                 hoist: payload.hoist ?? false,
                 mentionable: payload.mentionable ?? false,
-                permissions: payload.permissions ?? '0',
+                permissions: payload.permissions ?? NO_PERMISSIONS,
                 position: payload.position ?? 0,
                 managed: payload.managed ?? false,
             }
@@ -1113,7 +1115,7 @@ class GuildService {
                 color: payload.color ?? 0,
                 hoist: payload.hoist ?? false,
                 mentionable: payload.mentionable ?? false,
-                permissions: payload.permissions ?? '0',
+                permissions: payload.permissions ?? NO_PERMISSIONS,
                 position: payload.position ?? 0,
                 managed: payload.managed ?? false,
             }


### PR DESCRIPTION
## Summary
- Extract hardcoded permission string literal `'0'` into a named constant `NO_PERMISSIONS`
- Replace all 4 occurrences in `GuildService.ts` (lines 844, 950, 1030, 1116)
- Add clarifying comment explaining the Discord permission bitfield semantic

Closes #1628

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the hardcoded Discord permission literal '0' with a named NO_PERMISSIONS constant in GuildService to make zero-permission behavior explicit and easier to maintain. Adds a short comment explaining the Discord permission bitfield; closes #1628.

<sup>Written for commit c3fba571a4bee975e364fe27d6b3805a341e908e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

