### PR TITLE
ci: gate nginx config changes on nginx -t in the real image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
                   service: ${{ matrix.service }}
                   file: ${{ matrix.file }}
                   target: ${{ matrix.target }}
-                  load: ${{ matrix.service == 'bot' }}
+                  load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
             # Retry once on transient failure (buildx setup and build re-run
             # together, matching the previous separate retry steps).
             - name: Build ${{ matrix.service }} - retry once on transient failure
@@ -363,7 +363,7 @@ jobs:
                   service: ${{ matrix.service }}
                   file: ${{ matrix.file }}
                   target: ${{ matrix.target }}
-                  load: ${{ matrix.service == 'bot' }}
+                  load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
             # A built image is not a working image: the bot's native addons
             # (@discordjs/opus) and the baked Prisma engines only fail at
             # require()-time, which `docker build` never reaches. #1735 shipped a
@@ -378,6 +378,14 @@ jobs:
                     if (!frame.length) throw new Error('opus encoded an empty frame');
                     console.log('opus OK — encoded', frame.length, 'bytes');
                   "
+            # Include files are the #1908/#1910 rollback class: a missing or
+            # http-level-loaded include crashes nginx at boot, which
+            # `docker build` never reaches. Gate per
+            # decisions/2026-07-11-bluegreen-web-tier.md: `nginx -t` in the
+            # real image must pass before merge.
+            - name: Validate nginx config — nginx
+              if: matrix.service == 'nginx'
+              run: docker run --rm lucky-nginx:ci nginx -t
 
     docker-build-check:
         name: Build — Docker images

--- a/decisions/2026-07-11-bluegreen-web-tier.md
+++ b/decisions/2026-07-11-bluegreen-web-tier.md
@@ -112,7 +112,7 @@ Validation rule that follows: `nginx -t` against the real base image with the re
 docker build -f Dockerfile.nginx -t lucky-nginx:pr . && docker run --rm lucky-nginx:pr nginx -t
 ```
 
-Wiring this into CI as a required check is still open; until then it is a manual pre-merge step for any PR touching `nginx/` or `Dockerfile.nginx`.
+Wired into CI: the `docker-build` nginx leg in `.github/workflows/ci.yml` loads the image and runs `docker run --rm lucky-nginx:ci nginx -t`, and `Build — Docker images` (a required check) fails if it does not pass.
 
 ## Revisit when
 


### PR DESCRIPTION
Implements the validation rule from `decisions/2026-07-11-bluegreen-web-tier.md` (lessons from the 2.38.0 rollback, #1908/#1910): the `docker-build` nginx leg now loads the image and runs `docker run --rm lucky-nginx:ci nginx -t`, gated through the required `Build — Docker images` check. A broken include now fails pre-merge instead of crash-looping in production.

Verified the command itself passes against the current image (run on homelab docker).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now validates `nginx` config by loading the image in the `docker-build` job and running `nginx -t` (`docker run --rm lucky-nginx:ci nginx -t`). The required `Build — Docker images` check blocks merges on config errors; the decision doc is updated to reflect this.

<sup>Written for commit b5ebf766ed92c17a60f807544ed4d4f8e855f295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

