### PR TITLE
fix(deploy): make rolled-back deploys visible in failure output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -294,6 +294,7 @@ jobs:
 
                   deadline=$(($(date +%s) + 600))
                   attempt=0
+                  last_actual=""
 
                   while [ "$(date +%s)" -lt "$deadline" ]; do
                     attempt=$((attempt + 1))
@@ -315,6 +316,7 @@ jobs:
                         echo "==> Deployed SHA matches: $actual"
                         exit 0
                       fi
+                      last_actual="$actual"
                       echo "SHA mismatch (expected=$expected, actual=$actual)."
                     else
                       echo "Not ready (HTTP $http_code)."
@@ -327,7 +329,10 @@ jobs:
                     sleep "$sleep_for"
                   done
 
-                  echo "::error::Deployed version SHA did not match expected before deadline"
+                  echo "::error::Deployed version SHA did not match expected before deadline (expected=$expected, production=${last_actual:-unknown})"
+                  if [ -n "$last_actual" ] && [ "$last_actual" != "$expected" ]; then
+                    echo "::error::Production is running $last_actual instead of $expected. If the homelab auto-rollback restored service, this red check is a silent rollback, not a flaky probe. See the Notify failure step for details."
+                  fi
                   exit 1
 
             - name: Sentry release — finalize
@@ -360,3 +365,17 @@ jobs:
                   EXPECTED_SHA: ${{ steps.resolve_sha.outputs.sha }}
                   REPO: ${{ github.repository }}
               run: bash scripts/deploy/wait-homelab-status.sh wait
+
+            # Runs only when an earlier step failed. Annotates the run with the
+            # SHA production is actually serving so an auto-rollback to the
+            # last-good image is not indistinguishable from a flaky red check
+            # (#1892).
+            - name: Notify failure
+              if: failure()
+              env:
+                  WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  EXPECTED_SHA: ${{ steps.resolve_sha.outputs.sha }}
+                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+                  REPO: ${{ github.repository }}
+              run: bash scripts/deploy/notify-deploy-failure.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -369,9 +369,10 @@ jobs:
             # Runs only when an earlier step failed. Annotates the run with the
             # SHA production is actually serving so an auto-rollback to the
             # last-good image is not indistinguishable from a flaky red check
-            # (#1892).
+            # (#1892). Skipped when no deploy SHA was resolved: that failure
+            # predates the rollout and is handled by the step below.
             - name: Notify failure
-              if: failure()
+              if: failure() && steps.resolve_sha.outputs.sha != ''
               env:
                   WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -379,3 +380,10 @@ jobs:
                   RELEASE_TAG: ${{ github.event.release.tag_name }}
                   REPO: ${{ github.repository }}
               run: bash scripts/deploy/notify-deploy-failure.sh
+
+            # A failure with no resolved deploy SHA means the webhook never
+            # fired: there is no rollout (and no rollback) to diagnose, so
+            # skip the SHA comparison and say so plainly.
+            - name: Notify pre-deploy failure
+              if: failure() && steps.resolve_sha.outputs.sha == ''
+              run: echo "::error::Deploy failed before the rollout started (no deploy SHA resolved). This is a pre-deploy failure, not an auto-rollback."

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -56,15 +56,20 @@ export function setupHealthRoutes(app: Express): void {
             status: 'ok',
             redis: redisClient.isHealthy(),
             uptime: process.uptime(),
+            commitSha: process.env.COMMIT_SHA ?? null,
         })
     })
 
-    app.get('/api/health/version', apiLimiter, (_req: Request, res: Response) => {
-        res.json({
-            commitSha: process.env.COMMIT_SHA ?? null,
-            version: resolveRuntimeVersion(),
-        })
-    })
+    app.get(
+        '/api/health/version',
+        apiLimiter,
+        (_req: Request, res: Response) => {
+            res.json({
+                commitSha: process.env.COMMIT_SHA ?? null,
+                version: resolveRuntimeVersion(),
+            })
+        },
+    )
 
     app.get('/api/health/cache', apiLimiter, (_req: Request, res: Response) => {
         const metrics = redisClient.getMetrics()
@@ -77,55 +82,61 @@ export function setupHealthRoutes(app: Express): void {
         })
     })
 
