### PR TITLE
ci(review): add kimi-review job to review-tools

### DIFF
--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -52,7 +52,7 @@ jobs:
 
   kimi-review:
     # Pinned to branch until the reusable lands on .github release; re-pin to sha/tag after merge.
-    uses: LucasSantana-Dev/.github/.github/workflows/kimi-review.yml@feat/kimi-review
+    uses: LucasSantana-Dev/.github/.github/workflows/kimi-review.yml@623a99b5c494fc3f8f2c196b852aab04dab74da2
     secrets:
       KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
 

--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -31,12 +31,13 @@ concurrency:
   group: review-tools-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# Minimum permissions for both reusable workflows. An explicit block sets
+# Minimum permissions for all three reusable workflows. An explicit block sets
 # every unlisted scope to `none`, and a called reusable workflow cannot
 # request scopes the caller withheld — so the caller must grant the UNION of
 # what the reusables declare, or the run fails at startup (see #1423):
 #   - claude-review.yml needs contents:read, pull-requests:write,
 #     issues:write, and id-token:write (OIDC)
+#   - kimi-review.yml needs contents:read, pull-requests:write, issues:write
 #   - danger.yml needs contents:read, pull-requests:write, issues:write
 permissions:
   contents: read

--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -50,5 +50,11 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
+  kimi-review:
+    # Pinned to branch until the reusable lands on .github release; re-pin to sha/tag after merge.
+    uses: LucasSantana-Dev/.github/.github/workflows/kimi-review.yml@feat/kimi-review
+    secrets:
+      KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+
   danger:
     uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@bf372e78b4d3ce9a4d25362b5c75c661039c48ba # v1


### PR DESCRIPTION
Adds the Kimi (Moonshot, kimi-k2.6) PR review alongside the dark claude-review gate (#1836).

Depends on: LucasSantana-Dev/.github PR adding the reusable kimi-review.yml (branch feat/kimi-review). This PR is pinned to that branch for now; re-pin to sha/tag after it lands.

Requires: KIMI_API_KEY repo secret (Moonshot platform key from https://platform.moonshot.ai).

The job is non-blocking (not in required_status_checks), posts one structured review comment per run, updated in place on re-runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a non-blocking `kimi-review` CI job to run Moonshot Kimi (`kimi-k2.6`) PR reviews alongside `claude-review`. It posts one structured review comment per run, updates it on re-runs, and is pinned to `LucasSantana-Dev/.github` reusable SHA `623a99b`.

- **New Features**
  - Adds `kimi-review` to `.github/workflows/review-tools.yml` and documents its minimal permissions.

- **Migration**
  - Add `KIMI_API_KEY` repo secret (Moonshot platform key).

<sup>Written for commit 5f0065eb1e67504cf22ef8dbf48795a95cf2aafb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

