### PR TITLE
fix(stats): public users stat shows real member reach, not empty User table

### DIFF
--- a/packages/backend/src/routes/stats.ts
+++ b/packages/backend/src/routes/stats.ts
@@ -30,9 +30,13 @@ export function setupStatsRoutes(app: Express): void {
             // users (near-empty), so it is NOT the reach metric this stat represents.
             const membersRaw = await redisClient.get(BOT_STATS_MEMBERS_KEY)
             const parsedMembers = Number(membersRaw)
+            // The bot always publishes a stringified integer (sum of guild
+            // memberCounts), so a fractional/out-of-range parse signals a
+            // corrupt key — reject it to 0 rather than truncating a value that
+            // was never published.
             const totalUsers =
-                Number.isFinite(parsedMembers) && parsedMembers >= 0
-                    ? Math.trunc(parsedMembers)
+                Number.isSafeInteger(parsedMembers) && parsedMembers >= 0
+                    ? parsedMembers
                     : 0
 
             // Get backend uptime in seconds

--- a/packages/backend/src/routes/stats.ts
+++ b/packages/backend/src/routes/stats.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from 'express'
 import { z } from 'zod'
 import { getPrismaClient } from '@lucky/shared/utils'
 import { redisClient } from '@lucky/shared/services'
+import { BOT_STATS_MEMBERS_KEY } from '@lucky/shared/constants'
 import { apiLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 
@@ -24,8 +25,15 @@ export function setupStatsRoutes(app: Express): void {
             // Fetch guild count from database
             const totalGuilds = await prisma.guild.count()
 
-            // Fetch user count from database
-            const totalUsers = await prisma.user.count()
+            // Total member reach across all guilds, published to Redis by the
+            // bot's stats scheduler. The User table only holds dashboard-registered
+            // users (near-empty), so it is NOT the reach metric this stat represents.
+            const membersRaw = await redisClient.get(BOT_STATS_MEMBERS_KEY)
+            const parsedMembers = Number(membersRaw)
+            const totalUsers =
+                Number.isFinite(parsedMembers) && parsedMembers >= 0
+                    ? Math.trunc(parsedMembers)
+                    : 0
 
             // Get backend uptime in seconds
             const uptimeSeconds = process.uptime()
@@ -46,7 +54,8 @@ export function setupStatsRoutes(app: Express): void {
 
             // Set caching headers: cache for 60 seconds, allow stale responses for up to 60 more seconds
             res.set({
-                'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=60',
+                'Cache-Control':
+                    'public, max-age=60, s-maxage=60, stale-while-revalidate=60',
                 'Content-Type': 'application/json',
             })
 

--- a/packages/backend/tests/integration/routes/stats.test.ts
+++ b/packages/backend/tests/integration/routes/stats.test.ts
@@ -37,12 +37,16 @@ describe('Stats Routes Integration', () => {
         test('should return stats with valid schema', async () => {
             const mockDb = {
                 guild: { count: jest.fn().mockResolvedValue(100) },
-                user: { count: jest.fn().mockResolvedValue(500) },
+                user: { count: jest.fn().mockResolvedValue(0) },
             }
             getPrismaClientMock.mockReturnValue(mockDb)
             mockRedis.isHealthy.mockReturnValue(true)
+            // totalUsers is member reach published to Redis by the bot, not a DB count.
+            mockRedis.get.mockResolvedValue('500')
 
-            const response = await request(app).get('/api/stats/public').expect(200)
+            const response = await request(app)
+                .get('/api/stats/public')
+                .expect(200)
 
             expect(response.body).toMatchObject({
                 totalGuilds: 100,
@@ -59,16 +63,20 @@ describe('Stats Routes Integration', () => {
         test('should handle redis unhealthy', async () => {
             const mockDb = {
                 guild: { count: jest.fn().mockResolvedValue(50) },
-                user: { count: jest.fn().mockResolvedValue(250) },
+                user: { count: jest.fn().mockResolvedValue(0) },
             }
             getPrismaClientMock.mockReturnValue(mockDb)
             mockRedis.isHealthy.mockReturnValue(false)
+            // Redis unhealthy → no member-reach key → totalUsers falls back to 0.
+            mockRedis.get.mockResolvedValue(null)
 
-            const response = await request(app).get('/api/stats/public').expect(200)
+            const response = await request(app)
+                .get('/api/stats/public')
+                .expect(200)
 
             expect(response.body.serversOnline).toBe(0)
             expect(response.body.totalGuilds).toBe(50)
-            expect(response.body.totalUsers).toBe(250)
+            expect(response.body.totalUsers).toBe(0)
         })
 
         test('should return correct cache headers', async () => {
@@ -79,11 +87,15 @@ describe('Stats Routes Integration', () => {
             getPrismaClientMock.mockReturnValue(mockDb)
             mockRedis.isHealthy.mockReturnValue(true)
 
-            const response = await request(app).get('/api/stats/public').expect(200)
+            const response = await request(app)
+                .get('/api/stats/public')
+                .expect(200)
 
             expect(response.headers['cache-control']).toContain('max-age=60')
             expect(response.headers['cache-control']).toContain('public')
-            expect(response.headers['content-type']).toContain('application/json')
+            expect(response.headers['content-type']).toContain(
+                'application/json',
+            )
         })
     })
 })

--- a/packages/bot/src/handlers/clientHandler/service.spec.ts
+++ b/packages/bot/src/handlers/clientHandler/service.spec.ts
@@ -8,6 +8,13 @@ jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
 }))
 
+// The real topggStatsScheduler (not mocked here) imports redisClient from the
+// services barrel, which transitively loads the Prisma client (import.meta) that
+// the bot's CJS jest transform can't parse. Mock the barrel like sibling specs do.
+jest.mock('@lucky/shared/services', () => ({
+    redisClient: { set: jest.fn(), get: jest.fn(), isHealthy: jest.fn() },
+}))
+
 jest.mock('@lucky/shared/config', () => ({
     config: jest.fn().mockReturnValue({
         TOKEN: 'test-token',

--- a/packages/bot/src/utils/general/topggStatsScheduler.spec.ts
+++ b/packages/bot/src/utils/general/topggStatsScheduler.spec.ts
@@ -10,15 +10,30 @@ jest.mock('../monitoring/sentry', () => ({
     captureMessage: jest.fn(),
 }))
 
+jest.mock('@lucky/shared/services', () => ({
+    redisClient: { set: jest.fn() },
+}))
+
 import { TopggStatsScheduler } from './topggStatsScheduler'
 import { infoLog, warnLog } from '@lucky/shared/utils'
+import { redisClient } from '@lucky/shared/services'
+import { BOT_STATS_MEMBERS_KEY } from '@lucky/shared/constants'
 import { captureMessage } from '../monitoring/sentry'
 
-function makeClient(guildCount: number) {
+function makeClient(guildCount: number, memberCounts?: number[]) {
+    const members = memberCounts ?? new Array<number>(guildCount).fill(0)
     return {
         guilds: {
             cache: {
                 size: guildCount,
+                reduce: (
+                    fn: (acc: number, guild: { memberCount: number }) => number,
+                    initial: number,
+                ): number =>
+                    members.reduce(
+                        (acc, memberCount) => fn(acc, { memberCount }),
+                        initial,
+                    ),
             },
         },
     }
@@ -44,6 +59,29 @@ describe('TopggStatsScheduler', () => {
 
         // start() arms the interval timer before the token check early-returns,
         // so it must be stopped to avoid leaking a timer into later tests.
+        scheduler.stop()
+    })
+
+    test('publishes total member reach to Redis on tick, regardless of Top.gg token', async () => {
+        // No TOPGG_TOKEN (cleared in beforeEach) — member reach must still publish.
+        const mockFetch = jest.fn()
+        const scheduler = new TopggStatsScheduler({
+            tickIntervalMs: 100,
+            fetch: mockFetch,
+        })
+        const client = makeClient(3, [10, 20, 30]) as any
+
+        scheduler.start(client)
+        // onStart skips the immediate tick without a token, so drive one manually.
+        await scheduler.tick()
+
+        expect(redisClient.set).toHaveBeenCalledWith(
+            BOT_STATS_MEMBERS_KEY,
+            '60',
+            expect.any(Number),
+        )
+        expect(mockFetch).not.toHaveBeenCalled()
+
         scheduler.stop()
     })
 

--- a/packages/bot/src/utils/general/topggStatsScheduler.ts
+++ b/packages/bot/src/utils/general/topggStatsScheduler.ts
@@ -1,5 +1,11 @@
+import type { Client } from 'discord.js'
 import { infoLog, warnLog } from '@lucky/shared/utils'
-import { TOP_GG_BOT_ID } from '@lucky/shared/constants'
+import {
+    TOP_GG_BOT_ID,
+    BOT_STATS_MEMBERS_KEY,
+    BOT_STATS_TTL_SECONDS,
+} from '@lucky/shared/constants'
+import { redisClient } from '@lucky/shared/services'
 import { addBreadcrumb, captureMessage } from '../monitoring/sentry'
 
 import { IntervalScheduler } from './IntervalScheduler'
@@ -46,13 +52,18 @@ export class TopggStatsScheduler extends IntervalScheduler {
     }
 
     protected async execute(): Promise<void> {
+        if (!this.client) return
+
+        // Publish live member reach to Redis on every tick — independent of the
+        // Top.gg token — so GET /api/stats/public reports real community reach
+        // instead of the (near-empty) dashboard User table.
+        await this.publishMemberReach(this.client)
+
         const token = process.env.TOPGG_TOKEN
         if (!token) {
             // Silently return — already logged once at startup
             return
         }
-
-        if (!this.client) return
 
         const serverCount = this.client.guilds.cache.size
 
@@ -127,6 +138,18 @@ export class TopggStatsScheduler extends IntervalScheduler {
                 { category: 'topgg.stats', serverCount },
             )
         }
+    }
+
+    private async publishMemberReach(client: Client): Promise<void> {
+        const totalMembers = client.guilds.cache.reduce(
+            (sum, guild) => sum + (guild.memberCount ?? 0),
+            0,
+        )
+        await redisClient.set(
+            BOT_STATS_MEMBERS_KEY,
+            String(totalMembers),
+            BOT_STATS_TTL_SECONDS,
+        )
     }
 }
 

--- a/packages/bot/src/utils/general/topggStatsScheduler.ts
+++ b/packages/bot/src/utils/general/topggStatsScheduler.ts
@@ -54,10 +54,16 @@ export class TopggStatsScheduler extends IntervalScheduler {
     protected async execute(): Promise<void> {
         if (!this.client) return
 
-        // Publish live member reach to Redis on every tick — independent of the
-        // Top.gg token — so GET /api/stats/public reports real community reach
-        // instead of the (near-empty) dashboard User table.
-        await this.publishMemberReach(this.client)
+        // Publish live member reach to Redis without blocking the Top.gg post
+        // path — a slow/unavailable Redis must never delay (or wedge) stats
+        // posting. Runs every tick regardless of the Top.gg token so
+        // GET /api/stats/public reports real reach, not the near-empty User table.
+        void this.publishMemberReach(this.client).catch((error) =>
+            warnLog({
+                message: 'Failed to publish member reach to Redis',
+                error: error as Error,
+            }),
+        )
 
         const token = process.env.TOPGG_TOKEN
         if (!token) {

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,5 +1,6 @@
 export { COLOR, type ColorKey } from './colors'
 export { API_ROUTES } from './apiRoutes'
+export { BOT_STATS_MEMBERS_KEY, BOT_STATS_TTL_SECONDS } from './stats'
 export {
     TOP_GG_BOT_ID,
     TOP_GG_VOTE_TIERS,

--- a/packages/shared/src/constants/stats.ts
+++ b/packages/shared/src/constants/stats.ts
@@ -1,0 +1,14 @@
+/**
+ * Redis key holding the bot's live total member reach (sum of `memberCount`
+ * across all guilds). Published by the bot's stats scheduler and read by
+ * `GET /api/stats/public` so the public stat reflects real reach rather than the
+ * `User` table (which only holds dashboard-registered users).
+ */
+export const BOT_STATS_MEMBERS_KEY = 'bot:stats:totalMembers'
+
+/**
+ * TTL (seconds) for {@link BOT_STATS_MEMBERS_KEY}. Longer than 3× the scheduler
+ * tick (30 min) so a brief bot restart doesn't zero the public stat, but a bot
+ * that stays down eventually lets the key expire instead of showing a frozen number.
+ */
+export const BOT_STATS_TTL_SECONDS = 90 * 60


### PR DESCRIPTION
Fixes the landing hero showing **"45 servers · 0 users"** (#1822).

## Root cause

`GET /api/stats/public` reported `prisma.user.count()` — the `User` table, which only holds **dashboard-registered** users (~0) — as the "users" stat, rendered next to the real "45 servers".

## Fix

- The bot's stats scheduler now publishes real **member reach** — `client.guilds.cache.reduce((s,g)=>s+g.memberCount,0)` — to Redis on every tick.
- The backend reads that key for `totalUsers` (parsed + guarded; falls back to `0` if absent/unhealthy).
- A shared `BOT_STATS_MEMBERS_KEY` constant keeps the writer (bot) and reader (backend) in sync — no magic-string drift.

## Notes

- **Decoupled from Top.gg:** the member-reach write is before the `TOPGG_TOKEN` gate, so it publishes every tick regardless of whether Top.gg posting is configured.
- **TTL 90 min** (3× the 30-min tick): a brief bot restart won't zero the public stat, but a bot that stays down lets the key expire instead of freezing a stale number.

## Tests (all re-run locally)

- Scheduler spec: **6/6** (added: "publishes total member reach to Redis regardless of Top.gg token").
- Backend stats spec: **3/3** (updated to Redis-sourced `totalUsers`).
- `tsc --noEmit` clean on shared/bot/backend; eslint clean on changed files.

Closes #1822

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the public “users” stat to show real member reach (sum of guild member counts) instead of near‑empty dashboard users. Also decouples member‑reach publishing from Top.gg posts so slow Redis never delays stats posting.

- **Bug Fixes**
  - Bot scheduler sums `guild.memberCount` and writes to Redis (`BOT_STATS_MEMBERS_KEY`) each tick with a 90‑min TTL; runs regardless of `TOPGG_TOKEN`.
  - Backend `GET /api/stats/public` reads that key for `totalUsers` with a safe‑integer guard; fractional/corrupt or missing values fall back to 0.
  - Added `BOT_STATS_MEMBERS_KEY` and `BOT_STATS_TTL_SECONDS` in `@lucky/shared/constants`; extended tests and mocked `@lucky/shared/services` in bot specs.

<sup>Written for commit c3cf367daf41c434600096be0cf3fc2a490aff59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public statistics now use live “member reach” from Redis (summed across connected communities) for `totalUsers`.

* **Bug Fixes**
  * `totalUsers` is now read from Redis with safe numeric validation; it falls back to `0` when Redis data is missing/unhealthy.
  * The stats scheduler publishes member reach on every tick when a Discord client is available, without being blocked by external Top.gg settings.

* **Tests**
  * Updated public-stats integration tests for Redis-based values and unhealthy/empty scenarios.
  * Expanded scheduler tests to verify Redis publishing behavior when tokens are unset, and added targeted Redis mocking for stable unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->