### PR TITLE
fix(ci): clear stale audit-gate entries and bump fixed advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2460,15 +2460,6 @@
                 "url": "https://github.com/discordjs/discord.js?sponsor"
             }
         },
-        "node_modules/@discordjs/rest/node_modules/undici": {
-            "version": "6.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.17"
-            }
-        },
         "node_modules/@discordjs/util": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
@@ -5316,9 +5307,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/config": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.0.tgz",
-            "integrity": "sha512-CsoK2mhl0u+N4/8V+XroQMOUNIic4isqD+E2HBG8l1yGEKo62CFDu3FHo0FdwItjl6XkW+omA1STSzeN1DAXlg==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.1.tgz",
+            "integrity": "sha512-4znKhxTmXmuPye9Z6pbIyYb5VZlkZ05qG1L6Dr4g+7oTwc6V50Bs9XirFBDdjWt+H/AabMn9aUnxBcvj8z05aA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "c12": "3.3.4",
@@ -5334,9 +5325,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/dev": {
-            "version": "0.24.14",
-            "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.14.tgz",
-            "integrity": "sha512-NhFO49O2JPTdzYiLHvceQn/HiwmcKF/iGV39ko3CpYsoGqS3rz3ko6gzuxFSIeHNwNJeuNcDexyyGeTO3DW80A==",
+            "version": "0.24.17",
+            "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.17.tgz",
+            "integrity": "sha512-UvdZzmpFwknnfreh6Jije84ekkYGPYEJhXG1tFzCsCfQyzJifrOo38eZc0qajzvaC6OLUOrN9ML5XfCnEZL9DA==",
             "license": "ISC",
             "dependencies": {
                 "@electric-sql/pglite": "0.4.3",
@@ -5345,14 +5336,14 @@
                 "@prisma/get-platform": "7.2.0",
                 "@prisma/query-plan-executor": "7.2.0",
                 "@prisma/streams-local": "0.1.11",
-                "find-my-way": "9.6.0",
+                "find-my-way": "9.7.0",
                 "foreground-child": "3.3.1",
                 "get-port-please": "3.2.0",
                 "pathe": "2.0.3",
                 "proper-lockfile": "4.1.2",
                 "remeda": "2.33.4",
                 "std-env": "3.10.0",
-                "valibot": "1.2.0",
+                "valibot": "1.4.2",
                 "zeptomatch": "2.1.0"
             }
         },
@@ -5366,16 +5357,16 @@
             }
         },
         "node_modules/@prisma/engines": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.0.tgz",
-            "integrity": "sha512-lDWJp/pgSWCLfYsupmmNo96jfsbQnH1yjia8XVM2Kh8nRZhD0bQU2jCHuy3ZTPMLR3apRD3k145ybENalAYjYw==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.1.tgz",
+            "integrity": "sha512-UprXSMNXx2NF5ow4pqaQtE8OuBz6K78B0wc0tn2L28G5r933iWp1DR9Do2qWrsNvvFIP3x6mpEWnQtckMO0Uhg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.0",
+                "@prisma/debug": "7.9.1",
                 "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-                "@prisma/fetch-engine": "7.9.0",
-                "@prisma/get-platform": "7.9.0"
+                "@prisma/fetch-engine": "7.9.1",
+                "@prisma/get-platform": "7.9.1"
             }
         },
         "node_modules/@prisma/engines-version": {
@@ -5385,44 +5376,44 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines/node_modules/@prisma/debug": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.0.tgz",
-            "integrity": "sha512-i0KdVQuKUE6N9NloHs+sUNAk2c9svR3myBndQbA3BoeoArsSpwtNgTdHZL+wBtCLCcdS2OOC/PKhgTe36jkF5A==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
+            "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.0.tgz",
-            "integrity": "sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
+            "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.0"
+                "@prisma/debug": "7.9.1"
             }
         },
         "node_modules/@prisma/fetch-engine": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.0.tgz",
