### PR TITLE
docs(readme): reconcile test count claims — ~6,300 across all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <b>🎵 The Discord music bot that can't be shut down — because you host it.</b><br>
-  <strong>Self-hosted · Open-source · TypeScript monorepo · ~2500 tests · Zero prod incidents</strong>
+  <strong>Self-hosted · Open-source · TypeScript monorepo · ~6,300 tests · Zero prod incidents</strong>
 </p>
 
 <p align="center">
@@ -76,7 +76,7 @@ Unlike Groovy, Rythm, or Hydra (all shut down by third-party enforcement), Lucky
 - **Feature toggles**: Enable/disable per-guild
 
 ### 📈 Reliability & Monitoring
-- **CI/CD**: Every PR runs lint + build + ~2500 tests + SonarCloud gates
+- **CI/CD**: Every PR runs lint + build + ~6,300 tests + SonarCloud gates
 - **Zero incidents**: Battle-tested in production with full test coverage
 - **Sentry monitoring**: Real-time error tracking and telemetry
 - **Security scanning**: Trivy container scans on every Docker publish
@@ -110,7 +110,7 @@ Lucky solves this:
 | **Database** | PostgreSQL, Prisma ORM |
 | **Cache** | Redis |
 | **DevOps** | Docker, Docker Compose, Cloudflare Tunnel |
-| **Testing** | ~2500 unit + integration tests, Playwright e2e |
+| **Testing** | ~6,300 unit + integration tests, Playwright e2e |
 | **Quality** | SonarCloud, Trivy, Dependabot, ESLint |
 
 ---
@@ -253,7 +253,7 @@ SENTRY_DSN=...
 # Run all checks before committing (lint + build + test)
 npm run verify
 
-# Run all tests (~2500 total)
+# Run all tests (~6,300 total)
 npm run test:all
 
 # Run e2e smoke tests (Playwright)
@@ -351,7 +351,7 @@ Lucky is a **solo personal project** — actively developed and deployed to prod
 1. **Fork** the repository
 2. **Create a branch**: `feature/cool-thing` or `fix/bug-name`
 3. **Follow conventions**: Conventional commits, <50 line functions, tests first
-4. **Run the gate**: `npm run verify` (lint + build + ~2500 tests)
+4. **Run the gate**: `npm run verify` (lint + build + ~6,300 tests)
 5. **Open a PR** with a clear description
 
 **Response time** is best-effort due to solo maintenance, but all PRs are reviewed.


### PR DESCRIPTION
Fixes #1820

## Problem
README claimed ~2,500 tests while the social-preview image claimed 849+. Both were wrong/inconsistent.

## Actual counts
| Package | Tests |
|---------|-------|
| backend | 1,209 |
| bot | 2,554 (+ 95 it.each) |
| shared | 1,377 |
| frontend | 1,190 |
| **Total** | **~6,300** |

## Changes
- Updated all README references from ~2,500 to ~6,300

## Follow-up
The social-preview image (assets/lucky-social-preview.png) still shows '849+ Tests' and needs regeneration via the brand asset tool.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated README test count to ~6,300 across all packages and aligned CI/CD references. Fixes #1820.

- **Bug Fixes**
  - Replaced all "~2500 tests" mentions in README with "~6,300 tests" (intro, CI, stack table, scripts, contributing).
  - Social preview image still shows "849+ Tests" — regenerate via the brand asset tool.

<sup>Written for commit f2b64d2e9b615799e8f5c2d166701ca7d5db42f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing documentation to reflect the current suite size of approximately 6,300 tests.
  * Revised testing references across feature badges, CI/CD details, development instructions, and contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->