### PR TITLE
docs: refresh roadmap with visual map, open issues, and future work inventory

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,15 +74,17 @@ mindmap
       Guild Automation executors + web Apply
 ```
 
-## Overdue time gates
+## Decision gates by due date
+
+First four entries are overdue as of 2026-08-03.
 
 ```mermaid
 timeline
     title Decision gates by due date
     2026-06-25 : CSP Report-Only to enforce flip overdue : style-src unsafe-inline re-check overdue
-    2026-07-06 : Guild Automation complete-vs-descope gate passed : 3 of 7 executors migrated, frozen
-    2026-07-22 : Autoplay 21-day measurement window ended : Phase D routing re-measure due
-    2026-08-01 : Lavalink and youtube-source re-evaluation due : hard deadline from reliability ADR
+    2026-07-06 : Guild Automation complete-vs-descope decision overdue : 3 of 7 executors migrated, frozen
+    2026-07-22 : Autoplay 21-day measurement window ended : Phase D routing re-measure overdue
+    2026-08-01 : Lavalink and youtube-source re-evaluation overdue : hard deadline from reliability ADR
     2026-09-11 : RAG re-read routing revisit
     2026-10 : Node 26 LTS expected : TS 7 toolchain gate follows
 ```
@@ -146,7 +148,7 @@ Verified unshipped against the codebase on 2026-08-03.
 - **Dyno-parity wave 2** — keyword highlights (DM watch), Forms (modal → submission channel), fun pack (8ball/coin/dice), member tags. Source: `.claude/plans/2026-07-03-dyno-loss-features.md`.
 - **Bulk ops phases 3–4** — bulk-ban/warn/assign-role/remove-role/lockdown/slowmode, then bulk-mute/purge-advanced/seed-reaction-roles/unban. Executor infra ~90% present. Source: `.claude/plans/2026-06-23-batch-commands-design.md`, `decisions/2026-06-23-batch-operations-bullmq.md`. Tracked partly by #1765.
 - **Role Groups v2** — exclusivity/pick-one groups, multi-message groups, bot slash command, select-menu UI, full IdempotencyKey state machine. Source: `.claude/plans/2026-06-23-role-groups-design.md`.
-- **Music UX polish** — U1–U6 (queue position in /nowplaying, vote-skip progress, /queue header, /history autoplay-reason, /songinfo audio features, seed feedback) + elapsed-time progress, streamBridge fallback surfacing, `recommendationReason` threading, PlaybackControls loading states, SSE staleness indicator. Source: `.claude/plans/music-feature-backlog.md`, `.claude/plans/2026-07-10-feature-mapping-research.md`.
+- **Music UX polish** — U1–U6 (queue position in /nowplaying, vote-skip progress, /queue header, /history autoplay-reason, /songinfo audio features, seed feedback) + elapsed-time progress, `recommendationReason` threading, PlaybackControls loading states, SSE staleness indicator. (streamBridge fallback surfacing shipped in v2.39.0, #1920.) Source: `.claude/plans/music-feature-backlog.md`, `.claude/plans/2026-07-10-feature-mapping-research.md`.
 - **`/recommend` re-evaluation** — `MUSIC_RECOMMENDATIONS` toggle still OFF; its gate (Phase B outcome writes) has since shipped, so the enable decision is due. Source: `decisions/2026-05-21-autoplay-recommendation-roadmap.md`.
 - **Autoplay Phase D (ML personalization)** — deferred by gate; prerequisites: outcome coverage >70%, `channelId` + time-bucket columns on `recommendations`. 21-day measurement window ended ~2026-07-22 — re-measure routing decision due. Source: `decisions/2026-06-24-autoplay-phase-c-baseline-defer-coherence-layer.md`, `decisions/2026-07-01-autoplay-deploy-first-21d-measurement-window.md`.
 - **Mood clustering #1095** — on hold pending read-only spike (needs prod access). Source: `decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md`.
@@ -160,7 +162,7 @@ Verified unshipped against the codebase on 2026-08-03.
 
 - **Twitch EventSub Tier 2** — subscribe/gift/message, follow v2, cheer. **Blocked: needs broadcaster-scoped OAuth flow (new ADR + PR).** Source: `decisions/2026-06-22-twitch-eventsub-tier1-expansion.md`.
 - **Stripe premium tiers** — toggle placeholder + staged schema exist; deferred pending Phase 2 revenue validation. Note tension: README markets "no paywall, no premium tier." Source: `.claude/plans/backlog-2026-05-04.md` §J.
-- **Lavalink + youtube-source migration** — escalation gate (sustained >5% exhaustion, >3 concurrent VCs). **Hard re-evaluation deadline 2026-08-01 — due now.** Source: `decisions/2026-06-18-youtube-extraction-reliability.md`.
+- **Lavalink + youtube-source migration** — escalation gate (sustained >5% exhaustion, >3 concurrent VCs). **Hard re-evaluation deadline 2026-08-01 — overdue as of 2026-08-03.** Source: `decisions/2026-06-18-youtube-extraction-reliability.md`.
 - **YouTube po_token / cookies-from-browser** — data-gated escalation if a 403/velocity cluster appears. Source: same ADR.
 - **Top.gg completion** — submission checklist (support server, banner, webhook token) + ad campaign #1784. Source: `docs/TOP_GG_SUBMISSION.md`.
 - **BotBlock multi-directory sync** — growth Phase 2; dry-run on 2–3 directories first. Source: `decisions/2026-06-17-growth-channel-sequencing.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,29 +1,228 @@
 # Roadmap — Lucky
 
