### PR TITLE
docs(readme): drop test counts and the zero-incident claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Lucky is a **solo personal project** — actively developed and deployed to prod
 - **Automated scanning**: Trivy on every Docker build, Dependabot for dependencies
 - **Merge strategy**: Auto-merge for patch updates, manual review for major changes
 - **Monitoring**: Sentry for error tracking, custom telemetry in production
-- **Incident response**: Zero production incidents to date; post-incident reviews are public
+- **Incident response**: Incidents are tracked as public GitHub issues, with the root cause and fix written up in the open
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <b>🎵 The Discord music bot that can't be shut down — because you host it.</b><br>
-  <strong>Self-hosted · Open-source · TypeScript monorepo · ~6,300 tests · Zero prod incidents</strong>
+  <strong>Self-hosted · Open-source · TypeScript monorepo · No paywall, no premium tier</strong>
 </p>
 
 <p align="center">
@@ -76,8 +76,8 @@ Unlike Groovy, Rythm, or Hydra (all shut down by third-party enforcement), Lucky
 - **Feature toggles**: Enable/disable per-guild
 
 ### 📈 Reliability & Monitoring
-- **CI/CD**: Every PR runs lint + build + ~6,300 tests + SonarCloud gates
-- **Zero incidents**: Battle-tested in production with full test coverage
+- **CI/CD**: Every PR runs lint, build, the full test suite, and SonarCloud gates
+- **Auto-rollback**: A deploy that fails its health checks reverts to the last good build
 - **Sentry monitoring**: Real-time error tracking and telemetry
 - **Security scanning**: Trivy container scans on every Docker publish
 - **Dependency management**: Dependabot with auto-merge for patches
@@ -110,7 +110,7 @@ Lucky solves this:
 | **Database** | PostgreSQL, Prisma ORM |
 | **Cache** | Redis |
 | **DevOps** | Docker, Docker Compose, Cloudflare Tunnel |
-| **Testing** | ~6,300 unit + integration tests, Playwright e2e |
+| **Testing** | Jest + Vitest unit/integration, Playwright e2e |
 | **Quality** | SonarCloud, Trivy, Dependabot, ESLint |
 
 ---
@@ -258,7 +258,7 @@ SENTRY_DSN=...
 # Run all checks before committing (lint + build + test)
 npm run verify
 
-# Run all tests (~6,300 total)
+# Run all tests
 npm run test:all
 
 # Run e2e smoke tests (Playwright)
@@ -356,7 +356,7 @@ Lucky is a **solo personal project** — actively developed and deployed to prod
 1. **Fork** the repository
 2. **Create a branch**: `feature/cool-thing` or `fix/bug-name`
 3. **Follow conventions**: Conventional commits, <50 line functions, tests first
-4. **Run the gate**: `npm run verify` (lint + build + ~6,300 tests)
+4. **Run the gate**: `npm run verify` (lint + build + tests)
 5. **Open a PR** with a clear description
 
 **Response time** is best-effort due to solo maintenance, but all PRs are reviewed.


### PR DESCRIPTION
## Test counts

A test count says nothing about whether the bot works. It reads as filler, and it goes stale the moment anyone adds a test — the README said `~6,300` in five places while the suites actually totalled 6,955 (shared 1398, bot 3188, backend 1350, frontend 1019).

Replaced with what a reader is actually deciding on:

| before | after |
|---|---|
| `~6,300 tests · Zero prod incidents` | `No paywall, no premium tier` |
| `Every PR runs lint + build + ~6,300 tests + SonarCloud gates` | `Every PR runs lint, build, the full test suite, and SonarCloud gates` |
| `~6,300 unit + integration tests, Playwright e2e` | `Jest + Vitest unit/integration, Playwright e2e` |
| `# Run all tests (~6,300 total)` | `# Run all tests` |
| `npm run verify (lint + build + ~6,300 tests)` | `npm run verify (lint + build + tests)` |

The suite still runs on every PR. It just does not need a number attached to be worth having.

## The zero-incident claim

`Zero prod incidents` and `Zero incidents: Battle-tested in production with full test coverage` also had to go, because they stopped being true. Production sat on a stale build from 2026-07-16 for four days after two deploys failed their health checks and auto-rolled back without anyone noticing (#1890).

Swapped for the property that is genuinely worth advertising and that a self-hoster actually cares about:

> **Auto-rollback**: A deploy that fails its health checks reverts to the last good build

Verified in `scripts/deploy.sh:465` before claiming it, and it is exactly what kept service up during that incident. It answers "what happens when a deploy of a self-hosted bot goes wrong", which is a better pitch than a coverage boast.

## Note

The same test-count line was in the Top.gg listing (I had just updated it to `~6,900` during the resubmission). Same reasoning applies, so I will strip it there too rather than leave the two out of sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove test counts and all “zero incidents” claims from the README. Replace with durable details: “No paywall, no premium tier”, CI gate (lint, build, full test suite, SonarCloud), test stack (`Jest` + `Vitest`, `Playwright`), “Auto-rollback” on failed deploys, and that incidents are tracked as public GitHub issues with root cause and fix documented.

<sup>Written for commit 5ca1b6c2730dda428df8bedd72901404eb256701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

