### PR TITLE
fix(ci): bump org workflow SHA to fix claude-review failures (#1836)

### DIFF
--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -46,9 +46,9 @@ permissions:
 
 jobs:
   claude-review:
-    uses: LucasSantana-Dev/.github/.github/workflows/claude-review.yml@0e4a491c9ae4cae6859972da1813c6a581a1a082 # v1
+    uses: LucasSantana-Dev/.github/.github/workflows/claude-review.yml@bf372e78b4d3ce9a4d25362b5c75c661039c48ba # v1
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   danger:
-    uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@0e4a491c9ae4cae6859972da1813c6a581a1a082 # v1
+    uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@bf372e78b4d3ce9a4d25362b5c75c661039c48ba # v1


### PR DESCRIPTION
Fixes #1836

## Problem
Since 2026-07-15, the \`claude-review\` CI job has failed on every PR with \`is_error:true\` at \$0 cost. The upstream \`anthropics/claude-code-action@v1\` tag floated to a broken v1.0.175 release.

## Root Cause
This repo pinned the org-level reusable workflow to SHA \`0e4a491c\` (2026-07-02), which referenced the floating \`@v1\` tag. The org \`.github\` repo fixed this 10 hours ago by pinning to SHA \`af0559ee\` (v1.0.178), but Lucky never picked it up.

## Fix
Bump both reusable workflow references (claude-review + danger) to the latest org SHA \`bf372e78\` which includes the upstream pin.

## Verification
Once merged, re-running checks on any open PR should resolve the claude-review failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates our org reusable workflow references to fix the broken `claude-review` CI job and keep `danger` in sync with the pinned action.

- **Bug Fixes**
  - Pointed `LucasSantana-Dev/.github` reusable workflows to the pin that locks `anthropics/claude-code-action` to v1.0.178, resolving `claude-review` failures; re-running checks on open PRs should pass.

<sup>Written for commit b236ba2066f513dfc4fecc1fdee9993264232f27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

