### PR TITLE
fix(invite): adopt the adr curated permission set

### DIFF
--- a/docs/TOP_GG_SUBMISSION.md
+++ b/docs/TOP_GG_SUBMISSION.md
@@ -4,23 +4,27 @@ Copy-paste artifacts for filing Lucky on https://top.gg. Launch sequence in `~/.
 
 ## 1. Bot identification
 
-| Field | Value |
-|---|---|
-| Client ID | `962198089161134131` |
-| Invite URL | `https://discord.com/oauth2/authorize?client_id=962198089161134131&scope=bot%20applications.commands&permissions=36970496` |
-| Website | `https://lucky.lucassantana.tech` |
-| GitHub | `https://github.com/LucasSantana-Dev/Lucky` |
-| Support server | *Create a Lucky Discord server first (Phase 0 task #7), then paste invite here.* |
+| Field          | Value                                                                            |
+| -------------- | -------------------------------------------------------------------------------- |
+| Client ID      | `962198089161134131`                                                             |
+| Invite URL     | `https://lucky.lucassantana.tech/invite`                                         |
+| Website        | `https://lucky.lucassantana.tech`                                                |
+| GitHub         | `https://github.com/LucasSantana-Dev/Lucky`                                      |
+| Support server | _Create a Lucky Discord server first (Phase 0 task #7), then paste invite here._ |
 
-**Note on permissions integer `36970496`** — this is Read Messages (1024) + Send Messages (2048) + Manage Messages (8192) + Embed Links (16384) + Attach Files (32768) + Add Reactions (64) + Use External Emojis (262144) + Connect (1048576) + Speak (2097152) + Use Voice Activity (33554432). Scoped — not Admin. Use this for top.gg. The README invite still uses `permissions=8` (Admin) to match the existing Landing page; don't mix the two.
+**Note on the invite URL** — do not hardcode a `permissions=` integer here. `https://lucky.lucassantana.tech/invite` redirects to Discord via the backend, which builds the URL from `BOT_INVITE_PERMISSIONS` in `packages/shared/src/constants/invite.ts`, and logs the `utm_*` parameters on the way through so directory clicks are attributable.
+
+The curated set is `3173504` — View Audit Log, View Channels, Send Messages, Manage Messages, Embed Links, Connect, Speak — per `decisions/2026-06-18-invite-permission-scope.md`. **Never Administrator.** High-alarm permissions (Ban/Kick/ManageRoles/ManageChannels/ManageGuild/ModerateMembers) are escalated on demand rather than requested up front.
+
+_Historical note:_ this file previously specified `36970496` and described it as ten permissions summing to 37022784, which is neither that integer nor a set the bot could work with. The real `36970496` is Manage Messages, Use External Emojis, Connect, Speak, Use Voice Activity — with **no** View Channels and **no** Send Messages, so a bot invited with it could not read or post in a channel. It also claimed the README used `permissions=8` (Administrator); that was removed in #1889.
 
 ## 2. Short description (120 char cap)
 
 ```text
-Self-hosted Discord music bot with autoplay, dashboard, and moderation. TypeScript, open source, 2500+ tests.
+Self-hosted Discord music bot with autoplay, dashboard, and moderation. TypeScript, open source, no paywall.
 ```
 
-Character count: 111.
+Character count: 108.
 
 ## 3. Long description (Markdown supported)
 
@@ -30,6 +34,7 @@ Character count: 111.
 **Self-hosted Discord music bot + React dashboard.** Production-grade TypeScript monorepo — music, moderation, engagement — fully open source under ISC.
 
 ## Highlights
+
 - 🎵 **Music**: YouTube + Spotify + SoundCloud · autoplay with diversity-aware recommendations · `/queue smartshuffle` · `/session save|restore`
 - 🛡️ **Moderation**: warn · mute · kick · ban · case tracking · `/digest` weekly reports · automod presets
 - 📊 **Dashboard**: Discord OAuth · RBAC · guild management · feature toggles at [lucky.lucassantana.tech](https://lucky.lucassantana.tech)
@@ -37,13 +42,15 @@ Character count: 111.
 - ⚡ **Reliability**: music watchdog auto-recovery · provider health cooldown · queue snapshot restore · cold-Redis survival
 
 ## Why pick Lucky
+
 - Real autoplay — uses Spotify Discover + genre graphs, not a static playlist loop
 - Self-hostable in Docker — no vendor lock-in, no hidden costs
 - Active development — [releases every few days](https://github.com/LucasSantana-Dev/Lucky/releases)
-- 2500+ tests, SonarCloud A rating, zero production incidents in 2026
+- Every PR runs lint, build, the full test suite and SonarCloud gates; a deploy that fails its health checks rolls back to the last good build
 
 ## Get started
-- [Invite Lucky](https://discord.com/oauth2/authorize?client_id=962198089161134131&scope=bot%20applications.commands&permissions=36970496) to your server
+
+- [Invite Lucky](https://lucky.lucassantana.tech/invite) to your server
 - [Star on GitHub](https://github.com/LucasSantana-Dev/Lucky) if you find it useful
 - Report issues on [GitHub Issues](https://github.com/LucasSantana-Dev/Lucky/issues)
 
@@ -84,7 +91,10 @@ router.post('/webhooks/topgg-votes', async (req, res) => {
         return res.status(401).send('unauthorized')
     }
 
-    const { user: userId, type } = req.body as { user: string; type: 'upvote' | 'test' }
+    const { user: userId, type } = req.body as {
+        user: string
+        type: 'upvote' | 'test'
+    }
 
     if (type === 'test') return res.status(200).send('ok')
 

--- a/packages/backend/src/routes/invite.ts
+++ b/packages/backend/src/routes/invite.ts
@@ -4,10 +4,11 @@ import { logAndSwallow } from '@lucky/shared/utils/error'
 import { buildBotInviteUrl } from '@lucky/shared/constants'
 import { apiLimiter } from '../middleware/rateLimit'
 
-// Was a hardcoded permissions=36970496 (Manage Messages, Connect, Speak) —
-// over-scoped on message deletion and missing View Channels / Send Messages,
-// so it neither matched the landing page nor actually worked. Single source of
-// truth now lives in shared (#1894).
+// Was a hardcoded permissions=36970496 (Manage Messages, Use External Emojis,
+// Connect, Speak, Use Voice Activity) — no View Channels, no Send Messages, so
+// a bot invited with it could not read or post. Single source of truth now
+// lives in shared (#1894), pinned to
+// decisions/2026-06-18-invite-permission-scope.md (#1923).
 const DISCORD_INVITE_URL = buildBotInviteUrl()
 
 function toUtmString(value: unknown): string | undefined {

--- a/packages/backend/src/services/GuildService.ts
+++ b/packages/backend/src/services/GuildService.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import type { Client } from 'discord.js'
+import { BOT_INVITE_PERMISSIONS } from '@lucky/shared/constants'
 import { discordOAuthService, type DiscordGuild } from './DiscordOAuthService'
 import {
     setClient as setDiscordClient,
@@ -505,7 +506,11 @@ class GuildService {
         }
 
         const scopes = ['bot', 'applications.commands']
-        const permissions = '8'
+        // Was a hardcoded '8' — Administrator. The dashboard's "add Lucky to
+        // this server" flow asked every owner for full admin, contradicting
+        // both the ADR and the public listings (#1923). Shares the curated set
+        // with the landing page and the /invite redirect.
+        const permissions = BOT_INVITE_PERMISSIONS
         const redirectUri = process.env.WEBAPP_REDIRECT_URI
 
         let inviteUrl = `https://discord.com/api/oauth2/authorize?client_id=${clientId}&permissions=${permissions}&scope=${scopes.join('%20')}`

--- a/packages/backend/tests/unit/services/GuildService.test.ts
+++ b/packages/backend/tests/unit/services/GuildService.test.ts
@@ -6,6 +6,7 @@ import {
     afterEach,
     jest,
 } from '@jest/globals'
+import { BOT_INVITE_PERMISSIONS } from '@lucky/shared/constants'
 import { guildService, setBotClient } from '../../../src/services/GuildService'
 import { metricsService } from '../../../src/services/MetricsCache'
 import { discordOAuthService } from '../../../src/services/DiscordOAuthService'
@@ -163,7 +164,11 @@ describe('GuildService', () => {
             expect(result).toContain('discord.com/api/oauth2/authorize')
             expect(result).toContain(`guild_id=${guildId}`)
             expect(result).toContain('client_id=test-client-id')
-            expect(result).toContain('permissions=8')
+            // Was `permissions=8` (Administrator). The dashboard's "add Lucky
+            // to this server" flow must use the curated set, same as every
+            // other invite entry point (#1923).
+            expect(result).toContain(`permissions=${BOT_INVITE_PERMISSIONS}`)
+            expect(result).not.toContain('permissions=8&')
             expect(result).toContain('scope=bot')
         })
 

--- a/packages/frontend/src/lib/discord.test.ts
+++ b/packages/frontend/src/lib/discord.test.ts
@@ -4,20 +4,19 @@ import { BOT_INVITE_PERMISSIONS, getBotInviteUrl } from './discord'
 describe('getBotInviteUrl', () => {
     // Regression guard for #1888. The landing page and the docs page each built
     // their own invite URL, drifted, and the docs copy shipped `permissions=8`
-    // (Administrator) while the landing page and every public listing promised
-    // the minimal set. Top.gg's listing copy states "No admin permission", so
-    // this is a claim we make publicly, not just a preference.
+    // (Administrator) while the landing page promised a different set.
+    //
+    // The permission VALUE is asserted once, in
+    // packages/shared/src/constants/invite.spec.ts, against the ADR. Pinning
+    // the literal here too would just be a second place to forget (#1923).
+    // These tests cover what is frontend-specific: that the helper actually
+    // uses the shared constant and builds a well-formed URL.
     test('never requests Administrator', () => {
         const url = getBotInviteUrl()
 
         expect(url).toContain(`permissions=${BOT_INVITE_PERMISSIONS}`)
         expect(url).not.toContain('permissions=8&')
         expect(url).not.toMatch(/permissions=8$/)
-    })
-
-    test('requests the minimal permission set', () => {
-        // View Channels, Send Messages, Embed Links, Connect, Speak.
-        expect(BOT_INVITE_PERMISSIONS).toBe('3165184')
     })
 
     // Without applications.commands the bot joins but registers no slash

--- a/packages/frontend/tests/e2e/fixtures/test-data.ts
+++ b/packages/frontend/tests/e2e/fixtures/test-data.ts
@@ -1,3 +1,10 @@
+import { BOT_INVITE_PERMISSIONS } from '@lucky/shared/constants'
+
+// Invite fixtures build their URL from the shared constant on purpose. When
+// they hardcoded `permissions=8` (Administrator) the e2e flows kept passing
+// against a mocked Administrator response, so they could not have caught a
+// regression away from the curated scope (#1923).
+
 export const MOCK_DISCORD_USER = {
     id: '123456789012345678',
     username: 'testuser',
@@ -62,8 +69,7 @@ export const MOCK_GUILDS = [
         botAdded: false,
         effectiveAccess: MANAGE_EFFECTIVE_ACCESS,
         canManageRbac: true,
-        botInviteUrl:
-            'https://discord.com/api/oauth2/authorize?client_id=test-client-id&permissions=8&scope=bot%20applications.commands&guild_id=222222222222222222',
+        botInviteUrl: `https://discord.com/api/oauth2/authorize?client_id=test-client-id&permissions=${BOT_INVITE_PERMISSIONS}&scope=bot%20applications.commands&guild_id=222222222222222222`,
     },
     {
         id: '333333333333333333',
@@ -195,7 +201,6 @@ export const MOCK_API_RESPONSES = {
     },
     authUser: MOCK_DISCORD_USER,
     inviteUrl: {
-        inviteUrl:
-            'https://discord.com/api/oauth2/authorize?client_id=test-client-id&permissions=8&scope=bot%20applications.commands',
+        inviteUrl: `https://discord.com/api/oauth2/authorize?client_id=test-client-id&permissions=${BOT_INVITE_PERMISSIONS}&scope=bot%20applications.commands`,
     },
 }

--- a/packages/shared/src/constants/invite.spec.ts
+++ b/packages/shared/src/constants/invite.spec.ts
@@ -7,32 +7,59 @@ import {
 
 // Discord permission bits, for readable assertions.
 const ADMINISTRATOR = 1n << 3n
-const MANAGE_MESSAGES = 1n << 13n
+const VIEW_AUDIT_LOG = 1n << 7n
 const VIEW_CHANNEL = 1n << 10n
 const SEND_MESSAGES = 1n << 11n
+const MANAGE_MESSAGES = 1n << 13n
 const EMBED_LINKS = 1n << 14n
 const CONNECT = 1n << 20n
 const SPEAK = 1n << 21n
 
+// High-alarm permissions the ADR deliberately escalates on demand rather than
+// requesting up front.
+const KICK_MEMBERS = 1n << 1n
+const BAN_MEMBERS = 1n << 2n
+const MANAGE_CHANNELS = 1n << 4n
+const MANAGE_GUILD = 1n << 5n
+const MANAGE_ROLES = 1n << 28n
+const MODERATE_MEMBERS = 1n << 40n
+
 describe('bot invite permissions', () => {
     const bits = BigInt(BOT_INVITE_PERMISSIONS)
 
-    // The public listings state Lucky asks for no admin permission. Three
-    // copies of this value had already drifted: the docs page shipped
-    // Administrator and the backend redirect shipped Manage Messages (#1888,
-    // #1894), so this is a claim worth pinning rather than a style preference.
+    // This value is the curated default decided in
+    // decisions/2026-06-18-invite-permission-scope.md. Four copies had already
+    // drifted apart (#1888, #1894, #1923) — the docs page shipped
+    // Administrator, the backend redirect shipped a set missing View Channels
+    // entirely — so it is worth pinning to the decision rather than to taste.
     it('never requests Administrator', () => {
         expect(bits & ADMINISTRATOR).toBe(0n)
     })
 
-    it('never requests Manage Messages', () => {
-        expect(bits & MANAGE_MESSAGES).toBe(0n)
+    it('requests exactly the ADR curated set', () => {
+        const expected =
+            VIEW_AUDIT_LOG |
+            VIEW_CHANNEL |
+            SEND_MESSAGES |
+            MANAGE_MESSAGES |
+            EMBED_LINKS |
+            CONNECT |
+            SPEAK
+        expect(bits).toBe(expected)
     })
 
-    it('requests exactly the permissions the bot needs to function', () => {
-        const expected =
-            VIEW_CHANNEL | SEND_MESSAGES | EMBED_LINKS | CONNECT | SPEAK
-        expect(bits).toBe(expected)
+    // The ADR escalates these on demand: commands needing them check
+    // interaction.appPermissions and prompt, rather than the invite asking a
+    // server owner to hand them over up front (#1498).
+    it.each([
+        ['Kick Members', KICK_MEMBERS],
+        ['Ban Members', BAN_MEMBERS],
+        ['Manage Channels', MANAGE_CHANNELS],
+        ['Manage Guild', MANAGE_GUILD],
+        ['Manage Roles', MANAGE_ROLES],
+        ['Moderate Members', MODERATE_MEMBERS],
+    ])('never requests %s up front', (_label, bit) => {
+        expect(bits & bit).toBe(0n)
     })
 })
 

--- a/packages/shared/src/constants/invite.ts
+++ b/packages/shared/src/constants/invite.ts
@@ -1,19 +1,31 @@
 import { TOP_GG_BOT_ID } from './topgg'
 
 /**
- * Minimal permission set for the bot invite: View Channels, Send Messages,
- * Embed Links, Connect, Speak.
+ * The curated invite permission set, per
+ * `decisions/2026-06-18-invite-permission-scope.md`:
  *
- * NOT Administrator, and deliberately no Manage Messages. The public listings
- * (Top.gg, README) state that Lucky only asks for what it needs, so this value
- * is a promise we make to server admins, not a preference.
+ *   music        View Channels, Send Messages, Embed Links, Connect, Speak
+ *   cleanup      Manage Messages  — auto-mod deletes offending messages
+ *   attribution  View Audit Log   — read-only; `auditHandler` attributes mod cases
  *
- * This lives in shared because three copies had already drifted apart (#1888,
- * #1894): the docs page shipped `8` (Administrator), the backend redirect
- * shipped `36970496` (Manage Messages + Connect + Speak, and missing View
- * Channels / Send Messages entirely), and only the landing page was correct.
+ * **Never Administrator.** The bot genuinely does not need it: `Administrator`
+ * appears in this codebase only as `setDefaultMemberPermissions`, which gates
+ * *who may invoke a command*, not what the bot itself can do.
+ *
+ * The high-alarm permissions (Ban/Kick/ManageRoles/ManageChannels/ManageGuild/
+ * ModerateMembers) are deliberately **not** in the invite. They are escalated
+ * on demand, and commands needing them check `interaction.appPermissions` and
+ * prompt rather than throwing a raw `50013` (#1498).
+ *
+ * This lives in shared because five copies had drifted apart (#1888, #1894,
+ * #1923). The docs page shipped `8` (Administrator); so did the dashboard's
+ * "add Lucky to this server" flow in `GuildService.generateBotInviteUrl`. The
+ * backend redirect shipped `36970496` — Manage Messages, Use External Emojis,
+ * Connect, Speak, Use Voice Activity — with no View Channels and no Send
+ * Messages, so a bot invited with it could not read or post. The landing page
+ * shipped the music-only subset. None of them matched the ADR.
  */
-export const BOT_INVITE_PERMISSIONS = '3165184'
+export const BOT_INVITE_PERMISSIONS = '3173504'
 
 /** The Discord application id. Public: it appears in every OAuth invite URL. */
 export const BOT_CLIENT_ID = TOP_GG_BOT_ID


### PR DESCRIPTION
Closes #1923. Self-reported: #1893 changed the invite permission set without reading the ADR that governs it.

## What the ADR decided

`decisions/2026-06-18-invite-permission-scope.md` (PR #1497, via `/research-and-decide` with a decision-critic pass):

> **Include:** music (View/Send/Embed/Connect/Speak) + `ManageMessages` (cleanup) + `ViewAuditLog` (read-only; needed by `auditHandler`)

Sequenced behind graceful permission checks (#1498), which is **closed** — so the curated set should already have been live.

## Values, decoded exactly

| integer | permissions | status |
|---|---|---|
| `3173504` | ViewAuditLog, ViewChannel, SendMessages, ManageMessages, EmbedLinks, Connect, Speak | **adopted here** — the ADR set |
| `3165184` | ViewChannel, SendMessages, EmbedLinks, Connect, Speak | shipped in #1893, music-only |
| `36970496` | ManageMessages, UseExternalEmojis, Connect, Speak, UseVAD | old backend value — **no** ViewChannel, **no** SendMessages |
| `8` | Administrator | docs page (#1889) **and `GuildService`** |

Without `ViewAuditLog`, `auditHandler` attribution is silently degraded on every fresh install. That is the concrete cost of the value I shipped.

## The fifth copy nobody had counted

Tracing the call sites turned up `GuildService.generateBotInviteUrl()`:

```ts
const permissions = '8'   // Administrator
```

It backs `GET /api/guilds/:id/invite` (`routes/guilds.ts:87`), which the dashboard calls from `api.ts:182` — the **"add Lucky to this server"** button. So that flow asked every server owner for full Administrator while the Top.gg listing promised the opposite. #1888 and #1894 both counted copies and both missed it.

Now uses the shared constant, like every other entry point.

## Also corrected

`docs/TOP_GG_SUBMISSION.md` specified `36970496` and described it as ten permissions summing to **37022784** — neither that integer nor a set the bot could work with. It also claimed the README used `permissions=8`, removed in #1889. It now points at `/invite` instead of hardcoding an integer, so it cannot drift again.

Dropped its `2500+ tests` and `zero production incidents in 2026` lines too — same claims removed from the README in #1912, and this file is the source for listing copy. Short description re-counted at 108 chars (cap 120).

## Tests

Pinned to the decision rather than to taste:

- no `Administrator`
- exactly the seven curated bits
- none of the six high-alarm permissions the ADR escalates on demand (Kick/Ban/ManageChannels/ManageGuild/ManageRoles/ModerateMembers)

Removed the duplicated literal from `packages/frontend/src/lib/discord.test.ts` — a second place to forget is what caused this. The value is asserted once, in shared.

**Verified the guard bites:** reverting the constant to `3165184` fails the suite (`1 failed, 1403 passed`).

Suites green: shared **1404**, backend **1352**, frontend **1038**. Typecheck clean.

## Follow-up

The live Top.gg listing still says "no Manage Messages". I will correct that copy once this is deployed, so the page and the code agree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted the ADR-curated bot invite permissions across all entry points to stop Administrator prompts and restore audit attribution on fresh installs. Unifies invite URL generation and locks the value in tests and e2e fixtures to prevent drift.

- **Bug Fixes**
  - Set `BOT_INVITE_PERMISSIONS` to `3173504` in `packages/shared/src/constants/invite.ts` (music: View/Send/Embed/Connect/Speak + `ManageMessages` + `ViewAuditLog`) and route all invites through `buildBotInviteUrl()`.
  - Replaced `permissions=8` in `GuildService.generateBotInviteUrl()` with `BOT_INVITE_PERMISSIONS`; the dashboard “add Lucky to this server” no longer asks for Administrator.
  - Updated backend `/invite` to use the shared constant; corrected `docs/TOP_GG_SUBMISSION.md` to link `/invite` and removed outdated integers/claims.
  - Tests and fixtures pin the ADR decision: shared spec asserts the exact bits (no `Administrator`, none of the high‑alarm perms); frontend unit test stops duplicating the literal; e2e fixtures now build URLs from the shared constant (`packages/frontend/tests/e2e/fixtures/test-data.ts`) to avoid masking regressions.

<sup>Written for commit 385ef6ee2db1326e6eb7e8ece7ebe7509d2ff884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated bot invitation links to use a curated permission set.
  * Added Manage Messages and View Audit Log permissions where needed.
  * Excluded Administrator and high-risk escalation permissions from initial invitations.
  * Updated submission guidance, descriptions, and setup links.

* **Bug Fixes**
  * Corrected outdated invitation permissions and related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->