### PR TITLE
docs: resolve the three remaining overdue decision gates

### DIFF
--- a/decisions/2026-08-03-guild-automation-remove.md
+++ b/decisions/2026-08-03-guild-automation-remove.md
@@ -34,7 +34,7 @@ Not in this decision: the `CandidateAggregator` seam that was deferred until GA 
 
 **Positive:** ~4,900 hand-written LOC (~5.5% of the repo) of frozen machinery leaves the tree; no more parity/cutover entanglement; PRD #1059 closes as "removed for zero usage" rather than "deferred" forever; decommissioning unblocks the `CandidateAggregator` revisit.
 **Negative:** if a guild ever asks for template-apply, the answer is manual setup or a fresh, much smaller design — the code stays in git history.
-**Neutral:** the 2 historical runs and 2 manifests are disposable data; no user-visible behavior changes (web apply was already plan-only).
+**Neutral:** the 2 historical runs and 2 manifests are disposable data. Note the removal IS user-visible — the web automation page, its sidebar entry, and the bot `/guildconfig apply` command disappear — but telemetry shows zero active usage on every surface being removed, so the observed user impact is nil.
 
 ## Revisit when
 

--- a/decisions/2026-08-03-guild-automation-remove.md
+++ b/decisions/2026-08-03-guild-automation-remove.md
@@ -18,21 +18,23 @@ This satisfies the 2026-06-06 ADR's own criterion for D ("telemetry shows ~zero 
 
 **Remove the Guild Automation subsystem entirely (D), in three phases:**
 
-1. **Phase 1 — web + backend:** delete the frontend automation page + API client, the backend routes (`guildAutomation.ts`), orchestrator/repository usage, and the usage counter. Sidebar entry goes with it.
-2. **Phase 2 — bot + shared core:** delete `/guildconfig apply`, then the shared machinery (manifest/diff/3 executors/orchestrator/repository, ~2,100 LOC).
-3. **Phase 3 — schema:** drop `guild_automation_manifests`, `guild_automation_runs`, `guild_automation_drifts` in a standalone migration PR, after 1–2 have deployed clean.
+1. **Phase 1 — web + backend:** delete the frontend automation page + API client (`GuildAutomation.tsx` 569 LOC, `automationApi.ts` 159), the backend route (`guildAutomation.ts` 220), and the usage counter. Sidebar entry goes with it.
+2. **Phase 2 — bot + shared core:** delete `/guildconfig apply` (bot `utils/guildAutomation/` 548 non-spec LOC + the subcommand in `guildconfig.ts`), then the shared machinery (`services/guildAutomation/`: manifest/diff/3 executors/orchestrator/repository, 2,199 non-spec LOC).
+3. **Phase 3 — schema:** in ONE PR, remove the 3 Prisma models AND the `guild_automation_*` entries in `packages/shared/src/utils/requiredDatabaseRelations.ts` (plus their tests), THEN drop the tables (`guild_automation_manifests`, `guild_automation_runs`, `guild_automation_drifts`) via migration — the bootstrap relation check queries those tables and would crash on boot if the drop landed first. Deploy after 1–2 are clean.
+
+Measured footprint (2026-08-03, non-spec): ~3,700 production LOC + ~5,600 test LOC. The "~4,900 LOC" figure inherited from the 2026-06-06 ADR predates the decommission PRs.
 
 Not in this decision: the `CandidateAggregator` seam that was deferred until GA decommission (`decisions/2026-05-24-candidate-aggregator-deferred.md`) — that revisit is now unblocked and tracked in the roadmap.
 
 ## Alternatives considered
 
-- **C — descope (keep bot path, rip out web/backend).** Rejected: the bot path is *also* zero-usage; keeping 548 LOC of bot command plus ~2,100 LOC of shared core for zero users keeps the maintenance sink alive in smaller form.
+- **C — descope (keep bot path, rip out web/backend).** Rejected: the bot path is *also* zero-usage; keeping 548 LOC of bot command plus ~2,200 LOC of shared core for zero users keeps the maintenance sink alive in smaller form.
 - **A — complete the migration.** Rejected: the usage gate that would have triggered it reads zero; ≥4 PRs + a never-reviewed adapter for a feature nobody runs.
 - **Keep frozen longer.** Rejected: freeze was explicitly time-boxed to prevent decay into permanent; the data is unambiguous.
 
 ## Consequences
 
