### PR TITLE
fix(deps): clear new-baseline npm audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,27 +1728,6 @@
             "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
             "license": "(Apache-2.0 AND BSD-3-Clause)"
         },
-        "node_modules/@clack/core": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
-            "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
-            "license": "MIT",
-            "dependencies": {
-                "picocolors": "^1.0.0",
-                "sisteransi": "^1.0.5"
-            }
-        },
-        "node_modules/@clack/prompts": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
-            "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
-            "license": "MIT",
-            "dependencies": {
-                "@clack/core": "0.5.0",
-                "picocolors": "^1.0.0",
-                "sisteransi": "^1.0.5"
-            }
-        },
         "node_modules/@commitlint/cli": {
             "version": "21.0.1",
             "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.1.tgz",
@@ -2490,30 +2469,30 @@
             }
         },
         "node_modules/@electric-sql/pglite": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
-            "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
+            "integrity": "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==",
             "license": "Apache-2.0"
         },
         "node_modules/@electric-sql/pglite-socket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
-            "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.3.tgz",
+            "integrity": "sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==",
             "license": "Apache-2.0",
             "bin": {
                 "pglite-server": "dist/scripts/server.js"
             },
             "peerDependencies": {
-                "@electric-sql/pglite": "0.4.1"
+                "@electric-sql/pglite": "0.4.3"
             }
         },
         "node_modules/@electric-sql/pglite-tools": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
-            "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.3.tgz",
+            "integrity": "sha512-AlzLJTRJ8+UFgK8CmxIpyIpJ0+YaFw02IiOSdYrqxwPXdSyeIShz8aa9Tq+tYFXdPwcaMp/Fc80mQZ1dkOQ/wg==",
             "license": "Apache-2.0",
             "peerDependencies": {
-                "@electric-sql/pglite": "0.4.1"
+                "@electric-sql/pglite": "0.4.3"
             }
         },
         "node_modules/@emnapi/core": {
@@ -3211,18 +3190,6 @@
                 "@shikijs/themes": "^3.23.0",
                 "@shikijs/types": "^3.23.0",
                 "@shikijs/vscode-textmate": "^10.0.2"
-            }
-        },
-        "node_modules/@hono/node-server": {
-            "version": "1.19.13",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-            "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.14.1"
-            },
-            "peerDependencies": {
-                "hono": "^4"
             }
         },
         "node_modules/@hookform/resolvers": {
@@ -4423,12 +4390,6 @@
             "engines": {
                 "node": ">= 18"
             }
-        },
-        "node_modules/@kurkle/color": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-            "license": "MIT"
         },
         "node_modules/@lucky/backend": {
             "resolved": "packages/backend",
@@ -5684,9 +5645,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/config": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
-            "integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.0.tgz",
+            "integrity": "sha512-CsoK2mhl0u+N4/8V+XroQMOUNIic4isqD+E2HBG8l1yGEKo62CFDu3FHo0FdwItjl6XkW+omA1STSzeN1DAXlg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "c12": "3.3.4",
@@ -5702,22 +5663,20 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/dev": {
-            "version": "0.24.3",
-            "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
-            "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
+            "version": "0.24.14",
+            "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.14.tgz",
+            "integrity": "sha512-NhFO49O2JPTdzYiLHvceQn/HiwmcKF/iGV39ko3CpYsoGqS3rz3ko6gzuxFSIeHNwNJeuNcDexyyGeTO3DW80A==",
             "license": "ISC",
             "dependencies": {
-                "@electric-sql/pglite": "0.4.1",
-                "@electric-sql/pglite-socket": "0.1.1",
-                "@electric-sql/pglite-tools": "0.3.1",
-                "@hono/node-server": "1.19.11",
+                "@electric-sql/pglite": "0.4.3",
+                "@electric-sql/pglite-socket": "0.1.3",
+                "@electric-sql/pglite-tools": "0.3.3",
                 "@prisma/get-platform": "7.2.0",
                 "@prisma/query-plan-executor": "7.2.0",
-                "@prisma/streams-local": "0.1.2",
+                "@prisma/streams-local": "0.1.11",
+                "find-my-way": "9.6.0",
                 "foreground-child": "3.3.1",
                 "get-port-please": "3.2.0",
-                "hono": "^4.12.8",
-                "http-status-codes": "2.3.0",
                 "pathe": "2.0.3",
                 "proper-lockfile": "4.1.2",
                 "remeda": "2.33.4",
@@ -5736,51 +5695,63 @@
             }
         },
         "node_modules/@prisma/engines": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
