### PR TITLE
docs(readme): open the project to external contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,17 +349,25 @@ Multiple admin IDs can be comma-separated: `DEVELOPER_USER_IDS=id1,id2,id3`
 
 ## 🤝 Contributing
 
-Lucky is a **solo personal project** — actively developed and deployed to production, but not seeking external contributors. The codebase is open-source so you can learn from it, self-host it, and adapt it for your needs.
+**Contributions are welcome.** Lucky runs in production and is small enough that a single PR can visibly change how it behaves — bug fixes, features, docs, and tests are all fair game.
 
-**To contribute:**
+**Where to start**
+
+- Issues labelled [`ready-for-human`](https://github.com/LucasSantana-Dev/Lucky/issues?q=is%3Aissue+is%3Aopen+label%3Aready-for-human) are specified and unclaimed — that is the shortest path in.
+- Found something broken? Open an issue. A reproduction case is a genuinely useful contribution on its own.
+- Not sure whether an idea fits? Open an issue before building it and we will figure it out together, rather than after you have spent a weekend on it.
+
+**Making the change**
 
 1. **Fork** the repository
 2. **Create a branch**: `feature/cool-thing` or `fix/bug-name`
-3. **Follow conventions**: Conventional commits, <50 line functions, tests first
+3. **Follow conventions**: Conventional commits, <50 line functions, tests alongside the change
 4. **Run the gate**: `npm run verify` (lint + build + tests)
-5. **Open a PR** with a clear description
+5. **Open a PR** describing what changed and why
 
-**Response time** is best-effort due to solo maintenance, but all PRs are reviewed.
+CI runs the same gate on your PR, so a red check is information rather than a rejection. Automated reviewers (CodeRabbit, cubic, SonarCloud) will comment too — treat those as suggestions to weigh, not orders.
+
+**What to expect.** This is maintained alongside a full-time job, so review latency varies. Every PR gets read and gets a real answer; if something cannot be merged you will get the reasoning, not silence. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the repo-specific details that are easy to miss.
 
 ---
 


### PR DESCRIPTION
## The problem

The Contributing section opened with:

> Lucky is a **solo personal project** — actively developed and deployed to production, **but not seeking external contributors**.

and then immediately listed five steps for how to contribute. Anyone who read the first sentence never reached the second.

It was also already false. **Adolanium** and **Re-Gouveia-QA** have open PRs right now, and `CONTRIBUTING.md` has been welcoming the whole time — the README was the only thing in the repo turning people away.

## The change

Rewritten to say contributions are welcome and to answer what a first-time contributor actually needs:

- **Where to start** — a concrete link, not "look around"
- **A repro case counts** — lowers the bar below "ship a feature"
- **Ask before building** — so nobody burns a weekend on something that will not merge

Plus honest expectations: review latency varies, a red CI check is information rather than rejection, and the bot reviewers (CodeRabbit, cubic, Sonar) are suggestions to weigh rather than orders. That last one matters — a newcomer seeing three bots pile onto their first PR could easily read it as the maintainer being hostile.

Kept the one promise worth making: every PR gets a real answer, and a rejection comes with reasoning rather than silence.

## One thing that needs you

I pointed at [`ready-for-human`](https://github.com/LucasSantana-Dev/Lucky/issues?q=is%3Aissue+is%3Aopen+label%3Aready-for-human) (3 open) rather than `good first issue` or `help wanted`, because those two labels **exist but have zero open issues**:

```
$ gh issue list --label "good first issue" --state open   # empty
$ gh issue list --label "help wanted" --state open        # empty
```

Sending a newcomer to an empty list is worse than sending them nowhere. Labelling a handful of genuinely self-contained issues as `good first issue` is probably the highest-leverage next step for attracting contributors, and it needs your judgement on which ones qualify.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opened the project to external contributions by rewriting the README Contributing section. Adds a clear starting path via `ready-for-human` issues, treats repros as valid contributions, asks contributors to check ideas before building, and clarifies PR steps plus CI/bot feedback expectations.

<sup>Written for commit b86978fac063c895b9e12fd69ac35cd68bdef4b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the contribution guide with clearer guidance on finding issues, preparing pull requests, and interpreting CI feedback.
  * Added details about the collaborative review process and expected response times.
  * Added references to the project’s contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->