### PR TITLE
fix(docker): ship packages/shared's nested node_modules to runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,6 +141,14 @@ COPY --from=deps-production /app/package*.json ./
 COPY --from=deps-production /app/packages/shared/package*.json ./packages/shared/
 COPY --from=deps-production /app/packages/bot/package*.json ./packages/bot/
 COPY --from=deps-production /app/packages/bot/node_modules ./packages/bot/node_modules
+# packages/shared's own node_modules. npm nests a dep here instead of hoisting
+# it whenever another workspace pins a conflicting range (packages/frontend also
+# depends on axios, so both copies nested). shared/dist imports these at
+# runtime, so omitting this directory kills the container with
+# ERR_MODULE_NOT_FOUND. 9 packages are nested here as of this commit, which is
+# why this copies the whole directory rather than naming one dep. It comes from
+# deps-production, so it is already devDep-pruned.
+COPY --from=deps-production /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY --from=build /app/packages/shared/dist ./packages/shared/dist
 COPY --from=build /app/packages/shared/src/generated ./packages/shared/src/generated
 COPY --from=build /app/packages/shared/src/generated ./packages/shared/dist/generated
@@ -185,6 +193,14 @@ COPY --from=deps-production /app/package*.json ./
 COPY --from=deps-production /app/packages/shared/package*.json ./packages/shared/
 COPY --from=deps-production /app/packages/backend/package*.json ./packages/backend/
 COPY --from=deps-production /app/packages/backend/node_modules ./packages/backend/node_modules
+# packages/shared's own node_modules. npm nests a dep here instead of hoisting
+# it whenever another workspace pins a conflicting range (packages/frontend also
+# depends on axios, so both copies nested). shared/dist imports these at
+# runtime, so omitting this directory kills the container with
+# ERR_MODULE_NOT_FOUND. 9 packages are nested here as of this commit, which is
+# why this copies the whole directory rather than naming one dep. It comes from
+# deps-production, so it is already devDep-pruned.
+COPY --from=deps-production /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY --from=build /app/packages/shared/dist ./packages/shared/dist
 COPY --from=build /app/packages/shared/src/generated ./packages/shared/src/generated
 COPY --from=build /app/packages/shared/src/generated ./packages/shared/dist/generated


### PR DESCRIPTION
## Symptom

`lucky-staging-backend` is crash-looping on the host:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'axios'
  imported from /app/packages/shared/dist/services/LyricsService.js
```

Production is unaffected **only because it predates the cause**. It runs `597f2cf` (v2.36.1, 2026-07-16); the next production deploy from `main` would break identically.

## Root cause

npm nests a dependency under `packages/shared/node_modules` instead of hoisting it when another workspace pins a conflicting range. `packages/frontend` also depends on axios, so the lockfile now resolves:

```
packages/frontend/node_modules/axios  1.18.1
packages/shared/node_modules/axios    1.18.1
```

with **no** `node_modules/axios` at the root. That changed in `10b4a8cb` (#1869, npm audit remediation), which rewrote `package-lock.json`.

`deps-production` already copies that directory (Dockerfile L122) and prunes devDeps from it, but `production-bot` and `production-backend` never forwarded it. They copy root `node_modules`, `packages/<app>/node_modules` and `packages/shared/dist`, so `shared/dist` imported packages the image did not contain.

## Evidence

| image | `node_modules/axios` | `packages/shared/node_modules` | state |
|---|---|---|---|
| `lucky-backend:597f2cf` (prod) | present, 1.16.1 | absent | healthy 4d |
| `lucky-backend:staging-8011a29` | **absent** | **absent** | crash loop |

## Fix

Forward `packages/shared/node_modules` into both runtime stages, mirroring the existing `packages/<app>/node_modules` copies.

Copies the whole directory rather than naming axios, because `zod` is nested there too and is also a runtime dependency of shared, so it was the next crash waiting. Nested entries under `packages/shared`:

```
prod deps:  axios, zod          <- both needed at runtime
devDeps:    @swc/cli, typescript, glob, lru-cache,
            path-scurry, balanced-match, brace-expansion
```

The devDeps are already stripped by the `npm prune --omit=dev` in `deps-production`, so this adds no image bloat.

## Why not force hoisting instead

Adding axios to the root manifest or running `npm dedupe` would treat the symptom and stay fragile: any future range conflict in any workspace re-nests a dependency and breaks runtime again, silently, at container start. Copying the directory is deterministic and symmetric with what the bot and backend packages already get.

## Verification

Pending CI: once the image builds, confirm `/app/node_modules/axios` **or** `/app/packages/shared/node_modules/axios` resolves in `production-backend`, then that staging comes up healthy rather than restarting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship `packages/shared/node_modules` into both bot and backend runtime images to fix staging crashes from missing nested deps (`axios`, `zod`) imported by `packages/shared/dist`.

- **Bug Fixes**
  - Copy `packages/shared/node_modules` from `deps-production` into `production-bot` and `production-backend` stages.
  - Handles npm’s nested deps when workspace ranges conflict, preventing `ERR_MODULE_NOT_FOUND`.
  - Directory is already dev-pruned; no image bloat.

<sup>Written for commit b5712ab0b2aebf86f229e1820ea1458cdc039295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

