### PR TITLE
fix(db): drop/recreate partial index around support_sessions enum cast

### DIFF
--- a/prisma/migrations/20260713000000_support_session_status_enum/migration.sql
+++ b/prisma/migrations/20260713000000_support_session_status_enum/migration.sql
@@ -3,6 +3,15 @@
 -- filters (#1806). Existing values already match the enum members, so the
 -- USING cast preserves all rows.
 
+-- Drop the partial unique index BEFORE the type change. Its predicate compares
+-- status to a text literal (WHERE "status" = 'open'), which Postgres re-validates
+-- during ALTER COLUMN ... TYPE. Against the new enum type that becomes
+-- `SupportSessionStatus = text` — an operator that does not exist — so the ALTER
+-- fails with 42883 / P3018 unless the index is dropped first and recreated after.
+-- (This index is migration-only — partial indexes aren't expressible in
+-- schema.prisma — so nothing else drops it for us. #1837)
+DROP INDEX "support_sessions_one_open_per_user";
+
 -- CreateEnum
 CREATE TYPE "SupportSessionStatus" AS ENUM ('open', 'closed');
 
@@ -17,3 +26,9 @@ ALTER TABLE "support_sessions" DROP CONSTRAINT "support_sessions_status_check";
 ALTER TABLE "support_sessions" ALTER COLUMN "status" DROP DEFAULT,
 ALTER COLUMN "status" TYPE "SupportSessionStatus" USING ("status"::"SupportSessionStatus"),
 ALTER COLUMN "status" SET DEFAULT 'open';
+
+-- Recreate the partial unique index. The predicate now compares against the enum
+-- ('open' is a valid SupportSessionStatus literal), so it is type-consistent.
+CREATE UNIQUE INDEX "support_sessions_one_open_per_user"
+    ON "support_sessions"("guildId", "requestorId")
+    WHERE "status" = 'open';


### PR DESCRIPTION
## Problem

The v2.35.1 deploy **failed in production** (2026-07-16 02:29 UTC) at:

```
Applying migration `20260713000000_support_session_status_enum`
Error: P3018 / code 42883
ERROR: operator does not exist: "SupportSessionStatus" = text
```

Production was never impacted (containers never swapped — still healthy on v2.35.0), but the failed migration **wedged all future prod migrations** until manually resolved (done: `migrate resolve --rolled-back` + dropped the orphan enum type; prod `migrate status` = "up to date").

## Root cause

`20260712000000_support_sessions/migration.sql` creates a **partial unique index** whose predicate compares `status` to a text literal:

```sql
CREATE UNIQUE INDEX "support_sessions_one_open_per_user"
    ON "support_sessions"("guildId", "requestorId")
    WHERE "status" = 'open';
```

The enum migration drops the CHECK constraint but not this index. `ALTER COLUMN "status" TYPE "SupportSessionStatus"` forces Postgres to re-validate the index predicate against the new type → `SupportSessionStatus = text` → no such operator.

**Why nothing caught it:** partial indexes aren't expressible in `schema.prisma`, so Prisma's generator never emitted a drop/recreate and there is no CI drift check on migration-only objects. The original migration even documents this ("migration-only, no CI drift check runs"). Same class as #1735/#1734 — a defect only reachable when the SQL actually runs against a real DB.

## Fix

Drop the partial index before the type change, recreate it after (predicate is type-consistent against the enum):

```sql
DROP INDEX "support_sessions_one_open_per_user";
CREATE TYPE ... ; ALTER TABLE ... DROP CONSTRAINT ...; ALTER COLUMN ... TYPE ...;
CREATE UNIQUE INDEX "support_sessions_one_open_per_user" ... WHERE "status" = 'open';
```

Editing the migration in place is correct: it never applied successfully anywhere (rolled back in prod, never ran in staging — both still `text`), so there is no checksum drift.

## Verification

Applied the **full 45-migration chain** to a scratch `postgres:18-alpine` (matching prod's PG 18.3), with an injection control:

| chain | result |
|---|---|
| **broken** migration | reproduces prod's exact `operator does not exist: "SupportSessionStatus" = text` |
| **fixed** migration | 45/45 apply clean; `status` udt = `SupportSessionStatus`; partial index recreated |

The harness fails on the bug and passes on the fix — same harness, only the migration content differs.

## Follow-ups (tracked in #1837, not in this PR)

- `scripts/deploy.sh:358` — `curl: command not found` in the failure-notification path, so homelab deploy failures present as SHA-mismatch timeouts instead of reporting the real error. This is why the failure cause had to be dug out of the container log.
- **Prevention:** wire the scratch-DB full-chain apply above into CI so migration-only SQL defects can't merge again.

Closes #1837

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped and recreated the partial unique index `support_sessions_one_open_per_user` around the `support_sessions.status` enum migration to stop the “operator does not exist: SupportSessionStatus = text” error and unblock production migrations. Closes #1837.

- **Bug Fixes**
  - Drop the index before the type change; recreate it after with the same predicate (`WHERE "status" = 'open'`).
  - Avoids predicate revalidation mismatch when `status` changes from `text` to the enum.
  - Verified by running the full migration chain on Postgres 18: broken chain fails; fixed chain succeeds.

<sup>Written for commit 933d0e4b7259722b627720fd6092ceb6fda21671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

