### PR TITLE
fix(db): make support_sessions enum migration idempotent + re-runnable

### DIFF
--- a/decisions/2026-07-16-idempotent-migrations.md
+++ b/decisions/2026-07-16-idempotent-migrations.md
@@ -1,0 +1,47 @@
+# Migrations that transform existing objects must be idempotent, verified against a prod-version scratch DB
+
+- **Status:** Accepted
+- **Date:** 2026-07-16
+- **Tags:** database, prisma, migrations, ci, incident-driven
+
+## Context
+
+The `support_session_status_enum` migration (#1806/#1834) failed in production **twice** across releases 2.35.1 and 2.35.2, wedging all prod migrations each time (Prisma P3018):
+
+1. **2.35.1** — `ALTER COLUMN status TYPE enum` re-validated the partial index `support_sessions_one_open_per_user WHERE status = 'open'`; its text-literal predicate became `SupportSessionStatus = text` → `42883 operator does not exist`.
+2. **2.35.2** (after #1838 dropped/recreated the partial index) — failed at `DROP CONSTRAINT support_sessions_status_check` with `42704 does not exist`.
+
+The second failure exposed the real class defect: **`prisma migrate deploy` does not wrap a migration file in a transaction** (per-statement autocommit; SQL Server is Prisma's only wrapped dialect — [discussion #3774](https://github.com/prisma/prisma/discussions/3774)). So the *first* failed run had already committed `DROP CONSTRAINT` + `CREATE TYPE` before it errored, leaving prod in a **partial state**. #1838 assumed a clean pre-migration state and could not re-run against that residue.
+
+Two verification gaps let this ship: (a) the fix was tested only against a **clean** migration chain, never the actual partial prod state; (b) there is no CI step that runs `migrate deploy` against a real Postgres, so migration-only SQL defects (partial indexes aren't expressible in `schema.prisma`, so Prisma's drift check never sees them) are invisible until prod.
+
+## Decision
+
+**Any migration that transforms existing columns, constraints, indexes, or types must be authored idempotent** — safe to re-run against a partially-applied state — using per-statement guards:
+
+- `DROP ... IF EXISTS` for drops.
+- `CREATE TYPE` via `DO $$ BEGIN CREATE TYPE ...; EXCEPTION WHEN duplicate_object THEN NULL; END $$;` (Postgres has no `IF NOT EXISTS` for types).
+- `CREATE INDEX IF NOT EXISTS` / drop-then-create where the drop precedes in the same file.
+- Guard `ALTER COLUMN ... TYPE` re-application where the column may already be the target type.
+
+**We do NOT rely on transaction wrapping.** Prisma does not wrap migrations, and an explicit in-file `BEGIN/COMMIT` (a) would be omitted by Prisma-*generated* migrations, and (b) has an unverified interaction with Prisma's own `_prisma_migrations` bookkeeping. Idempotency is strictly stronger for recovery: it converges from any partial state, whereas a wrapper merely rolls back to the partial state and still needs guards to re-run.
+
+**Prevention is enforced in CI, not by author discipline alone:** a gate applies the full migration chain (and, where feasible, replays known partial states) against a **Postgres pinned to the production major version** (currently 18) on a scratch DB. This catches partial-apply and non-idempotency defects — and any migration-only SQL the Prisma drift check can't see — before merge. (Tracked as the prevention follow-up in #1837.)
+
+## Alternatives considered
+
+- **Explicit `BEGIN;/COMMIT;` transaction wrapper per migration** — rejected as the *primary* mechanism: Prisma-generated migrations omit it; `_prisma_migrations` interaction is only medium-confidence; and it does not by itself make a re-run against an existing-enum state succeed (still needs guards). Allowed as optional belt-and-suspenders where an author wants atomicity, but never a substitute for idempotency.
+- **Manual prod state reconciliation, keep migrations clean-state** — rejected: fragile, manual, per-incident, and re-introduces the same wedge risk on the next surprise state.
+- **New forward migration from the current partial state** — rejected: a "from partial state" migration breaks on clean/staging DBs, which are in a different state; it collapses into idempotent guards anyway, with a messier history.
+
+## Consequences
+
+- **Positive:** migrations recover from any partial-apply without manual DB surgery; a whole class of prod-wedge incidents is caught in CI; recovery from a wedged state is `migrate resolve --rolled-back` + redeploy, no hand-editing prod.
+- **Negative:** slightly more verbose migration SQL; the CI gate adds a Postgres-container step (~seconds) to the pipeline; authors must remember the `DO`-block idiom for enum types (mitigated by the CI gate catching omissions).
+- **Neutral:** hand-authored/edited migrations are already common here (partial indexes, CHECK constraints not expressible in `schema.prisma`), so idempotency guards fit existing practice.
+
+## Revisit when
+
+- Prisma ships transactional `migrate deploy` for PostgreSQL (would make atomicity the default and reduce the idempotency burden) — re-evaluate whether guards are still required.
+- The production Postgres major version changes — re-pin the CI gate's Postgres image to match (behaviour like index-predicate re-validation is version-sensitive).
+- The CI scratch-DB gate proves insufficient (a migration defect still reaches prod) — escalate to also replaying captured prod schema snapshots, not just the clean chain.

--- a/prisma/migrations/20260713000000_support_session_status_enum/migration.sql
+++ b/prisma/migrations/20260713000000_support_session_status_enum/migration.sql
@@ -2,25 +2,41 @@
 -- enum so a bad value can no longer evade the getExpired / getActiveForUser
 -- filters (#1806). Existing values already match the enum members, so the
 -- USING cast preserves all rows.
+--
+-- IDEMPOTENT / RE-RUNNABLE (#1837): prisma migrate deploy does NOT wrap a
+-- migration file in a transaction (per-statement autocommit), so a mid-file
+-- failure leaves earlier statements committed. This migration already
+-- partial-applied against production twice before this rewrite. Every statement
+-- below is therefore guarded so re-running against ANY partial state — enum
+-- already created, CHECK already dropped, index already dropped, or none of
+-- those — converges to the same final state instead of wedging. Verified on
+-- postgres:18-alpine (prod parity) against clean + both partial states, each
+-- run twice.
 
 -- Drop the partial unique index BEFORE the type change. Its predicate compares
 -- status to a text literal (WHERE "status" = 'open'), which Postgres re-validates
 -- during ALTER COLUMN ... TYPE. Against the new enum type that becomes
 -- `SupportSessionStatus = text` — an operator that does not exist — so the ALTER
 -- fails with 42883 / P3018 unless the index is dropped first and recreated after.
--- (This index is migration-only — partial indexes aren't expressible in
--- schema.prisma — so nothing else drops it for us. #1837)
-DROP INDEX "support_sessions_one_open_per_user";
+-- (Migration-only object — partial indexes aren't expressible in schema.prisma,
+-- so nothing else drops it for us.) The plain btree support_sessions_status_expiresAt_idx
+-- is intentionally left alone: ALTER COLUMN ... TYPE rebuilds plain indexes
+-- automatically; only the operator-dependent partial predicate needs handling.
+-- IF EXISTS: it may already be gone from a prior partial run.
+DROP INDEX IF EXISTS "support_sessions_one_open_per_user";
 
--- CreateEnum
-CREATE TYPE "SupportSessionStatus" AS ENUM ('open', 'closed');
+-- CreateEnum. CREATE TYPE has no IF NOT EXISTS; swallow duplicate_object so a
+-- prior partial run that already created the enum is tolerated.
+DO $$ BEGIN
+  CREATE TYPE "SupportSessionStatus" AS ENUM ('open', 'closed');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 -- Drop the now-redundant TEXT CHECK constraint (added in the support_sessions
 -- migration). The enum type enforces the same two values; keeping a
 -- migration-only CHECK would drift and reject valid rows if the enum ever gains
--- a member. Dropped before the type change so it isn't re-validated against the
--- new enum type.
-ALTER TABLE "support_sessions" DROP CONSTRAINT "support_sessions_status_check";
+-- a member. IF EXISTS: it may already be gone from a prior partial run.
+ALTER TABLE "support_sessions" DROP CONSTRAINT IF EXISTS "support_sessions_status_check";
 
 -- AlterTable
 ALTER TABLE "support_sessions" ALTER COLUMN "status" DROP DEFAULT,
@@ -29,6 +45,7 @@ ALTER COLUMN "status" SET DEFAULT 'open';
 
 -- Recreate the partial unique index. The predicate now compares against the enum
 -- ('open' is a valid SupportSessionStatus literal), so it is type-consistent.
+-- Statement 1 dropped it, so a plain CREATE is safe on any re-run.
 CREATE UNIQUE INDEX "support_sessions_one_open_per_user"
     ON "support_sessions"("guildId", "requestorId")
     WHERE "status" = 'open';


### PR DESCRIPTION
## Why a second fix

#1838 fixed the partial-index cause but assumed a **clean** pre-migration state. It shipped in 2.35.2 and **failed again** in prod — a different error:

```
Database error code: 42704
ERROR: constraint "support_sessions_status_check" of relation "support_sessions" does not exist
```

Root cause: **`prisma migrate deploy` does not wrap a migration in a transaction** (per-statement autocommit; confirmed via Prisma docs + [discussion #3774](https://github.com/prisma/prisma/discussions/3774)). The *original* failed run (2.35.1) had already committed `DROP CONSTRAINT` and `CREATE TYPE` before failing on the index — so prod was left in a **partial state** (enum exists, CHECK gone, partial index gone, column still text). #1838's clean-state migration then failed re-running against that residue.

## Fix

Guard every statement so re-running converges from **any** partial state:
- `DROP INDEX IF EXISTS` (partial index may already be gone)
- `CREATE TYPE` via `DO $$ ... EXCEPTION WHEN duplicate_object $$` (no `IF NOT EXISTS` for types; enum may already exist)
- `ALTER TABLE ... DROP CONSTRAINT IF EXISTS` (CHECK may already be gone)

The plain btree `support_sessions_status_expiresAt_idx` is intentionally **not** dropped — `ALTER COLUMN ... TYPE` rebuilds plain indexes automatically; only the partial index's operator-dependent predicate (`WHERE status = 'open'::text`) needs the drop/recreate. **Verified empirically on PG18** — a review claim that btree indexes block the type change was refuted by direct test.

## Verification (postgres:18-alpine, prod parity)

Applied against three DB states, **each run twice** (idempotency), all converge to `status = SupportSessionStatus` enum + partial index present:

| State | run 1 | re-run |
|---|---|---|
| CLEAN (fresh/staging) | ✓ | ✓ |
| PARTIAL-A (current prod: enum exists, index+CHECK gone) | ✓ | ✓ |
| PARTIAL-B (only CREATE TYPE committed) | ✓ | ✓ |

Plus the full 45-migration chain applies clean with the actual file.

## Decision & rationale

`/research-and-decide` → idempotent guards, **no** explicit `BEGIN/COMMIT` wrapper. Idempotency converges from any partial state (strictly stronger than atomicity, which would roll back to the partial state and still need guards to re-run), and avoids the unverified interaction between an in-file transaction and Prisma's `_prisma_migrations` bookkeeping. Class-prevention lives in the CI scratch-DB gate (#1837 follow-up), not per-migration ceremony Prisma-generated files would omit. ADR: `decisions/2026-07-16-idempotent-migrations.md`.

## Recovery (operator-gated, not in this PR)

Prod is currently re-wedged (P3018). After this merges + releases: `migrate resolve --rolled-back` then redeploy re-applies this migration against PARTIAL-A (proven).

Refs #1837

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `support_sessions` status enum migration idempotent and re-runnable to recover from partial runs in `prisma migrate deploy` (per-statement autocommit), addressing #1837. Also adds an ADR that formalizes idempotent migrations and a CI scratch-DB gate on the prod Postgres version.

- **Bug Fixes**
  - Guarded statements: `DROP INDEX IF EXISTS` for `"support_sessions_one_open_per_user"`, enum via `DO ... EXCEPTION WHEN duplicate_object`, and `DROP CONSTRAINT IF EXISTS` for `"support_sessions_status_check"`.
  - Keep plain btree `support_sessions_status_expiresAt_idx`; `ALTER COLUMN ... TYPE` rebuilds it automatically.
  - Verified on Postgres 18 across clean and partial states; safe to re-run.

<sup>Written for commit 9b56ebb227dda26ccba893ca09964001e1812dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

