### PR TITLE
ci: auto-update queued PR branches when main advances

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -1,0 +1,51 @@
+name: Auto-update PR branches
+
+# When main advances, bring every open PR that already has auto-merge enabled
+# up to date, so the branch-protection "require branches to be up to date" rule
+# doesn't strand a green, queued PR behind whatever just merged. This is the
+# manual `gh pr update-branch` loop (see the merge-train friction) automated.
+#
+# Scope is intentionally narrow: only PRs whose author has ALREADY enabled
+# auto-merge are touched — that's the opt-in signal, and it avoids surprising
+# other contributors' branches.
+#
+# Uses a PAT (RELEASE_PLEASE_TOKEN), not GITHUB_TOKEN, on purpose: a branch
+# update made with GITHUB_TOKEN does NOT re-trigger the PR's workflows, which
+# would leave required checks pending forever and the auto-merge never firing.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize runs so overlapping main pushes don't fight over the same PRs.
+  group: auto-update-pr-branches
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update behind, auto-merge-enabled PRs
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr list --repo "$REPO" --state open --base main \
+            --json number,isDraft,mergeStateStatus,autoMergeRequest \
+            --jq '.[]
+              | select(.isDraft == false
+                       and .autoMergeRequest != null
+                       and .mergeStateStatus == "BEHIND")
+              | .number' \
+          | while read -r pr; do
+              [ -n "$pr" ] || continue
+              echo "Updating #$pr (behind base, auto-merge enabled)..."
+              gh pr update-branch "$pr" --repo "$REPO" \
+                || echo "::warning::update-branch failed for #$pr (likely a conflict) — skipping"
+            done


### PR DESCRIPTION
## Problem
Branch protection requires branches be up to date, but GitHub auto-merge does **not** auto-update-branch. So every merge re-stales the sibling queued PRs, forcing a manual `gh pr update-branch` on each — I ran it ~10× in one session working through the backlog (the merge-train thrash).

## Fix
A workflow on `push: main` that update-branches every open PR which **already has auto-merge enabled** (the opt-in signal) and is `BEHIND`. As each queued PR lands, the rest are automatically re-based and re-run CI, so the train drains itself.

## Notes
- **Scope is narrow on purpose:** only auto-merge-enabled, non-draft PRs — other contributors' branches are never touched.
- **Uses `RELEASE_PLEASE_TOKEN` (PAT), not `GITHUB_TOKEN`:** a branch update made with `GITHUB_TOKEN` doesn't re-trigger the PR's workflows, which would leave required checks pending forever and auto-merge never firing. The repo already uses this PAT for the same reason in release-please.
- Conflicting PRs 422 on update-branch → logged as a warning and skipped (they need a manual resolve, as they should).
- `workflow_dispatch` included for manual runs.

Alternative considered: the repo-level "Automatically update branches" setting does the same thing with zero YAML — flip that instead and this workflow is redundant. This PR is the in-repo, reviewable version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically updates queued PR branches when `main` advances to keep auto-merge trains moving without manual updates. Only touches non-draft PRs with auto-merge enabled.

- **New Features**
  - Workflow updates branches for open PRs behind `main` with auto-merge enabled.
  - Uses `RELEASE_PLEASE_TOKEN` instead of `GITHUB_TOKEN` so required checks re-run and auto-merge can finish.
  - Skips drafts and conflicting PRs (logs a warning), serializes runs, and supports `workflow_dispatch`.

<sup>Written for commit 010b3f06a18cd002fb3e03afb9f2371f1ecb2eb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

