### PR TITLE
fix(docker): add direct_url to staging and dev compose for prisma migrations

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,6 +63,7 @@ services:
                 condition: service_healthy
         environment:
             - DATABASE_URL=postgresql://discordbot:${POSTGRES_PASSWORD?POSTGRES_PASSWORD_required}@postgres:5432/discordbot
+            - DIRECT_URL=postgresql://discordbot:${POSTGRES_PASSWORD?POSTGRES_PASSWORD_required}@postgres:5432/discordbot
             - NODE_ENV=development
             - DISCORD_TOKEN=${DISCORD_TOKEN}
             - CLIENT_ID=${CLIENT_ID}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -44,6 +44,7 @@ x-common-app-env: &common-app-env
     SENTRY_ENABLED: ${SENTRY_ENABLED:-false}
     SENTRY_ENVIRONMENT: staging
     DATABASE_URL: postgresql://discordbot:${POSTGRES_PASSWORD?POSTGRES_PASSWORD_required}@postgres:5432/discordbot
+    DIRECT_URL: postgresql://discordbot:${POSTGRES_PASSWORD?POSTGRES_PASSWORD_required}@postgres:5432/discordbot
     REDIS_HOST: redis
     REDIS_PORT: 6379
     REDIS_DB: ${REDIS_DB:-0}


### PR DESCRIPTION
## Summary

Adds missing `DIRECT_URL` environment variable to `docker-compose.staging.yml` and `docker-compose.dev.yml`.

**Why:** Prisma `migrate deploy` requires a non-pooled `DIRECT_URL` connection for schema migrations. PR #1674 added this to `docker-compose.yml` (production), but the staging and dev compose files were missing it, causing P1001 errors on fresh Docker stack boots.

**What:** Mirrors the `DIRECT_URL` value to both environments, set identical to `DATABASE_URL` (no pgbouncer in these stacks).

- `docker-compose.staging.yml`: Added to `x-common-app-env` anchor (line 47)
- `docker-compose.dev.yml`: Added to `lucky-bot-dev` service environment (line 66)

Closes #1793

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `DIRECT_URL` to `docker-compose.staging.yml` and `docker-compose.dev.yml` so Prisma `migrate deploy` uses a direct (non-pooled) connection. Set it equal to `DATABASE_URL` to avoid P1001 errors on fresh boots (closes #1793).

<sup>Written for commit 771458248474fdfa6dc60373c55046a56461c7ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and staging configurations with an additional direct database connection setting.
  * Services using the shared staging configuration now inherit the direct database connection automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->