### PR TITLE
test(frontend): wait for the starboard threshold input to render

### DIFF
--- a/packages/frontend/src/pages/Starboard.test.tsx
+++ b/packages/frontend/src/pages/Starboard.test.tsx
@@ -6,6 +6,25 @@ import { api } from '@/services/api'
 import { ApiError } from '@/services/ApiError'
 import type { StarboardConfig, StarboardEntry } from '@/services/starboardApi'
 
+/**
+ * The threshold input only exists after getConfig resolves and the component
+ * re-renders. Waiting on the mock having been *called* is not enough — on a
+ * slower runner the query ran first and `as HTMLInputElement` silently handed
+ * back null, surfacing as "Unable to fire a change event" rather than as a
+ * missing element. Wait for the element itself.
+ */
+async function findThresholdInput(
+    container: HTMLElement,
+): Promise<HTMLInputElement> {
+    return await waitFor(() => {
+        const input = container.querySelector<HTMLInputElement>(
+            'input[type="number"][max="100"]',
+        )
+        if (!input) throw new Error('threshold input not rendered yet')
+        return input
+    })
+}
+
 vi.mock('@/stores/guildStore')
 vi.mock('@/services/api')
 vi.mock('sonner', () => ({
@@ -179,9 +198,7 @@ describe('Starboard', () => {
         const emojiInput = screen.getByPlaceholderText('⭐') as HTMLInputElement
         expect(emojiInput.value).toBe('⭐')
 
-        const thresholdInput = container.querySelector(
-            'input[type="number"][max="100"]',
-        ) as HTMLInputElement
+        const thresholdInput = await findThresholdInput(container)
         expect(Number(thresholdInput.value)).toBe(3)
 
         const selfStarSwitch = screen.getByRole('switch', {
@@ -319,9 +336,7 @@ describe('Starboard', () => {
             expect(api.starboard.getConfig).toHaveBeenCalled()
         })
 
-        const thresholdInput = container.querySelector(
-            'input[type="number"][max="100"]',
-        ) as HTMLInputElement
+        const thresholdInput = await findThresholdInput(container)
         fireEvent.change(thresholdInput, { target: { value: '5' } })
 
         expect(thresholdInput.value).toBe('5')
@@ -519,9 +534,7 @@ describe('Starboard', () => {
             expect(api.starboard.getConfig).toHaveBeenCalled()
         })
 
-        const thresholdInput = container.querySelector(
-            'input[type="number"][max="100"]',
-        ) as HTMLInputElement
+        const thresholdInput = await findThresholdInput(container)
         fireEvent.change(thresholdInput, { target: { value: '' } })
 
         const saveButton = screen.getByRole('button', { name: /save/i })
@@ -568,9 +581,7 @@ describe('Starboard', () => {
         const emojiInput = screen.getByPlaceholderText('⭐') as HTMLInputElement
         expect(emojiInput.value).toBe('⭐')
 
-        const thresholdInput = container.querySelector(
-            'input[type="number"][max="100"]',
-        ) as HTMLInputElement
+        const thresholdInput = await findThresholdInput(container)
         expect(Number(thresholdInput.value)).toBe(3)
 
         const selfStarSwitch = screen.getByRole('switch', {


### PR DESCRIPTION
Blocks the 2.39.0 release (#1926), where `Test — frontend` failed:

```
FAIL src/pages/Starboard.test.tsx > Starboard > defaults to 3 threshold when saving with empty value
Error: Unable to fire a "change" event - please provide a DOM element.
  ❯ src/pages/Starboard.test.tsx:525:19
```

## Root cause

Four tests waited for the mock to have been **called**, then queried synchronously:

```ts
await waitFor(() => expect(api.starboard.getConfig).toHaveBeenCalled())

const thresholdInput = container.querySelector(
    'input[type="number"][max="100"]',
) as HTMLInputElement
fireEvent.change(thresholdInput, { target: { value: '' } })
```

`toHaveBeenCalled()` is satisfied the instant the mock is invoked — before its promise resolves and the component re-renders with the input. On a slower runner the query wins the race and returns `null`, which the `as HTMLInputElement` cast silently accepts. The failure then surfaces at `fireEvent` as a confusing *"provide a DOM element"* rather than at the query as a missing element.

Not caused by anything in this release. It is a pre-existing latent race that CI timing happened to expose.

## Fix

All four sites now go through one helper that waits for the **element**, and throws a named error if it never appears:

```ts
async function findThresholdInput(container: HTMLElement): Promise<HTMLInputElement> {
    return await waitFor(() => {
        const input = container.querySelector<HTMLInputElement>('input[type="number"][max="100"]')
        if (!input) throw new Error('threshold input not rendered yet')
        return input
    })
}
```

## On verification — read this before approving

**I could not reproduce it locally, and I could not prove the fix locally.** The suite passes on this machine both before and after, including with the wait deliberately removed again:

| local run | result |
|---|---|
| `Starboard.test.tsx` alone, ×3 | 24 passed each time |
| full frontend suite on the failing commit | 86 files, 1038 tests, all passed |
| helper reverted to a bare sync query | still 24 passed |

So local runs cannot demonstrate this. CI is the reproduction, and CI on this PR is the verification.

I am proposing it anyway because the change is strictly safer regardless of whether it turns out to be *the* cause: it removes a null-deref hidden behind a cast, and converts a silent wrong-shape failure into a named timeout. If `Test — frontend` fails here too, the diagnosis is wrong and I will say so rather than re-roll.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a CI flake in Starboard tests by waiting for the threshold input to render before interacting with it. Prevents null element errors caused by racing the `getConfig` call vs. the DOM render.

- **Bug Fixes**
  - Added `findThresholdInput(container)` that uses `waitFor` to return `input[type="number"][max="100"]` and throws a clear error if it never appears.
  - Replaced four synchronous `querySelector` calls after `api.starboard.getConfig` with the helper to eliminate null casts and “provide a DOM element” failures.

<sup>Written for commit 6b900e0170af9e5760779a7c296c852f8092912e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

