### PR TITLE
chore(schema): promote SupportSession.status to enum (#1806)

### DIFF
--- a/prisma/migrations/20260713000000_support_session_status_enum/migration.sql
+++ b/prisma/migrations/20260713000000_support_session_status_enum/migration.sql
@@ -6,6 +6,13 @@
 -- CreateEnum
 CREATE TYPE "SupportSessionStatus" AS ENUM ('open', 'closed');
 
+-- Drop the now-redundant TEXT CHECK constraint (added in the support_sessions
+-- migration). The enum type enforces the same two values; keeping a
+-- migration-only CHECK would drift and reject valid rows if the enum ever gains
+-- a member. Dropped before the type change so it isn't re-validated against the
+-- new enum type.
+ALTER TABLE "support_sessions" DROP CONSTRAINT "support_sessions_status_check";
+
 -- AlterTable
 ALTER TABLE "support_sessions" ALTER COLUMN "status" DROP DEFAULT,
 ALTER COLUMN "status" TYPE "SupportSessionStatus" USING ("status"::"SupportSessionStatus"),

--- a/prisma/migrations/20260713000000_support_session_status_enum/migration.sql
+++ b/prisma/migrations/20260713000000_support_session_status_enum/migration.sql
@@ -1,0 +1,12 @@
+-- Promote support_sessions.status from free TEXT ('open'|'closed') to a native
+-- enum so a bad value can no longer evade the getExpired / getActiveForUser
+-- filters (#1806). Existing values already match the enum members, so the
+-- USING cast preserves all rows.
+
+-- CreateEnum
+CREATE TYPE "SupportSessionStatus" AS ENUM ('open', 'closed');
+
+-- AlterTable
+ALTER TABLE "support_sessions" ALTER COLUMN "status" DROP DEFAULT,
+ALTER COLUMN "status" TYPE "SupportSessionStatus" USING ("status"::"SupportSessionStatus"),
+ALTER COLUMN "status" SET DEFAULT 'open';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -254,13 +254,18 @@ model GuildSettings {
 /// access (per-user + support-agent-role overwrites); this row tracks lifecycle
 /// so the sweep scheduler can auto-close expired tickets and enforce one open
 /// ticket per requestor.
+enum SupportSessionStatus {
+  open
+  closed
+}
+
 model SupportSession {
   id          String   @id @default(cuid())
   guildId     String
   guild       Guild    @relation(fields: [guildId], references: [discordId], onDelete: Cascade)
   channelId   String   @unique
   requestorId String
-  status      String   @default("open") // open | closed
+  status      SupportSessionStatus @default(open)
   expiresAt   DateTime
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt


### PR DESCRIPTION
## What
Promote `support_sessions.status` from free `TEXT` ('open'|'closed') to a native Prisma enum `SupportSessionStatus { open, closed }`.

## Why
Free text let a typo'd status value silently evade the `getExpired` / `getActiveForUser` filters (#1803 hygiene debate). An enum makes an invalid value impossible at the DB + type layer.

## Migration safety (non-destructive)
Existing rows are exactly 'open'/'closed' → the `USING ("status"::"SupportSessionStatus")` cast preserves all data. Drops/re-adds the `'open'` default around the type change (required by Postgres).

## Code impact
None — `'open'`/`'closed'` string literals stay valid against the enum's `"open" | "closed"` union. Typecheck green across shared/bot/backend.

Closes #1806.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promote `support_sessions.status` from free text to the `SupportSessionStatus` enum (`open` | `closed`) to prevent invalid statuses and keep filters accurate. Migration preserves existing values, keeps the default `open`, and removes the redundant `support_sessions_status_check` constraint.

- **Migration**
  - Run the DB migration; casts `status` to `SupportSessionStatus` via `USING` (no app code changes).

<sup>Written for commit 2efae84694cd4a269da5308b9a5100766e0163ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support session status reliability by restricting statuses to **Open** or **Closed**.
  * Existing sessions retain their current valid status, while new sessions default to **Open**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->