### PR TITLE
ci(docker): ESM module-load smoke on built bot image (#1849)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,6 +98,39 @@ jobs:
                 IMAGE="$(printf '%s' "${{ env.IMAGE_PREFIX }}-${{ matrix.service }}" | tr '[:upper:]' '[:lower:]')"
                 docker run --rm "$IMAGE:${{ steps.meta.outputs.version }}" yt-dlp --version
 
+            - name: Verify ESM module load — bot
+              if: matrix.service == 'bot'
+              run: |
+                # ESM smoke test for the bot: trigger the recurrence.ts → rrule
+                # import chain to catch CJS/ESM compatibility errors before deploy.
+                # This imports the core recurrence utilities that the /remind command
+                # uses. The rrule package is a CommonJS package whose named exports
+                # aren't statically resolvable by Node's ESM loader, so this fires at
+                # import-time when the module graph is evaluated—exactly the error
+                # that #1842 escaped to production.
+                #
+                # Side-effect-free: recurrence.ts has no top-level async code or
+                # side effects, only pure function definitions that use rrule.
+                IMAGE="$(printf '%s' "${{ env.IMAGE_PREFIX }}-${{ matrix.service }}" | tr '[:upper:]' '[:lower:]')"
+                docker run --rm "$IMAGE:${{ steps.meta.outputs.version }}" \
+                  node --input-type=module -e "
+                    try {
+                      const { buildRecurrenceRule, computeNextOccurrence, isValidTimezone } =
+                        await import('@lucky/shared/utils');
+                      if (typeof buildRecurrenceRule !== 'function' ||
+                          typeof computeNextOccurrence !== 'function' ||
+                          typeof isValidTimezone !== 'function') {
+                        throw new Error('recurrence utilities missing or malformed');
+                      }
+                      console.log('✓ ESM module load OK — recurrence utilities loaded');
+                      process.exit(0);
+                    } catch (error) {
+                      const message = error instanceof Error ? error.message : String(error);
+                      console.error('✗ ESM module load failed:', message);
+                      process.exit(1);
+                    }
+                  "
+
             # Phase A of the image-scan rollout (ADR 2026-05-16). Runs against
             # the freshly-pushed image — audit-only, exit-code 0, never blocks
             # CI. Findings land in the Code Scanning tab via SARIF upload, one


### PR DESCRIPTION
Fixes #1849. CI builds + pushes the bot image but never runs it, so #1842's rrule ESM import bug (`import { RRule } from 'rrule'`, a CJS package Node's ESM loader can't resolve by name) passed jest (CommonJS) and `tsc`, and only the homelab RUNTIME_PRECHECK caught it — aborting the v2.36.0 rollout.

Adds a `Verify ESM module load — bot` step that runs the **shipped image**:
```
docker run IMAGE node --input-type=module -e "await import('@lucky/shared/utils')"
```
This forces Node's ESM loader to evaluate the recurrence.ts → rrule import chain. Side-effect-free (the barrel only exports pure functions), and it uses the same `@lucky/shared/utils` specifier the bot imports at runtime, so a broken CJS/ESM interop fails the build **before the image is pushed**.

Closes #1849.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ESM module-load smoke test to the Docker publish workflow that runs the built `bot` image and verifies `@lucky/shared/utils` loads and exposes expected recurrence functions. This catches `rrule` CJS/ESM interop issues in the shipped image and blocks the push.

- **New Features**
  - Adds “Verify ESM module load — bot” step that runs `docker run ... node --input-type=module -e "…await import('@lucky/shared/utils')"` inside the built image, checks `buildRecurrenceRule`, `computeNextOccurrence`, and `isValidTimezone` are functions, logs success/failure, and fails on error. Runs only for `bot`; side-effect-free.

<sup>Written for commit 84f1991778bb84525efe3fb1b1b4d1ccbae2954a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

