### PR TITLE
docs: autoplay re-measure — coverage gate passed, route to reliability + UX

### DIFF
--- a/decisions/2026-08-03-autoplay-remeasure-gate-passed.md
+++ b/decisions/2026-08-03-autoplay-remeasure-gate-passed.md
@@ -25,7 +25,7 @@ Post-window (07-23 → 08-03): coverage **83.4%**, acceptance **0.950** — hold
 
 **Autoplay recommendation quality is at the "good point." Per the 2026-07-01 ADR §4 routing: work shifts to reliability and UX.**
 
-1. **Coverage gate is met** — the Phase D prerequisite from 2026-06-24 (coverage >70%) now holds. Phase D (coherence/ML personalization) may be re-evaluated on its merits; its remaining prerequisite is the `channelId` + time-bucket schema work. Phase D is *eligible*, not *scheduled*.
+1. **Coverage prerequisite met; Phase D stays DEFERRED.** The 2026-06-24 revisit condition has two clauses: coverage >70% **AND** a re-measured per-source acceptance **below 85%**. Only the first fired — per-source acceptance is 0.926–0.970, comfortably above 85% on a now-real (non-blind) basis. Per the pre-committed gate, **Phase D (coherence/ML personalization) remains deferred**; the system does not need it. The `channelId` + time-bucket schema work is therefore not urgent either — it is only a prerequisite *for* Phase D.
 2. **No further scorer/signal tuning without new telemetry evidence.** The over-queueing diagnosis (#1589) is confirmed as the coverage root cause: coverage recovered from 22.5% to 75.6% after it deployed.
 3. **Skip-reason signal: treat as zero-adoption, not a bug.** The emoji-prefill → reaction pipeline functions (2 rows), but users do not click. Per the revisit trigger: **the skip-reason feedback UX needs a redesign, not a fix.** Any redesign is a new, separate decision.
 4. **Next autoplay work, in order:** (a) reliability — #1636 extractor swap evaluation; (b) UX items from `.claude/plans/2026-07-10-feature-mapping-research.md`; (c) #1095 mood clustering stays on hold pending its prod-access spike.
@@ -36,8 +36,41 @@ Post-window (07-23 → 08-03): coverage **83.4%**, acceptance **0.950** — hold
 **Negative:** none beyond the cost of having waited for the window.
 **Neutral:** ARTIST_FALLBACK stays as-is — 2 picks in 21 days does not justify work.
 
+## Reproduction
+
+Definitions (mirror `recommendationTelemetryReadService`):
+
+- **coverage** = (`isAccepted` OR `isRejected`) / total picks in window
+- **acceptance** = `isAccepted` / (`isAccepted` + `isRejected`) — pending excluded
+
+Exact query (run 2026-08-03 against homelab prod; window bounds `[start, end)` on `createdAt`, DB timestamps UTC):
+
+```sh
+ssh homelab 'docker exec -i lucky-postgres sh -c '"'"'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'"'"''
+```
+
+```sql
+-- coverage + acceptance, window [2026-07-01, 2026-07-23)
+SELECT count(*) AS picks,
+  count(*) FILTER (WHERE "isAccepted" OR "isRejected") AS resolved,
+  round(100.0*count(*) FILTER (WHERE "isAccepted" OR "isRejected")/nullif(count(*),0),1) AS coverage_pct,
+  round(count(*) FILTER (WHERE "isAccepted")::numeric/nullif(count(*) FILTER (WHERE "isAccepted" OR "isRejected"),0),3) AS acceptance_rate
+FROM "recommendations"
+WHERE "createdAt" >= '2026-07-01' AND "createdAt" < '2026-07-23';
+
+-- per-source acceptance, same window
+SELECT coalesce("source"::text,'(null)') AS source, count(*) picks,
+  count(*) FILTER (WHERE "isAccepted") acc, count(*) FILTER (WHERE "isRejected") rej,
+  round(count(*) FILTER (WHERE "isAccepted")::numeric/nullif(count(*) FILTER (WHERE "isAccepted" OR "isRejected"),0),3) AS acceptance
+FROM "recommendations"
+WHERE "createdAt" >= '2026-07-01' AND "createdAt" < '2026-07-23'
+GROUP BY 1 ORDER BY picks DESC;
+```
+
+For the rolling regression guard, swap the window for `"createdAt" >= now() - interval '14 days'` (same shape as `scripts/autoplay-telemetry.sql`).
+
 ## Revisit when
 
-- Coverage drops below 60% over any rolling 14 days (guard against silent regression — same query as this ADR).
-- Phase D re-evaluation is actually proposed → requires the `channelId` + time-bucket schema ADR first.
+- Coverage drops below 60% over any rolling 14 days (guard against silent regression — query in Reproduction above).
+- Per-source acceptance drops below 85% on a real basis → Phase D earns its place *for that source* (2026-06-24 gate); the `channelId` + time-bucket schema ADR comes first.
 - A skip-reason UX redesign is proposed → new decision record.

--- a/decisions/2026-08-03-autoplay-remeasure-gate-passed.md
+++ b/decisions/2026-08-03-autoplay-remeasure-gate-passed.md
@@ -1,0 +1,43 @@
+# ADR 2026-08-03 — Autoplay re-measure: coverage gate PASSED, route to reliability + UX; skip-reason needs UX redesign
+
+**Status:** Accepted
+**Deciders:** Lucas Santana
+**Closes the loop on:** `decisions/2026-07-01-autoplay-deploy-first-21d-measurement-window.md` (Decision §4 routing), `decisions/2026-06-24-autoplay-phase-c-baseline-defer-coherence-layer.md` (Phase D prerequisite: coverage >70%)
+**Related issues:** #1646 (skipReason near-zero adoption), #1636 (extractor swap, now the top reliability item), #1095 (mood clustering, still on hold)
+
+## Measurement (prod, run 2026-08-03 against homelab Postgres)
+
+21-day window 2026-07-01 → 2026-07-22 (per the 2026-07-01 ADR):
+
+| Metric | Result | Gate | Verdict |
+|---|---|---|---|
+| Outcome coverage | **75.6%** (121/160 resolved) | >70% | PASS |
+| Acceptance rate | **0.950** | ≥0.85 | PASS |
+| SPOTIFY_REC acceptance | 0.970 (82 picks) | — | not dead weight |
+| SEED_SIMILAR acceptance | 0.926 (76 picks) | — | seed-similar wins |
+| ARTIST_FALLBACK | 2 picks, 0 resolved | — | negligible volume |
+
+Post-window (07-23 → 08-03): coverage **83.4%**, acceptance **0.950** — holding and improving without further changes.
+
+`skipReason`: **2 rows lifetime** (was 0 on 2026-07-01). The pipeline works; adoption is effectively zero. This is the ADR's "#1646 = zero adoption" branch.
+
+## Decision
+
+**Autoplay recommendation quality is at the "good point." Per the 2026-07-01 ADR §4 routing: work shifts to reliability and UX.**
+
+1. **Coverage gate is met** — the Phase D prerequisite from 2026-06-24 (coverage >70%) now holds. Phase D (coherence/ML personalization) may be re-evaluated on its merits; its remaining prerequisite is the `channelId` + time-bucket schema work. Phase D is *eligible*, not *scheduled*.
+2. **No further scorer/signal tuning without new telemetry evidence.** The over-queueing diagnosis (#1589) is confirmed as the coverage root cause: coverage recovered from 22.5% to 75.6% after it deployed.
+3. **Skip-reason signal: treat as zero-adoption, not a bug.** The emoji-prefill → reaction pipeline functions (2 rows), but users do not click. Per the revisit trigger: **the skip-reason feedback UX needs a redesign, not a fix.** Any redesign is a new, separate decision.
+4. **Next autoplay work, in order:** (a) reliability — #1636 extractor swap evaluation; (b) UX items from `.claude/plans/2026-07-10-feature-mapping-research.md`; (c) #1095 mood clustering stays on hold pending its prod-access spike.
+
+## Consequences
+
+**Positive:** the measurement window delivered a conclusive read; the fix-loop is broken with evidence; two ADRs' routing branches are now resolved with data.
+**Negative:** none beyond the cost of having waited for the window.
+**Neutral:** ARTIST_FALLBACK stays as-is — 2 picks in 21 days does not justify work.
+
+## Revisit when
+
+- Coverage drops below 60% over any rolling 14 days (guard against silent regression — same query as this ADR).
+- Phase D re-evaluation is actually proposed → requires the `channelId` + time-bucket schema ADR first.
+- A skip-reason UX redesign is proposed → new decision record.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,7 @@ mindmap
 
 ## Decision gates by due date
 
-First three entries are overdue as of 2026-08-03. The autoplay gate (2026-07-22) was decided 2026-08-03: coverage gate passed — see `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
+Overdue as of 2026-08-03: CSP enforce (06-25), Guild Automation (07-06), Lavalink (08-01). The autoplay gate (07-22) was decided 2026-08-03: coverage gate passed — see `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
 
 ```mermaid
 timeline
@@ -149,7 +149,7 @@ Verified unshipped against the codebase on 2026-08-03.
 - **Role Groups v2** — exclusivity/pick-one groups, multi-message groups, bot slash command, select-menu UI, full IdempotencyKey state machine. Source: `.claude/plans/2026-06-23-role-groups-design.md`.
 - **Music UX polish** — U1–U6 (queue position in /nowplaying, vote-skip progress, /queue header, /history autoplay-reason, /songinfo audio features, seed feedback) + elapsed-time progress, `recommendationReason` threading, PlaybackControls loading states, SSE staleness indicator. (streamBridge fallback surfacing shipped in v2.39.0, #1920.) Source: `.claude/plans/music-feature-backlog.md`, `.claude/plans/2026-07-10-feature-mapping-research.md`.
 - **`/recommend` re-evaluation** — `MUSIC_RECOMMENDATIONS` toggle still OFF; its gate (Phase B outcome writes) has since shipped, so the enable decision is due. Source: `decisions/2026-05-21-autoplay-recommendation-roadmap.md`.
-- **Autoplay Phase D (ML personalization)** — coverage gate (>70%) now MET (75.6% window, 83.4% post-window; decided 2026-08-03). Eligible, not scheduled; remaining prerequisite: `channelId` + time-bucket columns on `recommendations` (schema ADR first). Source: `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
+- **Autoplay Phase D (ML personalization)** — still DEFERRED. Coverage prerequisite met (75.6% window), but the 2026-06-24 gate's acceptance trigger (per-source <85%) did NOT fire: 0.926–0.970. The system does not need it. Source: `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
 - **Skip-reason feedback UX redesign** — pipeline works but adoption is ~zero (2 rows lifetime). Needs redesign, not a fix; new separate decision. Source: `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
 - **Mood clustering #1095** — on hold pending read-only spike (needs prod access). Source: `decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md`.
 - **VC multi-user taste blend** — likely the surviving chunk of the stale taste-blend plan; needs re-triage. Source: `.claude/plans/autoplay-taste-blend.md` (2026-04-11, stale).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,6 @@ mindmap
     Overdue gates
       CSP enforce flip — due 2026-06-25
       Guild Automation complete-vs-descope — due 2026-07-06
-      Autoplay re-measure routing — due 2026-07-22
       Lavalink re-evaluation — due 2026-08-01
     Open issues — 25
       Features
@@ -76,14 +75,14 @@ mindmap
 
 ## Decision gates by due date
 
-First four entries are overdue as of 2026-08-03.
+First three entries are overdue as of 2026-08-03. The autoplay gate (2026-07-22) was decided 2026-08-03: coverage gate passed — see `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
 
 ```mermaid
 timeline
     title Decision gates by due date
     2026-06-25 : CSP Report-Only to enforce flip overdue : style-src unsafe-inline re-check overdue
     2026-07-06 : Guild Automation complete-vs-descope decision overdue : 3 of 7 executors migrated, frozen
-    2026-07-22 : Autoplay 21-day measurement window ended : Phase D routing re-measure overdue
+    2026-07-22 : Autoplay re-measure DECIDED 2026-08-03 : coverage 75.6 percent, gate passed
     2026-08-01 : Lavalink and youtube-source re-evaluation overdue : hard deadline from reliability ADR
     2026-09-11 : RAG re-read routing revisit
     2026-10 : Node 26 LTS expected : TS 7 toolchain gate follows
@@ -150,7 +149,8 @@ Verified unshipped against the codebase on 2026-08-03.
 - **Role Groups v2** — exclusivity/pick-one groups, multi-message groups, bot slash command, select-menu UI, full IdempotencyKey state machine. Source: `.claude/plans/2026-06-23-role-groups-design.md`.
 - **Music UX polish** — U1–U6 (queue position in /nowplaying, vote-skip progress, /queue header, /history autoplay-reason, /songinfo audio features, seed feedback) + elapsed-time progress, `recommendationReason` threading, PlaybackControls loading states, SSE staleness indicator. (streamBridge fallback surfacing shipped in v2.39.0, #1920.) Source: `.claude/plans/music-feature-backlog.md`, `.claude/plans/2026-07-10-feature-mapping-research.md`.
 - **`/recommend` re-evaluation** — `MUSIC_RECOMMENDATIONS` toggle still OFF; its gate (Phase B outcome writes) has since shipped, so the enable decision is due. Source: `decisions/2026-05-21-autoplay-recommendation-roadmap.md`.
-- **Autoplay Phase D (ML personalization)** — deferred by gate; prerequisites: outcome coverage >70%, `channelId` + time-bucket columns on `recommendations`. 21-day measurement window ended ~2026-07-22 — re-measure routing decision due. Source: `decisions/2026-06-24-autoplay-phase-c-baseline-defer-coherence-layer.md`, `decisions/2026-07-01-autoplay-deploy-first-21d-measurement-window.md`.
+- **Autoplay Phase D (ML personalization)** — coverage gate (>70%) now MET (75.6% window, 83.4% post-window; decided 2026-08-03). Eligible, not scheduled; remaining prerequisite: `channelId` + time-bucket columns on `recommendations` (schema ADR first). Source: `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
+- **Skip-reason feedback UX redesign** — pipeline works but adoption is ~zero (2 rows lifetime). Needs redesign, not a fix; new separate decision. Source: `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
 - **Mood clustering #1095** — on hold pending read-only spike (needs prod access). Source: `decisions/2026-06-14-autoplay-mood-clustering-1095-hold.md`.
 - **VC multi-user taste blend** — likely the surviving chunk of the stale taste-blend plan; needs re-triage. Source: `.claude/plans/autoplay-taste-blend.md` (2026-04-11, stale).
 - **Reaction-roles dashboard follow-ups** — delete Discord message on dashboard delete; edit existing reaction-role message. Source: `decisions/2026-06-22-reaction-roles-dashboard-create.md`.


### PR DESCRIPTION
## What

Runs the overdue re-measure from the 2026-07-01 ADR (window ended 2026-07-22) against prod and records the routing decision.

## Prod numbers (window 2026-07-01 → 2026-07-22)

| Metric | Result | Gate | Verdict |
|---|---|---|---|
| Outcome coverage | 75.6% (121/160) | >70% | PASS |
| Acceptance | 0.950 | ≥0.85 | PASS |
| SPOTIFY_REC | 0.970 (82 picks) | — | not dead weight |
| SEED_SIMILAR | 0.926 (76 picks) | — | wins |

Post-window (07-23→08-03): 83.4% coverage, 0.950 acceptance — holding. skipReason: 2 rows lifetime → zero-adoption branch.

## Decision (new ADR)

- Autoplay at the "good point" → work shifts to reliability (#1636) and UX per the ADR §4 routing
- #1589 confirmed as coverage root cause (22.5% → 75.6%)
- Phase D eligible (coverage prerequisite met), not scheduled — schema ADR first
- Skip-reason needs UX redesign, not a fix

Roadmap updated to match. Docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ADR documenting the autoplay 21‑day re‑measure: coverage gate passed (75.6% window, 83.4% post‑window) and acceptance 0.950; routes next work to reliability and UX, and treats skip‑reason as a redesign item. Clarifies that Phase D (ML personalization) stays DEFERRED (per‑source acceptance 0.926–0.970, trigger not fired), embeds coverage/acceptance definitions and the exact SQL, and updates `docs/roadmap.md` to mark the gate decided, list overdue gates explicitly, and add the skip‑reason UX redesign.

<sup>Written for commit e35f60e2fcb5a678a20a4b1bb3e6b0d3084b09bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

