### PR TITLE
feat(security): add hsts and permissions-policy to vercel.json headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,14 @@
         {
             "source": "/(.*)",
             "headers": [
+                {
+                    "key": "Strict-Transport-Security",
+                    "value": "max-age=31536000; includeSubDomains; preload"
+                },
+                {
+                    "key": "Permissions-Policy",
+                    "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+                },
                 { "key": "X-Frame-Options", "value": "DENY" },
                 { "key": "X-Content-Type-Options", "value": "nosniff" },
                 {


### PR DESCRIPTION
Adds Strict-Transport-Security (max-age=31536000; includeSubDomains; preload) and Permissions-Policy (camera/microphone/geolocation/interest-cohort off) to the existing security header block in vercel.json.

Context: Caido parallel security sweep 2026-07-21 found Lucky at 4/6 core headers (missing HSTS + Permissions-Policy). All other headers (CSP, XFO, nosniff, Referrer-Policy) already present and unchanged.

Verification: after deploy, GET / should show 6/6 core security headers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add HSTS (max-age=31536000; includeSubDomains; preload) and Permissions-Policy in vercel.json to enforce HTTPS and disable camera, microphone, geolocation, and interest-cohort. Completes Caido core security headers (6/6).

<sup>Written for commit cdad04da6812aee32fcd903038442b23c64a8d96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

