### PR TITLE
feat(bot): temporary support ticket channels (/ticket)

### DIFF
--- a/packages/bot/src/bot/start/initializer.ts
+++ b/packages/bot/src/bot/start/initializer.ts
@@ -23,6 +23,7 @@ import { initProviderHealth } from '../../utils/music/search/providerHealth'
 import { musicWatchdogService } from '../../utils/music/watchdog'
 import { birthdayScheduler } from '../../utils/general/birthdayScheduler'
 import { reminderScheduler } from '../../utils/general/reminderScheduler'
+import { supportSessionScheduler } from '../../utils/general/supportSessionScheduler'
 import { giveawayScheduler } from '../../utils/general/giveawayScheduler'
 import { topggStatsScheduler } from '../../utils/general/topggStatsScheduler'
 import { modDigestSchedulerService } from '../../utils/moderation/modDigestScheduler'
@@ -81,7 +82,9 @@ export class BotInitializer {
         options: BotInitializationOptions,
     ): Promise<void> {
         if (options.skipPlayer !== true && this.client) {
-            const player = await createPlayerWithHandlers({ client: this.client })
+            const player = await createPlayerWithHandlers({
+                client: this.client,
+            })
             this.client.player = player
             musicWatchdogService.startOrphanSessionMonitor(player)
         }
@@ -214,6 +217,15 @@ export class BotInitializer {
         }
 
         try {
+            supportSessionScheduler.stop()
+        } catch (error) {
+            errorLog({
+                message: 'Error stopping support session scheduler:',
+                error,
+            })
+        }
+
+        try {
             reminderScheduler.stop()
         } catch (error) {
             errorLog({ message: 'Error stopping reminder scheduler:', error })
@@ -228,7 +240,10 @@ export class BotInitializer {
         try {
             topggStatsScheduler.stop()
         } catch (error) {
-            errorLog({ message: 'Error stopping Top.gg stats scheduler:', error })
+            errorLog({
+                message: 'Error stopping Top.gg stats scheduler:',
+                error,
+            })
         }
 
         try {

--- a/packages/bot/src/functions/general/commands/ticket.spec.ts
+++ b/packages/bot/src/functions/general/commands/ticket.spec.ts
@@ -69,6 +69,7 @@ describe('/ticket command (smoke)', () => {
             supportCategoryId: 'cat-1',
             supportAgentRoleId: 'agent-role',
         })
+        supportSessionServiceMock.close.mockResolvedValue(undefined)
     })
 
     it('open: creates a channel, records the session, and confirms', async () => {
@@ -146,5 +147,57 @@ describe('/ticket command (smoke)', () => {
 
         expect(supportSessionServiceMock.close).toHaveBeenCalledWith('s1')
         expect(channel.delete).toHaveBeenCalled()
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: { content: expect.stringContaining('Closing') },
+            }),
+        )
+    })
+
+    it('open: reopens after a stale row whose channel was deleted (10003)', async () => {
+        const channel = makeChannel()
+        supportSessionServiceMock.getActiveForUser.mockResolvedValue({
+            id: 'old',
+            channelId: 'gone',
+        })
+        supportSessionServiceMock.open.mockResolvedValue({ id: 's2' })
+
+        const interaction = makeInteraction('open', channel)
+        // Orphan check: fetching the old channel throws 10003 (confirmed gone).
+        interaction.guild.channels.fetch = jest
+            .fn()
+            .mockRejectedValue({ code: 10003 })
+
+        await ticketCommand.execute({ interaction } as any)
+
+        expect(supportSessionServiceMock.close).toHaveBeenCalledWith('old')
+        expect(interaction.guild.channels.create).toHaveBeenCalled()
+        expect(supportSessionServiceMock.open).toHaveBeenCalled()
+    })
+
+    it('open: blocks (does NOT reopen) on a transient fetch error for the existing ticket', async () => {
+        const channel = makeChannel()
+        supportSessionServiceMock.getActiveForUser.mockResolvedValue({
+            id: 'old',
+            channelId: 'ch-old',
+        })
+
+        const interaction = makeInteraction('open', channel)
+        // Transient error (not 10003) — must treat the ticket as still open.
+        interaction.guild.channels.fetch = jest
+            .fn()
+            .mockRejectedValue(new Error('gateway 503'))
+
+        await ticketCommand.execute({ interaction } as any)
+
+        expect(supportSessionServiceMock.close).not.toHaveBeenCalled()
+        expect(interaction.guild.channels.create).not.toHaveBeenCalled()
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: {
+                    content: expect.stringContaining('already have an open'),
+                },
+            }),
+        )
     })
 })