-            "integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.0.tgz",
+            "integrity": "sha512-lDWJp/pgSWCLfYsupmmNo96jfsbQnH1yjia8XVM2Kh8nRZhD0bQU2jCHuy3ZTPMLR3apRD3k145ybENalAYjYw==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.8.0",
-                "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
-                "@prisma/fetch-engine": "7.8.0",
-                "@prisma/get-platform": "7.8.0"
+                "@prisma/debug": "7.9.0",
+                "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+                "@prisma/fetch-engine": "7.9.0",
+                "@prisma/get-platform": "7.9.0"
             }
         },
         "node_modules/@prisma/engines-version": {
-            "version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
-            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
-            "integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
+            "version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad.tgz",
+            "integrity": "sha512-2BsPPFksz3CQUXG6af3rVCtJKg6+JJGJTtfgu2fU8DdXhOfkBjulCq8mwybCd6ge0/jhZq2kOtLAbmUDMyI1nA==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@prisma/engines/node_modules/@prisma/debug": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.0.tgz",
+            "integrity": "sha512-i0KdVQuKUE6N9NloHs+sUNAk2c9svR3myBndQbA3BoeoArsSpwtNgTdHZL+wBtCLCcdS2OOC/PKhgTe36jkF5A==",
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
-            "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.0.tgz",
+            "integrity": "sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.8.0"
+                "@prisma/debug": "7.9.0"
             }
         },
         "node_modules/@prisma/fetch-engine": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
-            "integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.0.tgz",
+            "integrity": "sha512-F0XlIgjbE3EywRVR/HpCerNI/dxo40vK66tHcWpsWYwH/Jk9+FsICEzATeMsZ7bdnpZz93hkD4sAb5rKLsCCpA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.8.0",
-                "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
-                "@prisma/get-platform": "7.8.0"
+                "@prisma/debug": "7.9.0",
+                "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+                "@prisma/get-platform": "7.9.0"
             }
         },
+        "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.0.tgz",
+            "integrity": "sha512-i0KdVQuKUE6N9NloHs+sUNAk2c9svR3myBndQbA3BoeoArsSpwtNgTdHZL+wBtCLCcdS2OOC/PKhgTe36jkF5A==",
+            "license": "Apache-2.0"
+        },
         "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
-            "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.0.tgz",
+            "integrity": "sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.8.0"
+                "@prisma/debug": "7.9.0"
             }
         },
         "node_modules/@prisma/get-platform": {
@@ -5858,9 +5829,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/streams-local": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
-            "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.11.tgz",
+            "integrity": "sha512-0TcebL559MByKqTJ+SsrFIEg228iw8UCVRFckzgfRSiJqczhs+MuAgWOF9lnOIV/IVqvu+KMnFTH0eDeTQMpUg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^8.12.0",
@@ -5869,7 +5840,7 @@
                 "proper-lockfile": "^4.1.2"
             },
             "engines": {
-                "bun": ">=1.3.6",
+                "bun": ">=1.2.0",
                 "node": ">=22.0.0"
             }
         },
@@ -5886,13 +5857,22 @@
             }
         },
         "node_modules/@prisma/studio-core": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
-            "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+            "version": "0.33.0",
+            "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.33.0.tgz",
+            "integrity": "sha512-V2fX/nKEymNTrHXwfP26PGjoLStO35Ogu+ex7CFJbLrMYEcZxxZpiSNOs7px23Hk5mzLWvM5RsqG6Ka+rha+wg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@radix-ui/react-toggle": "1.1.10",
-                "chart.js": "4.5.1"
+                "@visx/curve": "4.0.1-alpha.0",
+                "@visx/event": "4.0.1-alpha.0",
+                "@visx/grid": "4.0.1-alpha.0",
+                "@visx/group": "4.0.1-alpha.0",
+                "@visx/responsive": "4.0.1-alpha.0",
+                "@visx/scale": "4.0.1-alpha.0",
+                "@visx/shape": "4.0.1-alpha.0",
+                "d3-array": "3.2.4",
+                "d3-shape": "3.2.0",
+                "elkjs": "0.11.1"
             },
             "engines": {
                 "node": "^20.19 || ^22.12 || >=24.0",
@@ -11651,6 +11631,84 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/d3-array": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
+            "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-delaunay": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+            "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-format": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+            "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-geo": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+            "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/geojson": "*"
+            }
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+            "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+            "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-time-format": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
+            "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
+            "license": "MIT"
+        },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -11705,6 +11763,12 @@
             "dependencies": {
                 "@types/express": "*"
             }
