### PR TITLE
feat(bot): surface stream bridge fallback stage in now playing footer

### DIFF
--- a/packages/bot/src/handlers/player/streamBridge.spec.ts
+++ b/packages/bot/src/handlers/player/streamBridge.spec.ts
@@ -64,6 +64,8 @@ import {
     streamViaYtDlp,
     streamViaYtDlpSearch,
     createResilientStream,
+    getStreamBridgeFallbackLabel,
+    STREAM_BRIDGE_FALLBACK_METADATA_KEY,
 } from './streamBridge.js'
 
 // ---------------------------------------------------------------------------
@@ -414,5 +416,117 @@ describe('createResilientStream', () => {
                 stage: 'all-exhausted',
             }),
         )
+    })
+})
+
+// ---------------------------------------------------------------------------
+// fallback stage stamping — surfaces the resolved stage to the user (#1769)
+// ---------------------------------------------------------------------------
+
+describe('fallback stage stamping', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockCleanTitle.mockReturnValue('Test Track')
+        mockCleanAuthor.mockReturnValue('Test Artist')
+        mockCleanSearchQuery.mockReturnValue('test track test artist')
+        mockIsAvailable.mockReturnValue(true)
+    })
+
+    it('does not stamp metadata when the primary yt-dlp URL stage resolves', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => {
+            proc.stdout.emit('data', Buffer.from('stream data'))
+        })
+        const track = makeTrack()
+        await createResilientStream(track)
+        expect((track as { metadata?: unknown }).metadata).not.toEqual(
+            expect.objectContaining({
+                [STREAM_BRIDGE_FALLBACK_METADATA_KEY]: expect.anything(),
+            }),
+        )
+        expect(getStreamBridgeFallbackLabel(track)).toBeUndefined()
+    })
+
+    it('does not stamp metadata when the yt-dlp search stage resolves a Spotify track', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => {
+            proc.stdout.emit('data', Buffer.from('stream data'))
+        })
+        const track = makeTrack({ url: 'https://open.spotify.com/track/123' })
+        mockCleanSearchQuery.mockReturnValue('song name')
+        await createResilientStream(track)
+        expect(getStreamBridgeFallbackLabel(track)).toBeUndefined()
+    })
+
+    it('stamps soundcloud-full when the full SoundCloud search resolves', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        mockStreamViaSoundCloud.mockResolvedValue(fakeStream)
+        setImmediate(() => proc.emit('close', 1))
+        const track = makeTrack()
+        await createResilientStream(track)
+        expect(getStreamBridgeFallbackLabel(track)).toBe('SoundCloud search')
+    })
+
+    it('stamps soundcloud-title when only the title-only search resolves', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('close', 1))
+        mockStreamViaSoundCloud
+            .mockRejectedValueOnce(new Error('no results'))
+            .mockResolvedValueOnce(fakeStream)
+        const track = makeTrack()
+        await createResilientStream(track)
+        expect(getStreamBridgeFallbackLabel(track)).toBe(
+            'SoundCloud title-only search',
+        )
+    })
+
+    it('stamps soundcloud-core when only the core-title search resolves', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.emit('close', 1))
+        mockStreamViaSoundCloud
+            .mockRejectedValueOnce(new Error('no results'))
+            .mockRejectedValueOnce(new Error('no results'))
+            .mockResolvedValueOnce(fakeStream)
+        mockCleanTitle.mockReturnValue('Song (Official) Mix')
+        const track = makeTrack({ title: 'Song (Official) Mix' })
+        await createResilientStream(track)
+        expect(getStreamBridgeFallbackLabel(track)).toBe(
+            'SoundCloud simplified-title search',
+        )
+    })
+
+    it('preserves existing track metadata when stamping the fallback stage', async () => {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        mockStreamViaSoundCloud.mockResolvedValue(fakeStream)
+        setImmediate(() => proc.emit('close', 1))
+        const track = {
+            ...makeTrack(),
+            metadata: { isAutoplay: true },
+        }
+        await createResilientStream(track)
+        expect(track.metadata).toEqual({
+            isAutoplay: true,
+            [STREAM_BRIDGE_FALLBACK_METADATA_KEY]: 'soundcloud-full',
+        })
+    })
+})
+
+describe('getStreamBridgeFallbackLabel', () => {
+    it('returns undefined for a track without bridge metadata', () => {
+        expect(getStreamBridgeFallbackLabel({})).toBeUndefined()
+        expect(
+            getStreamBridgeFallbackLabel({ metadata: undefined }),
+        ).toBeUndefined()
+        expect(
+            getStreamBridgeFallbackLabel({
+                metadata: { isAutoplay: true },
+            }),
+        ).toBeUndefined()
     })
 })

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -125,6 +125,55 @@ export function streamViaYtDlpSearch(query: string): Promise<Readable> {
     return streamViaYtDlp(`ytsearch1:${query}`)
 }
 
