### PR TITLE
ci: unblock fork prs on sonar and danger gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,10 @@ jobs:
         name: SonarCloud Scan
         runs-on: ubuntu-latest
         needs: [test-backend, test-bot, test-frontend]
+        # Fork PRs get no secrets, so SONAR_TOKEN is never present and the
+        # token policy step would hard-fail this required check. Skip the job
+        # there instead; a skipped required check counts as passing.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         permissions:
             contents: read
             pull-requests: read

--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -15,7 +15,11 @@ name: Review Tools
 #   - cubic dashboard (AI review custom rules — see docs/review-tools.md)
 
 on:
-  pull_request:
+  # pull_request_target so danger can comment on fork PRs (fork pull_request
+  # tokens are forced read-only, so the comment POST 403s and fails the job).
+  # The reusable workflow checks out and executes BASE repo code only; never
+  # add a step here that checks out or runs PR head code.
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main


### PR DESCRIPTION
## Summary

Two structural failures block every fork PR's required checks (seen on #1863, #1864, #1865, #1866, #1867, #1674 after their CI was approved):

- **SonarCloud Scan (required) hard-fails on forks**: fork PRs get no secrets, so `SONAR_TOKEN` is never present and the token-policy step exits 1. Now the sonar job is skipped for fork PRs (a skipped required check counts as passing). Same pattern deploy-staging already uses.
- **danger 403s on forks**: `review-tools.yml` ran on `pull_request`, where the fork token is forced read-only and the comment POST fails with 403. Switched to `pull_request_target`; the reusable workflow checks out and executes base-repo code only (documented in the file header, same safety rule as the other target workflows).

## Test plan
- [x] actionlint clean on both files
- [ ] Next push to an external contributor PR: SonarCloud Scan shows skipped, danger posts its comment

After merge I will update the seven open contributor branches to main so they pick this up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks fork PRs by fixing CI gates for SonarCloud and `danger`. Fork PRs now pass required checks without secrets and get review comments.

- Bug Fixes
  - Skip SonarCloud Scan on fork PRs to avoid failing when `SONAR_TOKEN` is unavailable (skipped required check counts as passing).
  - Run review tools on `pull_request_target` so `danger` can comment on forks; workflow executes base-repo code only.

<sup>Written for commit 316f56793be78c7f3895c4e8a9d417e3e24c8d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