+        },
+        "node_modules/@types/geojson": {
+            "version": "7946.0.16",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+            "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+            "license": "MIT"
         },
         "node_modules/@types/hast": {
             "version": "3.0.4",
@@ -11789,6 +11853,12 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.17.24",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+            "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
             "license": "MIT"
         },
         "node_modules/@types/luxon": {
@@ -12560,6 +12630,147 @@
                 "vue-router": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@visx/curve": {
+            "version": "4.0.1-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/curve/-/curve-4.0.1-alpha.0.tgz",
+            "integrity": "sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg==",
+            "license": "MIT",
+            "dependencies": {
+                "@visx/vendor": "4.0.0-alpha.0"
+            }
+        },
+        "node_modules/@visx/event": {
+            "version": "4.0.1-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/event/-/event-4.0.1-alpha.0.tgz",
+            "integrity": "sha512-EQqCMSv/s8NbFjo+hz3FKsvvYfP+2QslsFJ/24/O5l/W+7UC6J6aAvO0ujVwrTwdYbuQ+vhxKi1xdPdKR/qj1g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/react": "*",
+                "@visx/point": "4.0.1-alpha.0"
+            }
+        },
+        "node_modules/@visx/grid": {
+            "version": "4.0.1-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/grid/-/grid-4.0.1-alpha.0.tgz",
+            "integrity": "sha512-rycutGmTHO+znNdPumheWMglm7YfpffvRwUkVy5zy4WoORIuKTMkDxwnOzHG2xMxU3EE/YCd37xFV5AxA30yeg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/react": "*",
+                "@visx/curve": "4.0.1-alpha.0",
+                "@visx/group": "4.0.1-alpha.0",
+                "@visx/point": "4.0.1-alpha.0",
+                "@visx/scale": "4.0.1-alpha.0",
+                "@visx/shape": "4.0.1-alpha.0",
+                "classnames": "^2.3.1"
+            },
+            "peerDependencies": {
+                "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+            }
+        },
+        "node_modules/@visx/group": {
+            "version": "4.0.1-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/group/-/group-4.0.1-alpha.0.tgz",
+            "integrity": "sha512-V19l7iQ7jccBv8kao/EByuI6o4xtxzzLV9nqVI1hRvmdzTVsuLpqlwzYCZUXJaTVvUWf8s4D2SQFjGkj/Nw+0w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/react": "*",
+                "classnames": "^2.3.1"
+            },
+            "peerDependencies": {
+                "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+            }
+        },
+        "node_modules/@visx/point": {
+            "version": "4.0.1-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/point/-/point-4.0.1-alpha.0.tgz",
+            "integrity": "sha512-ijTfr/Nx09f03vIj9nyTr3z4Xth4Y75427UaogJh6dnIRLMEFHQOwNu791sbfiNj0a+ZXuaE32h0vKrFe4/8Qg==",
+            "license": "MIT"
+        },
+        "node_modules/@visx/responsive": {
+            "version": "4.0.1-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/responsive/-/responsive-4.0.1-alpha.0.tgz",
+            "integrity": "sha512-o+1zGywQZY0+yOx3Iw87wc4bbPJRr/HnIukTwfOz4UVyj9pB1OQNVHB7OORO1+LBHJceWpB31co/ZV9KHncKrA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/lodash": "^4.17.13",
+                "@types/react": "*",
+                "lodash": "^4.17.21"
+            },
+            "peerDependencies": {
+                "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+            }
+        },
+        "node_modules/@visx/scale": {
+            "version": "4.0.1-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-4.0.1-alpha.0.tgz",
+            "integrity": "sha512-nzjeE87vFSAXGWFiiNfBpNLAf0Q8Qmf6syvKLjqNi4kGZkdhbUll3E/59YsgWXmjM8+llPLWzGsP+JPvo5eq1A==",
+            "license": "MIT",
+            "dependencies": {
+                "@visx/vendor": "4.0.0-alpha.0"
+            }
+        },
+        "node_modules/@visx/shape": {
+            "version": "4.0.1-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-4.0.1-alpha.0.tgz",
+            "integrity": "sha512-62QeiVNmPlterQGwhkEDcbq7M0MqY0lBsK5QKXtM9ZoPZWkuGV3aykA3+Xu20B2FAvyJq4LqJzBc7Sxr+EAdbA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/lodash": "^4.17.13",
+                "@types/react": "*",
+                "@visx/curve": "4.0.1-alpha.0",
+                "@visx/group": "4.0.1-alpha.0",
+                "@visx/scale": "4.0.1-alpha.0",
+                "@visx/vendor": "4.0.0-alpha.0",
+                "classnames": "^2.3.1",
+                "lodash": "^4.17.21"
+            },
+            "peerDependencies": {
+                "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+            }
+        },
+        "node_modules/@visx/vendor": {
+            "version": "4.0.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@visx/vendor/-/vendor-4.0.0-alpha.0.tgz",
+            "integrity": "sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==",
+            "license": "MIT and ISC",
+            "dependencies": {
+                "@types/d3-array": "3.0.3",
+                "@types/d3-color": "3.1.0",
+                "@types/d3-delaunay": "6.0.1",
+                "@types/d3-format": "3.0.1",
+                "@types/d3-geo": "3.1.0",
+                "@types/d3-interpolate": "3.0.1",
+                "@types/d3-path": "3.1.1",
+                "@types/d3-scale": "4.0.2",
+                "@types/d3-shape": "3.1.7",
+                "@types/d3-time": "3.0.0",
+                "@types/d3-time-format": "2.1.0",
+                "d3-array": "3.2.1",
+                "d3-color": "3.1.0",
+                "d3-delaunay": "6.0.2",
+                "d3-format": "3.1.0",
+                "d3-geo": "3.1.0",
+                "d3-interpolate": "3.0.1",
+                "d3-path": "3.1.0",
+                "d3-scale": "4.0.2",
+                "d3-shape": "3.2.0",
+                "d3-time": "3.1.0",
+                "d3-time-format": "4.1.0",
+                "internmap": "2.0.3"
+            }
+        },
+        "node_modules/@visx/vendor/node_modules/d3-array": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
+            "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@vitejs/plugin-react": {
@@ -13652,16 +13863,10 @@
             }
         },
         "node_modules/better-result": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.7.0.tgz",
