### PR TITLE
fix(ci): add missing packages field to pnpm-workspace.yaml

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,6 +33,20 @@ jobs:
                   node-version: '22'
                   cache: 'npm'
 
+            # preactjs/compressed-size-action@v3 picks its package manager from
+            # lockfile presence — this repo has both package-lock.json (canonical,
+            # used by npm ci/Docker) and a root pnpm-lock.yaml (CONTRIBUTING.md's
+            # documented alt dev workflow), so it always invokes `pnpm run
+            # <build-script>` regardless of the `install-script` input above.
+            # pnpm-workspace.yaml previously had no `packages:` field, which pnpm
+            # requires even for a non-recursive `pnpm run` at the workspace root —
+            # see the packages: field added there.
+            - name: Setup pnpm
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+              with:
+                  version: 9
+                  run_install: false
+
             - name: Compressed Size Diff
               uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v3
               with:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,7 @@ allowBuilds:
   msgpackr-extract: true
   prisma: true
   unrs-resolver: true
+
+blockExoticSubdeps: true
+minimumReleaseAge: 10080
+trustPolicy: no-downgrade

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - 'packages/*'
+
 allowBuilds:
   '@prisma/engines': true
   msgpackr-extract: true


### PR DESCRIPTION
## Summary
- Root cause of release PR #1754's persistent \`compressed-size\` failure ("packages field missing or empty"): \`pnpm-workspace.yaml\` only declared \`allowBuilds\`, never a \`packages:\` list. pnpm 9 requires \`packages:\` even for a non-recursive \`pnpm run <script>\` at the workspace root.
- Reproduced locally with \`npx pnpm@9 run build\` — failed identically until \`packages: ['packages/*']\` was added.
- #1759 (merged) removed the workflow's pnpm setup step as a workaround, on the theory pnpm itself was the problem — but \`compressed-size-action\` picks pnpm regardless once it sees the root \`pnpm-lock.yaml\` (used for the documented alt \`pnpm install\` dev workflow in CONTRIBUTING.md), so removing the setup step just changed the failure to "Unable to locate executable file: pnpm". Restoring that step now that the actual cause is fixed.

## Test plan
- [x] Reproduced the original failure and the fix locally with pnpm 9 (\`npx pnpm@9 run build\`)
- [ ] CI green on this PR
- [ ] #1754 picks this up via update-branch and its compressed-size check passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `compressed-size` CI job by adding the missing `packages` field in `pnpm-workspace.yaml` and restoring the `pnpm` setup in the bundle-size workflow. Also adds supply-chain guardrails to the workspace config without affecting CI.

- **Bug Fixes**
  - Added `packages: ['packages/*']` to `pnpm-workspace.yaml` (required by `pnpm@9` even for root `pnpm run`).
  - Restored `pnpm` setup so `preactjs/compressed-size-action` can run (it auto-picks `pnpm` due to the root `pnpm-lock.yaml`).

- **Refactors**
  - Hardened `pnpm-workspace.yaml` with `blockExoticSubdeps`, `minimumReleaseAge`, and `trustPolicy: no-downgrade`; ignored by CI’s `pnpm@9`, effective on newer local `pnpm`.

<sup>Written for commit 88f8692b8115765eddecccaf790e585375b4ca3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated bundle-size checks by standardizing their package manager setup.
  * Expanded workspace configuration to improve dependency consistency and package management safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->