### PR TITLE
ci: exempt env templates from danger env protection rule

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -129,12 +129,17 @@ async function checkLockfileGuard(): Promise<void> {
 // --- 5. .env protection -----------------------------------------------------
 // CLAUDE.md notes .env* is hooked-protected, but PRs can still slip
 // through if the hook was bypassed locally. Belt and suspenders.
-const envFiles = all.filter((p) => /(^|\/)\.env(\.|$)/.test(p))
+// Standard templates (.env.example/.env.sample/.env.template) are tracked in
+// the repo and safe; only real env files fail.
+const envTemplate = /(^|\/)\.env\.(example|sample|template)$/
+const envFiles = all.filter(
+    (p) => /(^|\/)\.env(\.|$)/.test(p) && !envTemplate.test(p),
+)
 if (envFiles.length > 0) {
     fail(
         `**.env* files in PR:** ${envFiles.join(', ')}. ` +
-            `These should never be committed. If this is \`.env.example\`, ` +
-            `it still needs explicit confirmation per project policy.`,
+            `These should never be committed. Templates ` +
+            `(\`.env.example\`, \`.env.sample\`, \`.env.template\`) are exempt.`,
     )
 }
 


### PR DESCRIPTION
## Summary

PR #1674 (external contributor) fails danger with no possible resolution: the `.env*` protection rule fires on `.env.example`, and its own message demands "explicit confirmation per project policy" but the code offers no confirmation mechanism. Any PR touching the tracked template fails forever.

Fix: exempt the standard template names (`.env.example`, `.env.sample`, `.env.template`) from the fail. Real `.env` files still fail.

Danger runs on `pull_request_target` against base-repo code, so once this merges, re-running danger on #1674 picks it up without a branch update.

## Test plan
- [ ] danger re-run on #1674 passes (only the changelog warning remains)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exempts `.env.example`, `.env.sample`, and `.env.template` from the Danger `.env*` protection so template updates don’t fail CI, while still blocking real `.env` files. This unblocks PRs that touch tracked env templates (e.g., #1674).

- **Bug Fixes**
  - Updated `dangerfile.ts` to ignore standard env templates in the `.env*` check.
  - The rule still fails on actual `.env` files.
  - Re-running Danger on affected PRs will pass.

<sup>Written for commit 0520fe5fcf392331a5953e23cf7d66c38424762f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