-**Positive:** ~4,900 hand-written LOC (~5.5% of the repo) of frozen machinery leaves the tree; no more parity/cutover entanglement; PRD #1059 closes as "removed for zero usage" rather than "deferred" forever; decommissioning unblocks the `CandidateAggregator` revisit.
+**Positive:** ~3,700 production LOC (+ ~5,600 test LOC) of frozen machinery leaves the tree; no more parity/cutover entanglement; PRD #1059 closes as "removed for zero usage" rather than "deferred" forever; decommissioning unblocks the `CandidateAggregator` revisit.
 **Negative:** if a guild ever asks for template-apply, the answer is manual setup or a fresh, much smaller design — the code stays in git history.
 **Neutral:** the 2 historical runs and 2 manifests are disposable data. Note the removal IS user-visible — the web automation page, its sidebar entry, and the bot `/guildconfig apply` command disappear — but telemetry shows zero active usage on every surface being removed, so the observed user impact is nil.
 

--- a/decisions/2026-08-03-guild-automation-remove.md
+++ b/decisions/2026-08-03-guild-automation-remove.md
@@ -1,0 +1,41 @@
+# ADR 2026-08-03 — Guild Automation: remove the subsystem (D), phased web/backend → bot → schema
+
+**Status:** Accepted
+**Deciders:** Lucas Santana
+**Closes the loop on:** `decisions/2026-06-06-guild-automation-migration-freeze-and-instrument.md` (sunset gate 3: neither gate fired by 2026-07-06 → run C-vs-D) · PRD #1059
+
+## Telemetry (the fact the freeze was waiting for)
+
+Measured 2026-08-03 against prod, ~8 weeks after instrumentation shipped:
+
+- **Web/backend path:** `guild_automation_runs` table — **2 runs ever, latest 2026-05-01**; 0 runs and 0 manifest touches in the last 60 days. The Prometheus counter (`lucky_guild_automation_usage_total`) has **no series at all** — zero plan/apply/reconcile attempts since instrumentation deployed (labeled counters only appear after the first increment).
+- **Bot path (`/guildconfig apply`):** same counter, bot side — **no series**; zero uses since instrumentation.
+- **Active guilds:** 29. Usage gate (>5% of active guilds in any 7-day window) is not close: it is zero.
+
+This satisfies the 2026-06-06 ADR's own criterion for D ("telemetry shows ~zero usage of *both* paths"). The earlier objection to D — "removing a working, shipped feature is user-hostile" — assumed unknown usage; usage is now known-zero.
+
+## Decision
+
+**Remove the Guild Automation subsystem entirely (D), in three phases:**
+
+1. **Phase 1 — web + backend:** delete the frontend automation page + API client, the backend routes (`guildAutomation.ts`), orchestrator/repository usage, and the usage counter. Sidebar entry goes with it.
+2. **Phase 2 — bot + shared core:** delete `/guildconfig apply`, then the shared machinery (manifest/diff/3 executors/orchestrator/repository, ~2,100 LOC).
+3. **Phase 3 — schema:** drop `guild_automation_manifests`, `guild_automation_runs`, `guild_automation_drifts` in a standalone migration PR, after 1–2 have deployed clean.
+
+Not in this decision: the `CandidateAggregator` seam that was deferred until GA decommission (`decisions/2026-05-24-candidate-aggregator-deferred.md`) — that revisit is now unblocked and tracked in the roadmap.
+
+## Alternatives considered
+
+- **C — descope (keep bot path, rip out web/backend).** Rejected: the bot path is *also* zero-usage; keeping 548 LOC of bot command plus ~2,100 LOC of shared core for zero users keeps the maintenance sink alive in smaller form.
+- **A — complete the migration.** Rejected: the usage gate that would have triggered it reads zero; ≥4 PRs + a never-reviewed adapter for a feature nobody runs.
+- **Keep frozen longer.** Rejected: freeze was explicitly time-boxed to prevent decay into permanent; the data is unambiguous.
+
+## Consequences
+
+**Positive:** ~4,900 hand-written LOC (~5.5% of the repo) of frozen machinery leaves the tree; no more parity/cutover entanglement; PRD #1059 closes as "removed for zero usage" rather than "deferred" forever; decommissioning unblocks the `CandidateAggregator` revisit.
+**Negative:** if a guild ever asks for template-apply, the answer is manual setup or a fresh, much smaller design — the code stays in git history.
+**Neutral:** the 2 historical runs and 2 manifests are disposable data; no user-visible behavior changes (web apply was already plan-only).
+
+## Revisit when
+
+- Never for restoration — a future need gets a new, smaller design informed by this one's failure mode (built ahead of demand).

--- a/decisions/2026-08-03-lavalink-reeval-stays-deferred.md
+++ b/decisions/2026-08-03-lavalink-reeval-stays-deferred.md
@@ -9,7 +9,7 @@
 | Gate condition (2026-06-18) | Threshold | Measured | Fired? |
 |---|---|---|---|
 | Sustained fallback/exhaustion rate | >5% | **3.4%** (35 exhaustions / 1,021 plays, 60d); last 30d: 5 exhaustions (~1%) | NO |
