### PR TITLE
fix(deps): bump eslint in lock to satisfy npm@12 ci (unblock release)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,7 +1216,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
             "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1226,7 +1226,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1260,7 +1260,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
             "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.7"
@@ -1683,7 +1683,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
             "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.29.7",
@@ -2520,6 +2520,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
             "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2531,6 +2532,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
             "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2541,6 +2543,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
             "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -5114,7 +5117,7 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
             "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -10669,7 +10672,7 @@
             "version": "1.15.40",
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
             "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10914,14 +10917,14 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@swc/types": {
             "version": "0.1.26",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
             "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -11871,6 +11874,7 @@
             "version": "19.2.15",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
             "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -11880,7 +11884,7 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -13626,6 +13630,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -15105,6 +15110,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/dargs": {
@@ -16061,9 +16067,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-            "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+            "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -21231,7 +21237,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
             "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -21762,7 +21768,7 @@
             "version": "3.3.12",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
             "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -22872,7 +22878,7 @@
             "version": "8.5.15",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
             "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -25543,6 +25549,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
             "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/tailwindcss-animate": {
@@ -26069,7 +26076,7 @@
             "version": "4.22.3",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
             "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.28.0"
@@ -27283,7 +27290,7 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"


### PR DESCRIPTION
## Root cause (corrected — it was NOT the BuildKit cache)
Every Docker `Build` job failed deterministically:
```
npm error code EUSAGE
npm error Invalid: lock file's eslint@10.6.0 does not satisfy eslint@10.7.0
```
**Reproduced locally with `npm@12.0.1`** (CI installs `npm@12.0.0`). npm 12's `npm ci` rejects a lockfile whose resolved version isn't the **max satisfying the range** once a newer in-range version publishes. `eslint@10.7.0` published; range is `^10.4.0`, lock pinned `10.6.0` → rejected. Local npm 10.9.4 is lenient (why `npm ci` passed locally); a fresh BuildKit cache (`v5-`) still failed, disproving the cache theory.

## Fix
`npm update eslint --package-lock-only` → lock's eslint `10.6.0 → 10.7.0`. **package-lock.json only**, no `package.json` range change, 41-line diff. Verified: `npm@12.0.1 ci --dry-run` passes.

## Scope note
Minimal by design — unblocks release #1775 + the whole queue now. Deliberately does NOT bundle the toolchain-modernization asks (npm→latest, node→latest, TS7): a node base-image bump is high-risk here (@discordjs/opus source-compiles; node:26-alpine broke #846) and belongs in its own validated PR. Recurrence (next in-range publish re-breaks npm 12 ci) is a process fix — Renovate lockfile-maintenance — tracked separately.