### PR TITLE
fix(bot): approve @discordjs/opus install script — P0 music playback outage

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,5 +138,8 @@
         "esbuild": "0.28.1",
         "qs": "^6.15.2",
         "@opentelemetry/core": "^2.8.0"
+    },
+    "allowScripts": {
+        "@discordjs/opus@0.10.0": true
     }
 }


### PR DESCRIPTION
## Incident

User reported "music not playing" + "why is Spotify not working" — investigated live prod logs (`lucky-bot`, guild Criativaria).

## Root cause

npm 12's native `install-scripts` allowlist feature (npm was bumped to 12.0.0 as part of the Docker toolchain fix in #1310) silently blocks lifecycle scripts for packages not explicitly approved. `@discordjs/opus`'s install script (`node-pre-gyp install --fallback-to-build`, which compiles the native Opus encoder) was never approved, so it silently no-op'd during every `npm ci --omit=dev` in the `deps-production` Docker stage — despite that stage having the full C toolchain (`build-base python3-dev opus-dev`) installed specifically to let this compile.

Confirmed on the running container:
```
$ docker exec lucky-bot find node_modules/@discordjs/opus -name '*.node'
(no output)
```

## Impact

**Total playback outage, all sources.** Every `/play` attempt — YouTube, Spotify-matched-YouTube, SoundCloud — successfully resolves a stream, then fails identically at `createAudioResource → OpusEncoder → OpusStream → loadModule` because no opus native binary (or any of its 4 JS fallbacks: mediaplex, opusscript, @evan/opus, node-opus) is present. This is why Spotify appeared broken too — Spotify search itself works fine; it fails at the exact same downstream encoding step as everything else.

## Fix

```json
"allowScripts": {
    "@discordjs/opus@0.10.0": true
}
```
Added via `npm install-scripts approve @discordjs/opus` (npm 12+ native command).

## Verification

Rebuilt the `deps-production` Docker stage in an isolated clone with this change:
```
npm warn install-scripts 6 packages had install scripts blocked ...
  (no longer lists @discordjs/opus)

$ docker run --rm opus-fix-test find node_modules/@discordjs/opus -name '*.node'
node_modules/@discordjs/opus/prebuild/node-v137-napi-v3-linux-x64-musl-1.2.6/opus.node
node_modules/@discordjs/opus/build-tmp-napi-v3/Release/opus.node
```
Binary now lands at exactly the path the runtime error was looking for.

## Follow-up (not done here — scope kept surgical to the outage)

6 other packages are in the same unapproved state in the production build (`@prisma/engines`, `esbuild`, `ffmpeg-static`, `msgpackr-extract`, `prisma`, `youtube-dl-exec`). None currently show evidence of breaking prod — Prisma engines are separately copied in from the `build` stage (#1734), `ffmpeg`/`yt-dlp` use system binaries not the npm-bundled ones, `msgpackr-extract` just falls back to a slower pure-JS path. Worth a deliberate review pass to decide per-package whether to approve or leave blocked, tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Approve `@discordjs/opus` install script in `package.json` so native Opus builds under `npm@12`, restoring music playback in production. Fixes P0 playback outage across all sources.

- **Bug Fixes**
  - Cause: `npm@12` allowlist blocked `@discordjs/opus` during `npm ci --omit=dev`, so no `opus.node`.
  - Change: Added `"allowScripts": { "@discordjs/opus@0.10.0": true }` in `package.json`.
  - Result: Opus builds and loads; playback works again. Verified by rebuild.

<sup>Written for commit 7c930e4db82312ec2b5b4914fd4f89fbe959a4ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled required installation scripts for the audio processing package to support successful setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->