### PR TITLE
fix(invite): route /invite through the backend and unify the permissions

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -50,6 +50,12 @@ server {
         add_header X-Content-Type-Options nosniff always;
         add_header Referrer-Policy strict-origin-when-cross-origin always;
 
+        # nosemgrep: generic.nginx.security.missing-internal.missing-internal
+        # The rule wants `internal;`, which would make this location
+        # unreachable from outside — this is a public entry point by design,
+        # exactly like the /api and / blocks below. Its SSRF concern does not
+        # apply: the upstream is a fixed literal with no request-derived input
+        # in the URL, so a client cannot steer where the proxy connects.
         set $invite_upstream http://backend:3000;
         proxy_pass $invite_upstream;
         proxy_http_version 1.1;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,6 +36,25 @@ server {
         proxy_read_timeout 300s;
     }
 
+    # Canonical invite URL. It is what the Top.gg listing, the README CTA and
+    # every tracked campaign link point at, so it has to reach Discord rather
+    # than the SPA. The frontend has no /invite route and its catch-all sends
+    # unknown paths to the landing page, which silently swallowed every invite
+    # click (#1888). vercel.json carries the same redirect for preview
+    # deploys, but production is served through the Cloudflare tunnel to this
+    # nginx, so the rule has to exist here too.
+    #
+    # permissions=3165184 is View Channels, Send Messages, Embed Links,
+    # Connect, Speak. NOT Administrator: the public listings state that Lucky
+    # asks for no admin permission. Keep in sync with getBotInviteUrl() in
+    # packages/frontend/src/lib/discord.ts.
+    #
+    # 302, not 301: browsers cache 301 permanently, so a wrong client_id or
+    # permission set would be unfixable for anyone who had already clicked.
+    location = /invite {
+        return 302 "https://discord.com/oauth2/authorize?client_id=962198089161134131&scope=bot%20applications.commands&permissions=3165184";
+    }
+
     location /api {
         set $backend_upstream http://backend:3000;
         proxy_pass $backend_upstream;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,23 +36,27 @@ server {
         proxy_read_timeout 300s;
     }
 
-    # Canonical invite URL. It is what the Top.gg listing, the README CTA and
-    # every tracked campaign link point at, so it has to reach Discord rather
-    # than the SPA. The frontend has no /invite route and its catch-all sends
-    # unknown paths to the landing page, which silently swallowed every invite
-    # click (#1888). vercel.json carries the same redirect for preview
-    # deploys, but production is served through the Cloudflare tunnel to this
-    # nginx, so the rule has to exist here too.
+    # Canonical invite URL, used by the Top.gg listing, the README CTA and
+    # every tracked campaign link. nginx only proxies /api, so this path fell
+    # through to the SPA, whose catch-all bounces unknown paths to the landing
+    # page — every invite click was silently swallowed (#1888).
     #
-    # permissions=3165184 is View Channels, Send Messages, Embed Links,
-    # Connect, Speak. NOT Administrator: the public listings state that Lucky
-    # asks for no admin permission. Keep in sync with getBotInviteUrl() in
-    # packages/frontend/src/lib/discord.ts.
-    #
-    # 302, not 301: browsers cache 301 permanently, so a wrong client_id or
-    # permission set would be unfixable for anyone who had already clicked.
+    # Proxied to the backend rather than redirected here, because
+    # backend/src/routes/invite.ts logs the utm_* parameters before redirecting.
+    # A `return 302` at the edge would fix the click and still lose the
+    # attribution that .agents/tracking-urls.md is built around (#1894).
     location = /invite {
-        return 302 "https://discord.com/oauth2/authorize?client_id=962198089161134131&scope=bot%20applications.commands&permissions=3165184";
+        add_header X-Frame-Options DENY always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+
+        set $invite_upstream http://backend:3000;
+        proxy_pass $invite_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
     }
 
     location /api {

--- a/packages/backend/src/routes/invite.ts
+++ b/packages/backend/src/routes/invite.ts
@@ -1,10 +1,14 @@
 import type { Express, Request, Response } from 'express'
 import { infoLog } from '@lucky/shared/utils'
 import { logAndSwallow } from '@lucky/shared/utils/error'
+import { buildBotInviteUrl } from '@lucky/shared/constants'
 import { apiLimiter } from '../middleware/rateLimit'
 
-const DISCORD_INVITE_URL =
-    'https://discord.com/oauth2/authorize?client_id=962198089161134131&scope=bot%20applications.commands&permissions=36970496'
+// Was a hardcoded permissions=36970496 (Manage Messages, Connect, Speak) —
+// over-scoped on message deletion and missing View Channels / Send Messages,
+// so it neither matched the landing page nor actually worked. Single source of
+// truth now lives in shared (#1894).
+const DISCORD_INVITE_URL = buildBotInviteUrl()
 
 function toUtmString(value: unknown): string | undefined {
     return typeof value === 'string' ? value : undefined

--- a/packages/frontend/src/lib/discord.ts
+++ b/packages/frontend/src/lib/discord.ts
@@ -1,3 +1,9 @@
+import {
+    BOT_CLIENT_ID,
+    BOT_INVITE_PERMISSIONS,
+    buildBotInviteUrl,
+} from '@lucky/shared/constants'
+
 // Discord CDN URL helpers. The backend returns avatar/icon HASHES, not full
 // URLs — build the CDN URL before passing to an <img>.
 
@@ -9,25 +15,18 @@ export function getGuildIconUrl(guildId: string, iconHash: string): string {
     return `https://cdn.discordapp.com/icons/${guildId}/${iconHash}.png?size=64`
 }
 
-// Minimal permission set (View Channels, Send Messages, Embed Links, Connect,
-// Speak) — matches the /invite command. NOT Administrator: requesting only what
-// the bot needs is safer and converts better with server admins, and the public
-// listings state that Lucky asks for no admin permission.
-export const BOT_INVITE_PERMISSIONS = '3165184'
-
-// Public Discord Application ID (a.k.a. client_id). Safe to ship: it appears in
-// every OAuth invite link and is not a secret. Used as the default so the CTA
-// works out of the box; override via VITE_DISCORD_CLIENT_ID for a fork.
-const DEFAULT_DISCORD_CLIENT_ID = '962198089161134131'
-
 /**
  * The one invite URL. Both the landing CTA and the docs page must use this:
  * they previously built their own, drifted, and the docs copy shipped
  * `permissions=8` (Administrator) while the landing page and every public
- * listing promised the minimal set (#1888).
+ * listing promised the minimal set (#1888). The permission set and URL shape
+ * now come from shared, which the backend `/invite` redirect uses too (#1894).
+ *
+ * VITE_DISCORD_CLIENT_ID overrides the application id for a fork.
  */
 export function getBotInviteUrl(): string {
-    const clientId =
-        import.meta.env.VITE_DISCORD_CLIENT_ID || DEFAULT_DISCORD_CLIENT_ID
-    return `https://discord.com/oauth2/authorize?client_id=${clientId}&scope=bot%20applications.commands&permissions=${BOT_INVITE_PERMISSIONS}`
+    const clientId = import.meta.env.VITE_DISCORD_CLIENT_ID || BOT_CLIENT_ID
+    return buildBotInviteUrl(clientId)
 }
+
+export { BOT_INVITE_PERMISSIONS }

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -2,6 +2,11 @@ export { COLOR, type ColorKey } from './colors'
 export { API_ROUTES } from './apiRoutes'
 export { BOT_STATS_MEMBERS_KEY, BOT_STATS_TTL_SECONDS } from './stats'
 export {
+    BOT_CLIENT_ID,
+    BOT_INVITE_PERMISSIONS,
+    buildBotInviteUrl,
+} from './invite'
+export {
     TOP_GG_BOT_ID,
     TOP_GG_VOTE_TIERS,
     TOP_GG_VOTE_URL,

--- a/packages/shared/src/constants/invite.spec.ts
+++ b/packages/shared/src/constants/invite.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+    BOT_CLIENT_ID,
+    BOT_INVITE_PERMISSIONS,
+    buildBotInviteUrl,
+} from './invite'
+
+// Discord permission bits, for readable assertions.
+const ADMINISTRATOR = 1n << 3n
+const MANAGE_MESSAGES = 1n << 13n
+const VIEW_CHANNEL = 1n << 10n
+const SEND_MESSAGES = 1n << 11n
+const EMBED_LINKS = 1n << 14n
+const CONNECT = 1n << 20n
+const SPEAK = 1n << 21n
+
+describe('bot invite permissions', () => {
+    const bits = BigInt(BOT_INVITE_PERMISSIONS)
+
+    // The public listings state Lucky asks for no admin permission. Three
+    // copies of this value had already drifted: the docs page shipped
+    // Administrator and the backend redirect shipped Manage Messages (#1888,
+    // #1894), so this is a claim worth pinning rather than a style preference.
+    it('never requests Administrator', () => {
+        expect(bits & ADMINISTRATOR).toBe(0n)
+    })
+
+    it('never requests Manage Messages', () => {
+        expect(bits & MANAGE_MESSAGES).toBe(0n)
+    })
+
+    it('requests exactly the permissions the bot needs to function', () => {
+        const expected =
+            VIEW_CHANNEL | SEND_MESSAGES | EMBED_LINKS | CONNECT | SPEAK
+        expect(bits).toBe(expected)
+    })
+})
+
+describe('buildBotInviteUrl', () => {
+    it('targets the Discord OAuth endpoint with the shared permission set', () => {
+        expect(buildBotInviteUrl()).toBe(
+            `https://discord.com/oauth2/authorize?client_id=${BOT_CLIENT_ID}` +
+                `&scope=bot%20applications.commands&permissions=${BOT_INVITE_PERMISSIONS}`,
+        )
+    })
+
+    // Without applications.commands the bot joins but registers no slash
+    // commands, which is the shape of the failure that got the Top.gg
+    // verification rejected (#1885).
+    it('requests the applications.commands scope', () => {
+        expect(buildBotInviteUrl()).toContain(
+            'scope=bot%20applications.commands',
+        )
+    })
+
+    it('accepts a fork client id', () => {
+        expect(buildBotInviteUrl('123')).toContain('client_id=123')
+    })
+})

--- a/packages/shared/src/constants/invite.ts
+++ b/packages/shared/src/constants/invite.ts
@@ -1,0 +1,28 @@
+import { TOP_GG_BOT_ID } from './topgg'
+
+/**
+ * Minimal permission set for the bot invite: View Channels, Send Messages,
+ * Embed Links, Connect, Speak.
+ *
+ * NOT Administrator, and deliberately no Manage Messages. The public listings
+ * (Top.gg, README) state that Lucky only asks for what it needs, so this value
+ * is a promise we make to server admins, not a preference.
+ *
+ * This lives in shared because three copies had already drifted apart (#1888,
+ * #1894): the docs page shipped `8` (Administrator), the backend redirect
+ * shipped `36970496` (Manage Messages + Connect + Speak, and missing View
+ * Channels / Send Messages entirely), and only the landing page was correct.
+ */
+export const BOT_INVITE_PERMISSIONS = '3165184'
+
+/** The Discord application id. Public: it appears in every OAuth invite URL. */
+export const BOT_CLIENT_ID = TOP_GG_BOT_ID
+
+/**
+ * The canonical Discord OAuth invite URL.
+ *
+ * @param clientId - Override for forks running their own application.
+ */
+export function buildBotInviteUrl(clientId: string = BOT_CLIENT_ID): string {
+    return `https://discord.com/oauth2/authorize?client_id=${clientId}&scope=bot%20applications.commands&permissions=${BOT_INVITE_PERMISSIONS}`
+}

--- a/vercel.json
+++ b/vercel.json
@@ -15,8 +15,14 @@
                     "key": "Permissions-Policy",
                     "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()"
                 },
-                { "key": "X-Frame-Options", "value": "DENY" },
-                { "key": "X-Content-Type-Options", "value": "nosniff" },
+                {
+                    "key": "X-Frame-Options",
+                    "value": "DENY"
+                },
+                {
+                    "key": "X-Content-Type-Options",
+                    "value": "nosniff"
+                },
                 {
                     "key": "Referrer-Policy",
                     "value": "strict-origin-when-cross-origin"
@@ -31,7 +37,7 @@
     "redirects": [
         {
             "source": "/invite",
-            "destination": "https://discord.com/oauth2/authorize?client_id=962198089161134131&scope=bot%20applications.commands&permissions=3165184",
+            "destination": "https://lucky-api.lucassantana.tech/invite",
             "permanent": false
         }
     ],


### PR DESCRIPTION
Follow-up to #1889 / #1888. That PR put the `/invite` redirect in `vercel.json`, which does not apply to production.

## Why the first fix missed

`lucky.lucassantana.tech` does not go through Vercel. It routes through the Cloudflare tunnel to the homelab nginx:

```yaml
ingress:
  - hostname: lucky.lucassantana.tech
    service: http://nginx:80
```

So the canonical invite URL still served the SPA, whose catch-all bounces unknown paths to the landing page. Verified against production after the v2.37.2 deploy:

```
$ curl -o /dev/null -w '%{http_code} %{redirect_url}' https://lucky.lucassantana.tech/invite
200          # no Location header
```

That URL is what the Top.gg listing body, the README CTA and every tracked campaign link in `.agents/tracking-urls.md` point at, so every invite click was swallowed and no `utm_source` ever recorded an install.

## Change

Adds the redirect to `nginx/nginx.conf`, where production actually serves it. `vercel.json` keeps its copy for preview deploys.

- `location = /invite` (exact match) so no other path is caught.
- `302`, not `301`: browsers cache 301 permanently, which would make a wrong `client_id` or permission set unfixable for anyone who had already clicked.
- `permissions=3165184` matches `getBotInviteUrl()` in `lib/discord.ts`. Not Administrator, per the public listing claim.

## Verification

Config validated with `nginx -t` against `nginxinc/nginx-unprivileged:1.31-alpine`, the same base `Dockerfile.nginx` builds from:

```
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

Will re-verify against production once deployed.

## Blocks

The Top.gg resubmission. The listing description links `/invite`, so a reviewer clicking it would land on the homepage rather than an invite prompt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `/invite` through the backend to preserve UTM attribution and redirect to Discord OAuth with the minimal permissions. Fixes invite links (Top.gg, README, campaigns) being swallowed by the SPA and stops attribution loss.

- **Bug Fixes**
  - `nginx/nginx.conf`: exact-match `location = /invite` now proxies to the backend so UTM params are logged before redirect; SPA no longer catches it; added notes on why `internal` is not used (Semgrep false positive).
  - Centralized the invite URL/permissions in `@lucky/shared` (`BOT_CLIENT_ID`, `BOT_INVITE_PERMISSIONS=3165184`, `buildBotInviteUrl()`), updated frontend/backend to use it with tests to pin the bits and scope; `vercel.json` now points `/invite` to the backend for previews.

<sup>Written for commit 7c2c9077c3fba1fd48a090f7f067ee4c9997a492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated `/invite` link that redirects visitors to the configured Discord authorization page.
  - Ensured consistent invite behavior across frontend and preview deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->