-    app.get('/api/health/auth-config', apiLimiter, (req: Request, res: Response) => {
-        const redirectUri = getOAuthRedirectUri(req)
-        const requestOrigin = resolveRequestOrigin(req)
-        const frontendOrigins = getFrontendOrigins()
-        const backendOrigins = (process.env.WEBAPP_BACKEND_URL ?? '')
-            .split(',')
-            .map((origin) => origin.trim())
-            .filter((origin) => origin.length > 0)
-        const clientId = process.env.CLIENT_ID?.trim() ?? ''
-        const expectedClientId =
-            process.env.WEBAPP_EXPECTED_CLIENT_ID?.trim() ?? ''
-        const sessionSecretConfigured = Boolean(
-            process.env.WEBAPP_SESSION_SECRET?.trim(),
-        )
-        const redisHealthy = redisClient.isHealthy()
+    app.get(
+        '/api/health/auth-config',
+        apiLimiter,
+        (req: Request, res: Response) => {
+            const redirectUri = getOAuthRedirectUri(req)
+            const requestOrigin = resolveRequestOrigin(req)
+            const frontendOrigins = getFrontendOrigins()
+            const backendOrigins = (process.env.WEBAPP_BACKEND_URL ?? '')
+                .split(',')
+                .map((origin) => origin.trim())
+                .filter((origin) => origin.length > 0)
+            const clientId = process.env.CLIENT_ID?.trim() ?? ''
+            const expectedClientId =
+                process.env.WEBAPP_EXPECTED_CLIENT_ID?.trim() ?? ''
+            const sessionSecretConfigured = Boolean(
+                process.env.WEBAPP_SESSION_SECRET?.trim(),
+            )
+            const redisHealthy = redisClient.isHealthy()
 
-        const healthResponse = buildAuthConfigHealth({
-            clientId,
-            redirectUri,
-            frontendOrigins,
-            backendOrigins,
-            requestOrigin,
-            sessionSecretConfigured,
-            redisHealthy,
-            expectedClientId,
-        })
-
-        // This endpoint is unauthenticated (it's used to verify OAuth config
-        // before a session can exist). clientId/redirectUri are already
-        // public — they're embedded in the OAuth login URL every visitor
-        // sees. But operational details (session/redis state, config
-        // validation warnings) aren't needed by anonymous callers and only
-        // help an attacker fingerprint the deployment, so they're redacted
-        // outside development. NODE_ENV=production covers staging too
-        // (docker-compose.staging.yml sets it), which is correct — staging
-        // is internet-facing and shouldn't leak diagnostics either.
-        if (process.env.NODE_ENV === 'production') {
-            res.json({
-                auth: {
-                    clientId: healthResponse.auth.clientId,
-                    redirectUri: healthResponse.auth.redirectUri,
-                    frontendOrigins: healthResponse.auth.frontendOrigins,
-                    clientIdConfigured: healthResponse.auth.clientIdConfigured,
-                    authorizeUrlPreview: healthResponse.auth.authorizeUrlPreview,
-                },
+            const healthResponse = buildAuthConfigHealth({
+                clientId,
+                redirectUri,
+                frontendOrigins,
+                backendOrigins,
+                requestOrigin,
+                sessionSecretConfigured,
+                redisHealthy,
+                expectedClientId,
             })
-            return
-        }
 
-        res.json(healthResponse)
-    })
+            // This endpoint is unauthenticated (it's used to verify OAuth config
+            // before a session can exist). clientId/redirectUri are already
+            // public — they're embedded in the OAuth login URL every visitor
+            // sees. But operational details (session/redis state, config
+            // validation warnings) aren't needed by anonymous callers and only
+            // help an attacker fingerprint the deployment, so they're redacted
+            // outside development. NODE_ENV=production covers staging too
+            // (docker-compose.staging.yml sets it), which is correct — staging
+            // is internet-facing and shouldn't leak diagnostics either.
+            if (process.env.NODE_ENV === 'production') {
+                res.json({
+                    auth: {
+                        clientId: healthResponse.auth.clientId,
+                        redirectUri: healthResponse.auth.redirectUri,
+                        frontendOrigins: healthResponse.auth.frontendOrigins,
+                        clientIdConfigured:
+                            healthResponse.auth.clientIdConfigured,
+                        authorizeUrlPreview:
+                            healthResponse.auth.authorizeUrlPreview,
+                    },
+                })
+                return
+            }
+
+            res.json(healthResponse)
+        },
+    )
 }

--- a/packages/backend/tests/unit/routes/health.test.ts
+++ b/packages/backend/tests/unit/routes/health.test.ts
@@ -33,6 +33,37 @@ function buildApp() {
     return app
 }
 
+describe('GET /api/health', () => {
+    const originalEnv = process.env
+
+    beforeEach(() => {
+        process.env = { ...originalEnv }
+    })
+
+    afterEach(() => {
+        process.env = originalEnv
+    })
+
+    test('includes the deployed commitSha from COMMIT_SHA', async () => {
+        process.env.COMMIT_SHA = 'abc123def456'
+
+        const res = await request(buildApp()).get('/api/health')
+
+        expect(res.status).toBe(200)
+        expect(res.body.status).toBe('ok')
+        expect(res.body.commitSha).toBe('abc123def456')
+    })
+
+    test('returns commitSha null when COMMIT_SHA is unset', async () => {
+        delete process.env.COMMIT_SHA
+
+        const res = await request(buildApp()).get('/api/health')
+
+        expect(res.status).toBe(200)
+        expect(res.body.commitSha).toBeNull()
+    })
+})
+
 describe('GET /api/health/version', () => {
     const originalEnv = process.env
 

--- a/scripts/deploy/notify-deploy-failure.sh
+++ b/scripts/deploy/notify-deploy-failure.sh
@@ -26,7 +26,7 @@ tag_label="${RELEASE_TAG:-no release tag}"
 
 base_url=$(bash "$(dirname "$0")/derive-webhook-origin.sh" "$webhook_url")
 
-health=$(curl -s --max-time 15 "${base_url}/api/health/version" 2>/dev/null || true)
+health=$(curl -sf --max-time 15 "${base_url}/api/health/version" 2>/dev/null || true)
 
 actual=$(printf '%s' "$health" | node -e '
         let d=""; process.stdin.on("data",c=>d+=c);

--- a/scripts/deploy/notify-deploy-failure.sh
+++ b/scripts/deploy/notify-deploy-failure.sh
@@ -26,7 +26,7 @@ tag_label="${RELEASE_TAG:-no release tag}"
 
 base_url=$(bash "$(dirname "$0")/derive-webhook-origin.sh" "$webhook_url")
 
-health=$(curl -sS --max-time 15 "${base_url}/api/health/version" 2>/dev/null || true)
+health=$(curl -s --max-time 15 "${base_url}/api/health/version" 2>/dev/null || true)
 
 actual=$(printf '%s' "$health" | node -e '
         let d=""; process.stdin.on("data",c=>d+=c);

--- a/scripts/deploy/notify-deploy-failure.sh
+++ b/scripts/deploy/notify-deploy-failure.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Annotate a failed deploy run with what production is ACTUALLY running.
+# A failed deploy that auto-rolled back must not read like a generic red
+# check (#1892): state whether the rollback restored service on an older
+# SHA and which SHA production serves now.
+#
+# Required env: WEBHOOK_URL, EXPECTED_SHA, REPO, GH_TOKEN (used by gh).
+# Optional env: RELEASE_TAG (release tag that triggered the deploy, if any).
+
+expected="${EXPECTED_SHA:?EXPECTED_SHA is required}"
+repo="${REPO:?REPO is required}"
+webhook_url="${WEBHOOK_URL:?WEBHOOK_URL is required}"
+tag_label="${RELEASE_TAG:-no release tag}"
+
+base_url=$(bash "$(dirname "$0")/derive-webhook-origin.sh" "$webhook_url")
+
+actual=$(curl -sS --max-time 15 "${base_url}/api/health/version" 2>/dev/null \
+    | node -e '
+        let d=""; process.stdin.on("data",c=>d+=c);
+        process.stdin.on("end",()=>{
+          try { const p=JSON.parse(d); console.log(p.commitSha ?? ""); }
+          catch { console.log(""); }
+        })' || true)
+
+if [ -z "$actual" ]; then
+    echo "::error::Deploy failed and the running production SHA could not be determined (health endpoint unreachable). Check the homelab deploy log (/tmp/lucky-deploy.log) for a possible auto-rollback."
+    exit 0
+fi
+
+if [ "$actual" = "$expected" ]; then
+    echo "::error::Deploy workflow failed AFTER the rollout: production is running the expected SHA $actual ($tag_label). The failure is in a post-deploy check, not the deploy itself."
+    exit 0
+fi
+
+# Production serves a different SHA than the one this run tried to deploy:
+# the homelab auto-rollback restored service on the last-good SHA. Say so
+# explicitly, and flag when that SHA is strictly older than the release
+# that triggered this deploy (a strictly worse state than never deploying).
+echo "::error::DEPLOY FAILED: auto-rollback restored service on $actual. Production is running $actual, NOT the deployed target $expected ($tag_label)."
+
+compare=$(gh api "repos/${repo}/compare/${actual}...${expected}" \
+    --jq '"\(.ahead_by) \(.behind_by)"' 2>/dev/null || echo "")
+ahead=$(echo "$compare" | awk '{print $1}')
+behind=$(echo "$compare" | awk '{print $2}')
+
+if [ -n "$ahead" ] && [ "$behind" = "0" ] && [ "$ahead" -gt 0 ]; then
+    echo "::error::PRODUCTION IS BEHIND THE RELEASE: $actual is $ahead commit(s) older than $expected ($tag_label). main has fixes production does not. Investigate the rollback cause and redeploy."
+fi

--- a/scripts/deploy/notify-deploy-failure.sh
+++ b/scripts/deploy/notify-deploy-failure.sh
@@ -6,18 +6,29 @@ set -euo pipefail
 # check (#1892): state whether the rollback restored service on an older
 # SHA and which SHA production serves now.
 #
-# Required env: WEBHOOK_URL, EXPECTED_SHA, REPO, GH_TOKEN (used by gh).
-# Optional env: RELEASE_TAG (release tag that triggered the deploy, if any).
+# Required env: WEBHOOK_URL, REPO, GH_TOKEN (used by gh).
+# Optional env: EXPECTED_SHA (empty means the run failed before the rollout),
+#               RELEASE_TAG (release tag that triggered the deploy, if any).
 
-expected="${EXPECTED_SHA:?EXPECTED_SHA is required}"
+expected="${EXPECTED_SHA:-}"
+
+# No resolved deploy SHA means the failure happened before the webhook fired:
+# there is no rollout (and no rollback) to diagnose. Say so plainly instead of
+# mislabeling a pre-deploy failure as an auto-rollback.
+if [ -z "$expected" ]; then
+    echo "::error::Deploy failed before the rollout started (no deploy SHA resolved). This is a pre-deploy failure, not an auto-rollback."
+    exit 0
+fi
+
 repo="${REPO:?REPO is required}"
 webhook_url="${WEBHOOK_URL:?WEBHOOK_URL is required}"
 tag_label="${RELEASE_TAG:-no release tag}"
 
 base_url=$(bash "$(dirname "$0")/derive-webhook-origin.sh" "$webhook_url")
 
-actual=$(curl -sS --max-time 15 "${base_url}/api/health/version" 2>/dev/null \
-    | node -e '
+health=$(curl -sS --max-time 15 "${base_url}/api/health/version" 2>/dev/null || true)
+
+actual=$(printf '%s' "$health" | node -e '
         let d=""; process.stdin.on("data",c=>d+=c);
         process.stdin.on("end",()=>{
           try { const p=JSON.parse(d); console.log(p.commitSha ?? ""); }
@@ -25,7 +36,14 @@ actual=$(curl -sS --max-time 15 "${base_url}/api/health/version" 2>/dev/null \
         })' || true)
 
 if [ -z "$actual" ]; then
-    echo "::error::Deploy failed and the running production SHA could not be determined (health endpoint unreachable). Check the homelab deploy log (/tmp/lucky-deploy.log) for a possible auto-rollback."
+    if [ -n "$health" ]; then
+        # The endpoint answered but carries no commitSha (older image without
+        # a baked-in SHA). That is not "unreachable": we simply cannot tell
+        # which SHA production serves.
+        echo "::error::Deploy failed and the health endpoint is reachable but reports no commitSha (pre-versioning image?). Check the homelab deploy log (/tmp/lucky-deploy.log) for a possible auto-rollback."
+    else
+        echo "::error::Deploy failed and the running production SHA could not be determined (health endpoint unreachable). Check the homelab deploy log (/tmp/lucky-deploy.log) for a possible auto-rollback."
+    fi
     exit 0
 fi
 
@@ -40,7 +58,7 @@ fi
 # that triggered this deploy (a strictly worse state than never deploying).
 echo "::error::DEPLOY FAILED: auto-rollback restored service on $actual. Production is running $actual, NOT the deployed target $expected ($tag_label)."
 
-compare=$(gh api "repos/${repo}/compare/${actual}...${expected}" \
+compare=$(timeout 15 gh api "repos/${repo}/compare/${actual}...${expected}" \
     --jq '"\(.ahead_by) \(.behind_by)"' 2>/dev/null || echo "")
 ahead=$(echo "$compare" | awk '{print $1}')
 behind=$(echo "$compare" | awk '{print $2}')


### PR DESCRIPTION
## Summary

Follow-up to #1890. The v2.37.0 deploy failed, auto-rolled back to v2.36.1, and nobody noticed for four days because a rolled-back deploy read like a generic red check. This PR makes the rollback state explicit:

- **Rollback-aware failure notification**: restores a `Notify failure` step (`if: failure()`) in `deploy.yml`, backed by new `scripts/deploy/notify-deploy-failure.sh`. On any failed deploy it queries `/api/health/version` and annotates the run with the SHA production actually serves: "auto-rollback restored service on `<sha>`" vs. a generic failure, or "failure is in a post-deploy check" when production does run the expected SHA.
- **Loud failure when production ends up older than the release**: the script compares the running SHA against the deploy target via the GitHub compare API; when the running SHA is strictly older (behind_by=0, ahead_by>0) it emits `PRODUCTION IS BEHIND THE RELEASE: <sha> is N commit(s) older than <tag>`. The `Validate deployed version` step's final error now also names the last observed production SHA instead of a bare mismatch.
- **Pollable deployed SHA**: `/api/health` now includes `commitSha` (from the `COMMIT_SHA` env var already baked into the image via the Dockerfile ARG/ENV, same source as `/api/health/version`), so a scheduled check can alert when the running SHA drifts from the latest tag.

Note: the `Notify failure` step referenced in the issue had been removed in #1897; this restores it in rollback-aware form.

## Verification

- `npx jest tests/unit/routes/health.test.ts tests/integration/routes/health.test.ts` in packages/backend: 2 suites, 20 tests passed (includes 2 new `/api/health` commitSha tests).
- `npm run type:check` (backend): clean; full monorepo type:check also ran via pre-commit hook and passed.
- `eslint src/routes/health.ts`: clean (test file is ignored by the repo eslint config, as before).
- `bash -n scripts/deploy/notify-deploy-failure.sh`: OK; deploy.yml parses as valid YAML.
- Script branch behavior exercised locally with stubbed curl/gh: rollback case, post-deploy-check case, and unreachable-health case all emit the intended annotations and exit 0.

Closes #1892

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make rolled-back deploys obvious in CI and surface the live commit SHA so silent rollbacks don’t read like generic failures. Failed deploys now say when production auto-rolled back, which SHA is serving, and when the failure happened before rollout.

- **Bug Fixes**
  - Restore a rollback-aware "Notify failure" step in deploy.yml using scripts/deploy/notify-deploy-failure.sh. It reads /api/health/version to annotate the run with the live commitSha, distinguishes auto-rollback vs. post-deploy checks, adds a clear pre-deploy failure message when no SHA is resolved, treats HTTP errors as unreachable, and warns when production is behind the release.
  - Expose commitSha on /api/health and /api/health/version (from COMMIT_SHA) and add tests. The "Validate deployed version" step now prints the expected and last-seen production SHA with a clear hint when they differ.

<sup>Written for commit 07ab6ae20a71250b12c2b55e43c092bbae570382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health checks now include a deployed commit identifier when available.
  * Deployment failure notifications now distinguish pre-deployment failures from post-deployment verification failures.
* **Bug Fixes**
  * Improved “validate deployed version” timeout reporting by showing the last served commit identifier (when detected) and clarifying rollback vs. flaky checks.
  * Deployment failure diagnostics better differentiate between unreachable health checks and missing commit info.
* **Tests**
  * Added unit test coverage for `/api/health` with `COMMIT_SHA` set and unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->