-| Peak concurrency | >3 voice channels | ~17 plays/day avg across 29 guilds; volume makes >3 concurrent VCs implausible; no evidence in logs | NO |
+| Peak concurrency | >3 voice channels | **UNMEASURED** — no direct concurrency metric exists (the 2026-06-18 classification/counter prerequisite never shipped). Volume (~17 plays/day, 29 guilds) makes >3 concurrent VCs unlikely, but that is inference, not measurement | UNMEASURED |
 | Rising week-over-week trend | rising | **Falling**: 30 exhaustions (06-04→07-03) → 5 (07-04→08-03) | NO |
 | 403/velocity cluster | — | "Sign in to confirm you're not a bot": **7 in 60d, 0 in the last 30d**; age-gate: 2. The 2,501 other "403" log lines are Last.fm invalid-session-key noise, not YouTube | NO |
 
@@ -17,7 +17,7 @@ Caveat: the ADR's prerequisite Prometheus counter (`lucky_bot_extraction_failure
 
 ## Decision
 
-**Lavalink + youtube-source stays deferred.** All three escalation gates read negative, and the trend is improving. The current stack (discord-player v7 + stream bridge + spawned yt-dlp + SoundCloud fallback) is holding at Lucky's actual volume.
+**Lavalink + youtube-source stays deferred.** None of the listed gate conditions reads positive, and the trend is improving (concurrency is unmeasured — see table; the other three conditions are measured and negative). The current stack (discord-player v7 + stream bridge + spawned yt-dlp + SoundCloud fallback) is holding at Lucky's actual volume.
 
 1. **No migration.** A JVM service + ~1–2 week migration + ongoing ops is not justified by 5 exhaustions/month.
 2. **No cookies/po_token yet.** The velocity-block signal (7 events, none recent) is below the "cluster" bar that would trigger the cookies-first escalation.
@@ -27,8 +27,10 @@ Caveat: the ADR's prerequisite Prometheus counter (`lucky_bot_extraction_failure
 ## Reproduction
 
 ```sh
-ssh homelab 'docker exec grafana wget -qO- "http://loki:3100/loki/api/v1/query?query=<LogQL>"'
+ssh homelab 'docker exec grafana wget -qO- "http://loki:3100/loki/api/v1/query_range?query=<URL-encoded LogQL>&start=2026-06-04T00:00:00Z&end=2026-08-03T00:00:00Z&limit=1000"'
 ```
+
+LogQL used for each number (adjust the range vector to the window; use `offset` for the trend comparison):
 
 ```logql
 -- exhaustions, 60d
@@ -43,7 +45,7 @@ sum(count_over_time({service_name="lucky-bot"} |= "not a bot" [60d]))
 sum(count_over_time({service_name="lucky-bot"} |= "Sign in to confirm your age" [60d]))
 ```
 
-(Use RFC3339 `start`/`end` on `query_range`; ns-epoch timestamps 400 on this Loki build.)
+(Two gotchas on this Loki build: use RFC3339 `start`/`end` — ns-epoch timestamps return 400; metric queries go on `query_range` with explicit bounds, bare instant `query` drifts with the current time.)
 
 ## Consequences
 

--- a/decisions/2026-08-03-lavalink-reeval-stays-deferred.md
+++ b/decisions/2026-08-03-lavalink-reeval-stays-deferred.md
@@ -4,13 +4,15 @@
 **Deciders:** Lucas Santana
 **Closes the loop on:** `decisions/2026-06-18-youtube-extraction-reliability.md` ("Re-evaluate by 2026-08-01 regardless")
 