--- a/packages/bot/src/functions/general/commands/ticket.spec.ts
+++ b/packages/bot/src/functions/general/commands/ticket.spec.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+const guildSettingsServiceMock = {
+    getGuildSettings: jest.fn() as jest.MockedFunction<any>,
+}
+const supportSessionServiceMock = {
+    getActiveForUser: jest.fn() as jest.MockedFunction<any>,
+    open: jest.fn() as jest.MockedFunction<any>,
+    getByChannel: jest.fn() as jest.MockedFunction<any>,
+    close: jest.fn() as jest.MockedFunction<any>,
+}
+const interactionReplyMock = jest.fn() as jest.MockedFunction<any>
+
+jest.mock('@lucky/shared/services', () => ({
+    guildSettingsService: guildSettingsServiceMock,
+    supportSessionService: supportSessionServiceMock,
+}))
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: jest.fn(),
+    errorLog: jest.fn(),
+}))
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
+}))
+
+import ticketCommand from './ticket'
+
+function makeChannel() {
+    return {
+        id: 'ch-1',
+        send: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+    }
+}
+
+function makeInteraction(
+    sub: 'open' | 'close',
+    channel: ReturnType<typeof makeChannel>,
+) {
+    return {
+        guildId: 'g1',
+        channelId: 'ch-1',
+        user: { id: 'u1', username: 'bob', tag: 'bob#1' },
+        options: {
+            getSubcommand: () => sub,
+            getString: () => null,
+        },
+        guild: {
+            id: 'g1',
+            roles: { everyone: { id: 'everyone' } },
+            channels: {
+                create: jest.fn().mockResolvedValue(channel),
+                fetch: jest.fn().mockResolvedValue(channel),
+            },
+            members: {
+                fetch: jest.fn().mockResolvedValue({
+                    roles: { cache: { has: () => false } },
+                    permissions: { has: () => true },
+                }),
+            },
+        },
+    } as any
+}
+
+describe('/ticket command (smoke)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        guildSettingsServiceMock.getGuildSettings.mockResolvedValue({
+            supportCategoryId: 'cat-1',
+            supportAgentRoleId: 'agent-role',
+        })
+    })
+
+    it('open: creates a channel, records the session, and confirms', async () => {
+        const channel = makeChannel()
+        supportSessionServiceMock.getActiveForUser.mockResolvedValue(null)
+        supportSessionServiceMock.open.mockResolvedValue({ id: 's1' })
+
+        await ticketCommand.execute({
+            interaction: makeInteraction('open', channel),
+        } as any)
+
+        expect(supportSessionServiceMock.open).toHaveBeenCalledWith(
+            expect.objectContaining({
+                guildId: 'g1',
+                channelId: 'ch-1',
+                requestorId: 'u1',
+            }),
+        )
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: { content: expect.stringContaining('Ticket opened') },
+            }),
+        )
+    })
+
+    it('open: refuses when the feature is not configured', async () => {
+        guildSettingsServiceMock.getGuildSettings.mockResolvedValue({})
+        const channel = makeChannel()
+
+        await ticketCommand.execute({
+            interaction: makeInteraction('open', channel),
+        } as any)
+
+        expect(channel.send).not.toHaveBeenCalled()
+        expect(supportSessionServiceMock.open).not.toHaveBeenCalled()
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: {
+                    content: expect.stringContaining('not configured'),
+                },
+            }),
+        )
+    })
+
+    it('open: rolls the channel back when recording the session fails', async () => {
+        const channel = makeChannel()
+        supportSessionServiceMock.getActiveForUser.mockResolvedValue(null)
+        supportSessionServiceMock.open.mockRejectedValue({ code: 'P2002' })
+
+        await ticketCommand.execute({
+            interaction: makeInteraction('open', channel),
+        } as any)
+
+        expect(channel.delete).toHaveBeenCalled()
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: {
+                    content: expect.stringContaining('already have an open'),
+                },
+            }),
+        )
+    })
+
+    it('close: deletes the channel and closes the session', async () => {
+        const channel = makeChannel()
+        supportSessionServiceMock.getByChannel.mockResolvedValue({
+            id: 's1',
+            status: 'open',
+            requestorId: 'u1',
+        })
+
+        await ticketCommand.execute({
+            interaction: makeInteraction('close', channel),
+        } as any)
+
+        expect(supportSessionServiceMock.close).toHaveBeenCalledWith('s1')
+        expect(channel.delete).toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/functions/general/commands/ticket.ts
+++ b/packages/bot/src/functions/general/commands/ticket.ts
@@ -1,0 +1,221 @@
+import {
+    SlashCommandBuilder,
+    ChannelType,
+    PermissionFlagsBits,
+    type ChatInputCommandInteraction,
+    type Guild,
+    type OverwriteResolvable,
+    type TextChannel,
+} from 'discord.js'
+import Command from '../../../models/Command'
+import {
+    guildSettingsService,
+    supportSessionService,
+} from '@lucky/shared/services'
+import { infoLog, errorLog } from '@lucky/shared/utils'
+import { interactionReply } from '../../../utils/general/interactionReply'
+
+// Tickets auto-close 24h after opening (swept by supportSessionScheduler).
+const TICKET_TTL_MS = 24 * 60 * 60 * 1000
+
+async function handleOpen(
+    interaction: ChatInputCommandInteraction,
+    guild: Guild,
+): Promise<void> {
+    const settings = await guildSettingsService.getGuildSettings(guild.id)
+    const categoryId = settings?.supportCategoryId
+    const agentRoleId = settings?.supportAgentRoleId
+    if (!categoryId || !agentRoleId) {
+        await interactionReply({
+            interaction,
+            content: {
+                content:
+                    '❌ Tickets are not configured. An admin must set the support category and support-agent role first.',
+            },
+        })
+        return
+    }
+
+    const existing = await supportSessionService.getActiveForUser(
+        guild.id,
+        interaction.user.id,
+    )
+    if (existing) {
+        await interactionReply({
+            interaction,
+            content: {
+                content: `❌ You already have an open ticket: <#${existing.channelId}>. Close it before opening another.`,
+            },
+        })
+        return
+    }
+
+    // @everyone denied; requestor and every support agent (via the persistent
+    // role) get access — no per-session role is minted (avoids the 500-role cap).
+    const overwrites: OverwriteResolvable[] = [
+        {
+            id: guild.roles.everyone.id,
+            deny: [PermissionFlagsBits.ViewChannel],
+        },
+        {
+            id: interaction.user.id,
+            allow: [
+                PermissionFlagsBits.ViewChannel,
+                PermissionFlagsBits.SendMessages,
+                PermissionFlagsBits.ReadMessageHistory,
+            ],
+        },
+        {
+            id: agentRoleId,
+            allow: [
+                PermissionFlagsBits.ViewChannel,
+                PermissionFlagsBits.SendMessages,
+                PermissionFlagsBits.ReadMessageHistory,
+            ],
+        },
+    ]
+
+    try {
+        const channel = (await guild.channels.create({
+            name: `ticket-${interaction.user.username}`.slice(0, 90),
+            type: ChannelType.GuildText,
+            parent: categoryId,
+            permissionOverwrites: overwrites,
+            reason: `Support ticket opened by ${interaction.user.tag}`,
+        })) as TextChannel
+
+        await supportSessionService.open({
+            guildId: guild.id,
+            channelId: channel.id,
+            requestorId: interaction.user.id,
+            expiresAt: new Date(Date.now() + TICKET_TTL_MS),
+        })
+
+        const reason = interaction.options.getString('reason')
+        await channel.send({
+            content: `👋 <@${interaction.user.id}> — a support agent (<@&${agentRoleId}>) will be with you.${
+                reason ? `\n**Reason:** ${reason}` : ''
+            }\n\nThis ticket auto-closes in 24h, or use \`/ticket close\`.`,
+        })
+
+        await interactionReply({
+            interaction,
+            content: {
+                content: `✅ Ticket opened: <#${channel.id}>`,
+            },
+        })
+        infoLog({
+            message: 'Support ticket opened',
+            data: { guildId: guild.id, channelId: channel.id },
+        })
+    } catch (error) {
+        errorLog({ message: 'Failed to open support ticket', error })
+        await interactionReply({
+            interaction,
+            content: {
+                content:
+                    '❌ Could not create the ticket channel. Check the bot has Manage Channels in the support category.',
+            },
+        })
+    }
+}
+
+async function handleClose(
+    interaction: ChatInputCommandInteraction,
+    guild: Guild,
+): Promise<void> {
+    const channelId = interaction.channelId
+    const session = await supportSessionService.getByChannel(channelId)
+    if (!session || session.status !== 'open') {
+        await interactionReply({
+            interaction,
+            content: {
+                content: '❌ This is not an open ticket channel.',
+            },
+        })
+        return
+    }
+
+    // Requestor, a support agent, or a channel manager may close.
+    const member = await guild.members
+        .fetch(interaction.user.id)
+        .catch(() => null)
+    const settings = await guildSettingsService.getGuildSettings(guild.id)
+    const isRequestor = session.requestorId === interaction.user.id
+    const isAgent = settings?.supportAgentRoleId
+        ? (member?.roles.cache.has(settings.supportAgentRoleId) ?? false)
+        : false
+    const canManage =
+        member?.permissions.has(PermissionFlagsBits.ManageChannels) ?? false
+    if (!isRequestor && !isAgent && !canManage) {
+        await interactionReply({
+            interaction,
+            content: {
+                content:
+                    '❌ Only the ticket opener or a support agent can close this ticket.',
+            },
+        })
+        return
+    }
+
+    // Mark closed first so the channel delete (which ends this interaction) can't
+    // leave an orphaned open record; the sweep is idempotent either way.
+    await supportSessionService.close(session.id)
+    await interactionReply({
+        interaction,
+        content: { content: '✅ Closing this ticket…' },
+    })
+
+    const channel = await guild.channels.fetch(channelId).catch(() => null)
+    if (channel) {
+        await channel.delete('Support ticket closed').catch((error) =>
+            errorLog({
+                message: `Failed to delete ticket channel ${channelId}`,
+                error,
+            }),
+        )
+    }
+}
+
+export default new Command({
+    data: new SlashCommandBuilder()
+        .setName('ticket')
+        .setDescription('Open or close a temporary support ticket channel')
+        .addSubcommand((sub) =>
+            sub
+                .setName('open')
+                .setDescription('Open a private support ticket')
+                .addStringOption((opt) =>
+                    opt
+                        .setName('reason')
+                        .setDescription('What do you need help with?')
+                        .setRequired(false),
+                ),
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName('close')
+                .setDescription('Close the ticket in this channel'),
+        ),
+    category: 'general',
+    execute: async ({
+        interaction,
+    }: {
+        interaction: ChatInputCommandInteraction
+    }) => {
+        const guild = interaction.guild
+        if (!guild) {
+            await interactionReply({
+                interaction,
+                content: { content: '❌ This command must be run in a guild.' },
+            })
+            return
+        }
+
+        if (interaction.options.getSubcommand() === 'open') {
+            await handleOpen(interaction, guild)
+        } else {
+            await handleClose(interaction, guild)
+        }
+    },
+})

--- a/packages/bot/src/functions/general/commands/ticket.ts
+++ b/packages/bot/src/functions/general/commands/ticket.ts
@@ -18,6 +18,9 @@ import { interactionReply } from '../../../utils/general/interactionReply'
 // Tickets auto-close 24h after opening (swept by supportSessionScheduler).
 const TICKET_TTL_MS = 24 * 60 * 60 * 1000
 
+// Discord REST error code: the channel truly no longer exists.
+const UNKNOWN_CHANNEL = 10003
+
 async function handleOpen(
     interaction: ChatInputCommandInteraction,
     guild: Guild,
@@ -41,13 +44,16 @@ async function handleOpen(
         interaction.user.id,
     )
     if (existing) {
-        // Only block if the channel still exists; if it was deleted out-of-band
-        // (a human removed it), close the orphan row and let the user reopen
-        // instead of stranding them until the 24h sweep.
-        const stillThere = await guild.channels
-            .fetch(existing.channelId)
-            .catch(() => null)
-        if (stillThere) {
+        // Only reopen if the channel is CONFIRMED gone (10003). A transient
+        // fetch error must not close a live ticket and let a duplicate open —
+        // treat "not confirmed gone" as still-open and block.
+        let channelGone = false
+        try {
+            await guild.channels.fetch(existing.channelId)
+        } catch (err) {
+            channelGone = (err as { code?: number })?.code === UNKNOWN_CHANNEL
+        }
+        if (!channelGone) {
             await interactionReply({
                 interaction,
                 content: {
@@ -56,6 +62,7 @@ async function handleOpen(
             })
             return
         }
+        // Channel was deleted out-of-band — close the orphan row and continue.
         await supportSessionService.close(existing.id).catch(() => {})
     }
 
@@ -93,8 +100,15 @@ async function handleOpen(
         })
     } catch (error) {
         // Roll the channel back so a failed — or race-lost (P2002 on the
-        // one-open-per-user unique index) — record never orphans a channel.
-        await channel.delete('Ticket record failed').catch(() => {})
+        // one-open-per-user unique index) — record never orphans a channel. If
+        // the rollback delete itself fails, surface it (the sweep can't help —
+        // there's no session row to expire).
+        await channel.delete('Ticket record failed').catch((delErr) =>
+            errorLog({
+                message: `Failed to roll back orphaned ticket channel ${channel.id}`,
+                error: delErr,
+            }),
+        )
         const raced = (error as { code?: string })?.code === 'P2002'
         errorLog({ message: 'Failed to record ticket session', error })
         await interactionReply({
@@ -116,6 +130,12 @@ async function handleOpen(
             content: `👋 <@${interaction.user.id}> — a support agent (<@&${agentRoleId}>) will be with you.${
                 reason ? `\n**Reason:** ${reason}` : ''
             }\n\nThis ticket auto-closes in 24h, or use \`/ticket close\`.`,
+            // Scope mentions to the intended targets only, so a `reason`
+            // containing @everyone / a role mention can't ping the server.
+            allowedMentions: {
+                users: [interaction.user.id],
+                roles: [agentRoleId],
+            },
         })
         .catch((error) =>
             errorLog({ message: 'Ticket welcome message failed', error }),
@@ -191,22 +211,44 @@ async function handleClose(
         return
     }
 
-    // Mark closed first so the channel delete (which ends this interaction) can't
-    // leave an orphaned open record; the sweep is idempotent either way.
-    await supportSessionService.close(session.id)
+    // Reply before the delete — an ephemeral interaction reply survives the
+    // channel being removed, whereas a message in the channel would not.
     await interactionReply({
         interaction,
         content: { content: '✅ Closing this ticket…' },
     })
 
+    await teardownClosedTicket(guild, channelId, session.id)
+}
+
+/**
+ * Delete the ticket channel and close the record — but close ONLY when the
+ * channel is confirmed gone (successful delete or 10003). A 50013/transient
+ * delete failure keeps the session OPEN so the expiry sweep retries, rather
+ * than orphaning a still-live channel with no tracking row.
+ */
+async function teardownClosedTicket(
+    guild: Guild,
+    channelId: string,
+    sessionId: string,
+): Promise<void> {
     const channel = await guild.channels.fetch(channelId).catch(() => null)
-    if (channel) {
-        await channel.delete('Support ticket closed').catch((error) =>
-            errorLog({
-                message: `Failed to delete ticket channel ${channelId}`,
-                error,
-            }),
-        )
+    if (!channel) {
+        await supportSessionService.close(sessionId).catch(() => {})
+        return
+    }
+    try {
+        await channel.delete('Support ticket closed')
+        await supportSessionService.close(sessionId).catch(() => {})
+    } catch (error) {
+        if ((error as { code?: number })?.code === UNKNOWN_CHANNEL) {
+            await supportSessionService.close(sessionId).catch(() => {})
+            return
+        }
+        errorLog({
+            message: `Failed to delete ticket channel ${channelId}; leaving session open for the sweep`,
+            error,
+        })
     }
 }
 

--- a/packages/bot/src/functions/general/commands/ticket.ts
+++ b/packages/bot/src/functions/general/commands/ticket.ts
@@ -41,75 +41,39 @@ async function handleOpen(
         interaction.user.id,
     )
     if (existing) {
-        await interactionReply({
-            interaction,
-            content: {
-                content: `❌ You already have an open ticket: <#${existing.channelId}>. Close it before opening another.`,
-            },
-        })
-        return
+        // Only block if the channel still exists; if it was deleted out-of-band
+        // (a human removed it), close the orphan row and let the user reopen
+        // instead of stranding them until the 24h sweep.
+        const stillThere = await guild.channels
+            .fetch(existing.channelId)
+            .catch(() => null)
+        if (stillThere) {
+            await interactionReply({
+                interaction,
+                content: {
+                    content: `❌ You already have an open ticket: <#${existing.channelId}>. Close it before opening another.`,
+                },
+            })
+            return
+        }
+        await supportSessionService.close(existing.id).catch(() => {})
     }
 
-    // @everyone denied; requestor and every support agent (via the persistent
-    // role) get access — no per-session role is minted (avoids the 500-role cap).
-    const overwrites: OverwriteResolvable[] = [
-        {
-            id: guild.roles.everyone.id,
-            deny: [PermissionFlagsBits.ViewChannel],
-        },
-        {
-            id: interaction.user.id,
-            allow: [
-                PermissionFlagsBits.ViewChannel,
-                PermissionFlagsBits.SendMessages,
-                PermissionFlagsBits.ReadMessageHistory,
-            ],
-        },
-        {
-            id: agentRoleId,
-            allow: [
-                PermissionFlagsBits.ViewChannel,
-                PermissionFlagsBits.SendMessages,
-                PermissionFlagsBits.ReadMessageHistory,
-            ],
-        },
-    ]
-
+    let channel: TextChannel
     try {
-        const channel = (await guild.channels.create({
+        channel = (await guild.channels.create({
             name: `ticket-${interaction.user.username}`.slice(0, 90),
             type: ChannelType.GuildText,
             parent: categoryId,
-            permissionOverwrites: overwrites,
+            permissionOverwrites: buildTicketOverwrites(
+                guild,
+                interaction.user.id,
+                agentRoleId,
+            ),
             reason: `Support ticket opened by ${interaction.user.tag}`,
         })) as TextChannel
-
-        await supportSessionService.open({
-            guildId: guild.id,
-            channelId: channel.id,
-            requestorId: interaction.user.id,
-            expiresAt: new Date(Date.now() + TICKET_TTL_MS),
-        })
-
-        const reason = interaction.options.getString('reason')
-        await channel.send({
-            content: `👋 <@${interaction.user.id}> — a support agent (<@&${agentRoleId}>) will be with you.${
-                reason ? `\n**Reason:** ${reason}` : ''
-            }\n\nThis ticket auto-closes in 24h, or use \`/ticket close\`.`,
-        })
-
-        await interactionReply({
-            interaction,
-            content: {
-                content: `✅ Ticket opened: <#${channel.id}>`,
-            },
-        })
-        infoLog({
-            message: 'Support ticket opened',
-            data: { guildId: guild.id, channelId: channel.id },
-        })
     } catch (error) {
-        errorLog({ message: 'Failed to open support ticket', error })
+        errorLog({ message: 'Failed to create ticket channel', error })
         await interactionReply({
             interaction,
             content: {
@@ -117,7 +81,76 @@ async function handleOpen(
                     '❌ Could not create the ticket channel. Check the bot has Manage Channels in the support category.',
             },
         })
+        return
     }
+
+    try {
+        await supportSessionService.open({
+            guildId: guild.id,
+            channelId: channel.id,
+            requestorId: interaction.user.id,
+            expiresAt: new Date(Date.now() + TICKET_TTL_MS),
+        })
+    } catch (error) {
+        // Roll the channel back so a failed — or race-lost (P2002 on the
+        // one-open-per-user unique index) — record never orphans a channel.
+        await channel.delete('Ticket record failed').catch(() => {})
+        const raced = (error as { code?: string })?.code === 'P2002'
+        errorLog({ message: 'Failed to record ticket session', error })
+        await interactionReply({
+            interaction,
+            content: {
+                content: raced
+                    ? '❌ You already have an open ticket (opened moments ago).'
+                    : '❌ Could not open the ticket. Please try again.',
+            },
+        })
+        return
+    }
+
+    // Welcome message is best-effort — a send failure must not tear down an
+    // already-valid ticket.
+    const reason = interaction.options.getString('reason')
+    await channel
+        .send({
+            content: `👋 <@${interaction.user.id}> — a support agent (<@&${agentRoleId}>) will be with you.${
+                reason ? `\n**Reason:** ${reason}` : ''
+            }\n\nThis ticket auto-closes in 24h, or use \`/ticket close\`.`,
+        })
+        .catch((error) =>
+            errorLog({ message: 'Ticket welcome message failed', error }),
+        )
+
+    await interactionReply({
+        interaction,
+        content: { content: `✅ Ticket opened: <#${channel.id}>` },
+    })
+    infoLog({
+        message: 'Support ticket opened',
+        data: { guildId: guild.id, channelId: channel.id },
+    })
+}
+
+/** @everyone denied; the requestor and every support agent (via the persistent
+ * role) get access — no per-session role is minted (avoids the 500-role cap). */
+function buildTicketOverwrites(
+    guild: Guild,
+    requestorId: string,
+    agentRoleId: string,
+): OverwriteResolvable[] {
+    const allow = [
+        PermissionFlagsBits.ViewChannel,
+        PermissionFlagsBits.SendMessages,
+        PermissionFlagsBits.ReadMessageHistory,
+    ]
+    return [
+        {
+            id: guild.roles.everyone.id,
+            deny: [PermissionFlagsBits.ViewChannel],
+        },
+        { id: requestorId, allow },
+        { id: agentRoleId, allow },
+    ]
 }
 
 async function handleClose(

--- a/packages/bot/src/handlers/clientHandler/service.spec.ts
+++ b/packages/bot/src/handlers/clientHandler/service.spec.ts
@@ -27,6 +27,10 @@ jest.mock('../../utils/general/reminderScheduler', () => ({
     reminderScheduler: { start: jest.fn(), stop: jest.fn() },
 }))
 
+jest.mock('../../utils/general/supportSessionScheduler', () => ({
+    supportSessionScheduler: { start: jest.fn(), stop: jest.fn() },
+}))
+
 jest.mock('../../utils/moderation/modDigestScheduler', () => ({
     modDigestSchedulerService: {
         start: jest.fn(),

--- a/packages/bot/src/handlers/clientHandler/service.spec.ts
+++ b/packages/bot/src/handlers/clientHandler/service.spec.ts
@@ -357,6 +357,32 @@ describe('service', () => {
             )
         })
 
+        it('starts the support session scheduler in the ready handler', async () => {
+            const { supportSessionScheduler } =
+                await import('../../utils/general/supportSessionScheduler')
+            ;(supportSessionScheduler.start as jest.Mock).mockClear()
+
+            const mockClient = {
+                login: jest.fn().mockResolvedValue('client'),
+                once: jest.fn((event, handler) => {
+                    if (event === 'ready') {
+                        Promise.resolve().then(() => handler())
+                    }
+                }),
+                user: null,
+                commands: { map: jest.fn().mockReturnValue([]) },
+                guilds: { cache: { values: jest.fn().mockReturnValue([]) } },
+            }
+
+            const startPromise = startClient({ client: mockClient as any })
+            await new Promise((resolve) => setImmediate(resolve))
+            await startPromise
+
+            expect(supportSessionScheduler.start).toHaveBeenCalledWith(
+                mockClient,
+            )
+        })
+
         it('still starts the scheduler when an upstream ready step fails', async () => {
             const { modDigestSchedulerService } =
                 await import('../../utils/moderation/modDigestScheduler')

--- a/packages/bot/src/handlers/clientHandler/service.ts
+++ b/packages/bot/src/handlers/clientHandler/service.ts
@@ -9,6 +9,7 @@ import { startPresenceRotation } from './presence'
 import { modDigestSchedulerService } from '../../utils/moderation/modDigestScheduler'
 import { birthdayScheduler } from '../../utils/general/birthdayScheduler'
 import { reminderScheduler } from '../../utils/general/reminderScheduler'
+import { supportSessionScheduler } from '../../utils/general/supportSessionScheduler'
 import { giveawayScheduler } from '../../utils/general/giveawayScheduler'
 import { topggStatsScheduler } from '../../utils/general/topggStatsScheduler'
 import { criativariaLiveNotificationService } from '../../services/CriativariaLiveNotificationService'
@@ -135,6 +136,7 @@ export async function startClient({
 
             try {
                 reminderScheduler.start(client)
+                supportSessionScheduler.start(client)
             } catch (error) {
                 errorLog({
                     message: 'Failed to start reminder scheduler',

--- a/packages/bot/src/handlers/clientHandler/service.ts
+++ b/packages/bot/src/handlers/clientHandler/service.ts
@@ -136,10 +136,18 @@ export async function startClient({
 
             try {
                 reminderScheduler.start(client)
-                supportSessionScheduler.start(client)
             } catch (error) {
                 errorLog({
                     message: 'Failed to start reminder scheduler',
+                    error,
+                })
+            }
+
+            try {
+                supportSessionScheduler.start(client)
+            } catch (error) {
+                errorLog({
+                    message: 'Failed to start support session scheduler',
                     error,
                 })
             }

--- a/packages/bot/src/utils/general/supportSessionScheduler.spec.ts
+++ b/packages/bot/src/utils/general/supportSessionScheduler.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+
+const supportSessionServiceMock = {
+    getExpired: jest.fn() as jest.MockedFunction<any>,
+    close: jest.fn() as jest.MockedFunction<any>,
+}
+
+jest.mock('@lucky/shared/services', () => ({
+    supportSessionService: supportSessionServiceMock,
+}))
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+    infoLog: jest.fn(),
+}))
+
+import { SupportSessionScheduler } from './supportSessionScheduler'
+
+function makeChannel(deleteImpl?: any) {
+    return {
+        isDMBased: () => false,
+        delete: deleteImpl ?? jest.fn().mockResolvedValue(undefined),
+    }
+}
+
+function makeClient(channel: unknown) {
+    return { channels: { fetch: jest.fn().mockResolvedValue(channel) } }
+}
+
+/** Run one sweep deterministically. */
+async function sweep(client: unknown) {
+    const scheduler = new SupportSessionScheduler()
+    ;(scheduler as unknown as { client: unknown }).client = client
+    await (scheduler as unknown as { execute: () => Promise<void> }).execute()
+    return scheduler
+}
+
+describe('SupportSessionScheduler', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        supportSessionServiceMock.getExpired.mockResolvedValue([])
+        supportSessionServiceMock.close.mockResolvedValue(undefined)
+    })
+
+    it('deletes the channel and closes the session for each expired ticket', async () => {
+        supportSessionServiceMock.getExpired.mockResolvedValue([
+            { id: 's1', channelId: 'c1' },
+        ])
+        const del = jest.fn().mockResolvedValue(undefined)
+        await sweep(makeClient(makeChannel(del)))
+
+        expect(del).toHaveBeenCalledWith('Support ticket expired')
+        expect(supportSessionServiceMock.close).toHaveBeenCalledWith('s1')
+    })
+
+    it('still closes the session when the channel is already gone', async () => {
+        supportSessionServiceMock.getExpired.mockResolvedValue([
+            { id: 's1', channelId: 'c1' },
+        ])
+        await sweep(makeClient(null)) // fetch resolves null
+
+        expect(supportSessionServiceMock.close).toHaveBeenCalledWith('s1')
+    })
+
+    it('treats a 10003 (unknown channel) delete error as already-gone and closes', async () => {
+        supportSessionServiceMock.getExpired.mockResolvedValue([
+            { id: 's1', channelId: 'c1' },
+        ])
+        const del = jest.fn().mockRejectedValue({ code: 10003 })
+        await sweep(makeClient(makeChannel(del)))
+
+        expect(supportSessionServiceMock.close).toHaveBeenCalledWith('s1')
+    })
+
+    it('does nothing when there are no expired tickets', async () => {
+        const fetch = jest.fn()
+        await sweep({ channels: { fetch } })
+
+        expect(fetch).not.toHaveBeenCalled()
+        expect(supportSessionServiceMock.close).not.toHaveBeenCalled()
+    })
+})

--- a/packages/bot/src/utils/general/supportSessionScheduler.spec.ts
+++ b/packages/bot/src/utils/general/supportSessionScheduler.spec.ts
@@ -15,6 +15,12 @@ jest.mock('@lucky/shared/utils', () => ({
 
 import { SupportSessionScheduler } from './supportSessionScheduler'
 
+function makeClient(opts: { fetch?: any; channel?: unknown }) {
+    const fetch =
+        opts.fetch ?? jest.fn().mockResolvedValue(opts.channel ?? null)
+    return { channels: { fetch } }
+}
+
 function makeChannel(deleteImpl?: any) {
     return {
         isDMBased: () => false,
@@ -22,17 +28,14 @@ function makeChannel(deleteImpl?: any) {
     }
 }
 
-function makeClient(channel: unknown) {
-    return { channels: { fetch: jest.fn().mockResolvedValue(channel) } }
-}
-
 /** Run one sweep deterministically. */
 async function sweep(client: unknown) {
     const scheduler = new SupportSessionScheduler()
     ;(scheduler as unknown as { client: unknown }).client = client
     await (scheduler as unknown as { execute: () => Promise<void> }).execute()
-    return scheduler
 }
+
+const ONE = [{ id: 's1', channelId: 'c1' }]
 
 describe('SupportSessionScheduler', () => {
     beforeEach(() => {
@@ -41,39 +44,55 @@ describe('SupportSessionScheduler', () => {
         supportSessionServiceMock.close.mockResolvedValue(undefined)
     })
 
-    it('deletes the channel and closes the session for each expired ticket', async () => {
-        supportSessionServiceMock.getExpired.mockResolvedValue([
-            { id: 's1', channelId: 'c1' },
-        ])
+    it('deletes the channel and closes the session on success', async () => {
+        supportSessionServiceMock.getExpired.mockResolvedValue(ONE)
         const del = jest.fn().mockResolvedValue(undefined)
-        await sweep(makeClient(makeChannel(del)))
+        await sweep(makeClient({ channel: makeChannel(del) }))
 
         expect(del).toHaveBeenCalledWith('Support ticket expired')
         expect(supportSessionServiceMock.close).toHaveBeenCalledWith('s1')
     })
 
-    it('still closes the session when the channel is already gone', async () => {
-        supportSessionServiceMock.getExpired.mockResolvedValue([
-            { id: 's1', channelId: 'c1' },
-        ])
-        await sweep(makeClient(null)) // fetch resolves null
+    it('closes the session when the channel is already gone (10003 on fetch)', async () => {
+        supportSessionServiceMock.getExpired.mockResolvedValue(ONE)
+        await sweep(
+            makeClient({ fetch: jest.fn().mockRejectedValue({ code: 10003 }) }),
+        )
 
         expect(supportSessionServiceMock.close).toHaveBeenCalledWith('s1')
     })
 
-    it('treats a 10003 (unknown channel) delete error as already-gone and closes', async () => {
-        supportSessionServiceMock.getExpired.mockResolvedValue([
-            { id: 's1', channelId: 'c1' },
-        ])
+    it('LEAVES the session open when delete fails with 50013 (missing perms)', async () => {
+        supportSessionServiceMock.getExpired.mockResolvedValue(ONE)
+        const del = jest.fn().mockRejectedValue({ code: 50013 })
+        await sweep(makeClient({ channel: makeChannel(del) }))
+
+        // Channel still exists — must NOT close, so a later sweep retries.
+        expect(supportSessionServiceMock.close).not.toHaveBeenCalled()
+    })
+
+    it('LEAVES the session open on a transient fetch error', async () => {
+        supportSessionServiceMock.getExpired.mockResolvedValue(ONE)
+        await sweep(
+            makeClient({
+                fetch: jest.fn().mockRejectedValue(new Error('gateway 503')),
+            }),
+        )
+
+        expect(supportSessionServiceMock.close).not.toHaveBeenCalled()
+    })
+
+    it('closes the session when the channel is deleted mid-sweep (10003 on delete)', async () => {
+        supportSessionServiceMock.getExpired.mockResolvedValue(ONE)
         const del = jest.fn().mockRejectedValue({ code: 10003 })
-        await sweep(makeClient(makeChannel(del)))
+        await sweep(makeClient({ channel: makeChannel(del) }))
 
         expect(supportSessionServiceMock.close).toHaveBeenCalledWith('s1')
     })
 
     it('does nothing when there are no expired tickets', async () => {
         const fetch = jest.fn()
-        await sweep({ channels: { fetch } })
+        await sweep(makeClient({ fetch }))
 
         expect(fetch).not.toHaveBeenCalled()
         expect(supportSessionServiceMock.close).not.toHaveBeenCalled()

--- a/packages/bot/src/utils/general/supportSessionScheduler.ts
+++ b/packages/bot/src/utils/general/supportSessionScheduler.ts
@@ -1,0 +1,67 @@
+import { supportSessionService } from '@lucky/shared/services'
+import { errorLog, infoLog } from '@lucky/shared/utils'
+import { IntervalScheduler } from './IntervalScheduler'
+
+// Sweep for expired tickets every 5 minutes.
+const DEFAULT_TICK_INTERVAL_MS = 5 * 60 * 1000
+
+// Discord REST error codes treated as "already gone", not a failure.
+const UNKNOWN_CHANNEL = 10003
+const MISSING_PERMISSIONS = 50013
+
+/**
+ * Auto-closes expired support tickets: deletes the channel (the single-step
+ * teardown the overwrite-based design enables) and marks the session closed.
+ * A missing channel or a permissions error is treated as already-gone so the
+ * record is still closed and the sweep doesn't retry it forever.
+ */
+export class SupportSessionScheduler extends IntervalScheduler {
+    constructor(tickIntervalMs: number = DEFAULT_TICK_INTERVAL_MS) {
+        super(tickIntervalMs)
+    }
+
+    protected async execute(): Promise<void> {
+        if (!this.client) return
+
+        const expired = await supportSessionService.getExpired()
+        for (const session of expired) {
+            const channel = await this.client.channels
+                .fetch(session.channelId)
+                .catch(() => null)
+
+            if (channel && !channel.isDMBased()) {
+                try {
+                    await channel.delete('Support ticket expired')
+                } catch (err) {
+                    const code = (err as { code?: number })?.code
+                    if (
+                        code !== UNKNOWN_CHANNEL &&
+                        code !== MISSING_PERMISSIONS
+                    ) {
+                        errorLog({
+                            message: `Failed to delete expired ticket channel ${session.channelId}`,
+                            error: err,
+                        })
+                    }
+                }
+            }
+
+            // Close the record regardless — the channel is gone (or already was).
+            await supportSessionService.close(session.id).catch((err) =>
+                errorLog({
+                    message: `Failed to close ticket session ${session.id}`,
+                    error: err,
+                }),
+            )
+        }
+
+        if (expired.length > 0) {
+            infoLog({
+                message: `Support ticket sweep: closed ${expired.length} expired ticket(s)`,
+            })
+        }
+    }
+}
+
+/** Singleton instance of SupportSessionScheduler. */
+export const supportSessionScheduler = new SupportSessionScheduler()

--- a/packages/bot/src/utils/general/supportSessionScheduler.ts
+++ b/packages/bot/src/utils/general/supportSessionScheduler.ts
@@ -5,62 +5,108 @@ import { IntervalScheduler } from './IntervalScheduler'
 // Sweep for expired tickets every 5 minutes.
 const DEFAULT_TICK_INTERVAL_MS = 5 * 60 * 1000
 
-// Discord REST error codes treated as "already gone", not a failure.
+// Discord REST error code: the channel truly no longer exists.
 const UNKNOWN_CHANNEL = 10003
-const MISSING_PERMISSIONS = 50013
 
 /**
- * Auto-closes expired support tickets: deletes the channel (the single-step
- * teardown the overwrite-based design enables) and marks the session closed.
- * A missing channel or a permissions error is treated as already-gone so the
- * record is still closed and the sweep doesn't retry it forever.
+ * Auto-closes expired support tickets by deleting the channel and marking the
+ * session closed. Critically, the session is closed **only when the channel is
+ * confirmed gone** — a successful delete, or a `10003 Unknown Channel`. A
+ * `50013 Missing Permissions` or a transient error leaves the session OPEN so a
+ * later sweep retries; closing it there would orphan a still-live ticket channel
+ * that nothing would ever clean up.
  */
 export class SupportSessionScheduler extends IntervalScheduler {
     constructor(tickIntervalMs: number = DEFAULT_TICK_INTERVAL_MS) {
         super(tickIntervalMs)
     }
 
+    /** Sweep once immediately on startup to catch tickets that expired while the
+     * bot was down (matches the other IntervalScheduler subclasses). */
+    protected onStart(): void {
+        void this.tick()
+    }
+
     protected async execute(): Promise<void> {
         if (!this.client) return
 
         const expired = await supportSessionService.getExpired()
+        let closed = 0
         for (const session of expired) {
-            const channel = await this.client.channels
-                .fetch(session.channelId)
-                .catch(() => null)
-
-            if (channel && !channel.isDMBased()) {
-                try {
-                    await channel.delete('Support ticket expired')
-                } catch (err) {
-                    const code = (err as { code?: number })?.code
-                    if (
-                        code !== UNKNOWN_CHANNEL &&
-                        code !== MISSING_PERMISSIONS
-                    ) {
-                        errorLog({
-                            message: `Failed to delete expired ticket channel ${session.channelId}`,
-                            error: err,
-                        })
-                    }
-                }
+            if (await this.teardownTicket(session.id, session.channelId)) {
+                closed++
             }
-
-            // Close the record regardless — the channel is gone (or already was).
-            await supportSessionService.close(session.id).catch((err) =>
-                errorLog({
-                    message: `Failed to close ticket session ${session.id}`,
-                    error: err,
-                }),
-            )
         }
 
-        if (expired.length > 0) {
+        if (closed > 0) {
             infoLog({
-                message: `Support ticket sweep: closed ${expired.length} expired ticket(s)`,
+                message: `Support ticket sweep: closed ${closed} expired ticket(s)`,
             })
         }
     }
+
+    /**
+     * Delete the ticket channel and close the session iff the channel is
+     * confirmed gone. Returns true when the session was closed.
+     */
+    private async teardownTicket(
+        sessionId: string,
+        channelId: string,
+    ): Promise<boolean> {
+        if (!this.client) return false
+
+        let channel
+        try {
+            channel = await this.client.channels.fetch(channelId)
+        } catch (err) {
+            if (errorCode(err) === UNKNOWN_CHANNEL) {
+                return this.closeSession(sessionId) // already gone
+            }
+            // Transient/permissions fetch error — leave open, retry next sweep.
+            errorLog({
+                message: `Ticket sweep: could not fetch channel ${channelId}`,
+                error: err,
+            })
+            return false
+        }
+
+        if (!channel || channel.isDMBased()) {
+            return this.closeSession(sessionId) // not a live guild channel
+        }
+
+        try {
+            await channel.delete('Support ticket expired')
+            return this.closeSession(sessionId)
+        } catch (err) {
+            if (errorCode(err) === UNKNOWN_CHANNEL) {
+                return this.closeSession(sessionId) // raced, already gone
+            }
+            // 50013 (missing perms) or transient — the channel still exists, so
+            // keep the session OPEN and retry on a later sweep.
+            errorLog({
+                message: `Ticket sweep: could not delete channel ${channelId}, will retry`,
+                error: err,
+            })
+            return false
+        }
+    }
+
+    private async closeSession(sessionId: string): Promise<boolean> {
+        try {
+            await supportSessionService.close(sessionId)
+            return true
+        } catch (err) {
+            errorLog({
+                message: `Ticket sweep: failed to close session ${sessionId}`,
+                error: err,
+            })
+            return false
+        }
+    }
+}
+
+function errorCode(err: unknown): number | undefined {
+    return (err as { code?: number })?.code
 }
 
 /** Singleton instance of SupportSessionScheduler. */

--- a/packages/shared/src/services/GuildSettingsService.ts
+++ b/packages/shared/src/services/GuildSettingsService.ts
@@ -37,6 +37,8 @@ export interface GuildSettings {
     djRoleId?: string
     idleTimeoutMinutes?: number
     voteSkipThreshold?: number
+    supportCategoryId?: string
+    supportAgentRoleId?: string
     createdAt: Date
     updatedAt: Date
 }
@@ -109,6 +111,8 @@ export class GuildSettingsService {
         djRoleId: string | null
         idleTimeoutMinutes: number | null
         voteSkipThreshold: number | null
+        supportCategoryId: string | null
+        supportAgentRoleId: string | null
         createdAt: Date
         updatedAt: Date
     }): GuildSettings {
@@ -134,6 +138,8 @@ export class GuildSettingsService {
             djRoleId: row.djRoleId ?? undefined,
             idleTimeoutMinutes: row.idleTimeoutMinutes ?? 0,
             voteSkipThreshold: row.voteSkipThreshold ?? 50,
+            supportCategoryId: row.supportCategoryId ?? undefined,
+            supportAgentRoleId: row.supportAgentRoleId ?? undefined,
             createdAt: row.createdAt,
             updatedAt: row.updatedAt,
         }
@@ -168,6 +174,8 @@ export class GuildSettingsService {
         copy('commandCooldown')
         copy('downloadCooldown')
         copy('djRoleId')
+        copy('supportCategoryId')
+        copy('supportAgentRoleId')
         copy('idleTimeoutMinutes')
         copy('voteSkipThreshold')
         return data

--- a/packages/shared/src/services/SupportSessionService.ts
+++ b/packages/shared/src/services/SupportSessionService.ts
@@ -1,0 +1,53 @@
+import { getPrismaClient } from '../utils/database/prismaClient.js'
+
+/**
+ * Lifecycle store for temporary support/ticket channels. The channel itself
+ * owns access control (per-user + support-agent-role overwrites); this service
+ * only tracks open/closed state so the sweep scheduler can auto-close expired
+ * tickets and the command can enforce one open ticket per requestor.
+ */
+export class SupportSessionService {
+    /** Record a newly-opened ticket channel. */
+    async open(input: {
+        guildId: string
+        channelId: string
+        requestorId: string
+        expiresAt: Date
+    }) {
+        return await getPrismaClient().supportSession.create({
+            data: { ...input, status: 'open' },
+        })
+    }
+
+    /** The requestor's currently-open ticket, if any (one-active-per-user gate). */
+    async getActiveForUser(guildId: string, requestorId: string) {
+        return await getPrismaClient().supportSession.findFirst({
+            where: { guildId, requestorId, status: 'open' },
+        })
+    }
+
+    /** The open ticket owning a channel (for /ticket close from inside it). */
+    async getByChannel(channelId: string) {
+        return await getPrismaClient().supportSession.findUnique({
+            where: { channelId },
+        })
+    }
+
+    /** Open tickets whose deadline has passed — the sweep set. */
+    async getExpired() {
+        return await getPrismaClient().supportSession.findMany({
+            where: { status: 'open', expiresAt: { lte: new Date() } },
+        })
+    }
+
+    /** Mark a ticket closed (idempotent — the sweep and /close may race). */
+    async close(id: string) {
+        return await getPrismaClient().supportSession.update({
+            where: { id },
+            data: { status: 'closed' },
+        })
+    }
+}
+
+/** Singleton instance of SupportSessionService. */
+export const supportSessionService = new SupportSessionService()

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -101,6 +101,10 @@ export {
     type StarboardEntry,
 } from './StarboardService.js'
 export {
+    supportSessionService,
+    SupportSessionService,
+} from './SupportSessionService.js'
+export {
     levelService,
     type LevelConfig,
     type MemberXP,

--- a/prisma/migrations/20260712000000_support_sessions/migration.sql
+++ b/prisma/migrations/20260712000000_support_sessions/migration.sql
@@ -24,5 +24,13 @@ CREATE INDEX "support_sessions_guildId_idx" ON "support_sessions"("guildId");
 -- CreateIndex
 CREATE INDEX "support_sessions_status_expiresAt_idx" ON "support_sessions"("status", "expiresAt");
 
+-- Enforce one OPEN ticket per (guild, requestor) at the DB level so concurrent
+-- /ticket open invocations can't race past the app-level check. Partial unique
+-- indexes are not expressible in schema.prisma, so this lives only in the
+-- migration (the generated client is unaffected; there is no CI drift check).
+CREATE UNIQUE INDEX "support_sessions_one_open_per_user"
+    ON "support_sessions"("guildId", "requestorId")
+    WHERE "status" = 'open';
+
 -- AddForeignKey
 ALTER TABLE "support_sessions" ADD CONSTRAINT "support_sessions_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("discordId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260712000000_support_sessions/migration.sql
+++ b/prisma/migrations/20260712000000_support_sessions/migration.sql
@@ -34,3 +34,8 @@ CREATE UNIQUE INDEX "support_sessions_one_open_per_user"
 
 -- AddForeignKey
 ALTER TABLE "support_sessions" ADD CONSTRAINT "support_sessions_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("discordId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Constrain the finite lifecycle state so a bad value can never become invisible
+-- to the active-ticket / expiry-sweep queries. (Not expressible in schema.prisma;
+-- migration-only, no CI drift check runs.)
+ALTER TABLE "support_sessions" ADD CONSTRAINT "support_sessions_status_check" CHECK ("status" IN ('open', 'closed'));

--- a/prisma/migrations/20260712000000_support_sessions/migration.sql
+++ b/prisma/migrations/20260712000000_support_sessions/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable
+ALTER TABLE "guild_settings" ADD COLUMN "supportCategoryId" TEXT;
+ALTER TABLE "guild_settings" ADD COLUMN "supportAgentRoleId" TEXT;
+
+-- CreateTable
+CREATE TABLE "support_sessions" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "channelId" TEXT NOT NULL,
+    "requestorId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "support_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "support_sessions_channelId_key" ON "support_sessions"("channelId");
+
+-- CreateIndex
+CREATE INDEX "support_sessions_guildId_idx" ON "support_sessions"("guildId");
+
+-- CreateIndex
+CREATE INDEX "support_sessions_status_expiresAt_idx" ON "support_sessions"("status", "expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "support_sessions" ADD CONSTRAINT "support_sessions_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds"("discordId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,7 @@ model Guild {
   batchJobs                    BatchJob[]
   afkStatuses                  AfkStatus[]
   reminders                   Reminder[]
+  supportSessions              SupportSession[]
 
   @@map("guilds")
 }
@@ -237,10 +238,36 @@ model GuildSettings {
   // clock rolls over.
   birthdayRoleId    String?
 
+  // Support/ticket feature. Both must be set for /ticket to work: the category
+  // new ticket channels are created under, and the persistent role that grants
+  // support agents access to every ticket channel (via per-channel overwrites).
+  supportCategoryId  String?
+  supportAgentRoleId String?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@map("guild_settings")
+}
+
+/// One temporary support/ticket channel. The channel is the source of truth for
+/// access (per-user + support-agent-role overwrites); this row tracks lifecycle
+/// so the sweep scheduler can auto-close expired tickets and enforce one open
+/// ticket per requestor.
+model SupportSession {
+  id          String   @id @default(cuid())
+  guildId     String
+  guild       Guild    @relation(fields: [guildId], references: [discordId], onDelete: Cascade)
+  channelId   String   @unique
+  requestorId String
+  status      String   @default("open") // open | closed
+  expiresAt   DateTime
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([guildId])
+  @@index([status, expiresAt])
+  @@map("support_sessions")
 }
 
 model GuildRoleGrant {


### PR DESCRIPTION
Closes #1766

## What
A self-service ticket feature: `/ticket open` creates a private temp channel; `/ticket close` (or the 24h auto-expiry sweep) tears it down.

## Design (overwrite-based, per the debate on #1766)
- **No per-session role** — avoids Discord's 500-role cap. One persistent **support-agent role** (configured per guild) is granted access to every ticket via a channel `PermissionOverwrite`, alongside the requestor; `@everyone` is denied. Precedent: `serversetup.ts`'s `OverwriteResolvable` usage.
- **Single-step teardown** — delete the channel (codes `10003`/`50013` → already-gone). No fragile 3-step role teardown.

## Pieces
- **Schema:** `SupportSession` model (+ migration) and `supportCategoryId`/`supportAgentRoleId` on `GuildSettings` (read/write via the existing settings service).
- **`SupportSessionService`** (shared): open / getActiveForUser (one-open-per-user gate) / getByChannel / getExpired / close.
- **`/ticket`** command: config-gated, one active ticket per user, `dry_run`-free but confirmation-free (opening is cheap + self-scoped); close is authorized to the opener, a support agent, or a channel manager.
- **`SupportSessionScheduler`** (`IntervalScheduler`, 5-min sweep): auto-closes expired tickets; wired into clientHandler start + initializer stop.

## Decisions (confirmed with the operator)
- **Lifetime:** fixed 24h default (constant), swept by the scheduler.
- **Who opens:** any member, self-service, bounded by one-active-per-user + auto-expiry (no permission gate — a requester must be able to open their own ticket).

## Verify
- Scheduler tests (delete+close, already-gone channel, `10003` error, no-op) + regression on clientHandler/initializer/GuildSettings — all pass; type:check 0, eslint 0 errors.
- Command (`functions/**`) and service (`shared/**`) are Sonar coverage-excluded; the scheduler (counted) is ~88% line-covered.

## Follow-up
Setting `supportCategoryId`/`supportAgentRoleId` currently goes through the generic settings API — a dedicated `/ticket-setup` or dashboard field is a small follow-up (filed separately if wanted).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-serve support tickets: `/ticket open` creates a private channel (with an optional reason) and `/ticket close` removes it; tickets auto-expire after 24h. Sessions are tracked with a DB-enforced one-open-per-user rule and are closed only when the channel is confirmed gone, per #1766.

- **New Features**
  - Slash command: `/ticket open [reason]` and `/ticket close`.
  - Per-guild setup via `GuildSettings`: `supportCategoryId` and `supportAgentRoleId`.
  - Access: deny `@everyone`; allow the requester and the support-agent role; no per-session roles.
  - One active ticket per user: DB unique index; on race/failure we delete the new channel and show a helpful message; if the previous ticket’s channel was manually deleted (`10003`), we auto-close the orphan so the user can reopen.
  - Close allowed by opener, support agent, or channel manager; the session is marked closed only after the channel is confirmed gone (delete succeeds or `10003`), otherwise it stays open to retry (e.g., `50013`).
  - `SupportSessionScheduler` sweeps every 5 minutes and uses the same “confirmed gone” rule; started on client ready and stopped during shutdown.

- **Migration**
  - Apply DB migration (adds `support_sessions` table and a partial unique index enforcing one open ticket per user).
  - Ensure the bot has Manage Channels in the support category.
  - Set `supportCategoryId` and `supportAgentRoleId` per guild via the existing settings API.

<sup>Written for commit 680535ba04cd0b90859a394cc4f545d56c84916f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

