### PR TITLE
chore: add per-package eslint configs for backend, bot, and shared

### DIFF
--- a/packages/backend/eslint.config.js
+++ b/packages/backend/eslint.config.js
@@ -1,0 +1,7 @@
+// Backend lint entry point (#1621). Reuses the root flat config as the single
+// source of truth for rules: its globs are cwd-relative ("src/**/*.ts",
+// project "./tsconfig.json"), so they resolve to this package when lint runs
+// from here. Append extra blocks below for backend-specific overrides.
+import baseConfig from "../../eslint.config.js"
+
+export default baseConfig

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,9 +13,9 @@
         "test:watch": "jest --watch",
         "test:coverage": "jest --coverage",
         "test:mutation": "stryker run",
-        "lint": "eslint . -c ../../eslint.config.js",
+        "lint": "eslint .",
         "lint:fix": "npm run lint -- --fix",
-        "lint:full": "eslint . -c ../../eslint.config.js"
+        "lint:full": "eslint ."
     },
     "dependencies": {
         "@lucky/shared": "file:../shared",

--- a/packages/bot/eslint.config.js
+++ b/packages/bot/eslint.config.js
@@ -1,0 +1,8 @@
+// Bot lint entry point (#1621). Reuses the root flat config as the single
+// source of truth for rules, including the #1357 ratchet block that is pinned
+// to packages/{bot,shared}/src via basePath. discord.js is a library and adds
+// no runtime globals, so the root Node globals suffice. Append extra blocks
+// below for bot-specific overrides.
+import baseConfig from "../../eslint.config.js"
+
+export default baseConfig

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -15,7 +15,7 @@
         "test": "jest",
         "test:coverage": "jest --coverage",
         "test:mutation": "stryker run",
-        "lint": "eslint . -c ../../eslint.config.js",
+        "lint": "eslint .",
         "lint:fix": "npm run lint -- --fix",
         "commands:clear-guild": "tsx src/scripts/clearGuildCommandsCli.ts",
         "commands:clear-guild:dist": "node dist/scripts/clearGuildCommandsCli.js"

--- a/packages/shared/eslint.config.js
+++ b/packages/shared/eslint.config.js
@@ -1,0 +1,8 @@
+// Shared lint entry point (#1621). Reuses the root flat config as the single
+// source of truth for rules, including the #1357 ratchet block that is pinned
+// to packages/{bot,shared}/src via basePath. #1619 (Sonar coverage exclusion)
+// is still undecided, so shared stays aligned with the enforced setup like
+// bot. Append extra blocks below for shared-specific overrides.
+import baseConfig from "../../eslint.config.js"
+
+export default baseConfig

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -83,7 +83,7 @@
         "test:ci": "jest --ci",
         "test:mutation": "stryker run",
         "docs:check": "node check-docs-coverage.mjs",
-        "lint": "eslint . -c ../../eslint.config.js",
+        "lint": "eslint .",
         "lint:fix": "npm run lint -- --fix"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary

Adds a dedicated `eslint.config.js` to `packages/backend`, `packages/bot`, and `packages/shared` (ESLint 10 flat config, matching the root setup). Each package config imports and re-exports the root flat config, so the root file stays the single source of truth for rules: no rule silently changes severity or disappears. The root config's globs are cwd-relative (`src/**/*.ts`, `project: "./tsconfig.json"`) and the #1357 ratchet block is pinned via `basePath`, so behavior from each package directory is unchanged. Package `lint` scripts now run `eslint .` against the local config instead of `-c ../../eslint.config.js`.

Package notes:

- backend: strict root rule set applies as before (0 errors).
- bot: discord.js is a library and adds no runtime globals, so the root Node globals suffice; the #1357 ratchet block continues to apply.
- shared: #1619 (Sonar coverage exclusion) is still undecided, so shared stays aligned with the enforced setup like bot; no special-casing added.

## Verification

`npm run lint` in each package, before vs after (identical results, zero new errors, zero newly suppressed rules):

- packages/backend: 0 errors, 4 warnings (unchanged)
- packages/bot: 0 errors, 73 warnings (unchanged)
- packages/shared: 0 errors, 23 warnings (unchanged)

Pre-commit hooks also passed: prettier, secretlint, and full `type:check` across all four workspaces.

Root `eslint.config.js` is intentionally untouched: root-level `npm run lint` and lint-staged still run from the repo root and depend on it (root lint already reports 54 pre-existing errors on main, unrelated to this change).

Closes #1621

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added per-package ESLint flat configs for `packages/backend`, `packages/bot`, and `packages/shared` that re-export the root config, so each package can run `eslint .` locally with unchanged rules and severities. This simplifies lint scripts and keeps behavior identical while allowing future per-package overrides.

- **Refactors**
  - Added `eslint.config.js` in `packages/backend`, `packages/bot`, and `packages/shared` that import and export the root `eslint.config.js`.
  - Updated each package’s `lint` script to `eslint .` (removed `-c ../../eslint.config.js`).
  - Preserved root config behavior: cwd-relative globs and the #1357 ratchet block remain pinned via `basePath`.

<sup>Written for commit 739ba99e93649b8821368b873f31c7cfff9c1632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized linting across backend, bot, and shared packages.
  * Package lint commands now automatically use the repository’s shared ESLint configuration.
  * Added package-level ESLint entry points to ensure consistent rules across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->