-_Refreshed 2026-05-05. Version: v2.9.0._
+_Refreshed 2026-08-03. Version: v2.39.x. Supersedes the 2026-05-05 (v2.9.0) roadmap._
+_Sources: 25 open GitHub issues + full sweep of `decisions/` and `.claude/plans/`, verified unshipped against the codebase. Spec: `.claude/plans/spec-visual-roadmap.md`._
 
-## Now (active)
+## Visual map
 
-- **queueManipulation.ts modularisation** — Split 961-LOC hotspot into `candidateSelection.ts`, `queueOrchestration.ts`, `queueEditOps.ts`. Unblocks multiple downstream refactors.
-- **Autoplay tuning** — PR [#805](https://github.com/LucasSantana-Dev/Lucky/pull/805) in CI: artist exact-match routing, stop-clears-snapshot, Last.fm boost 0→0.20, deep-dive per-artist cap, mood cache.
+```mermaid
+mindmap
+  root((Lucky Roadmap))
+    Overdue gates
+      CSP enforce flip — due 2026-06-25
+      Guild Automation complete-vs-descope — due 2026-07-06
+      Autoplay re-measure routing — due 2026-07-22
+      Lavalink re-evaluation — due 2026-08-01
+    Open issues — 25
+      Features
+        1777 mod-log Dyno parity
+        1765 bulk command family
+        1813 TTL delete v2
+        1792 channel cleanup tracking
+      CI and Ops
+        1935 deploy webhook result
+        1934 prometheus alert rules
+        1933 trivy findings dismiss
+        1800 blue-green phase 1b
+        1785 blue-green zero downtime
+        1651 alertmanager black hole
+        1481 renovate dark since May
+        1538 two lockfiles drift
+      Security
+        1480 deploy posture secrets
+        1880 discordjs-opus chain
+        1878 react-router v8
+        1879 test toolchain advisories
+        1914 CSP defined in 3 places
+        1714 session cookie sameSite
+      Bot and tech debt
+        1929 bot health vs broken music
+        1919 message.delete swallows 403
+        1634 jest vs vitest split
+        1705 TS 7 blocked on ts-jest
+        1924 three serving layers undocumented
+        1882 POSTGRES_PASSWORD gotcha
+        1784 top.gg ad campaign
+    Future features
+      Context-menu pack — quote, user card, report, bookmark, starboard
+      Welcome and Leave editor
+      Giveaways dashboard page
+      Integration feeds spine — RSS, YouTube, Twitch clips
+      Voice flows — logging, join-to-create, voice XP
+      Dyno parity wave 2 — highlights, forms, fun, tags
+      Bulk ops phases 3-4
+      Role Groups v2
+      Music UX polish U1-U6
+      /recommend toggle re-evaluation
+      Autoplay phase D — gated
+    Future integrations
+      Twitch EventSub tier 2 — blocked on OAuth flow
+      Stripe premium — deferred on revenue validation
+      Lavalink migration — gate fired, re-evaluate
+      BotBlock directories — growth phase 2
+      Discord App Directory — threshold gated
+      Top.gg submission checklist + ads
+    Future infrastructure
+      Blue-green prod wiring and phases 2-3
+      Docker CI optimization P1-P4
+      Vitest migration — accepted not executed
+      Monitoring — logging track, OTel, alert fixes
+      Staging lifecycle auto-stop
+      Mutation gate tiers 1-4
+      Node 26 and TS 7 — gated
+      Redis removal — gated
+      Guild Automation executors + web Apply
+```
 
-## Next (proposed)
+## Overdue time gates
 
-- **autoplay.ts split** — 1,074-LOC command file → `autoplaySettings.ts`, `autoplayDiversity.ts`, `autoplaySeeding.ts`.
-- **Prisma homelab migration** — Apply `GlobalFeatureToggle` table migration to homelab DB. Run `npx prisma migrate deploy` on homelab after stop/start.
-- **2026-04-24-autoplay-genre-locale**  _(proposed)_  `autoplay,music,i18n`
+```mermaid
+timeline
+    title Decision gates by due date
+    2026-06-25 : CSP Report-Only to enforce flip overdue : style-src unsafe-inline re-check overdue
+    2026-07-06 : Guild Automation complete-vs-descope gate passed : 3 of 7 executors migrated, frozen
+    2026-07-22 : Autoplay 21-day measurement window ended : Phase D routing re-measure due
+    2026-08-01 : Lavalink and youtube-source re-evaluation due : hard deadline from reliability ADR
+    2026-09-11 : RAG re-read routing revisit
+    2026-10 : Node 26 LTS expected : TS 7 toolchain gate follows
+```
 
-## Deferred
+## Open issues (25)
 
-- **Phase 3: Stripe premium service** — Feature toggle placeholder active (`premiumService.isPremium`). DB schema staged. Deferred pending Phase 2 revenue validation.
-- **GuildAutomationExecutionService event-driven refactor** — 1,238-LOC service. Candidate for event emitter pattern. Post-v2.9.
-- **AutoMod.tsx decompose** — 984-LOC React component → 3-way split. Low priority.
+### Features
 
-## Recently shipped
+| # | Title | Labels |
+|---|-------|--------|
+| [#1777](https://github.com/LucasSantana-Dev/Lucky/issues/1777) | mod-log/server-log parity with Dyno (event coverage + per-event routing + ignore lists) | cat:feature, ready-for-agent |
+| [#1765](https://github.com/LucasSantana-Dev/Lucky/issues/1765) | generalize bulk actions into a /bulk-* command family | ready-for-agent |
+| [#1813](https://github.com/LucasSantana-Dev/Lucky/issues/1813) | TTL delete mode (v2) — deferred from #1687 | ready-for-agent |
+| [#1792](https://github.com/LucasSantana-Dev/Lucky/issues/1792) | channel cleanup: track/disable configs after repeated purge failures | ready-for-human |
 
-- **v2.9.0: Admin panel + feature gates** — Global feature toggle management via web dashboard (`GlobalFeatureToggle` table, `requireAdmin` guard). `/artist` and `/album` gated behind toggles. PR [#801](https://github.com/LucasSantana-Dev/Lucky/pull/801), [#800](https://github.com/LucasSantana-Dev/Lucky/pull/800).
-- **Test quality hardening** — Tightened false-positive assertions in music buttons and now-playing specs; all 2865 tests pass. PR [#804](https://github.com/LucasSantana-Dev/Lucky/pull/804).
-- **v2.8.0: /artist and /album commands** — Last.fm-powered artist/album browsing with feature toggle gates. PR [#799](https://github.com/LucasSantana-Dev/Lucky/pull/799).
-- **v2.7.0: Vercel feature flags migration** — Replaced Unleash with Vercel FeatureFlags. 19 flags live. PR [#796](https://github.com/LucasSantana-Dev/Lucky/pull/796).
-- **Autoplay Phase 1+2** — `/artist`, `/album`, diversity scaling, Last.fm tag scoring, autoplay seed/diversity subcommands.
-- **RBAC + guild access controls** — Role-based per-module permissions with `requireGuildModuleAccess` middleware.
+### CI / Ops
+
+| # | Title | Labels |
+|---|-------|--------|
+| [#1785](https://github.com/LucasSantana-Dev/Lucky/issues/1785) | blue/green zero-downtime deploys — true B/G for web tier, fast-rollover for the bot | ready-for-agent |
+| [#1800](https://github.com/LucasSantana-Dev/Lucky/issues/1800) | blue/green web tier Phase 1b — cold-start wiring + live staging validation | ready-for-agent |
+| [#1651](https://github.com/LucasSantana-Dev/Lucky/issues/1651) | LuckyBotDown fired 4.5h, alertmanager never dispatched — silent alert black hole | ready-for-human |
+| [#1481](https://github.com/LucasSantana-Dev/Lucky/issues/1481) | Renovate not running since Dependabot→Renovate migration — dep automation dark since 2026-05-27 | ready-for-human |
+| [#1935](https://github.com/LucasSantana-Dev/Lucky/issues/1935) | report explicit rollout/rollback result from the homelab deploy webhook | ready-for-human, cat:ci |
+| [#1934](https://github.com/LucasSantana-Dev/Lucky/issues/1934) | apply calibrated memory alert rules to the live homelab prometheus | ready-for-human, cat:ci |
+| [#1933](https://github.com/LucasSantana-Dev/Lucky/issues/1933) | dismiss the 39 stale Trivy secret findings from the vendored yt-dlp scan | ready-for-agent, cat:ci |
+| [#1538](https://github.com/LucasSantana-Dev/Lucky/issues/1538) | repo carries two lockfiles (package-lock + pnpm-lock) that drift independently | ready-for-human |
+
+### Security
+
+| # | Title | Labels |
+|---|-------|--------|
+| [#1480](https://github.com/LucasSantana-Dev/Lucky/issues/1480) | deploy posture — orphaned high-priv secrets + unscoped secrets + no Production env policy | cat:security, ready-for-human |
+| [#1880](https://github.com/LucasSantana-Dev/Lucky/issues/1880) | @discordjs/opus pulls an unfixable node-pre-gyp chain | dependencies, cat:security |
+| [#1878](https://github.com/LucasSantana-Dev/Lucky/issues/1878) | migrate to react-router v8 to clear GHSA-qwww-vcr4-c8h2 | dependencies, cat:security |
+| [#1879](https://github.com/LucasSantana-Dev/Lucky/issues/1879) | modernise dev test toolchain to clear brace-expansion advisory chain | dependencies, cat:tech-debt |
+| [#1914](https://github.com/LucasSantana-Dev/Lucky/issues/1914) | CSP is defined in three places and has drifted | infra, cat:tech-debt |
+| [#1714](https://github.com/LucasSantana-Dev/Lucky/issues/1714) | session cookie sameSite=none in production may be stricter than needed | ready-for-agent |
+
+### Bot / tech debt / docs
+
+| # | Title | Labels |
+|---|-------|--------|
+| [#1929](https://github.com/LucasSantana-Dev/Lucky/issues/1929) | observability: bot reports healthy while music is completely broken | bot, music, needs-triage |
+| [#1919](https://github.com/LucasSantana-Dev/Lucky/issues/1919) | message.delete() swallows permission errors as if they were 404s | bot, moderation, cat:bug |
+| [#1634](https://github.com/LucasSantana-Dev/Lucky/issues/1634) | test runner fragmentation — Jest vs Vitest across monorepo packages | cat:tech-debt |
+| [#1705](https://github.com/LucasSantana-Dev/Lucky/issues/1705) | TypeScript 7 migration blocked: ts-jest has no TS7-compatible release | needs-info |
+| [#1924](https://github.com/LucasSantana-Dev/Lucky/issues/1924) | record which layer serves which host (three serving layers, undocumented) | infra, cat:docs |
+| [#1882](https://github.com/LucasSantana-Dev/Lucky/issues/1882) | changing POSTGRES_PASSWORD in .env after first boot silently does nothing | cat:tech-debt, cat:docs |
+| [#1784](https://github.com/LucasSantana-Dev/Lucky/issues/1784) | launch $10 Top.gg ad campaign once listing passes verification (blocked ~1-2wk) | ready-for-human |
+
+## Future features
+
+Verified unshipped against the codebase on 2026-08-03.
+
+- **Context-menu pack** — Quote-as-embed, User card (mod history + level), Report message→mod case, Bookmark (new table), Pin-to-starboard. Wave 1: Quote → User card → Report. Source: `.claude/plans/2026-06-23-bot-flows-backlog-design.md`, tiering in `decisions/2026-06-21-context-menu-adoption-strategy.md`.
+- **Welcome/Leave dedicated editor** — `WelcomeLeaveEditor.tsx` with embed/plaintext toggle, token picker, live preview. Called "cheapest high-value win in the whole backlog." Source: `.claude/plans/2026-06-23-bot-flows-backlog-design.md`.
+- **Giveaways dashboard page** — bot side (models + scheduler) shipped; dashboard CRUD + `managementGiveaways` routes never landed. Source: same design doc.
+- **Integration feeds spine** — `FeedSubscription` model, generic poller/embed/control services; RSS first → YouTube (WebSub) → Twitch clips (Helix); `IntegrationFeeds.tsx`. ~5 weeks, highest growth value. Source: same design doc.
+- **Voice flows (greenfield)** — `voiceStateHandler.ts` fan-out: voice logging, Join-to-Create temp channels, Voice XP with anti-AFK. Source: same design doc.
+- **Dyno-parity wave 2** — keyword highlights (DM watch), Forms (modal → submission channel), fun pack (8ball/coin/dice), member tags. Source: `.claude/plans/2026-07-03-dyno-loss-features.md`.
+- **Bulk ops phases 3–4** — bulk-ban/warn/assign-role/remove-role/lockdown/slowmode, then bulk-mute/purge-advanced/seed-reaction-roles/unban. Executor infra ~90% present. Source: `.claude/plans/2026-06-23-batch-commands-design.md`, `decisions/2026-06-23-batch-operations-bullmq.md`. Tracked partly by #1765.
+- **Role Groups v2** — exclusivity/pick-one groups, multi-message groups, bot slash command, select-menu UI, full IdempotencyKey state machine. Source: `.claude/plans/2026-06-23-role-groups-design.md`.
+- **Music UX polish** — U1–U6 (queue position in /nowplaying, vote-skip progress, /queue header, /history autoplay-reason, /songinfo audio features, seed feedback) + elapsed-time progress, streamBridge fallback surfacing, `recommendationReason` threading, PlaybackControls loading states, SSE staleness indicator. Source: `.claude/plans/music-feature-backlog.md`, `.claude/plans/2026-07-10-feature-mapping-research.md`.
+- **`/recommend` re-evaluation** — `MUSIC_RECOMMENDATIONS` toggle still OFF; its gate (Phase B outcome writes) has since shipped, so the enable decision is due. Source: `decisions/2026-05-21-autoplay-recommendation-roadmap.md`.
+- **Autoplay Phase D (ML personalization)** — deferred by gate; prerequisites: outcome coverage >70%, `channelId` + time-bucket columns on `recommendations`. 21-day measurement window ended ~2026-07-22 — re-measure routing decision due. Source: `decisions/2026-06-24-autoplay-phase-c-baseline-defer-coherence-layer.md`, `decisions/2026-07-01-autoplay-deploy-first-21d-measurement-window.md`.
+- **Mood clustering #1095** — on hold pending read-only spike (needs prod access). Source: `decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md`.
+- **VC multi-user taste blend** — likely the surviving chunk of the stale taste-blend plan; needs re-triage. Source: `.claude/plans/autoplay-taste-blend.md` (2026-04-11, stale).
+- **Reaction-roles dashboard follow-ups** — delete Discord message on dashboard delete; edit existing reaction-role message. Source: `decisions/2026-06-22-reaction-roles-dashboard-create.md`.
+- **Move-message extensions** — slash-command variant, mod-log archival, web UI. Source: `.claude/plans/move-message.md`.
+- **In-bot growth (deferred)** — `/share` cards, vote perks; revisit if external channels stall. Source: `decisions/2026-06-18-in-bot-growth.md`.
+- **i18n residual cleanup** — per-page/config translation coverage. Source: `.claude/plans/i18n-language-switcher.md`.
+
+## Future integrations
+
+- **Twitch EventSub Tier 2** — subscribe/gift/message, follow v2, cheer. **Blocked: needs broadcaster-scoped OAuth flow (new ADR + PR).** Source: `decisions/2026-06-22-twitch-eventsub-tier1-expansion.md`.
+- **Stripe premium tiers** — toggle placeholder + staged schema exist; deferred pending Phase 2 revenue validation. Note tension: README markets "no paywall, no premium tier." Source: `.claude/plans/backlog-2026-05-04.md` §J.
+- **Lavalink + youtube-source migration** — escalation gate (sustained >5% exhaustion, >3 concurrent VCs). **Hard re-evaluation deadline 2026-08-01 — due now.** Source: `decisions/2026-06-18-youtube-extraction-reliability.md`.
+- **YouTube po_token / cookies-from-browser** — data-gated escalation if a 403/velocity cluster appears. Source: same ADR.
+- **Top.gg completion** — submission checklist (support server, banner, webhook token) + ad campaign #1784. Source: `docs/TOP_GG_SUBMISSION.md`.
+- **BotBlock multi-directory sync** — growth Phase 2; dry-run on 2–3 directories first. Source: `decisions/2026-06-17-growth-channel-sequencing.md`.
+- **Discord App Directory** — growth Phase 3; gated on verification threshold (~100+ servers / 10K users). Source: same ADR.
+- **Spotify Extended Quota / Last.fm-all-in for Discover** — conditional on Spotify 429 rate >5–10%. Source: `decisions/2026-06-01-musical-taste-discover-performance.md`.
+
+## Future infrastructure
+
+### Deploy / CI
+
+- **Blue/green Phase 1b prod wiring** — works on staging; prod cutover deferred for operator sign-off. Phase 2 (bot post-deploy health-gate), Phase 3 (destructive-migration CI check) deferred. Tracked by #1800, #1785. Source: `decisions/2026-07-11-bluegreen-web-tier.md`.
+- **Music queue persist+restore across deploys** — pilot gate: first instrument "was music playing at SIGTERM" logging. Source: `decisions/2026-07-11-bot-redeploy-no-bluegreen.md`.
+- **Docker CI optimization P1–P4** — baselined (cold 443s, cache 101% over limit), not started: provenance/sbom off, kill double opus compile, cache mode=max→min (required), pre-built base image (gated). Source: `.claude/plans/2026-07-12-docker-ci-optimization.md`.
+- **CI follow-ups** — unify docker matrices; `workflow_run` chain replacing image-wait poll; AI-reviewer consolidation (3 reviewers/PR, parked as product decision). Source: `decisions/2026-07-27-ci-workflow-efficiency.md`.
+- **Shared-build artifact cache across CI jobs** — sanctioned, deliberately waiting for a concrete CI-time complaint. Source: `decisions/2026-07-12-moonrepo-adoption-deferred.md`.
+- **Frontend stale-image detection** — build-version marker in served HTML. Source: `decisions/2026-06-24-deploy-frontend-health-gate.md`.
+- **Idempotent-migrations CI gate** — full-chain apply + partial-state replay on Postgres 18. Tracked as #1837. Source: `decisions/2026-07-16-idempotent-migrations.md`.
+- **Node 26 / TypeScript 7** — gated (Node 26 LTS ~Oct 2026; TS 7.1 + ecosystem support). Related: #1705. Source: `decisions/2026-07-12-toolchain-modernization-node-ts.md`.
+
+### Monitoring / observability
+
+- **Alert black hole fix** — #1651 (alertmanager never dispatched; Discord channel shares failure domain with bot).
+- **Broker-failure instrumentation** — metric/Sentry breadcrumb on Redis pub/sub publish failure. Source: `decisions/2026-06-13-message-broker-rabbitmq-kafka.md`.
+- **Logging-quality track** — structured JSON, bot correlation IDs, audit of ~60 silent `.catch` swallows, pino/OTel; activates on next log-quality-slowed incident. Source: `decisions/2026-07-01-bot-monitoring-dead-man-first.md`.
+- **OpenTelemetry tracing** — deferred; Sentry-native (~$26/mo) is the fast path if accepted. Source: `decisions/2026-05-31-tracing-defer-reaffirmed.md`.
+- **Failure-mode metrics** — 429/timeout/slow-query counters; promote to P1 if a >2h diagnosis mystery occurs. Source: `decisions/2026-05-30-observability-remediation-strategy.md`.
+- **Manual monitoring wiring** — Sentry release/source maps, off-box heartbeat, Grafana alert rules + Discord contact point. Source: `monitoring/README.md`.
+
+### Security / testing
+
+- **CSP Report-Only → enforce** — flip due ~2026-06-25, overdue. Also #1914 (CSP defined in 3 places). Source: `.claude/plans/2026-06-11-security-headers-1283.md`.
+- **Vitest migration** — accepted, not executed (bot/shared/backend still Jest); Stryker runner swap included. Tracked by #1634. Source: `decisions/2026-06-27-standardize-test-runner-vitest.md`.
+- **Backend mutation-gate tiers 1–4** — pilot on `requestId.ts`, break 90→82, then expand; promotion to required check is a separate decision. Source: `decisions/2026-06-16-backend-mutation-gate-rollout.md`.
+- **#1378 ESLint typing tail** — 136 violations (86 non-null-assertion, 50 no-unsafe-*); 6-phase plan to warn→error. Source: `.claude/plans/2026-06-13-1378-typing-tail.md`.
+
+### Platform / data
+
+- **Guild Automation: complete-vs-descope decision — OVERDUE (gate was 2026-07-06)** — frozen at 3/7 executors, ~3,500 LOC of frozen machinery carried. If completed: `DiscordWriteAdapter` build, 4 remaining executors, real web Apply (PRD #1059). Source: `decisions/2026-06-06-guild-automation-migration-freeze-and-instrument.md`, `decisions/2026-05-21-discord-write-adapter-port.md`.
+- **Staging lifecycle** — auto-stop after N idle days, fold staging bot in, Docker image prune policy, logrotate. Source: `decisions/2026-07-02-resource-hygiene-alert-calibration-first.md`, `decisions/2026-07-03-staging-test-bot.md`.
+- **Full Redis removal** — pub/sub → Postgres LISTEN/NOTIFY; separate gated decision. Source: `decisions/2026-05-31-redis-scope-reduction.md`.
+- **`channelId` + time-bucket on `recommendations`** — schema work in the Phase-D prerequisite path.
+
+### Tech debt / refactors pending
+
+- **Frontend god-components** — `AutoMod.tsx` (~984 LOC), `ServerSettings.tsx` (~914), `Sidebar.tsx` split. Recurring across 4 backlogs, never executed. Source: `.claude/plans/backlog-2026-05-04.md`.
+- **`bot/utils/` structural refactor + DI container** — "document but don't ship yet." Source: `.claude/plans/lucky-refactor-map.md`.
+- **Music subsystem event-emitter unification** — typed `EventEmitter<MusicEvents>`. Source: `.claude/plans/backlog-2026-05-04.md` B5.
+- **Music structural items** — `replenisher.ts` split, `candidateScorer.ts` slim, `searchQueryCleaner` spec, watchdog/snapshot metrics. Source: `.claude/plans/music-feature-backlog.md` (stale, post-v3).
+- **`COMMAND_CATEGORIES` unification** — needs product/i18n decision. Source: `decisions/2026-06-04-redundancy-consolidation.md`.
+- **`CandidateAggregator` seam** — prerequisite (Guild Automation decommission) has fired; eligible for revisit. Source: `decisions/2026-05-24-candidate-aggregator-deferred.md`.
+- **Legacy `MusicRecommendationService` cleanup** — documented dead code. Source: `decisions/2026-06-10-defer-autoplay-engine-extraction.md`.
+
+## Explicit non-goals (do not re-propose)
+
+- Apple Music / YouTube Music taste integration — `.claude/plans/autoplay-taste-blend.md` out-of-scope.
+- RabbitMQ/Kafka/NATS — keep Redis pub/sub; revisit only on multi-instance or durable-history needs (`decisions/2026-06-13-message-broker-rabbitmq-kafka.md`).
+- Blue/green for the bot process — ruled out (`decisions/2026-07-11-bot-redeploy-no-bluegreen.md`); fast-rollover + queue-restore pilot instead.
+- Moonrepo/turbo — deferred with thresholds (`decisions/2026-07-12-moonrepo-adoption-deferred.md`).
+
+## Recently shipped (context)
+
+- v2.38–v2.39: blue/green web tier on staging, release-please, dependabot reactivation, SENTRY_RELEASE wiring, idempotent migrations.
+- Dyno-parity wave 1: reminders, AFK, channel cleanup, giveaways persistence; tickets; move-message context menu.
+- Spotify OAuth + taste integration; autoplay Phase C baseline; recommendation outcome writes (#1275).
+- Twitch EventSub Tier 1; reaction-roles dashboard create/delete; Role Groups v1; bulk-move-messages + bulk-kick.


### PR DESCRIPTION
## What

Rewrites `docs/roadmap.md` (stale since 2026-05-05, v2.9.0) as a visual roadmap:

- **Mermaid mindmap** — full inventory at a glance: issues / features / integrations / infrastructure
- **Mermaid timeline** — dated decision gates, 4 overdue flagged (CSP enforce, Guild Automation decision, autoplay re-measure, Lavalink re-eval)
- **25 open issues** grouped (Features / CI-Ops / Security / Bot-debt-docs) with links + labels
- **Future features / integrations / infrastructure** — every item verified unshipped against the codebase (2026-08-03), each with source citation (`decisions/`, `.claude/plans/`, `docs/`)
- **Non-goals section** — recorded do-not-re-propose items (Apple Music, Kafka, bot B/G, moonrepo)

## Sources

Full sweep of `decisions/` (~130 ADRs), `.claude/plans/` (~40 plans), `docs/`, README, and `gh issue list`. Spec: `.claude/plans/spec-visual-roadmap.md`.

## Verification

Both Mermaid blocks parse clean (mindmap + timeline, checked with mermaid parser). Docs-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites `docs/roadmap.md` into a visual roadmap (Mermaid mindmap + timeline), replacing the stale v2.9.0 with a v2.39.x refresh dated 2026-08-03. Marks only past-due gates as overdue (Guild Automation and Lavalink), removes shipped “streamBridge fallback surfacing,” and keeps a clean inventory of 25 open issues and future features/integrations/infrastructure with sources and verified-unshipped checks, plus non-goals and a “Recently shipped” context; Mermaid parses clean and this is docs-only.

<sup>Written for commit 3f714122539599c3248728d33231627040956f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Replaced the outdated v2.9.0 roadmap with an updated v2.39.x roadmap dated August 3, 2026.
  - Added visual and timeline overviews, decision gates, categorized open issues, planned features and integrations, infrastructure work, and explicit non-goals.
  - Included context on recently shipped v2.38–v2.39 updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->