### PR TITLE
fix(invite): add /invite where cloudflare pages reads it

### DIFF
--- a/packages/frontend/public/_redirects
+++ b/packages/frontend/public/_redirects
@@ -1,1 +1,10 @@
-/* /index.html 200
+# Cloudflare Pages serves lucky.lucassantana.tech (project lucky-webapp), so
+# this file — not vercel.json and not nginx/nginx.conf — is what governs the
+# public site. Rules are evaluated top to bottom, so /invite must come before
+# the SPA catch-all or the catch-all swallows it (#1888).
+#
+# Proxied to the backend rather than sent straight to Discord: the backend
+# handler logs the utm_* parameters before redirecting, which is what
+# .agents/tracking-urls.md is built around (#1894).
+/invite  https://lucky-api.lucassantana.tech/invite  302
+/*       /index.html                                 200


### PR DESCRIPTION
Third attempt at #1888, and the first one aimed at the layer that actually serves the site. Correcting myself: the previous two fixes were in the wrong place.

## Where the traffic really goes

| host | served by | governed by |
|---|---|---|
| `lucky.lucassantana.tech` | **Cloudflare Pages** (`lucky-webapp`, `deploy-frontend-cf.yml`) | `packages/frontend/public/_redirects` |
| `lucky-api.lucassantana.tech` | Cloudflare Tunnel → homelab nginx | `nginx/nginx.conf` |

So `vercel.json` (#1889) applies to neither, and the nginx block (#1893) applies only to the API host. The public site kept returning `200` with the SPA.

## How I confirmed it rather than guessing again

The live response for `/invite` carries:

```
content-security-policy: ... script-src 'self' https://static.cloudflareinsights.com ...
```

That `static.cloudflareinsights.com` allowance exists **only** in `packages/frontend/public/_headers`. `nginx/nginx.conf` serves a different CSP without it, so the request was demonstrably never reaching nginx.

Meanwhile the API host already works, which confirms #1893 landed correctly:

```
$ curl -sI https://lucky-api.lucassantana.tech/invite
HTTP/2 302
location: https://discord.com/oauth2/authorize?client_id=962198089161134131&scope=bot%20applications.commands&permissions=3165184
```

## The change

`_redirects` rules are evaluated top to bottom, and the existing `/*  /index.html  200` catch-all matched `/invite` first — that is the mechanism that swallowed every invite click.

```
/invite  https://lucky-api.lucassantana.tech/invite  302
/*       /index.html                                 200
```

Points at the backend rather than Discord directly, so the `[invite] click` utm logging from #1893 still runs.

Nothing from #1893 is reverted: the nginx block and the shared `BOT_INVITE_PERMISSIONS` constant are what make the destination correct.

## Verification

`_redirects` confirmed present in `packages/frontend/dist/` after `npm run build:frontend`, which is the directory `wrangler pages deploy` uploads.

Will verify against production once the Pages deploy runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cloudflare Pages `_redirects` rule so `/invite` now 302s to the backend, fixing the route being swallowed by the SPA. Keeps UTM tracking by routing through the API.

<sup>Written for commit fbb7674c0ef8461f98c5498eae33d3727ed34f71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

