### PR TITLE
docs(readme): update node.js version references to 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="https://github.com/LucasSantana-Dev/Lucky/actions/workflows/ci.yml"><img src="https://github.com/LucasSantana-Dev/Lucky/actions/workflows/ci.yml/badge.svg" alt="CI Status" /></a>
   <a href="https://lucky.lucassantana.tech/invite?utm_source=github&utm_medium=readme&utm_campaign=readme-badge"><img src="https://img.shields.io/badge/Invite-Lucky%20Bot-5865F2?logo=discord&logoColor=white" alt="Invite Lucky" /></a>
   <a href="https://top.gg/bot/962198089161134131"><img src="https://img.shields.io/badge/top.gg-Lucky-FF3366?logo=topdotgg&logoColor=white" alt="Lucky on top.gg" /></a>
-  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-22.x-green.svg" alt="Node.js 22" /></a>
+  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-24.x-green.svg" alt="Node.js 24" /></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.9-blue.svg" alt="TypeScript 5.9" /></a>
   <a href="https://discord.js.org/"><img src="https://img.shields.io/badge/Discord.js-14-purple.svg" alt="Discord.js 14" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-ISC-yellow.svg" alt="ISC License" /></a>
@@ -105,7 +105,7 @@ Lucky solves this:
 | Layer | Technology |
 |-------|------------|
 | **Bot** | Discord.js 14, Discord Player 7, TypeScript 5.9 |
-| **Backend** | Express 5, REST API, Node.js 22 |
+| **Backend** | Express 5, REST API, Node.js 24 |
 | **Frontend** | React 19, Vite, Tailwind 4, shadcn/ui |
 | **Database** | PostgreSQL, Prisma ORM |
 | **Cache** | Redis |
@@ -119,7 +119,7 @@ Lucky solves this:
 
 ### Prerequisites
 
-- **Node.js 22+** (or Docker)
+- **Node.js 24+** (or Docker)
 - **PostgreSQL** and **Redis**
 - **FFmpeg** (for audio processing)
 - **Discord Bot Token** ([create one](https://discord.com/developers/applications))


### PR DESCRIPTION
Closes #1819

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the README to require `Node.js` 24 so docs match the current runtime and avoid setup confusion. Updates the version badge, tech stack table, and prerequisites (22 → 24), closing #1819.

<sup>Written for commit ec12b5b29fec9b43eeadc75906bb27714a6a283c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented Node.js requirement and technology stack references from version 22 to version 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->