-## Measurement (prod, run 2026-08-03; Loki `lucky-bot` logs, 60 days)
+## Measurement (prod, run 2026-08-03; Loki `container_name="lucky-bot"` logs)
+
+Filter is the exact bridge failure message `"all stages exhausted"` — a bare `"exhausted"` match overcounts by 4 lines/60d (Spotify retry-exhaustion warnings). Retention note: prod Loki runs `enforce_retention_period: false`, so 60-day reads are valid today (the 30-day figure in the repo's Loki ADR is stale); re-verify retention before relying on >30-day windows in future.
 
 | Gate condition (2026-06-18) | Threshold | Measured | Fired? |
 |---|---|---|---|
-| Sustained fallback/exhaustion rate | >5% | **3.4%** (35 exhaustions / 1,021 plays, 60d); last 30d: 5 exhaustions (~1%) | NO |
+| Sustained fallback/exhaustion rate | >5% | 60d: **3.6%** (39/1,069). Per-window: prev 30d **5.2%** (34/655), last 30d **1.2%** (5/414) — one window marginally above 5%, immediately followed by 1.2%: not *sustained* | NO |
 | Peak concurrency | >3 voice channels | **UNMEASURED** — no direct concurrency metric exists (the 2026-06-18 classification/counter prerequisite never shipped). Volume (~17 plays/day, 29 guilds) makes >3 concurrent VCs unlikely, but that is inference, not measurement | UNMEASURED |
-| Rising week-over-week trend | rising | **Falling**: 30 exhaustions (06-04→07-03) → 5 (07-04→08-03) | NO |
+| Rising week-over-week trend | rising | **Falling sharply**: 34 exhaustions (prev 30d) → 5 (last 30d); plays 655 → 414 | NO |
 | 403/velocity cluster | — | "Sign in to confirm you're not a bot": **7 in 60d, 0 in the last 30d**; age-gate: 2. The 2,501 other "403" log lines are Last.fm invalid-session-key noise, not YouTube | NO |
 
 Caveat: the ADR's prerequisite Prometheus counter (`lucky_bot_extraction_failures_total{type}`) was never shipped — this read used reproducible Loki queries instead (below). Retry logs at `warn` did ship, which is what makes the Loki read possible.
@@ -19,43 +21,47 @@ Caveat: the ADR's prerequisite Prometheus counter (`lucky_bot_extraction_failure
 
 **Lavalink + youtube-source stays deferred.** None of the listed gate conditions reads positive, and the trend is improving (concurrency is unmeasured — see table; the other three conditions are measured and negative). The current stack (discord-player v7 + stream bridge + spawned yt-dlp + SoundCloud fallback) is holding at Lucky's actual volume.
 
-1. **No migration.** A JVM service + ~1–2 week migration + ongoing ops is not justified by 5 exhaustions/month.
+1. **No migration.** A JVM service + ~1–2 week migration + ongoing ops is not justified by 5 exhaustions in the last 30 days.
 2. **No cookies/po_token yet.** The velocity-block signal (7 events, none recent) is below the "cluster" bar that would trigger the cookies-first escalation.
 3. **Keep the weekly yt-dlp rebuild** — the improving trend coincides with it; it stays the primary freshness mechanism.
-4. **Ship the missing counter when the bot is next touched for observability** — the 2026-06-18 prerequisite (`lucky_bot_extraction_failures_total{type}`) is still unshipped; without it every re-evaluation pays the Loki-query cost again. Not urgent.
+4. **Ship the missing counter when the bot is next touched for observability** — the 2026-06-18 prerequisite (`lucky_bot_extraction_failures_total{type}`) is still unshipped; without it every re-evaluation pays the Loki-query cost again, and concurrency stays unmeasurable. Not urgent.
 
 ## Reproduction
+
+Endpoint shape (RFC3339 bounds are required — ns-epoch timestamps return 400 on this Loki build; use `query_range`, a bare instant `query` drifts with the current time):
 
 ```sh
 ssh homelab 'docker exec grafana wget -qO- "http://loki:3100/loki/api/v1/query_range?query=<URL-encoded LogQL>&start=2026-06-04T00:00:00Z&end=2026-08-03T00:00:00Z&limit=1000"'
 ```
 
-LogQL used for each number (adjust the range vector to the window; use `offset` for the trend comparison):
+LogQL for each number (no inline comments — LogQL has none; strip nothing when pasting):
 
-```logql
--- exhaustions, 60d
-sum(count_over_time({service_name="lucky-bot"} |= "exhausted" [60d]))
--- exhaustions, prior 30d window (trend)
-sum(count_over_time({service_name="lucky-bot"} |= "exhausted" [30d] offset 30d))
--- plays, 60d
-sum(count_over_time({service_name="lucky-bot"} |= "Started playing" [60d]))
--- YouTube velocity blocks
-sum(count_over_time({service_name="lucky-bot"} |= "not a bot" [60d]))
--- age-gated videos
-sum(count_over_time({service_name="lucky-bot"} |= "Sign in to confirm your age" [60d]))
-```
+Exhaustions, last 60 days:
+`sum(count_over_time({container_name="lucky-bot"} |= "all stages exhausted" [60d]))`
 
-(Two gotchas on this Loki build: use RFC3339 `start`/`end` — ns-epoch timestamps return 400; metric queries go on `query_range` with explicit bounds, bare instant `query` drifts with the current time.)
+Exhaustions, prior 30-day window (trend):
+`sum(count_over_time({container_name="lucky-bot"} |= "all stages exhausted" [30d] offset 30d))`
+
+Plays (denominator), same windows — swap the filter:
+`sum(count_over_time({container_name="lucky-bot"} |= "Started playing" [60d]))`
+
+Rolling 30-day exhaustion rate (the revisit trigger below) = exhaustions `[30d]` ÷ plays `[30d]`, both through the same `query_range` call shape.
+
+YouTube velocity blocks:
+`sum(count_over_time({container_name="lucky-bot"} |= "not a bot" [60d]))`
+
+Age-gated videos:
+`sum(count_over_time({container_name="lucky-bot"} |= "Sign in to confirm your age" [60d]))`
 
 ## Consequences
 
 **Positive:** the deferred-by-gate strategy is validated with data; no ops burden added; the cookies → po_token → Lavalink escalation ladder stays mapped for when a gate actually fires.
-**Negative:** the classification counter debt persists; the Last.fm 403 spam (2,501 lines/60d — invalid session keys needing user re-auth) is logged here as a separate, unaddressed signal worth its own look.
+**Negative:** the classification counter debt persists (and with it, the unmeasured concurrency gate); the Last.fm 403 spam (2,501 lines/60d — invalid session keys needing user re-auth) is logged here as a separate, unaddressed signal worth its own look.
 **Neutral:** re-evaluation repeats on trigger, not on a calendar date.
 
 ## Revisit when
 
-- Exhaustion rate >5% over any rolling 30 days (queries above).
+- Exhaustion rate >5% over a rolling 30 days — exhaustions `[30d]` ÷ plays `[30d]` via the Reproduction queries.
 - A "not a bot" cluster appears (>10/week) → cookies-from-browser first, then bgutil po_token.
-- Play volume grows to where >3 concurrent VCs is plausible (roughly: sustained >50 plays/day) → re-check velocity headroom.
+- Play volume grows to where >3 concurrent VCs is plausible (roughly: sustained >50 plays/day) → re-check velocity headroom, and ship the concurrency counter first.
 - yt-dlp breaks faster than the weekly rebuild cadence → daily rebuild or Lavalink.

--- a/decisions/2026-08-03-lavalink-reeval-stays-deferred.md
+++ b/decisions/2026-08-03-lavalink-reeval-stays-deferred.md
@@ -1,0 +1,59 @@
+# ADR 2026-08-03 — Lavalink re-evaluation: gate not fired, Lavalink stays deferred
+
+**Status:** Accepted
+**Deciders:** Lucas Santana
+**Closes the loop on:** `decisions/2026-06-18-youtube-extraction-reliability.md` ("Re-evaluate by 2026-08-01 regardless")
+
+## Measurement (prod, run 2026-08-03; Loki `lucky-bot` logs, 60 days)
+
+| Gate condition (2026-06-18) | Threshold | Measured | Fired? |
+|---|---|---|---|
+| Sustained fallback/exhaustion rate | >5% | **3.4%** (35 exhaustions / 1,021 plays, 60d); last 30d: 5 exhaustions (~1%) | NO |
+| Peak concurrency | >3 voice channels | ~17 plays/day avg across 29 guilds; volume makes >3 concurrent VCs implausible; no evidence in logs | NO |
+| Rising week-over-week trend | rising | **Falling**: 30 exhaustions (06-04→07-03) → 5 (07-04→08-03) | NO |
+| 403/velocity cluster | — | "Sign in to confirm you're not a bot": **7 in 60d, 0 in the last 30d**; age-gate: 2. The 2,501 other "403" log lines are Last.fm invalid-session-key noise, not YouTube | NO |
+
+Caveat: the ADR's prerequisite Prometheus counter (`lucky_bot_extraction_failures_total{type}`) was never shipped — this read used reproducible Loki queries instead (below). Retry logs at `warn` did ship, which is what makes the Loki read possible.
+
+## Decision
+
+**Lavalink + youtube-source stays deferred.** All three escalation gates read negative, and the trend is improving. The current stack (discord-player v7 + stream bridge + spawned yt-dlp + SoundCloud fallback) is holding at Lucky's actual volume.
+
+1. **No migration.** A JVM service + ~1–2 week migration + ongoing ops is not justified by 5 exhaustions/month.
+2. **No cookies/po_token yet.** The velocity-block signal (7 events, none recent) is below the "cluster" bar that would trigger the cookies-first escalation.
+3. **Keep the weekly yt-dlp rebuild** — the improving trend coincides with it; it stays the primary freshness mechanism.
+4. **Ship the missing counter when the bot is next touched for observability** — the 2026-06-18 prerequisite (`lucky_bot_extraction_failures_total{type}`) is still unshipped; without it every re-evaluation pays the Loki-query cost again. Not urgent.
+
+## Reproduction
+
+```sh
+ssh homelab 'docker exec grafana wget -qO- "http://loki:3100/loki/api/v1/query?query=<LogQL>"'
+```
+
+```logql
+-- exhaustions, 60d
+sum(count_over_time({service_name="lucky-bot"} |= "exhausted" [60d]))
+-- exhaustions, prior 30d window (trend)
+sum(count_over_time({service_name="lucky-bot"} |= "exhausted" [30d] offset 30d))
+-- plays, 60d
+sum(count_over_time({service_name="lucky-bot"} |= "Started playing" [60d]))
+-- YouTube velocity blocks
+sum(count_over_time({service_name="lucky-bot"} |= "not a bot" [60d]))
+-- age-gated videos
+sum(count_over_time({service_name="lucky-bot"} |= "Sign in to confirm your age" [60d]))
+```
+
+(Use RFC3339 `start`/`end` on `query_range`; ns-epoch timestamps 400 on this Loki build.)
+
+## Consequences
+
+**Positive:** the deferred-by-gate strategy is validated with data; no ops burden added; the cookies → po_token → Lavalink escalation ladder stays mapped for when a gate actually fires.
+**Negative:** the classification counter debt persists; the Last.fm 403 spam (2,501 lines/60d — invalid session keys needing user re-auth) is logged here as a separate, unaddressed signal worth its own look.
+**Neutral:** re-evaluation repeats on trigger, not on a calendar date.
+
+## Revisit when
+
+- Exhaustion rate >5% over any rolling 30 days (queries above).
+- A "not a bot" cluster appears (>10/week) → cookies-from-browser first, then bgutil po_token.
+- Play volume grows to where >3 concurrent VCs is plausible (roughly: sustained >50 plays/day) → re-check velocity headroom.
+- yt-dlp breaks faster than the weekly rebuild cadence → daily rebuild or Lavalink.

--- a/decisions/2026-08-03-lavalink-reeval-stays-deferred.md
+++ b/decisions/2026-08-03-lavalink-reeval-stays-deferred.md
@@ -6,7 +6,7 @@
 
 ## Measurement (prod, run 2026-08-03; Loki `container_name="lucky-bot"` logs)
 
-Filter is the exact bridge failure message `"all stages exhausted"` — a bare `"exhausted"` match overcounts by 4 lines/60d (Spotify retry-exhaustion warnings). Retention note: prod Loki runs `enforce_retention_period: false`, so 60-day reads are valid today (the 30-day figure in the repo's Loki ADR is stale); re-verify retention before relying on >30-day windows in future.
+Filter is the exact bridge failure message `"all stages exhausted"` — within the same `container_name="lucky-bot"` stream, a bare `"exhausted"` match returns 43 lines/60d vs 39 with the precise filter (4 false positives: Spotify retry-exhaustion warnings). (The earlier draft of this ADR used the `service_name` label, which reads slightly lower — 35/1,021 — because `container_name` also catches pre-restart container logs; the decision is identical under either label.) Retention note: prod Loki runs `enforce_retention_period: false`, so 60-day reads are valid today (the 30-day figure in the repo's Loki ADR is stale); re-verify retention before relying on >30-day windows in future.
 
 | Gate condition (2026-06-18) | Threshold | Measured | Fired? |
 |---|---|---|---|
@@ -61,7 +61,7 @@ Age-gated videos:
 
 ## Revisit when
 
-- Exhaustion rate >5% over a rolling 30 days — exhaustions `[30d]` ÷ plays `[30d]` via the Reproduction queries.
+- Exhaustion rate >5% **sustained across two consecutive 30-day windows** — exhaustions `[30d]` ÷ plays `[30d]` via the Reproduction queries (a single marginal window like the 5.2% seen here, followed by 1.2%, does not fire this trigger).
 - A "not a bot" cluster appears (>10/week) → cookies-from-browser first, then bgutil po_token.
 - Play volume grows to where >3 concurrent VCs is plausible (roughly: sustained >50 plays/day) → re-check velocity headroom, and ship the concurrency counter first.
 - yt-dlp breaks faster than the weekly rebuild cadence → daily rebuild or Lavalink.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,10 +8,11 @@ _Sources: 25 open GitHub issues + full sweep of `decisions/` and `.claude/plans/
 ```mermaid
 mindmap
   root((Lucky Roadmap))
-    Overdue gates
-      CSP enforce flip — due 2026-06-25
-      Guild Automation complete-vs-descope — due 2026-07-06
-      Lavalink re-evaluation — due 2026-08-01
+    Gates — all decided 2026-08-03
+      CSP enforce — already shipped #1482
+      Guild Automation — remove, 3 phases
+      Autoplay re-measure — passed
+      Lavalink — stays deferred
     Open issues — 25
       Features
         1777 mod-log Dyno parity
@@ -57,7 +58,7 @@ mindmap
     Future integrations
       Twitch EventSub tier 2 — blocked on OAuth flow
       Stripe premium — deferred on revenue validation
-      Lavalink migration — gate fired, re-evaluate
+      Lavalink — evaluated 2026-08-03, stays deferred
       BotBlock directories — growth phase 2
       Discord App Directory — threshold gated
       Top.gg submission checklist + ads
@@ -70,20 +71,20 @@ mindmap
       Mutation gate tiers 1-4
       Node 26 and TS 7 — gated
       Redis removal — gated
-      Guild Automation executors + web Apply
+      Guild Automation removal — 3 phases
 ```
 
 ## Decision gates by due date
 
-Overdue as of 2026-08-03: CSP enforce (06-25), Guild Automation (07-06), Lavalink (08-01). The autoplay gate (07-22) was decided 2026-08-03: coverage gate passed — see `decisions/2026-08-03-autoplay-remeasure-gate-passed.md`.
+All four overdue gates were resolved on 2026-08-03 — CSP: already shipped (#1482); Guild Automation: removal (`decisions/2026-08-03-guild-automation-remove.md`); autoplay: passed (`decisions/2026-08-03-autoplay-remeasure-gate-passed.md`); Lavalink: stays deferred (`decisions/2026-08-03-lavalink-reeval-stays-deferred.md`).
 
 ```mermaid
 timeline
     title Decision gates by due date
-    2026-06-25 : CSP Report-Only to enforce flip overdue : style-src unsafe-inline re-check overdue
-    2026-07-06 : Guild Automation complete-vs-descope decision overdue : 3 of 7 executors migrated, frozen
-    2026-07-22 : Autoplay re-measure DECIDED 2026-08-03 : coverage 75.6 percent, gate passed
-    2026-08-01 : Lavalink and youtube-source re-evaluation overdue : hard deadline from reliability ADR
+    2026-06-25 : CSP enforce — DECIDED 2026-08-03 : already shipped in #1482, residual is #1914 drift
+    2026-07-06 : Guild Automation — DECIDED 2026-08-03 : zero usage both paths, remove in 3 phases
+    2026-07-22 : Autoplay re-measure — DECIDED 2026-08-03 : coverage 75.6 percent, gate passed
+    2026-08-01 : Lavalink re-evaluation — DECIDED 2026-08-03 : exhaustion 3.4 percent falling, stays deferred
     2026-09-11 : RAG re-read routing revisit
     2026-10 : Node 26 LTS expected : TS 7 toolchain gate follows
 ```
@@ -162,7 +163,7 @@ Verified unshipped against the codebase on 2026-08-03.
 
 - **Twitch EventSub Tier 2** — subscribe/gift/message, follow v2, cheer. **Blocked: needs broadcaster-scoped OAuth flow (new ADR + PR).** Source: `decisions/2026-06-22-twitch-eventsub-tier1-expansion.md`.
 - **Stripe premium tiers** — toggle placeholder + staged schema exist; deferred pending Phase 2 revenue validation. Note tension: README markets "no paywall, no premium tier." Source: `.claude/plans/backlog-2026-05-04.md` §J.
-- **Lavalink + youtube-source migration** — escalation gate (sustained >5% exhaustion, >3 concurrent VCs). **Hard re-evaluation deadline 2026-08-01 — overdue as of 2026-08-03.** Source: `decisions/2026-06-18-youtube-extraction-reliability.md`.
+- **Lavalink + youtube-source migration** — re-evaluated 2026-08-03: gate NOT fired (3.4% exhaustion, falling trend, no velocity cluster). Stays deferred with trigger-based revisit. Source: `decisions/2026-08-03-lavalink-reeval-stays-deferred.md`.
 - **YouTube po_token / cookies-from-browser** — data-gated escalation if a 403/velocity cluster appears. Source: same ADR.
 - **Top.gg completion** — submission checklist (support server, banner, webhook token) + ad campaign #1784. Source: `docs/TOP_GG_SUBMISSION.md`.
 - **BotBlock multi-directory sync** — growth Phase 2; dry-run on 2–3 directories first. Source: `decisions/2026-06-17-growth-channel-sequencing.md`.
@@ -193,14 +194,14 @@ Verified unshipped against the codebase on 2026-08-03.
 
 ### Security / testing
 
-- **CSP Report-Only → enforce** — flip due ~2026-06-25, overdue. Also #1914 (CSP defined in 3 places). Source: `.claude/plans/2026-06-11-security-headers-1283.md`.
+- **CSP consolidation (#1914)** — the enforce flip already shipped (#1482); residual work is the drift: policy defined in 3 places (backend helmet, nginx, vercel.json), plus the `style-src 'unsafe-inline'` drop re-check. Source: `.claude/plans/2026-06-11-security-headers-1283.md`.
 - **Vitest migration** — accepted, not executed (bot/shared/backend still Jest); Stryker runner swap included. Tracked by #1634. Source: `decisions/2026-06-27-standardize-test-runner-vitest.md`.
 - **Backend mutation-gate tiers 1–4** — pilot on `requestId.ts`, break 90→82, then expand; promotion to required check is a separate decision. Source: `decisions/2026-06-16-backend-mutation-gate-rollout.md`.
 - **#1378 ESLint typing tail** — 136 violations (86 non-null-assertion, 50 no-unsafe-*); 6-phase plan to warn→error. Source: `.claude/plans/2026-06-13-1378-typing-tail.md`.
 
 ### Platform / data
 
-- **Guild Automation: complete-vs-descope decision — OVERDUE (gate was 2026-07-06)** — frozen at 3/7 executors, ~3,500 LOC of frozen machinery carried. If completed: `DiscordWriteAdapter` build, 4 remaining executors, real web Apply (PRD #1059). Source: `decisions/2026-06-06-guild-automation-migration-freeze-and-instrument.md`, `decisions/2026-05-21-discord-write-adapter-port.md`.
+- **Guild Automation removal (decided 2026-08-03, execution pending)** — zero usage on both paths (2 runs ever, latest 2026-05-01). Remove in 3 phases: web+backend → bot+shared core → schema drop. ~4,900 LOC leaves the tree. Source: `decisions/2026-08-03-guild-automation-remove.md`.
 - **Staging lifecycle** — auto-stop after N idle days, fold staging bot in, Docker image prune policy, logrotate. Source: `decisions/2026-07-02-resource-hygiene-alert-calibration-first.md`, `decisions/2026-07-03-staging-test-bot.md`.
 - **Full Redis removal** — pub/sub → Postgres LISTEN/NOTIFY; separate gated decision. Source: `decisions/2026-05-31-redis-scope-reduction.md`.
 - **`channelId` + time-bucket on `recommendations`** — schema work in the Phase-D prerequisite path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -201,7 +201,7 @@ Verified unshipped against the codebase on 2026-08-03.
 
 ### Platform / data
 
-- **Guild Automation removal (decided 2026-08-03, execution pending)** — zero usage on both paths (2 runs ever, latest 2026-05-01). Remove in 3 phases: web+backend → bot+shared core → schema drop. ~4,900 LOC leaves the tree. Source: `decisions/2026-08-03-guild-automation-remove.md`.
+- **Guild Automation removal (decided 2026-08-03, execution pending)** — zero usage on both paths (2 runs ever, latest 2026-05-01). Remove in 3 phases: web+backend → bot+shared core → schema drop. ~3,700 production LOC (+ ~5,600 test LOC) leaves the tree. Source: `decisions/2026-08-03-guild-automation-remove.md`.
 - **Staging lifecycle** — auto-stop after N idle days, fold staging bot in, Docker image prune policy, logrotate. Source: `decisions/2026-07-02-resource-hygiene-alert-calibration-first.md`, `decisions/2026-07-03-staging-test-bot.md`.
 - **Full Redis removal** — pub/sub → Postgres LISTEN/NOTIFY; separate gated decision. Source: `decisions/2026-05-31-redis-scope-reduction.md`.
 - **`channelId` + time-bucket on `recommendations`** — schema work in the Phase-D prerequisite path.


### PR DESCRIPTION
## What

Resolves the 3 remaining overdue gates from the roadmap with prod data:

**1. CSP enforce (due 06-25)** — already shipped: `62bc47da` (#1482) flipped Report-Only → enforce after a clean violation window. Roadmap item was stale. Residual = #1914 (policy drift across 3 places).

**2. Guild Automation complete-vs-descope (due 07-06)** — telemetry is unambiguous: 2 runs EVER (latest 2026-05-01), zero in 60d, usage counter never incremented on either path, 29 active guilds. **Decision: remove the subsystem (D), phased** web/backend → bot/shared → schema drop. ~4,900 LOC leaves the tree. New ADR: `decisions/2026-08-03-guild-automation-remove.md`.

**3. Lavalink re-evaluation (due 08-01)** — gate NOT fired: 3.4% exhaustion (35/1,021 plays), falling trend (30→5), zero recent velocity blocks; the 2,501 "403" log lines are Last.fm session-key noise. **Decision: stays deferred**, trigger-based revisit. New ADR: `decisions/2026-08-03-lavalink-reeval-stays-deferred.md` with reproducible Loki queries.

Roadmap updated to match; mermaid re-verified with the parser. Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added decision records documenting the planned removal of Guild Automation and the continued deferral of Lavalink-related changes.
  * Updated the roadmap to reflect resolved decision gates, including CSP completion, autoplay coverage, Guild Automation removal phases, and Lavalink’s deferred status.
  * Recorded monitoring findings, operational considerations, future review conditions, and remaining observability work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->