### PR TITLE
fix(deploy): poll docker-publish until terminal state (#1848)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,9 +125,8 @@ jobs:
                     exit 0
                   fi
                   commit_sha="$RESOLVED_SHA"
-                  max_wait=600
+                  max_wait=1800
                   interval=15
-                  elapsed=0
 
                   echo "==> Checking if docker-publish is running for ${commit_sha}..."
 
@@ -202,11 +201,15 @@ jobs:
                     fi
                   fi
 
-                  echo "==> Docker build in progress (run $run_id), waiting up to ${max_wait}s..."
+                  echo "==> Docker build in progress (run $run_id), polling until terminal state (max wait: ${max_wait}s)..."
 
-                  while [ $elapsed -lt $max_wait ]; do
+                  deadline=$(($(date +%s) + max_wait))
+
+                  while true; do
                     sleep $interval
-                    elapsed=$((elapsed + interval))
+
+                    now=$(date +%s)
+                    elapsed=$((now - deadline + max_wait))
 
                     run_info=$(gh run view "$run_id" \
                       --repo "${{ github.repository }}" \
@@ -228,10 +231,12 @@ jobs:
                         exit 1
                       fi
                     fi
-                  done
 
-                  echo "::error::Timed out waiting for Docker images after ${max_wait}s"
-                  exit 1
+                    if [ "$(date +%s)" -ge $deadline ]; then
+                      echo "::error::Timed out waiting for Docker images after ${max_wait}s"
+                      exit 1
+                    fi
+                  done
 
             - name: Sentry release — create
               if: ${{ env.SENTRY_AUTH_TOKEN != '' }}


### PR DESCRIPTION
Fixes #1848. The `Wait for Docker images` step aborted the deploy after a fixed 600s even when the multi-image build succeeded moments later (observed on v2.36.0 — build completed just after the window, deploy needed a manual re-run).

Now polls the docker-publish run until it reaches a **terminal** conclusion: success → proceed, failure/cancelled → abort, still-running → keep waiting. 1800s (30min) backstop prevents a truly stuck build from waiting forever. This removes the wall-clock race while preserving the abort-on-genuine-failure behavior.

Closes #1848.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wait for the `docker-publish` workflow run to reach a terminal state instead of timing out at 600s, preventing false deploy failures on long multi-image builds. Adds a 30‑minute backstop to avoid hanging on stuck runs.

- **Bug Fixes**
  - Polls every 15s; success → proceed, failure/cancelled → abort.
  - Clearer timeout handling and messaging. Fixes #1848.

<sup>Written for commit 7fe54580d4936c432c2b1b35de7a6567caaa606d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

