### PR TITLE
chore(ci): unify CI to node 24 (prod parity) + toolchain ADR

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -30,7 +30,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
 
             # preactjs/compressed-size-action@v3 picks its package manager from
@@ -68,7 +68,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
 
             - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - name: Install dependencies
               run: npm ci --legacy-peer-deps --ignore-scripts
@@ -48,7 +48,7 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - name: Install dependencies
               run: npm ci --legacy-peer-deps --ignore-scripts
@@ -82,7 +82,7 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
@@ -104,7 +104,7 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
@@ -129,7 +129,7 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
@@ -165,7 +165,7 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
@@ -190,7 +190,7 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Download shared artifact
@@ -415,7 +415,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'npm'
             - run: npm ci --legacy-peer-deps --ignore-scripts
             - name: Security audit

--- a/.github/workflows/deploy-frontend-cf.yml
+++ b/.github/workflows/deploy-frontend-cf.yml
@@ -30,7 +30,7 @@ jobs:
       # frontend build (which imports @lucky/shared and repo-root CHANGELOG.md).
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/madge.yml
+++ b/.github/workflows/madge.yml
@@ -32,7 +32,7 @@ jobs:
 
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: '22'
+                  node-version: '24'
 
             - name: Install madge
               # --ignore-scripts: this static-analysis job needs only the source

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --legacy-peer-deps --ignore-scripts
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --legacy-peer-deps --ignore-scripts
@@ -121,7 +121,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --legacy-peer-deps --ignore-scripts

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,7 +10,7 @@ jobs:
     quality:
         uses: LucasSantana-Dev/.github/.github/workflows/quality.yml@aae80785af816b7dde59e50f66855be65d120685
         with:
-            node-version: '22'
+            node-version: '24'
             has-dockerfile: true
             run-deadcode: true
             package-manager: npm

