### PR TITLE
fix(deploy): use wget not curl for status/notify POSTs (#1837)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -82,15 +82,33 @@ resolve_http_probe_script() {
     echo "$DEPLOY_DIR/scripts/http-probe.sh"
 }
 
+# POST a JSON body to a URL. Uses busybox wget, NOT curl: this script runs
+# inside the webhook container (minimal Alpine), which ships wget but not curl —
+# curl calls here failed with "command not found", so a failed deploy could not
+# report its homelab-deploy commit status and surfaced as a SHA-mismatch timeout
+# instead of its real cause (#1837). Best-effort: never fail the deploy on a
+# reporting error. $3 is an optional GitHub token for the status API.
+post_json() {
+    local url="$1" body="$2" token="${3:-}"
+    if [[ -n "$token" ]]; then
+        wget -q -O /dev/null \
+            --header "Authorization: token $token" \
+            --header "Content-Type: application/json" \
+            --post-data "$body" "$url" || true
+    else
+        wget -q -O /dev/null \
+            --header "Content-Type: application/json" \
+            --post-data "$body" "$url" || true
+    fi
+}
+
 notify() {
     local color="$1" title="$2" desc="$3"
     [[ -z "$DISCORD_WEBHOOK" ]] && return
     local commit_msg commit_sha
     commit_sha=$(git -C "$DEPLOY_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
     commit_msg=$(git -C "$DEPLOY_DIR" log -1 --format='%s' 2>/dev/null || echo "unknown")
-    curl -s -o /dev/null -X POST "$DISCORD_WEBHOOK" \
-        -H "Content-Type: application/json" \
-        -d "{
+    post_json "$DISCORD_WEBHOOK" "{
             \"embeds\": [{
                 \"title\": \"$title\",
                 \"description\": \"$desc\",
@@ -104,7 +122,7 @@ notify() {
                 ],
                 \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
             }]
-        }" || true
+        }"
 }
 
 print_targeted_logs() {
@@ -355,12 +373,10 @@ acquire_lock() {
 post_deploy_status() {
     [[ -z "$GITHUB_DEPLOY_STATUS_TOKEN" ]] && return 0
     [[ -z "$DEPLOYED_SHA" ]] && return 0
-    curl -s -o /dev/null \
-        -X POST \
-        -H "Authorization: token $GITHUB_DEPLOY_STATUS_TOKEN" \
-        -H "Content-Type: application/json" \
+    post_json \
         "https://api.github.com/repos/${GITHUB_REPO}/statuses/${DEPLOYED_SHA}" \
-        -d "{\"state\":\"${1}\",\"description\":\"${2}\",\"context\":\"homelab-deploy\"}" || true
+        "{\"state\":\"${1}\",\"description\":\"${2}\",\"context\":\"homelab-deploy\"}" \
+        "$GITHUB_DEPLOY_STATUS_TOKEN"
 }
 
 # Runs all post-rollout health checks. Returns 0 if healthy, 1 on the first hard
@@ -515,12 +531,10 @@ fi
 if ! acquire_lock; then
     log "ERROR: LOCK_CONTENTION (another deploy is already running)"
     if [[ -n "$GITHUB_DEPLOY_STATUS_TOKEN" && -n "$incoming_sha" ]]; then
-        curl -s -o /dev/null \
-            -X POST \
-            -H "Authorization: token $GITHUB_DEPLOY_STATUS_TOKEN" \
-            -H "Content-Type: application/json" \
+        post_json \
             "https://api.github.com/repos/${GITHUB_REPO}/statuses/${incoming_sha}" \
-            -d '{"state":"error","description":"Deploy skipped — another deploy in progress","context":"homelab-deploy"}' || true
+            '{"state":"error","description":"Deploy skipped — another deploy in progress","context":"homelab-deploy"}' \
+            "$GITHUB_DEPLOY_STATUS_TOKEN"
         log "INFO: posted error status for ${incoming_sha}"
     fi
     notify 16711680 "Deploy Skipped" "Another deploy is already in progress"


### PR DESCRIPTION
The last loose end from the #1837 migration-wedge incident: `deploy.sh` runs **inside the `lucky-webhook` container** — a minimal Alpine that ships busybox `wget` but **not curl**. All three `curl` calls failed with `command not found`, so a failed deploy could not POST its `homelab-deploy` commit status. That's why both migration failures surfaced as **SHA-mismatch timeouts** instead of "MIGRATION_FAILED" — the real cause had to be dug out of the container's `/tmp/lucky-deploy.log`.

## Fix

Route all three POSTs — Discord `notify` + the two GitHub status calls (`post_deploy_status` + lock-contention) — through one `post_json()` helper using busybox wget (`--post-data` / `--header`). Root-cause fix at a shared function rather than three patched sites.

## Why wget, not ax

I was asked to use `ax`, but verified it first: **`ax` is a local-machine tool (`~/.local/bin/ax`), absent from both the homelab host and the webhook container.** Using it would reintroduce the exact `command not found` failure. `wget` is already present in the container, needs no image rebuild, and takes effect on the next deploy (deploy.sh is bind-mounted from the host git checkout).

## Verified (not assumed)

- Webhook container tooling checked live: `curl` MISSING, `wget` `/usr/bin/wget` present, `apk`/busybox present, no node/ax.
- busybox wget **1.37.0** supports `--post-data` / `--header` / `-O` and **HTTPS** (ca-certificates present; `api.github.com/zen` reachable).
- The exact `post_json` wget form ran **from the actual webhook container** against httpbin — JSON body + header echoed back, rc=0.
- No `curl` remains in deploy.sh; shellcheck clean (the one SC1007 warning is a pre-existing `CDPATH=` idiom, untouched).

Refs #1837

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `deploy.sh` to use busybox `wget` for all JSON POSTs from the `lucky-webhook` container, restoring Discord and GitHub status reporting when `curl` is missing. Addresses #1837 where failed deploys looked like SHA-mismatch timeouts instead of the real error.

- **Bug Fixes**
  - Added `post_json()` helper (busybox `wget` + headers) and routed Discord `notify` and both GitHub status calls through it.
  - Restores commit status updates for `post_deploy_status` and lock-contention cases.
  - Makes reporting best-effort so deploys don’t fail on notify errors; no image rebuild needed.

<sup>Written for commit eb0a213f214428a6a5a5aa153edb38a7beea39ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

