### PR TITLE
ci: remove kimi-review until an api key is set

### DIFF
--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -31,29 +31,31 @@ concurrency:
   group: review-tools-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# Minimum permissions for all three reusable workflows. An explicit block sets
-# every unlisted scope to `none`, and a called reusable workflow cannot
-# request scopes the caller withheld — so the caller must grant the UNION of
-# what the reusables declare, or the run fails at startup (see #1423):
-#   - claude-review.yml needs contents:read, pull-requests:write,
-#     issues:write, and id-token:write (OIDC)
-#   - kimi-review.yml needs contents:read, pull-requests:write, issues:write
+# Minimum permissions for the reusable workflows called below. An explicit
+# block sets every unlisted scope to `none`, and a called reusable workflow
+# cannot request scopes the caller withheld — so the caller must grant the
+# UNION of what the reusables declare, or the run fails at startup (see #1423):
 #   - danger.yml needs contents:read, pull-requests:write, issues:write
+#
+# id-token:write was here for claude-review's OIDC. That job is gone, and so is
+# kimi-review, so nothing left needs it.
 permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: write
 
 jobs:
   # claude-review removed: the upstream action crashes on every PR (#1836) and
   # `continue-on-error` is not valid on reusable-workflow jobs (actionlint).
-  # kimi-review is the replacement AI reviewer.
-  kimi-review:
-    # Pinned to branch until the reusable lands on .github release; re-pin to sha/tag after merge.
-    uses: LucasSantana-Dev/.github/.github/workflows/kimi-review.yml@623a99b5c494fc3f8f2c196b852aab04dab74da2
-    secrets:
-      KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
-
+  #
+  # kimi-review removed too (#1877): KIMI_API_KEY was never set, so the job
+  # failed on every PR in the repo with "KIMI_API_KEY secret is empty" and made
+  # the check list permanently red. Gating it on the secret is not an option
+  # here — the `secrets` context is not available in a job-level `if`, and
+  # `continue-on-error` is invalid on reusable-workflow jobs, same as above.
+  # To re-enable: set the KIMI_API_KEY repo secret and restore the job.
+  #
+  # AI review is currently covered by cubic and CodeRabbit, which run as apps
+  # rather than workflow jobs.
   danger:
     uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@bf372e78b4d3ce9a4d25362b5c75c661039c48ba # v1


### PR DESCRIPTION
Closes #1877.

`kimi-review / review` failed on **every** PR in the repo:

```
##[error]KIMI_API_KEY secret is empty. Create a key at https://platform.moonshot.ai and set it on the repo.
```

The secret was never configured. It is not a required check, so it never blocked a merge, but it left the check list permanently red on every PR — the same failure mode the `Security` gate had before #1876, and it trains reviewers to stop reading red.

## Why removed rather than gated

Both softer options are unavailable for this job:

- `secrets` is not available in a job-level `if`, so the job cannot skip itself when the key is absent.
- `continue-on-error` is invalid on reusable-workflow jobs.

That is the same constraint that forced `claude-review` to be deleted rather than softened (#1836), so this follows that precedent, including leaving the re-enable steps in a comment.

AI review is still covered by cubic and CodeRabbit, which run as apps rather than workflow jobs, so nothing is lost in practice.

## Also

Drops `id-token: write` from the workflow's `permissions` block. It was there for `claude-review`'s OIDC; that job is already gone and `danger` does not need it, so the block now matches the comment documenting it.

`actionlint` clean. Only the `danger` job remains in this workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `kimi-review` job from `.github/workflows/review-tools.yml` until `KIMI_API_KEY` is configured, eliminating an always-failing check on every PR. Also removed `id-token: write` from workflow `permissions` since only `danger` remains and does not require OIDC.

<sup>Written for commit ecacf3c5e204ec282d33c3b74f20ba3124dbb842. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