--- a/.github/workflows/queueresolver-canary.yml
+++ b/.github/workflows/queueresolver-canary.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/decisions/2026-07-12-toolchain-modernization-node-ts.md
+++ b/decisions/2026-07-12-toolchain-modernization-node-ts.md
@@ -1,0 +1,73 @@
+# Lucky toolchain modernization — Node & TypeScript
+
+- **Date:** 2026-07-12
+- **Status:** Accepted
+- **Deciders:** Lucas Santana
+- **Method:** `/research-and-decide` — repo evidence + external research (document-specialist) → decision-critic (verdict NEEDS_REVISION; both blockers resolved below) → this ADR
+
+## Context
+
+Operator directive: *"node and npm should always be latest stable."* npm was already moved to
+`npm@latest` (separate merged PR). This ADR resolves **Node base image** and **TypeScript
+version** for the Lucky monorepo (packages shared/bot/backend/frontend; discord.js v14;
+`@discordjs/opus ^0.10.0` — the **only** native dep; Next.js frontend; prod = homelab Docker,
+merge-to-main = prod deploy; single-container bot).
+
+Current state: root `engines "node": ">=22 <27"`; Docker base = `node:24-alpine` (build+prod);
+CI = `node-version: '22'` (17 spots) → **CI tests on 22 but prod ships 24**. TypeScript `^6.0.3`;
+`@typescript-eslint ^8.59`.
+
+External research (2026-07, cited): Node **26.5.0 is latest but CURRENT, not LTS until Oct 2026**;
+Active LTS = 24 (Krypton) + 22 (Jod). Node 26 = new ABI (NODE_MODULE_VERSION 147) → native
+modules must rebuild; **`@discordjs/opus` has no node-26 prebuild** (alpine source-compile).
+**TypeScript 7.0 GA'd 2026-07-08** but ecosystem is hard-blocked: `@typescript-eslint` peer-deps
+`typescript <6.1.0` (no TS7 until the 7.1 API, ~Oct 2026), and **Next.js 16 build breaks on TS7**.
+
+## Decision
+
+**Interpretation of the directive (critic's blocker #1, resolved):** for a *production* bot,
+"latest stable" = **latest LTS**, not the Current release. Node 24 (Krypton) IS the latest
+production-recommended LTS. This is the sound default; operator can correct if bleeding-edge
+Current was actually intended.
+
+1. **Node: stay on 24 (LTS).** Do NOT bump to 26 — it is Current (not LTS until Oct 2026) and
+   `@discordjs/opus` (the only native dep — confirmed, no sharp/canvas/bcrypt) has no node-26
+   prebuild.
+2. **Unify CI onto Node 24** (`node-version '22' → '24'`, all 17 workflow spots) so CI tests
+   exactly what Docker/prod runs — closes a real test-vs-prod gap. **Keep `engines ">=22 <27"`
+   unchanged** (dropping 22 is a separate low-value change with a publish caveat — root
+   package.json is not marked `private` — so leave it).
+3. **TypeScript: stay on 6.x; defer TS7.** Ecosystem hard-blocked (`@typescript-eslint` +
+   Next.js 16). This is orthogonal to the Node decision.
+
+## Alternatives considered
+
+- **Bump Node to 26 now** (literal "latest stable = Current") — rejected: not LTS, opus has no
+  node-26 prebuild → alpine source-compile risk on a single-container prod bot; the artifact's
+  earlier claim that PR #846 already made node:26-alpine build is **unverified** (Dockerfile
+  comment, not a tested CI build) — so 26 is not de-risked. (Critic blocker #2, resolved by
+  dropping the claim and gating node-26 on a real CI build.)
+- **Adopt TS7 now** — rejected: `@typescript-eslint` peer-dep `<6.1.0` breaks lint; Next.js 16
+  build breaks. Hard gate.
+- **Leave CI on 22** — rejected: CI must test what prod ships (24).
+- **Drop Node 22 from engines** — deferred: harmless to keep; root is not `private`, so avoid
+  narrowing a possibly-consumed range without need.
+
+## Consequences
+
+- **Positive:** CI now tests Node 24 = prod parity (the one real bug-surface here); zero native
+  ABI churn (stay 24); no ecosystem breakage (stay TS6); low-risk, ~17-line workflow change.
+- **Negative:** not "bleeding-edge latest" per a literal reading of the directive — but that
+  reading is unsafe for a prod bot. Node 24 & TS6 lag the newest releases by one major each.
+- **Neutral:** `@discordjs/opus` still source-compiles per ABI (unchanged); engines range
+  unchanged.
+
+## Revisit when
+
+- **Node 26:** ALL of — (a) Node 26 reaches **LTS** (~Oct 2026); AND (b) `@discordjs/opus`
+  publishes a node-26 (musl) prebuild OR a CI `docker build --build-arg NODE_VERSION=26-alpine`
+  job proves the source-compile works. Then bump Docker + CI together to 26.
+- **TypeScript 7:** ALL of — (a) TS **7.1** GA (stable programmatic API, ~Oct 2026); AND
+  (b) `@typescript-eslint` ships a TS7-compatible release; AND (c) Next.js fixes TS7 detection.
+  Then fold Lucky into the org-wide TS7 migration.
+- Re-open early if a security advisory forces a Node/TS bump.


### PR DESCRIPTION
## Decision (ADR included)
`/research-and-decide` on Lucky toolchain modernization (node + TS7). Research + decision-critic (NEEDS_REVISION → both blockers resolved).

## Change
CI ran `node-version: '22'` (17 spots) while Docker/prod builds+runs **node 24** → CI wasn't testing what ships. **Unify all CI to node 24.** Keep `engines >=22 <27`.

## Decisions recorded (`decisions/2026-07-12-toolchain-modernization-node-ts.md`)
- **Node → stay 24 LTS.** "Latest stable" for a prod bot = latest **LTS**; Node 26 is Current (not LTS until Oct 2026) and `@discordjs/opus` (the *only* native dep) has no node-26 prebuild. Revisit: 26-LTS **and** an opus node-26 prebuild / proven CI build.
- **Defer TS7.** `@typescript-eslint` peer-deps `typescript <6.1.0`; Next.js 16 build breaks on TS7. Revisit: TS 7.1 GA + @typescript-eslint TS7 support + Next16 fix.

Low-risk: workflow + docs only, no code changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies all CI jobs to Node 24 to match Docker/prod and remove test-vs-prod drift. Adds an ADR documenting the decision to stay on Node 24 LTS and defer TypeScript 7.

- **Refactors**
  - CI now uses Node 24 in all workflows (was 22); engines stay `>=22 <27`.
  - ADR added with rationale and revisit triggers (Node 26 when LTS and `@discordjs/opus` prebuild available; TS7 when `@typescript-eslint` and Next.js 16 support land).

<sup>Written for commit 9dbcc6a030d72a54e6c250e230037480bdd5a974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

