### PR TITLE
fix(deps): resolve high-severity npm audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13440,18 +13440,6 @@
                 "node": ">= 6.0.0"
             }
         },
-        "node_modules/axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
-                "https-proxy-agent": "^5.0.1",
-                "proxy-from-env": "^2.1.0"
-            }
-        },
         "node_modules/b4a": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
@@ -13905,21 +13893,34 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -13949,9 +13950,9 @@
             "optional": true
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -20342,9 +20343,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {
@@ -27697,7 +27698,7 @@
                 "@sentry/react": "^10.53.1",
                 "@tanstack/react-query": "^5.100.14",
                 "@vercel/analytics": "^2.0.1",
-                "axios": "^1.16.1",
+                "axios": "^1.18.1",
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
                 "framer-motion": "^12.40.0",
@@ -27932,6 +27933,18 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "packages/frontend/node_modules/axios": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
         "packages/frontend/node_modules/eslint": {
             "version": "10.3.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
@@ -28144,7 +28157,7 @@
             "dependencies": {
                 "@prisma/client": "^7.8.0",
                 "@sentry/node": "^10.53.1",
-                "axios": "^1.16.1",
+                "axios": "^1.18.1",
                 "bullmq": "^5.79.1",
                 "chalk": "^5.6.2",
                 "dotenv": "^17.4.2",
@@ -28218,6 +28231,18 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "packages/shared/node_modules/axios": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
         "packages/shared/node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -28226,9 +28251,9 @@
             "license": "MIT"
         },
         "packages/shared/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -39,7 +39,7 @@
         "@sentry/react": "^10.53.1",
         "@tanstack/react-query": "^5.100.14",
         "@vercel/analytics": "^2.0.1",
-        "axios": "^1.16.1",
+        "axios": "^1.18.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.40.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -89,7 +89,7 @@
     "dependencies": {
         "@prisma/client": "^7.8.0",
         "@sentry/node": "^10.53.1",
-        "axios": "^1.16.1",
+        "axios": "^1.18.1",
         "bullmq": "^5.79.1",
         "chalk": "^5.6.2",
         "dotenv": "^17.4.2",


### PR DESCRIPTION
The Security CI gate (`npm audit --audit-level=high`) is failing on all PRs due to pre-existing vulnerabilities. This PR clears it:

- axios ^1.16.1 -> ^1.18.1 (packages/frontend, packages/shared) — fixes 8 high-severity advisories (DoS recursion, prototype pollution, proxy bypass, etc.)
- `npm audit fix` for body-parser and brace-expansion

Verified locally: `npm audit --audit-level=high` = **0 vulnerabilities**, `npm run build:shared` passes.

Unblocks #1868.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing Security CI gate by updating vulnerable dependencies; npm audit --audit-level=high now reports 0. Unblocks #1868.

- **Dependencies**
  - Bump `axios` to ^1.18.1 in `packages/frontend` and `packages/shared`.
  - Apply `npm audit fix` to update `body-parser` and `brace-expansion`.

<sup>Written for commit 7a5ecd84cdfd085af2929516cf1923493510b049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