+/**
+ * SoundCloud fallback stages that can resolve a track when the primary
+ * yt-dlp paths fail. When one of these resolves, the stage is stamped onto
+ * the track's metadata so the Now Playing embed can tell the user a fallback
+ * happened. Primary yt-dlp resolutions leave the metadata untouched.
+ */
+export type StreamBridgeFallbackStage =
+    | 'soundcloud-full'
+    | 'soundcloud-title'
+    | 'soundcloud-core'
+
+export const STREAM_BRIDGE_FALLBACK_METADATA_KEY = 'streamBridgeFallbackStage'
+
+const FALLBACK_STAGE_LABELS: Record<StreamBridgeFallbackStage, string> = {
+    'soundcloud-full': 'SoundCloud search',
+    'soundcloud-title': 'SoundCloud title-only search',
+    'soundcloud-core': 'SoundCloud simplified-title search',
+}
+
+/**
+ * Human-readable label of the fallback stage that resolved this track, or
+ * undefined when the primary yt-dlp source resolved it (or no stream was
+ * bridged at all). Used to render a subtle footnote in the Now Playing embed.
+ */
+export function getStreamBridgeFallbackLabel(track: {
+    metadata?: unknown
+}): string | undefined {
+    const stage = (track.metadata as Record<string, unknown> | undefined)?.[
+        STREAM_BRIDGE_FALLBACK_METADATA_KEY
+    ]
+    if (typeof stage !== 'string') return undefined
+    return FALLBACK_STAGE_LABELS[stage as StreamBridgeFallbackStage]
+}
+
+function stampFallbackStage(
+    track: Pick<Track, 'title' | 'author' | 'duration' | 'url'>,
+    stage: StreamBridgeFallbackStage,
+): void {
+    const mutable = track as { metadata?: unknown }
+    const existing =
+        typeof mutable.metadata === 'object' && mutable.metadata !== null
+            ? (mutable.metadata as Record<string, unknown>)
+            : {}
+    mutable.metadata = {
+        ...existing,
+        [STREAM_BRIDGE_FALLBACK_METADATA_KEY]: stage,
+    }
+}
+
 export async function createResilientStream(
     track: Pick<Track, 'title' | 'author' | 'duration' | 'url'>,
     _ext?: unknown,
@@ -270,10 +319,12 @@ export async function createResilientStream(
     }
 
     try {
-        return await streamViaSoundCloud(
+        const stream = await streamViaSoundCloud(
             cleanSearchQuery(cleanedTitle, cleanedAuthor),
             track.duration,
         )
+        stampFallbackStage(track, 'soundcloud-full')
+        return stream
     } catch (primaryError) {
         debugLog({
             message:
@@ -286,7 +337,9 @@ export async function createResilientStream(
     }
 
     try {
-        return await streamViaSoundCloud(cleanedTitle, track.duration)
+        const stream = await streamViaSoundCloud(cleanedTitle, track.duration)
+        stampFallbackStage(track, 'soundcloud-title')
+        return stream
     } catch (titleOnlyError) {
         debugLog({
             message:
@@ -303,7 +356,9 @@ export async function createResilientStream(
         openParen > 0 ? cleanedTitle.slice(0, openParen).trim() : cleanedTitle
     if (coreTitle && coreTitle !== cleanedTitle) {
         try {
-            return await streamViaSoundCloud(coreTitle, track.duration)
+            const stream = await streamViaSoundCloud(coreTitle, track.duration)
+            stampFallbackStage(track, 'soundcloud-core')
+            return stream
         } catch (coreError) {
             const attemptedStages = [
                 youtubeStage || 'yt-dlp',

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -19,6 +19,7 @@ import {
     scrobble as lastFmScrobble,
 } from '../../lastfm'
 import { getSkipReasonEmojis } from '../../utils/music/skipReasonMap'
+import { getStreamBridgeFallbackLabel } from './streamBridge'
 
 /**
  * Track which guilds have logged a skip-reason prefill failure in this session.
@@ -234,10 +235,14 @@ export async function sendNowPlayingEmbed(
     const baseFooter = isAutoplay
         ? `Autoplay • ${autoplayCount ?? 0}/${constants.MAX_AUTOPLAY_TRACKS ?? 50} songs`
         : requesterInfo
-    const footer =
+    let footer =
         baseFooter && !baseFooter.includes('/invite')
             ? `${baseFooter} • /invite to add Lucky`
             : baseFooter
+    // Subtle footnote when the streamBridge resolved via a fallback stage
+    // instead of the primary yt-dlp source (#1769).
+    const fallbackLabel = getStreamBridgeFallbackLabel(track)
+    if (fallbackLabel) footer = `${footer} • via fallback: ${fallbackLabel}`
 
     const fields = [
         {


### PR DESCRIPTION
## Summary

The streamBridge fallback cascade (yt-dlp -> YouTube search for Spotify tracks -> SoundCloud full search -> title-only -> core-title) logged internally via warnLog when a stage failed, but never told the user a fallback happened or which stage resolved the track.

- When a non-primary SoundCloud stage resolves the stream, the resolving stage is stamped onto the track metadata (`soundcloud-full`, `soundcloud-title`, `soundcloud-core`).
- The Now Playing embed renders a subtle footer footnote (`via fallback: SoundCloud search`, etc.) only when a fallback stage resolved. Primary yt-dlp resolutions leave the embed exactly as before.

## Verification

- `npx jest src/handlers/player/streamBridge.spec.ts`: 30/30 passed (7 new tests covering primary-stage no-stamp, all three fallback stage stamps, metadata preservation, label helper).
- Broader sweep `npx jest src/handlers/player src/utils/music src/functions/music`: 1468 passed, 1 skipped (pre-existing skip).
- `npx tsc --noEmit` (packages/bot): clean.
- eslint on touched files: 0 errors; the two complexity warnings are pre-existing on main (verified against origin/main).

Closes #1769

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows when a SoundCloud fallback stage was used by stamping the stage on track metadata and adding a subtle “via fallback” note in the Now Playing footer. Primary `yt-dlp` resolutions remain unchanged.

- **New Features**
  - Stamp `streamBridgeFallbackStage` on track metadata when `soundcloud-full`, `soundcloud-title`, or `soundcloud-core` resolves.
  - Add “via fallback: …” footnote in the Now Playing embed via `getStreamBridgeFallbackLabel`.

<sup>Written for commit 83babac453c31602a24851a706d49ba4cf2dfe8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