-            "integrity": "sha512-F0XlIgjbE3EywRVR/HpCerNI/dxo40vK66tHcWpsWYwH/Jk9+FsICEzATeMsZ7bdnpZz93hkD4sAb5rKLsCCpA==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.1.tgz",
+            "integrity": "sha512-9DwxrNTeT25Orbu9CWh0CZvVlyY1lmscpbaeLZcOnuR7zcuFrt91YSmmOfIm7zJ08YOZ6mVzURKwLoMwEBcK8w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.0",
+                "@prisma/debug": "7.9.1",
                 "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-                "@prisma/get-platform": "7.9.0"
+                "@prisma/get-platform": "7.9.1"
             }
         },
         "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.0.tgz",
-            "integrity": "sha512-i0KdVQuKUE6N9NloHs+sUNAk2c9svR3myBndQbA3BoeoArsSpwtNgTdHZL+wBtCLCcdS2OOC/PKhgTe36jkF5A==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
+            "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.0.tgz",
-            "integrity": "sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
+            "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.0"
+                "@prisma/debug": "7.9.1"
             }
         },
         "node_modules/@prisma/get-platform": {
@@ -10259,6 +10250,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10275,6 +10267,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10291,6 +10284,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -10307,9 +10301,7 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10326,9 +10318,7 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10345,9 +10335,7 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10364,9 +10352,7 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10383,9 +10369,7 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10402,9 +10386,7 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10421,6 +10403,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10437,6 +10420,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10453,6 +10437,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -10622,9 +10607,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -10642,9 +10624,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -10662,9 +10641,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -10682,9 +10658,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13850,15 +13823,15 @@
             "optional": true
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/browserslist": {
@@ -15622,15 +15595,6 @@
                 "url": "https://github.com/discordjs/discord.js?sponsor"
             }
         },
-        "node_modules/discord.js/node_modules/undici": {
-            "version": "6.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.17"
-            }
-        },
         "node_modules/dom-accessibility-api": {
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -15763,9 +15727,9 @@
             "license": "MIT"
         },
         "node_modules/effect": {
-            "version": "3.22.0",
-            "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
-            "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
+            "version": "3.22.1",
+            "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.1.tgz",
+            "integrity": "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ==",
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
@@ -16719,9 +16683,9 @@
             }
         },
         "node_modules/exsolve": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-            "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+            "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
             "license": "MIT"
         },
         "node_modules/ext-list": {
@@ -17614,9 +17578,9 @@
             }
         },
         "node_modules/giget": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
-            "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+            "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
             "license": "MIT",
             "bin": {
                 "giget": "dist/cli.mjs"
@@ -17672,19 +17636,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/glob/node_modules/minimatch": {
@@ -21610,19 +21561,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
         "node_modules/minimist": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -23156,15 +23094,15 @@
             }
         },
         "node_modules/prisma": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.0.tgz",
-            "integrity": "sha512-isQTJEK4pyOlAVzm6kBUDjzgdsgs0A/snpB38ycTHeOHW34qfepP+ClQltgDXqjZBnXALhEtE4duh9L3tN5fHw==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.1.tgz",
+            "integrity": "sha512-aPqePoZIqwlAchbgbFDO/wHqGB+7H1nj9gaM+OsL9h77S5S3TnLd9BgD3LnoeDikULo7cl2HSUrEyQ55Z7DYbg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/config": "7.9.0",
-                "@prisma/dev": "0.24.14",
-                "@prisma/engines": "7.9.0",
+                "@prisma/config": "7.9.1",
+                "@prisma/dev": "0.24.17",
+                "@prisma/engines": "7.9.1",
                 "@prisma/studio-core": "0.33.0",
                 "mysql2": "3.15.3",
                 "postgres": "3.4.7"
