### PR TITLE
ci(migrations): apply-and-reapply gate on prod-version Postgres (#1837 prevention)

### DIFF
--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -32,6 +32,11 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
                   fetch-depth: 0
+                  # This job applies UNTRUSTED PR migration SQL via `psql -f`,
+                  # whose backslash commands (\!) can shell out. Don't leave the
+                  # GITHUB_TOKEN in .git/config for a malicious migration to read
+                  # — this job only reads locally and never pushes.
+                  persist-credentials: false
 
             - name: Detect migration changes
               id: detect

--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -47,16 +47,38 @@ jobs:
                       # commits merged to base afterwards aren't picked up.
                       BASE_SHA=$(git merge-base "$BASE_SHA" HEAD)
                   fi
-                  if git diff --name-only "$BASE_SHA" HEAD -- prisma/migrations | grep -q '/migration.sql$'; then
+                  # ADDED migration files (the only ones idempotency re-apply can
+                  # meaningfully validate). Modified/deleted/renamed are handled
+                  # separately below — migrations are append-only.
+                  ADDED=$(git diff --name-only --diff-filter=A "$BASE_SHA" HEAD -- prisma/migrations | grep '/migration.sql$' || true)
+                  # Non-additive changes to existing migration files (history rewrite).
+                  REWRITTEN=$(git diff --name-only --diff-filter=MDR "$BASE_SHA" HEAD -- prisma/migrations | grep '/migration.sql$' || true)
+                  { echo "BASE_SHA=$BASE_SHA"; } >> "$GITHUB_OUTPUT"
+                  { echo "rewritten<<EOF"; echo "$REWRITTEN"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+                  if [ -n "$ADDED" ]; then
                       echo "changed=true" >> "$GITHUB_OUTPUT"
                   else
                       echo "changed=false" >> "$GITHUB_OUTPUT"
                   fi
-                  echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_OUTPUT"
+
+            # Migrations are append-only: an already-applied migration is
+            # checksum-tracked by Prisma, so editing/renaming/deleting one drifts
+            # from the databases where the original already ran — which this gate
+            # cannot model (it only sees the replacement). Fail loudly. Editing a
+            # migration that never successfully applied anywhere (e.g. a
+            # rolled-back one being repaired) is the rare exception; do it via an
+            # admin/override merge with the reason stated, not silently.
+            - name: Reject rewritten migration history
+              if: steps.detect.outputs.rewritten != ''
+              run: |
+                  echo "::error::Non-additive change to existing migration(s) — migrations are append-only:"
+                  echo "${{ steps.detect.outputs.rewritten }}"
+                  echo "If this is an intentional repair of a never-applied migration, override deliberately."
+                  exit 1
 
             - name: No migration changes — gate not applicable
-              if: steps.detect.outputs.changed != 'true'
-              run: echo "✅ No prisma/migrations changes in this diff — nothing to validate."
+              if: steps.detect.outputs.changed != 'true' && steps.detect.outputs.rewritten == ''
+              run: echo "✅ No added prisma/migrations in this diff — nothing to validate."
 
             # Start Postgres via `docker run` (not a services: block) so it only
             # spins up when migrations actually changed — non-migration PRs pay
@@ -101,9 +123,13 @@ jobs:
                   PGPASSWORD: ci
               run: |
                   set -euo pipefail
-                  NEW=$(git diff --name-only "${{ steps.detect.outputs.BASE_SHA }}" HEAD -- prisma/migrations \
+                  # ADDED migrations only — a re-apply models "the migration runs a
+                  # second time against a DB where it already ran". Editing an
+                  # existing migration is rejected earlier (append-only), so only
+                  # --diff-filter=A files reach here.
+                  NEW=$(git diff --name-only --diff-filter=A "${{ steps.detect.outputs.BASE_SHA }}" HEAD -- prisma/migrations \
                       | grep '/migration.sql$' || true)
-                  echo "Re-applying changed migrations against the migrated DB:"
+                  echo "Re-applying added migrations against the migrated DB:"
                   echo "$NEW"
                   for f in $NEW; do
                       echo "==> re-applying ${f#prisma/migrations/}"

--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -9,13 +9,15 @@ name: Migration Gate
 # job applies the full migration chain against a Postgres pinned to the
 # production major version, then re-applies the PR's own migrations to prove
 # idempotency. It would have caught both the 2.35.1 and 2.35.2 prod failures.
+#
+# The job ALWAYS runs (no paths: filter) so it can be a REQUIRED status check:
+# a path-filtered required check never reports on unrelated PRs and would block
+# them forever. When a change touches no migrations, the job reports success
+# without spinning up Postgres.
 
 on:
     pull_request:
         branches: [main, 'release/**']
-        paths:
-            - 'prisma/migrations/**'
-            - '.github/workflows/migration-gate.yml'
     merge_group:
         branches: [main, 'release/**']
 
@@ -23,73 +25,87 @@ permissions:
     contents: read
 
 jobs:
-    migrate-apply:
+    migrate-gate:
         name: Migrations apply on Postgres 18
         runs-on: ubuntu-latest
-        services:
-            postgres:
-                # Pinned to the PRODUCTION major version. Bump this when prod
-                # Postgres changes — index-predicate re-validation and cast
-                # behaviour are version-sensitive (ADR revisit-when).
-                image: postgres:18-alpine
-                env:
-                    POSTGRES_USER: discordbot
-                    POSTGRES_PASSWORD: ci
-                    POSTGRES_DB: discordbot
-                ports:
-                    - 5432:5432
-                options: >-
-                    --health-cmd "pg_isready -U discordbot -d discordbot"
-                    --health-interval 5s
-                    --health-timeout 5s
-                    --health-retries 10
-        env:
-            PGPASSWORD: ci
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
                   fetch-depth: 0
 
-            - name: Ensure psql client
-              run: psql --version || (sudo apt-get update && sudo apt-get install -y postgresql-client)
+            - name: Detect migration changes
+              id: detect
+              run: |
+                  BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                      # Use the actual merge-base, not the PR-open snapshot, so
+                      # commits merged to base afterwards aren't picked up.
+                      BASE_SHA=$(git merge-base "$BASE_SHA" HEAD)
+                  fi
+                  if git diff --name-only "$BASE_SHA" HEAD -- prisma/migrations | grep -q '/migration.sql$'; then
+                      echo "changed=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "changed=false" >> "$GITHUB_OUTPUT"
+                  fi
+                  echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
-            # Clean-apply: mirrors `prisma migrate deploy` (per-statement,
-            # ON_ERROR_STOP) against a fresh prod-version DB. Catches migrations
-            # that fail to apply — e.g. an ALTER COLUMN TYPE blocked by a partial
-            # index predicate (the 2.35.1 failure, 42883/P3018).
+            - name: No migration changes — gate not applicable
+              if: steps.detect.outputs.changed != 'true'
+              run: echo "✅ No prisma/migrations changes in this diff — nothing to validate."
+
+            # Start Postgres via `docker run` (not a services: block) so it only
+            # spins up when migrations actually changed — non-migration PRs pay
+            # nothing while the check still reports success.
+            - name: Start Postgres 18
+              if: steps.detect.outputs.changed == 'true'
+              run: |
+                  docker run -d --name mgate-pg \
+                      -e POSTGRES_USER=discordbot \
+                      -e POSTGRES_PASSWORD=ci \
+                      -e POSTGRES_DB=discordbot \
+                      -p 5432:5432 \
+                      postgres:18-alpine
+                  for i in $(seq 1 30); do
+                      docker exec mgate-pg pg_isready -U discordbot -d discordbot && break
+                      sleep 1
+                  done
+
+            # Clean-apply: mirrors non-transactional `prisma migrate deploy`.
+            # Catches migrations that fail on a fresh prod-version DB (the 2.35.1
+            # failure: ALTER COLUMN TYPE blocked by a partial-index predicate).
             - name: Apply full migration chain (clean apply)
+              if: steps.detect.outputs.changed == 'true'
+              env:
+                  PGPASSWORD: ci
               run: |
                   set -euo pipefail
+                  psql --version || (sudo apt-get update && sudo apt-get install -y postgresql-client)
                   for f in $(find prisma/migrations -name migration.sql | sort); do
                       echo "==> applying ${f#prisma/migrations/}"
                       psql -h localhost -U discordbot -d discordbot -v ON_ERROR_STOP=1 -q -f "$f"
                   done
                   echo "✅ Full chain applied cleanly on Postgres 18."
 
-            # Idempotency: re-apply THIS PR's new migrations against the
-            # already-migrated DB. A migration authored per the idempotency ADR
-            # (IF EXISTS / IF NOT EXISTS / DO-EXCEPTION guards) re-applies cleanly;
-            # a non-idempotent one errors — catching the class that wedged 2.35.2
-            # (DROP CONSTRAINT on an already-dropped constraint, 42704). Only the
-            # PR's own migrations are re-checked: historic migrations predate this
-            # convention and are never re-run against a live prod row.
-            - name: Re-apply PR migrations (idempotency)
+            # Idempotency: re-apply THIS change's new migrations against the
+            # already-migrated DB. Idempotent migrations (per the ADR) re-apply
+            # cleanly; a non-idempotent one errors — catching the 2.35.2 class
+            # (DROP CONSTRAINT on an already-dropped constraint, 42704).
+            - name: Re-apply changed migrations (idempotency)
+              if: steps.detect.outputs.changed == 'true'
+              env:
+                  PGPASSWORD: ci
               run: |
                   set -euo pipefail
-                  BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
-                  if [ "${{ github.event_name }}" = "pull_request" ]; then
-                      BASE_SHA=$(git merge-base "$BASE_SHA" HEAD)
-                  fi
-                  NEW=$(git diff --name-only "$BASE_SHA" HEAD -- prisma/migrations \
+                  NEW=$(git diff --name-only "${{ steps.detect.outputs.BASE_SHA }}" HEAD -- prisma/migrations \
                       | grep '/migration.sql$' || true)
-                  if [ -z "$NEW" ]; then
-                      echo "No new migration files in this change — nothing to re-check."
-                      exit 0
-                  fi
-                  echo "Re-applying this PR's migrations against the migrated DB:"
+                  echo "Re-applying changed migrations against the migrated DB:"
                   echo "$NEW"
                   for f in $NEW; do
                       echo "==> re-applying ${f#prisma/migrations/}"
                       psql -h localhost -U discordbot -d discordbot -v ON_ERROR_STOP=1 -q -f "$f"
                   done
-                  echo "✅ PR migrations are idempotent (re-applied cleanly)."
+                  echo "✅ Changed migrations are idempotent (re-applied cleanly)."
+
+            - name: Stop Postgres
+              if: always() && steps.detect.outputs.changed == 'true'
+              run: docker rm -f mgate-pg || true

--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -65,7 +65,7 @@ jobs:
                       -e POSTGRES_DB=discordbot \
                       -p 5432:5432 \
                       postgres:18-alpine
-                  for i in $(seq 1 30); do
+                  for _ in $(seq 1 30); do
                       docker exec mgate-pg pg_isready -U discordbot -d discordbot && break
                       sleep 1
                   done

--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -1,0 +1,95 @@
+name: Migration Gate
+
+# Prevention gate for the migration-wedge incident (#1837, ADR
+# decisions/2026-07-16-idempotent-migrations.md). Prisma `migrate deploy` is
+# non-transactional, so a defective migration can (a) fail to apply on a clean
+# DB or (b) fail to re-apply against a partially-applied state — both of which
+# wedge production and are invisible to the schema-drift check (partial indexes,
+# CHECK constraints, and enum casts aren't expressible in schema.prisma). This
+# job applies the full migration chain against a Postgres pinned to the
+# production major version, then re-applies the PR's own migrations to prove
+# idempotency. It would have caught both the 2.35.1 and 2.35.2 prod failures.
+
+on:
+    pull_request:
+        branches: [main, 'release/**']
+        paths:
+            - 'prisma/migrations/**'
+            - '.github/workflows/migration-gate.yml'
+    merge_group:
+        branches: [main, 'release/**']
+
+permissions:
+    contents: read
+
+jobs:
+    migrate-apply:
+        name: Migrations apply on Postgres 18
+        runs-on: ubuntu-latest
+        services:
+            postgres:
+                # Pinned to the PRODUCTION major version. Bump this when prod
+                # Postgres changes — index-predicate re-validation and cast
+                # behaviour are version-sensitive (ADR revisit-when).
+                image: postgres:18-alpine
+                env:
+                    POSTGRES_USER: discordbot
+                    POSTGRES_PASSWORD: ci
+                    POSTGRES_DB: discordbot
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd "pg_isready -U discordbot -d discordbot"
+                    --health-interval 5s
+                    --health-timeout 5s
+                    --health-retries 10
+        env:
+            PGPASSWORD: ci
+        steps:
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  fetch-depth: 0
+
+            - name: Ensure psql client
+              run: psql --version || (sudo apt-get update && sudo apt-get install -y postgresql-client)
+
+            # Clean-apply: mirrors `prisma migrate deploy` (per-statement,
+            # ON_ERROR_STOP) against a fresh prod-version DB. Catches migrations
+            # that fail to apply — e.g. an ALTER COLUMN TYPE blocked by a partial
+            # index predicate (the 2.35.1 failure, 42883/P3018).
+            - name: Apply full migration chain (clean apply)
+              run: |
+                  set -euo pipefail
+                  for f in $(find prisma/migrations -name migration.sql | sort); do
+                      echo "==> applying ${f#prisma/migrations/}"
+                      psql -h localhost -U discordbot -d discordbot -v ON_ERROR_STOP=1 -q -f "$f"
+                  done
+                  echo "✅ Full chain applied cleanly on Postgres 18."
+
+            # Idempotency: re-apply THIS PR's new migrations against the
+            # already-migrated DB. A migration authored per the idempotency ADR
+            # (IF EXISTS / IF NOT EXISTS / DO-EXCEPTION guards) re-applies cleanly;
+            # a non-idempotent one errors — catching the class that wedged 2.35.2
+            # (DROP CONSTRAINT on an already-dropped constraint, 42704). Only the
+            # PR's own migrations are re-checked: historic migrations predate this
+            # convention and are never re-run against a live prod row.
+            - name: Re-apply PR migrations (idempotency)
+              run: |
+                  set -euo pipefail
+                  BASE_SHA="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                      BASE_SHA=$(git merge-base "$BASE_SHA" HEAD)
+                  fi
+                  NEW=$(git diff --name-only "$BASE_SHA" HEAD -- prisma/migrations \
+                      | grep '/migration.sql$' || true)
+                  if [ -z "$NEW" ]; then
+                      echo "No new migration files in this change — nothing to re-check."
+                      exit 0
+                  fi
+                  echo "Re-applying this PR's migrations against the migrated DB:"
+                  echo "$NEW"
+                  for f in $NEW; do
+                      echo "==> re-applying ${f#prisma/migrations/}"
+                      psql -h localhost -U discordbot -d discordbot -v ON_ERROR_STOP=1 -q -f "$f"
+                  done
+                  echo "✅ PR migrations are idempotent (re-applied cleanly)."


### PR DESCRIPTION
Prevention gate for the migration-wedge incident (#1837), the mandated follow-up from `decisions/2026-07-16-idempotent-migrations.md`. The `support_session_status_enum` migration failed in prod **twice** (2.35.1, 2.35.2), each wedging all prod migrations — invisible to the schema-drift check because partial indexes / CHECK constraints / enum casts aren't expressible in `schema.prisma`.

## What it does

A new `Migration Gate` workflow, triggered only on `prisma/migrations/**` changes:
1. Spins up **`postgres:18-alpine`** (pinned to the production major version).
2. **Clean-apply** — applies the full migration chain via psql (`ON_ERROR_STOP`, mirroring Prisma's non-transactional per-statement `migrate deploy`). Catches migrations that fail on a fresh DB.
3. **Idempotency re-apply** — re-applies *this PR's own* new migrations against the already-migrated DB. A migration authored per the idempotency ADR re-applies cleanly; a non-idempotent one errors.

## Proven to fire (not a no-op)

Verified locally against both historical failures + the fix:

| Case | Clean-apply | Re-apply | Gate |
|---|---|---|---|
| 2.35.1 original (no `DROP INDEX`) | ❌ `42883 operator does not exist: SupportSessionStatus = text` | — | **caught** |
| 2.35.2 #1838 (no `IF EXISTS`) | ✅ | ❌ `42704 constraint does not exist` | **caught** |
| current idempotent migrations | ✅ | ✅ | **pass** |

## ⚠️ Needs a follow-up to actually gate

This adds the **check**, but a check only blocks merge if it's in branch protection's `required_status_checks`. Like the destructive-interaction gate (see `gotcha_destructive_gate_not_required_check`), it's advisory until added. After merge, add `Migrations apply on Postgres 18` to the required contexts on `main` (and `release/**` if used) — operator or via `gh api`.

## Revisit-when

Bump the pinned `postgres:18-alpine` when production Postgres changes major version — index-predicate re-validation and cast behaviour are version-sensitive (per the ADR).

Refs #1837

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI Migration Gate that validates `prisma/migrations` against Postgres 18 to enforce idempotency and prevent wedges like #1837. It now also enforces append-only history and only re-applies added migration files.

- **New Features**
  - Adds a `Migration Gate` workflow on PRs and merge groups to `main`/`release/**`; always reports and skips Postgres when no migration changes.
  - Enforces append-only migrations; rejects modified/renamed/deleted existing migration files.
  - On changes, spins up `postgres:18-alpine`, clean-applies the full chain with `psql -v ON_ERROR_STOP=1`, then re-applies added migrations to verify idempotency; catches partial-index, CHECK-constraint, and enum-cast issues (covers #1837).
  - Security hardening: uses `actions/checkout` with `persist-credentials: false`; silences SC2034.

- **Migration**
  - After merge, make “Migrations apply on Postgres 18” a required status check for `main` (and `release/**`).
  - Bump the pinned Postgres image when production’s major version changes.

<sup>Written for commit 6fdeef681f07fab337d7e8f08b09292d8e66eff3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation for database migration changes.
  * Verifies migrations apply successfully in sequence and can be reapplied safely.
  * Runs checks only when migration files change, with automatic cleanup of temporary test resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->