### PR TITLE
fix(ci): make claude-review non-blocking — upstream action crash (#1836)

### DIFF
--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -46,12 +46,9 @@ permissions:
   id-token: write
 
 jobs:
-  claude-review:
-    uses: LucasSantana-Dev/.github/.github/workflows/claude-review.yml@bf372e78b4d3ce9a4d25362b5c75c661039c48ba # v1
-    continue-on-error: true  # Temporary: upstream action crashes, see #1836
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-
+  # claude-review removed: the upstream action crashes on every PR (#1836) and
+  # `continue-on-error` is not valid on reusable-workflow jobs (actionlint).
+  # kimi-review is the replacement AI reviewer.
   kimi-review:
     # Pinned to branch until the reusable lands on .github release; re-pin to sha/tag after merge.
     uses: LucasSantana-Dev/.github/.github/workflows/kimi-review.yml@623a99b5c494fc3f8f2c196b852aab04dab74da2

--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -47,6 +47,7 @@ permissions:
 jobs:
   claude-review:
     uses: LucasSantana-Dev/.github/.github/workflows/claude-review.yml@bf372e78b4d3ce9a4d25362b5c75c661039c48ba # v1
+    continue-on-error: true  # Temporary: upstream action crashes, see #1836
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
Fixes #1836

## Problem
The `claude-review` CI job has been failing on every PR since 2026-07-15 with `is_error:true` at \$0 cost. This is a known upstream bug in `anthropics/claude-code-action` (v1.0.175 → v1.0.178) that Anthropic has not resolved.

Pinning to SHA \`af0559ee\` (v1.0.178) did not fix the crash.

## Solution
Add \`continue-on-error: true\` to the claude-review job so PRs are not blocked by an upstream crash. The review still runs and reports when functional, but failures will not prevent merges.

## When to Revert
Once Anthropic releases a fixed version of claude-code-action and the org-level reusable workflow is updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `claude-review` job to stop upstream `anthropics/claude-code-action` crashes from blocking merges (#1836), and switch to `kimi-review` via the reusable workflow in `.github/workflows/review-tools.yml`. Reviews still run, but failures in the old action no longer affect CI.

<sup>Written for commit 358986818417c5d1068f16b49260f33e7dd82234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

