### PR TITLE
fix(docker): copy+chown @prisma engines in production-backend — P0 deploy pipeline blocker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,10 +185,17 @@ COPY --from=build /app/packages/shared/src/generated ./packages/shared/src/gener
 COPY --from=build /app/packages/shared/src/generated ./packages/shared/dist/generated
 COPY --from=build /app/packages/backend/dist ./packages/backend/dist
 COPY --from=build /app/prisma ./prisma
+# prisma/@prisma/engines are devDeps, so deps-production's `npm ci --omit=dev`
+# ships node_modules WITHOUT the migrate schema-engine — `prisma migrate deploy`
+# (run via this backend image, see scripts/deploy.sh) then fails to write the
+# engine binary as the non-root `backend` user. The bot stage above already
+# works around this by copying the build stage's full @prisma from ./node_modules
+# (#1734/#1735); backend needs the same copy + chown, it just never got it.
+COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S backend -u 1001 -G nodejs && \
-    chown -R backend:nodejs /app/packages/backend/dist /app/prisma
+    chown -R backend:nodejs /app/packages/backend/dist /app/prisma /app/node_modules/@prisma
 
 USER backend
 


### PR DESCRIPTION
## Problem

Discovered while trying to deploy #1757 (the opus playback fix): every deploy currently fails at the migration step.

\`scripts/deploy.sh\` runs \`prisma migrate deploy\` via the **backend** image (\`docker_compose run --rm --no-deps backend ...\`), which fails:
\`\`\`
Error: Can't write to /app/node_modules/@prisma/engines please make sure you install "prisma" with the right permissions.
[deploy] ERROR: MIGRATION_FAILED (prisma migrate deploy)
\`\`\`

## Root cause

\`deps-production\`'s \`npm ci --omit=dev\` ships \`node_modules\` **without** the Prisma migrate schema-engine, since \`prisma\`/\`@prisma/engines\` are devDependencies. The **bot** Dockerfile stage already has a fix for exactly this (#1734/#1735): it copies the full \`@prisma\` from the \`build\` stage and chowns it to the non-root runtime user. The **backend** stage — which is what actually runs migrations — never got the same fix. It only chowns \`/app/packages/backend/dist /app/prisma\`, not \`/app/node_modules/@prisma\`, and never copies the working engines in from \`build\` at all.

## Fix

Mirrors the bot stage's existing pattern onto backend:
\`\`\`dockerfile
COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
...
chown -R backend:nodejs /app/packages/backend/dist /app/prisma /app/node_modules/@prisma
\`\`\`

## Verification

Built \`production-backend\` in isolation:
\`\`\`
$ docker run --rm backend-fix-test sh -c 'ls -ld /app/node_modules/@prisma'
drwxr-xr-x 1 backend nodejs ... /app/node_modules/@prisma

$ docker run --rm backend-fix-test sh -c 'find /app/node_modules/@prisma -iname "*schema-engine*"'
-rwxr-xr-x 1 backend nodejs 22280136 ... /app/node_modules/@prisma/engines/schema-engine-linux-musl-openssl-3.0.x

$ docker run --rm backend-fix-test sh -lc 'npx prisma migrate status ...'
Error: Connection url is empty.   # <- only fails on missing DATABASE_URL (expected, no real env in this isolated test) — permission error is gone
\`\`\`

## Impact

This is currently blocking **all** deploys to the homelab, including the P0 opus-playback fix (#1757, already merged). Needs to merge and deploy ASAP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the production backend Docker image to include and chown Prisma engines so `prisma migrate deploy` runs without permission errors. Unblocks the deploy pipeline.

- **Bug Fixes**
  - Copy `@prisma` from the build stage into `/app/node_modules/@prisma` in the backend image and `chown -R backend:nodejs`.
  - Prevents the write error caused by `npm ci --omit=dev` omitting `@prisma/engines` and running migrations as the non-root `backend` user.

<sup>Written for commit ec5a7339cd86143174041cf0dc316a9789a86bc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved production container setup to ensure Prisma database operations run correctly at runtime.
  - Updated file permissions so backend processes can access required database engine and schema files without elevated privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->