@@ -25710,9 +25648,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.19",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-            "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
@@ -25801,19 +25739,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/test-exclude/node_modules/glob": {
@@ -26794,9 +26719,9 @@
             }
         },
         "node_modules/valibot": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-            "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+            "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
             "license": "MIT",
             "peerDependencies": {
                 "typescript": ">=5"
@@ -28134,9 +28059,9 @@
             "license": "MIT"
         },
         "packages/shared/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -42,46 +42,6 @@ const TRANSITIVE = Symbol('transitive');
  * inherited by the acceptance.
  */
 const ACCEPTED = {
-    '@discordjs/node-pre-gyp': {
-        reason:
-            'No fixed version exists. Reached via @discordjs/opus, which is already at its ' +
-            'latest (0.10.0), and every published version (0.5.3 through 0.10.0) depends on ' +
-            "this package. npm's suggested remediation is @discordjs/opus@0.2.1, a downgrade " +
-            'to a 2021 release that swaps in unmaintained node-pre-gyp plus patch-package and ' +
-            "would break voice, the bot's core function.",
-        until: 'A @discordjs/opus release drops or replaces @discordjs/node-pre-gyp.',
-        advisories: TRANSITIVE,
-    },
-    // The four below are the same advisory as above, cascading down one chain:
-    // @discordjs/opus -> @discordjs/node-pre-gyp -> rimraf -> glob -> minimatch
-    // -> brace-expansion. They resolve together or not at all. Overrides do not
-    // help: forcing brace-expansion tree-wide was attempted three ways (range
-    // override, exact-version override, full lock regeneration) and npm keeps
-    // the old copies, because the intermediate minimatch versions request
-    // ^1.1.7 and ^2.0.2.
-    rimraf: {
-        reason: 'Transitive via @discordjs/node-pre-gyp.',
-        until: 'Same as @discordjs/node-pre-gyp.',
-        advisories: TRANSITIVE,
-    },
-    glob: {
-        reason: 'Transitive via rimraf.',
-        until: 'Same as @discordjs/node-pre-gyp.',
-        advisories: TRANSITIVE,
-    },
-    minimatch: {
-        reason: 'Transitive via glob.',
-        until: 'Same as @discordjs/node-pre-gyp.',
-        advisories: TRANSITIVE,
-    },
-    'brace-expansion': {
-        reason: 'Transitive via minimatch.',
-        until: 'Same as @discordjs/node-pre-gyp.',
-        advisories: {
-            1124334: 'GHSA-mh99-v99m-4gvg, DoS via unbounded expansion length',
-        },
-    },
-
     // TEMPORARY. Remove with the react-router v8 migration (#1878).
     'react-router': {
         reason:


### PR DESCRIPTION
## Why

Security gate fails on every PR (e.g. #1941): `scripts/audit-gate.mjs` exits 1 because its own anti-rot check found 4 ACCEPTED entries that are no longer reported (`@discordjs/node-pre-gyp`, `rimraf`, `glob`, `minimatch`) — and behind that, `brace-expansion` was blocking on a re-issued advisory id.

## What

- `npm audit fix` (non-breaking): `brace-expansion` 5.0.7 → 5.0.9 (GHSA-mh99-v99m-4gvg), `valibot` 1.2.0 → 1.4.2 (GHSA-5qjj-4xww-7phc); nested vulnerable brace-expansion copies deduped.
- Deleted the 5 stale ACCEPTED entries from `scripts/audit-gate.mjs` (the @discordjs/opus → node-pre-gyp chain is now only reported as moderate, below the gate's high/critical bar).
- `react-router`/`react-router-dom` stay accepted pending the v8 migration (#1878) — untouched.

## Verification

`node scripts/audit-gate.mjs` → exit 0: "No unaccepted high/critical findings in production dependencies." Production audit now reports only the accepted react-router pair as high.

Relates #1879 (dev toolchain advisories — partial; this clears the production-visible ones).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI security audit gate by removing stale ACCEPTED entries and applying non‑breaking `npm audit fix` updates. The gate now passes; only the accepted `react-router` pair remains high until the v8 migration.

- **Bug Fixes**
  - Removed 5 stale ACCEPTED entries in `scripts/audit-gate.mjs` for the `@discordjs/node-pre-gyp` → `rimraf` → `glob` → `minimatch` → `brace-expansion` chain (no longer high/critical in prod).
  - Gate exits 0; `react-router`/`react-router-dom` remain accepted pending v8 migration (#1878).

- **Dependencies**
  - `brace-expansion` 5.0.7 → 5.0.9 (GHSA-mh99-v99m-4gvg).
  - `valibot` 1.2.0 → 1.4.2 (GHSA-5qjj-4xww-7phc).

<sup>Written for commit 169ea64a367e8a5575eb4627b333e5ad99cd3ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed several accepted production-audit entries and their associated advisory rationale and version pinning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->