-            "integrity": "sha512-7zrmXjAK8u8Z6SOe4R65XObOR5X+Y2I/VVku3t5cPOGQ8/WsBcfFmfnIPiEl5EBMDOzPHRwbiPbMtQBKYdw7RA==",
-            "license": "MIT",
-            "dependencies": {
-                "@clack/prompts": "^0.11.0"
-            },
-            "bin": {
-                "better-result": "bin/cli.mjs"
-            }
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.10.0.tgz",
+            "integrity": "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw==",
+            "license": "MIT"
         },
         "node_modules/bgutils-js": {
             "version": "3.2.0",
@@ -14428,18 +14633,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/chart.js": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-            "license": "MIT",
-            "dependencies": {
-                "@kurkle/color": "^0.3.0"
-            },
-            "engines": {
-                "pnpm": ">=8"
-            }
-        },
         "node_modules/chokidar": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -14497,6 +14690,12 @@
             "funding": {
                 "url": "https://polar.sh/cva"
             }
+        },
+        "node_modules/classnames": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+            "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+            "license": "MIT"
         },
         "node_modules/cli-cursor": {
             "version": "5.0.0",
@@ -15116,6 +15315,133 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-delaunay": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+            "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+            "license": "ISC",
+            "dependencies": {
+                "delaunator": "5"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-geo": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+            "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.5.0 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/dargs": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
@@ -15392,6 +15718,15 @@
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
             "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
             "license": "MIT"
+        },
+        "node_modules/delaunator": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+            "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+            "license": "ISC",
+            "dependencies": {
+                "robust-predicates": "^3.0.2"
+            }
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -15724,9 +16059,9 @@
             "license": "MIT"
         },
         "node_modules/effect": {
-            "version": "3.21.2",
-            "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
-            "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
+            "version": "3.22.0",
+            "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
+            "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
@@ -15739,6 +16074,12 @@
             "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/elkjs": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+            "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+            "license": "EPL-2.0"
         },
         "node_modules/emittery": {
             "version": "0.13.1",
@@ -16676,9 +17017,9 @@
             }
         },
         "node_modules/exsolve": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-            "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+            "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
             "license": "MIT"
         },
         "node_modules/ext-list": {
@@ -16746,6 +17087,12 @@
             ],
             "license": "MIT"
         },
+        "node_modules/fast-decode-uri-component": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+            "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+            "license": "MIT"
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16773,6 +17120,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fast-querystring": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+            "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-decode-uri-component": "^1.0.1"
+            }
+        },
         "node_modules/fast-safe-stringify": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -16798,9 +17154,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "funding": [
                 {
                     "type": "github",
@@ -17025,6 +17381,20 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/find-my-way": {
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+            "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-querystring": "^1.0.0",
+                "safe-regex2": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/find-up": {
@@ -17548,9 +17918,9 @@
             }
         },
         "node_modules/giget": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
