### PR TITLE
ci(bundle-size): skip yt-dlp postinstall in size limit check job (#1827)

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -59,6 +59,13 @@ jobs:
     size-limit:
         name: Size Limit Check
         runs-on: ubuntu-latest
+        env:
+            # This job runs a bare `npm ci` (needs the frontend build), so unlike
+            # ci.yml/madge it can't use --ignore-scripts. Without this, youtube-dl-exec's
+            # postinstall fetches the yt-dlp binary from GitHub unauthenticated (~60/hr/IP)
+            # and flakes red on shared-runner rate limits (#1827). The build doesn't need
+            # the binary — skip the download. Mirrors the compressed-size job above.
+            YOUTUBE_DL_SKIP_DOWNLOAD: 'true'
         steps:
             - name: Checkout PR
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
## Problem
The **Size Limit Check** job (`bundle-size.yml` → `size-limit`) intermittently fails at *Install dependencies* with:
```
npm error command sh -c node scripts/postinstall.js   (youtube-dl-exec)
npm error Error: { "message": "API rate limit exceeded for <runner-ip> ..." }
```
Seen on run 29234912026 (PR #1826, an unrelated docs change).

## Root cause
That job runs a bare `npm ci --legacy-peer-deps` — it needs the frontend build, so it can't use the `--ignore-scripts` convention that ci.yml and madge.yml already use. So youtube-dl-exec's postinstall runs and fetches the yt-dlp binary from GitHub **unauthenticated** (60 req/hr/IP), flaking on shared-runner rate limits.

Every other `npm ci` site is already immune:
- `ci.yml` (all 9 jobs) + `mutation.yml` + `deploy-frontend-cf.yml` → `--ignore-scripts`
- `madge.yml` → `--ignore-scripts`
- `bundle-size.yml` **compressed-size** job → `YOUTUBE_DL_SKIP_DOWNLOAD` env

The `size-limit` sibling job was the single hole.

## Fix
Add `YOUTUBE_DL_SKIP_DOWNLOAD: 'true'` to the `size-limit` job env. The postinstall short-circuits before any network fetch (`YOUTUBE_DL_SKIP_DOWNLOAD ? skip : installBinary()`). The build doesn't use the binary. Mirrors the compressed-size sibling in the same file — no `--ignore-scripts` needed (the job's later `db:generate` step is explicit, not a postinstall).

Closes #1827.

_Surfaced by a backlog-reprioritization pass (2026-07-13) as the top-leverage CI-signal fix — flaky red on unrelated PRs erodes review signal repo-wide._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `youtube-dl-exec` postinstall (which downloads `yt-dlp`) in the Size Limit Check `size-limit` job to prevent GitHub rate-limit failures during `npm ci`. Set YOUTUBE_DL_SKIP_DOWNLOAD=true since the binary isn't needed, mirroring the compressed-size job; closes #1827.

<sup>Written for commit 3b2392f258031ad3dbad4ab09cc1c35e41203f16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated bundle-size checks by preventing unnecessary binary downloads during validation.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->