### PR TITLE
docs(readme): point contributors at good first issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,8 @@ Multiple admin IDs can be comma-separated: `DEVELOPER_USER_IDS=id1,id2,id3`
 
 **Where to start**
 
-- Issues labelled [`ready-for-human`](https://github.com/LucasSantana-Dev/Lucky/issues?q=is%3Aissue+is%3Aopen+label%3Aready-for-human) are specified and unclaimed — that is the shortest path in.
+- [`good first issue`](https://github.com/LucasSantana-Dev/Lucky/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) — self-contained, scoped, and written so you can start without asking anything first.
+- [`ready-for-human`](https://github.com/LucasSantana-Dev/Lucky/issues?q=is%3Aissue+is%3Aopen+label%3Aready-for-human) — specified and unclaimed, but assumes more repo context.
 - Found something broken? Open an issue. A reproduction case is a genuinely useful contribution on its own.
 - Not sure whether an idea fits? Open an issue before building it and we will figure it out together, rather than after you have spent a weekend on it.
 


### PR DESCRIPTION
Follow-up to #1913. That PR pointed at `ready-for-human` because `good first issue` had **zero** open issues at the time and sending a newcomer to an empty list is worse than sending them nowhere.

It now has two (#1882, #1914), and it is the label GitHub surfaces in its own contributor-discovery UI, so it should be listed first.

Also says what separates the two tiers, which was implicit before:

- **`good first issue`** — self-contained, scoped, written so you can start without asking anything first
- **`ready-for-human`** — specified and unclaimed, but assumes more repo context

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README to direct new contributors to the good first issue label first, since it now has open issues and is surfaced in GitHub’s contributor UI. Keep ready-for-human as the second tier and clarify how the two labels differ.

<sup>Written for commit da64277644d61f1b32785f9a41c14a241397878c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to provide separate links for “good first issue” and “ready-for-human” opportunities.
  * Removed wording that favored one option as the shortest path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->