-            "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+            "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
             "license": "MIT",
             "bin": {
                 "giget": "dist/cli.mjs"
@@ -17751,9 +18121,9 @@
             "license": "ISC"
         },
         "node_modules/grammex": {
-            "version": "3.1.12",
-            "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
-            "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
+            "version": "3.1.13",
+            "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.13.tgz",
+            "integrity": "sha512-LnPnhOBLEJEVKS8WFDVaA397L9Kq55Q9oSITJiVLHVdhAclfUkWzQv74KhvZHKL2Q09Pb1XdsrOsZ4LfTFFTEg==",
             "license": "MIT"
         },
         "node_modules/graphmatch": {
@@ -17935,15 +18305,6 @@
             "integrity": "sha512-mJLY5tErGWtsw8hO2fJ2vK4IpG6S1AIgVkduRo4FqFJhgI2H3XLzgemRemk45zcnFyxNNpOfrIDle2KcnJM0lA==",
             "license": "ISC"
         },
-        "node_modules/hono": {
-            "version": "4.12.25",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-            "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16.9.0"
-            }
-        },
         "node_modules/hosted-git-info": {
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
@@ -18035,12 +18396,6 @@
             "version": "10.17.60",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
             "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-            "license": "MIT"
-        },
-        "node_modules/http-status-codes": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-            "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
             "license": "MIT"
         },
         "node_modules/http2-wrapper": {
@@ -18323,6 +18678,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/ioredis": {
@@ -20834,9 +21198,9 @@
             "license": "MIT"
         },
         "node_modules/linkify-it": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
             "dev": true,
             "funding": [
                 {
@@ -23070,16 +23434,16 @@
             }
         },
         "node_modules/prisma": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
-            "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.0.tgz",
+            "integrity": "sha512-isQTJEK4pyOlAVzm6kBUDjzgdsgs0A/snpB38ycTHeOHW34qfepP+ClQltgDXqjZBnXALhEtE4duh9L3tN5fHw==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/config": "7.8.0",
-                "@prisma/dev": "0.24.3",
-                "@prisma/engines": "7.8.0",
-                "@prisma/studio-core": "0.27.3",
+                "@prisma/config": "7.9.0",
+                "@prisma/dev": "0.24.14",
+                "@prisma/engines": "7.9.0",
+                "@prisma/studio-core": "0.33.0",
                 "mysql2": "3.15.3",
                 "postgres": "3.4.7"
             },
@@ -23824,6 +24188,15 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/ret": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+            "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/retry": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -23897,6 +24270,12 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/robust-predicates": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+            "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+            "license": "Unlicense"
         },
         "node_modules/rolldown": {
             "version": "1.0.3",
@@ -24246,6 +24625,28 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safe-regex2": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+            "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "ret": "~0.5.0"
+            },
+            "bin": {
+                "safe-regex2": "bin/safe-regex2.js"
             }
         },
         "node_modules/safer-buffer": {
@@ -24634,12 +25035,6 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
-        },
-        "node_modules/sisteransi": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "license": "MIT"
         },
         "node_modules/size-limit": {
             "version": "12.1.0",


### PR DESCRIPTION
Same moving-baseline pattern as #1869: new advisories published after that PR (hono/node-server serve-static traversal, fast-uri, prisma chain) flipped the Security gate red on every open PR (first seen on #1687).

npm audit fix only, no manual bumps. Verified: 0 vulnerabilities at --audit-level=high.

Merge first to unblock the PR fleet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved newly published npm advisories via `npm audit fix` to bring the Security gate back to green. No manual bumps; `npm audit --audit-level=high` now reports 0 vulnerabilities.

- **Dependencies**
  - Upgraded `prisma` to `7.9.0` and related packages: `@prisma/engines`, `@prisma/config`, `@prisma/dev`, `@prisma/studio-core`, `@prisma/streams-local`.
  - Replaced `chart.js` with `@visx/*` and `d3-*` (pulled in by `@prisma/studio-core`).
  - Bumped `fast-uri` to `3.1.4`.
  - Added `find-my-way` (and parsing deps) and removed `@hono/node-server`, `hono`, `http-status-codes`.
  - Updated misc libs: `effect`, `giget`, `grammex`, `linkify-it`, `better-result`.

<sup>Written for commit 2d5dc75f6172d63d1fe19080d073985f67cb0855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

