### PR TITLE
ci(docker): exclude vendored yt-dlp venv from trivy image scan

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -153,6 +153,12 @@ jobs:
                   ignore-unfixed: true
                   exit-code: '0'
                   vuln-type: os,library
+                  # Exclude the yt-dlp pip venv (/opt/ytdlp, see Dockerfile).
+                  # yt-dlp's extractor modules ship hardcoded public API and
+                  # test tokens (jwt-token, aws-access-key-id rules) that are
+                  # false positives against Lucky: they live in a third-party
+                  # package and cannot be edited by us. See issue #1703.
+                  skip-dirs: /opt/ytdlp/**
 
             - name: Upload Trivy SARIF
               if: always()


### PR DESCRIPTION
## Summary

The Trivy image scan in `.github/workflows/docker-publish.yml` reports 39 false-positive secret findings (38 jwt-token + 1 aws-access-key-id) from the vendored yt-dlp pip package installed at `/opt/ytdlp` in the bot image. These tokens are hardcoded public API and test credentials shipped by yt-dlp's own extractor modules (youtube.py, twitter.py, shahid.py, etc.); they are not Lucky secrets and cannot be edited because `pip install yt-dlp` overwrites them on every rebuild.

Fix: add `skip-dirs: /opt/ytdlp/**` to the Trivy image scan step, with a comment explaining why.

## Verification

- Local Trivy 0.71.2 behavior test: planted a JWT-shaped token in a fake `opt/ytdlp/lib/python3.14/site-packages/yt_dlp/extractor/fake.py` tree and ran `trivy fs --scanners secret`. Without `--skip-dirs`: 1 secret found. With `--skip-dirs '.../opt/ytdlp/**'`: 0 secrets found. The glob suppresses the finding.
- Workflow YAML parses cleanly (PyYAML).
- Pre-commit hooks passed: lint-staged (secretlint) and monorepo type:check (shared, bot, backend, frontend) all green.
- Full image-scan validation is CI-only: the scan runs against the pushed ghcr image, which requires the docker-publish workflow on main.

Closes #1703

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the vendored `yt-dlp` venv at `/opt/ytdlp/**` from the `Trivy` image secret scan to remove 39 false positives from third-party extractor test tokens. This reduces CI noise and keeps real secret findings visible. Addresses #1703.

<sup>Written for commit 16f8e1f46fced53aa7c56ae80222fdc57261e027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

