### PR TITLE
docs(adr): reminder-scope permission tier (#1767)

### DIFF
--- a/decisions/2026-07-12-reminder-scope-permission-tier.md
+++ b/decisions/2026-07-12-reminder-scope-permission-tier.md
@@ -1,0 +1,90 @@
+# Permission tier for channel-wide / role-wide reminders
+
+- **Date:** 2026-07-12
+- **Status:** Accepted
+- **Deciders:** Lucas Santana
+- **Scope:** `#1767` — expanding `/remind` beyond personal to channel-wide and role-wide
+- **Method:** `/research-and-decide` — repo-evidence research → decision-critic
+  (verdict NEEDS_REVISION) → reconcile → this ADR
+
+## Context
+
+`/remind` is gaining channel-wide (post to a channel) and role-wide (ping a whole
+role) forms. Personal `/remind` has **no** permission gate today. The broadcast
+forms have a larger blast radius — a role reminder can ping hundreds — so they need
+a gate. The debate flagged the exact tier as an open product decision to confirm
+against this repo's actual moderator-role conventions.
+
+## Decision
+
+- **Personal reminders:** unchanged — no gate.
+- **Channel-wide reminders:** `setDefaultMemberPermissions(ManageGuild)`.
+- **Role-wide reminders:** `setDefaultMemberPermissions(ManageGuild)`.
+
+Uniform **ManageGuild** for both broadcast forms, enforced via
+`setDefaultMemberPermissions` only (no additional runtime check — see below).
+
+### Implementation requirements (non-negotiable)
+
+- Role-wide reminders **must** send with per-message
+  `allowedMentions: { roles: [roleId] }` — the established scoping in `vaga.ts:265`
+  and `customCommandHandler.ts`. This restricts the ping to exactly the target role
+  and can never expand to `@everyone`. There is no global allow-all `allowedMentions`
+  on the client, so per-message scoping is the sole and sufficient control.
+
+## Repo convention (the evidence this rests on)
+
+- Broadcast / scheduled-channel-post commands are uniformly `ManageGuild`:
+  `automessage` (scheduled channel posts — the closest analog to a channel-wide
+  reminder), `embed`, `giveaway`, `settings`, `level`, `customcommand`.
+- The one existing command that mass-pings a role — `vaga` — is `ManageGuild`
+  (the direct analog to a role-wide reminder), and scopes the ping per-message with
+  `allowedMentions: { roles }`.
+- Both `vaga` and `automessage` rely **solely** on `setDefaultMemberPermissions`
+  with no runtime `permissions.has(...)` check — a deliberate, consistent convention.
+- `ManageRoles` is used only for role _administration_ (`roles sync/status`), never
+  for "may ping a role". Administrator is reserved for server-wide config
+  (`guildconfig`, `serversetup`, `automod`).
+
+## Alternatives considered
+
+1. **Channel = ManageMessages, Role = ManageGuild** (the debate's initial sketch):
+   tier by blast radius so a channel moderator can set channel reminders. Rejected —
+   the repo has no ManageMessages-gated broadcast command; the closest analog
+   (`automessage`) is ManageGuild, so this introduces an inconsistent, lower bar for
+   scheduled channel posts. (Revisit trigger below re-opens this if demand appears.)
+2. **Role = ManageRoles:** rejected — ManageRoles is role administration, not "may
+   ping a role"; the repo's actual role-ping command (`vaga`) uses ManageGuild.
+3. **Administrator for role-wide:** rejected — over-gated; Administrator is reserved
+   for server-wide config, not a single broadcast action.
+4. **Add a runtime `permissions.has(ManageGuild)` check** (raised by the critic,
+   because `setDefaultMemberPermissions` is admin-overridable in Discord's UI):
+   rejected. An admin deliberately granting a role access to `/remind` via that UI
+   is **authorized delegation, not privilege escalation** — and this is exactly how
+   the repo's other broadcast commands behave (`vaga`/`automessage` add no runtime
+   check). Role-ping abuse is **annoyance-tier** (a bad ping), not a
+   confidentiality/integrity/data-loss boundary, so a hard non-overridable gate
+   would over-engineer the risk _and_ break consistency with the analogs while
+   removing admins' legitimate delegation.
+5. **No gate (like personal):** rejected — mass-ping blast radius needs a gate.
+
+## Consequences
+
+- **Positive:** consistent with the two direct existing analogs; one simple tier;
+  no new permission surface; admins retain per-command delegation via Discord's UI;
+  role ping is hard-scoped by `allowedMentions`.
+- **Negative:** a channel-only reminder is gated slightly heavier than its blast
+  radius strictly requires — a ManageMessages-only moderator can't set one. Accepted
+  for consistency with `automessage`.
+- **Neutral:** personal reminders keep their zero-gate behavior; enforcement is
+  Discord-side-default + admin-overridable (intended flexibility, not a hole, for an
+  annoyance-tier action).
+
+## Revisit when
+
+- Per-module RBAC (`GuildRoleAccessService` / `RBAC_MODULES`) is extended to
+  reminders — the gate then moves to that system and this becomes the fallback default; **or**
+- Any other channel-scoped broadcast command ships with a **ManageMessages** tier —
+  that signals a deliberate pattern shift toward proportional gating, and channel-wide
+  reminders should follow it (re-opening alternative 1); **or**
+- Guild admins report the ManageGuild bar is too high for channel-only reminders.


### PR DESCRIPTION
ADR resolving #1767's open permission-tier question via /research-and-decide. Decision: **channel-wide AND role-wide reminders both require ManageGuild** (setDefaultMemberPermissions only), matching the repo's uniform convention — automessage (scheduled channel posts) and vaga (role ping) are both ManageGuild. Personal reminders stay ungated.

decision-critic (NEEDS_REVISION) pushed to add a runtime permission check; reconciled as **rejected** — admin-override of setDefaultMemberPermissions is authorized delegation (matches vaga/automessage, which add no runtime check), and role-ping abuse is annoyance-tier, not an escalation/data boundary. The critic's real catch — allowedMentions scope — is addressed: role pings **must** send `allowedMentions: { roles: [roleId] }` (verified: no global allow-all; vaga/customCommand already scope per-message).

Unblocks #1767 implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ADR that sets channel-wide and role-wide reminders to require ManageGuild via Discord `setDefaultMemberPermissions` (no runtime check). Personal reminders stay ungated, and role pings must use per-message `allowedMentions: { roles: [roleId] }`; this resolves the permission-tier decision for #1767.

<sup>Written for commit bcd80bcec3ae996d18507f25b558f37d62a9c6c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record defining permission rules for personal, channel-wide, and role-wide reminders.
  * Documented mention restrictions for role-wide reminders and conditions for revisiting the decision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->