### PR TITLE
fix(reminders): loader-agnostic rrule import (unbreak 2.36.0 deploy)

### DIFF
--- a/packages/shared/src/utils/recurrence.ts
+++ b/packages/shared/src/utils/recurrence.ts
@@ -1,5 +1,17 @@
-import { RRule } from 'rrule'
+import * as rruleModule from 'rrule'
 import { DateTime } from 'luxon'
+
+// rrule is a CommonJS package. Node's ESM loader can't statically detect its
+// named exports, so `import { RRule } from 'rrule'` throws at runtime in the
+// built bot ESM ("does not provide an export named 'RRule'", #1842 prod
+// precheck) — while a plain default import breaks jest's CJS interop instead
+// (`.default` is undefined). Resolve the class from whichever shape the active
+// loader exposes: Node ESM puts the CJS exports under `.default`, jest's
+// __importStar puts them on the namespace directly.
+const RRule =
+    (rruleModule as { RRule?: typeof import('rrule').RRule }).RRule ??
+    (rruleModule as unknown as { default: typeof import('rrule') }).default
+        .RRule
 
 /**
  * Recurrence patterns exposed by the /remind command. Each maps to an RRULE


### PR DESCRIPTION
## What
`import { RRule } from 'rrule'` (added in #1842) throws in the built bot **ESM** that Node runs — `SyntaxError: Named export 'RRule' not found` — because rrule is a CommonJS package whose named exports Node's ESM loader can't statically resolve. This aborted the v2.36.0 homelab rollout at RUNTIME_PRECHECK; **prod stayed safely on 2.35.3, no outage.**

It passed all CI because jest runs CommonJS (require interop) and `tsc --noEmit` is happy — the failure only appears when the ESM artifact is actually evaluated. See #1849 for the CI gap.

## Fix
Namespace-import rrule and resolve `RRule` from whichever shape the active loader exposes (Node ESM → `.default`, jest `__importStar` → namespace). A plain default import would fix ESM but break jest, so the fallback covers both.

## Verified in both loaders
- Built ESM: `import('dist/utils/recurrence.js')` loads + computes next occurrence.
- jest: shared 1384/1384, bot reminder specs 31/31.
- typecheck: clean.

Follow-up: #1849 (add a CI startup-smoke that boots the built image so this class ships never again).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `rrule` import loader-agnostic so the ESM build runs without crashing and `jest` keeps working, unblocking the v2.36.0 deploy.

- **Bug Fixes**
  - Replace `import { RRule } from 'rrule'` with a namespace import and resolve `RRule` from `module.RRule` or `module.default.RRule`.
  - Fixes Node ESM runtime error: "Named export 'RRule' not found" (since `rrule` is CommonJS).
  - Verified: built ESM loads and computes; all `jest` tests pass; typecheck clean.

<sup>Written for commit e355d6cbd7ab335bfd1601f11460bed1e5245e6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recurrence handling compatibility across different module loading environments.
  * Preserved existing recurrence behavior and public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->