### PR TITLE
fix(bot): music voice reconnect races — stale-song revert + stacked join/leave

### DIFF
--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -86,6 +86,36 @@ describe('setupLifecycleHandlers', () => {
         expect(watchdogArmMock).toHaveBeenCalledWith(queue)
     })
 
+    it('does NOT restore snapshot on connection when the guild is an intentional stop (post-kick /play)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-1', name: 'Guild 1' },
+            metadata: { requestedBy: { id: 'user-1' } },
+            connection: {
+                state: { status: 'ready' },
+                joinConfig: {},
+            },
+        } as unknown as GuildQueue
+
+        await handlers.connection(queue)
+
+        // #1948: a stale pre-kick snapshot must not override the fresh /play.
+        expect(restoreSnapshotMock).not.toHaveBeenCalled()
+        expect(watchdogArmMock).toHaveBeenCalledWith(queue)
+    })
+
     it('aborts the restore and continues with an empty queue when it exceeds the deadline', async () => {
         jest.useFakeTimers()
         let capturedSignal: AbortSignal | undefined

--- a/packages/bot/src/handlers/player/lifecycleHandlers.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.ts
@@ -47,7 +47,10 @@ export const setupLifecycleHandlers = (player: {
             })
         }
 
-        if (ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED) {
+        if (
+            ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED &&
+            !musicWatchdogService.isIntentionalStop(queue.guild.id)
+        ) {
             const metadata = queue.metadata as QueueMetadata | undefined
             // Abort the restore if the deadline wins the race, so a slow restore
             // can't keep enqueueing tracks after we've moved on with an empty queue.

--- a/packages/bot/src/utils/music/watchdog.spec.ts
+++ b/packages/bot/src/utils/music/watchdog.spec.ts
@@ -288,6 +288,49 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         expect(nodes.create).not.toHaveBeenCalled()
     })
 
+    // Mutation testing (PR #1950 follow-up): same gap as checkAndRecover's
+    // lock release, for the orphan-monitor side of the lock.
+    it('releases the orphan-recovery lock after completion so a later scan can run', async () => {
+        listGuildIdsMock.mockResolvedValue(['guild-recover-twice'])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now() - 60_000,
+            voiceChannelId: 'vc-active',
+            tracks: [{ title: 'Song', url: 'https://example.com/song' }],
+        })
+        restoreSnapshotMock.mockResolvedValue({
+            restoredCount: 1,
+            sessionSnapshotId: 'snapshot-recover',
+        })
+
+        const voiceChannel = {
+            type: ChannelType.GuildVoice,
+            members: { filter: jest.fn().mockReturnValue({ size: 2 }) },
+        }
+        const queue = {
+            setRepeatMode: jest.fn(),
+            connect: jest.fn().mockResolvedValue(undefined),
+        }
+        const guild = {
+            channels: {
+                cache: { get: jest.fn().mockReturnValue(voiceChannel) },
+            },
+        }
+        const nodes = {
+            get: jest.fn().mockReturnValue(null),
+            create: jest.fn().mockReturnValue(queue),
+        }
+        const client = {
+            guilds: { cache: { get: jest.fn().mockReturnValue(guild) } },
+        }
+        const player = { nodes, client } as unknown as Player
+
+        const service = new MusicWatchdogService()
+        await service.scanOrphanSessions(player)
+        await service.scanOrphanSessions(player)
+
+        expect(restoreSnapshotMock).toHaveBeenCalledTimes(2)
+    })
+
     it('reuses existing queue during orphan recovery and avoids creating a new queue', async () => {
         listGuildIdsMock.mockResolvedValue(['guild-existing'])
         getSnapshotMock.mockResolvedValue({
@@ -563,6 +606,27 @@ describe('MusicWatchdogService — checkAndRecover edge cases', () => {
             'requeue_current',
         ])
         expect(play).toHaveBeenCalledTimes(1)
+    })
+
+    // Mutation testing (PR #1950 follow-up): the finally-block lock release
+    // had no coverage proving it actually runs — a stuck lock would
+    // permanently block recovery for that guild.
+    it('releases the recovery lock after completion so a later call can run', async () => {
+        const play = jest.fn().mockResolvedValue(undefined)
+        const service = new MusicWatchdogService({ timeoutMs: 100 })
+        const queue = {
+            guild: { id: 'guild-lock-release' },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection: { state: { status: 'ready' } },
+            node: { isPlaying: () => false, play },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        await service.checkAndRecover(queue)
+        const secondAction = await service.checkAndRecover(queue)
+
+        expect(secondAction).toBe('requeue_current')
+        expect(play).toHaveBeenCalledTimes(2)
     })
 })
 

--- a/packages/bot/src/utils/music/watchdog.spec.ts
+++ b/packages/bot/src/utils/music/watchdog.spec.ts
@@ -240,6 +240,54 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         )
     })
 
+    it('skips orphan recovery for a guild already being recovered by checkAndRecover (#1949)', async () => {
+        const guildId = 'guild-lock-cross'
+        const connection = { state: { status: 'ready' } }
+        // Never resolves, so checkAndRecover's recovery lock stays held for
+        // the duration of this test.
+        const play = jest.fn(() => new Promise(() => {}))
+        const queue = {
+            guild: { id: guildId },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection,
+            node: { isPlaying: () => false, play },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const service = new MusicWatchdogService()
+        void service.checkAndRecover(queue) // fire-and-forget: holds the lock
+        await Promise.resolve()
+
+        listGuildIdsMock.mockResolvedValue([guildId])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now(),
+            voiceChannelId: 'vc-active',
+            tracks: [{ title: 'Song', url: 'https://example.com/song' }],
+        })
+        const voiceChannel = {
+            type: ChannelType.GuildVoice,
+            members: { filter: jest.fn().mockReturnValue({ size: 2 }) },
+        }
+        const guild = {
+            channels: {
+                cache: { get: jest.fn().mockReturnValue(voiceChannel) },
+            },
+        }
+        const nodes = {
+            get: jest.fn().mockReturnValue(queue),
+            create: jest.fn(),
+        }
+        const client = {
+            guilds: { cache: { get: jest.fn().mockReturnValue(guild) } },
+        }
+        const player = { nodes, client } as unknown as Player
+
+        await service.scanOrphanSessions(player)
+
+        expect(restoreSnapshotMock).not.toHaveBeenCalled()
+        expect(nodes.create).not.toHaveBeenCalled()
+    })
+
     it('reuses existing queue during orphan recovery and avoids creating a new queue', async () => {
         listGuildIdsMock.mockResolvedValue(['guild-existing'])
         getSnapshotMock.mockResolvedValue({
@@ -490,6 +538,31 @@ describe('MusicWatchdogService — checkAndRecover edge cases', () => {
 
         expect(action).toBe('none')
         expect(play).not.toHaveBeenCalled()
+    })
+
+    // #1949: overlapping checkAndRecover calls for the same guild must not
+    // both drive playback recovery — that's what stacked the join/leave cycles.
+    it('does not run two checkAndRecover recoveries concurrently for the same guild', async () => {
+        const play = jest.fn().mockResolvedValue(undefined)
+        const service = new MusicWatchdogService({ timeoutMs: 100 })
+        const queue = {
+            guild: { id: 'guild-concurrent' },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection: { state: { status: 'ready' } },
+            node: { isPlaying: () => false, play },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const [firstAction, secondAction] = await Promise.all([
+            service.checkAndRecover(queue),
+            service.checkAndRecover(queue),
+        ])
+
+        expect([firstAction, secondAction].sort()).toEqual([
+            'none',
+            'requeue_current',
+        ])
+        expect(play).toHaveBeenCalledTimes(1)
     })
 })
 

--- a/packages/bot/src/utils/music/watchdog.ts
+++ b/packages/bot/src/utils/music/watchdog.ts
@@ -40,11 +40,15 @@ export class MusicWatchdogService {
     private readonly states = new Map<string, WatchdogGuildState>()
     private readonly intentionalStops = new Set<string>()
     private orphanMonitorInterval: ReturnType<typeof setInterval> | null = null
+    // Guards checkAndRecover and recoverOrphanSession from running concurrently
+    // for the same guild — without this, a flaky connection can trigger both
+    // the watchdog's rejoin cycle and the orphan monitor's fresh connect() at
+    // once, producing stacked join/leave cycles.
+    private readonly recoveringGuilds = new Set<string>()
 
     constructor(options: MusicWatchdogOptions = {}) {
         this.timeoutMs =
-            options.timeoutMs ??
-            parseIntEnv('MUSIC_WATCHDOG_TIMEOUT_MS', 25000)
+            options.timeoutMs ?? parseIntEnv('MUSIC_WATCHDOG_TIMEOUT_MS', 25000)
         this.recoveryWaitTimeoutMs =
             options.recoveryWaitTimeoutMs ??
             parseIntEnv('MUSIC_WATCHDOG_RECOVERY_WAIT_MS', 5000)
@@ -150,6 +154,12 @@ export class MusicWatchdogService {
             return 'none'
         }
 
+        if (this.recoveringGuilds.has(guildId)) {
+            state.lastRecoveryDetail = 'recovery_already_in_progress'
+            return 'none'
+        }
+        this.recoveringGuilds.add(guildId)
+
         let action: RecoveryAction = 'none'
         let detail = 'nothing_to_recover'
         let didRejoin = false
@@ -207,6 +217,8 @@ export class MusicWatchdogService {
                 error,
                 data: { guildId },
             })
+        } finally {
+            this.recoveringGuilds.delete(guildId)
         }
 
         state.lastRecoveryAction = action
@@ -280,46 +292,54 @@ export class MusicWatchdogService {
         const membersInChannel = voiceChannel.members.filter((m) => !m.user.bot)
         if (membersInChannel.size === 0) return
 
-        infoLog({
-            message: 'Watchdog detected orphan session, attempting rejoin',
-            data: { guildId, voiceChannelId, snapshotAgeMs: ageMs },
-        })
+        if (this.recoveringGuilds.has(guildId)) return
+        this.recoveringGuilds.add(guildId)
 
-        const queue = existingQueue ?? player.nodes.create(guild)
-        if (!existingQueue) {
-            queue.setRepeatMode(3)
-            await queue.connect(voiceChannel)
-        }
+        try {
+            infoLog({
+                message: 'Watchdog detected orphan session, attempting rejoin',
+                data: { guildId, voiceChannelId, snapshotAgeMs: ageMs },
+            })
 
-        const restoreResult = await musicSessionSnapshotService.restoreSnapshot(
-            queue,
-            undefined,
-            { skipCurrentTrack: true },
-        )
-        if (!restoreResult || restoreResult.restoredCount <= 0) {
-            await musicSessionSnapshotService.deleteSnapshot(guildId)
+            const queue = existingQueue ?? player.nodes.create(guild)
+            if (!existingQueue) {
+                queue.setRepeatMode(3)
+                await queue.connect(voiceChannel)
+            }
+
+            const restoreResult =
+                await musicSessionSnapshotService.restoreSnapshot(
+                    queue,
+                    undefined,
+                    { skipCurrentTrack: true },
+                )
+            if (!restoreResult || restoreResult.restoredCount <= 0) {
+                await musicSessionSnapshotService.deleteSnapshot(guildId)
+
+                const state = this.ensureState(guildId)
+                state.lastRecoveryAction = 'failed'
+                state.lastRecoveryAt = Date.now()
+                state.lastRecoveryDetail = 'snapshot_restore_empty'
+
+                infoLog({
+                    message:
+                        'Watchdog orphan session restore produced no tracks; snapshot cleared',
+                    data: { guildId, voiceChannelId },
+                })
+                return
+            }
 
             const state = this.ensureState(guildId)
-            state.lastRecoveryAction = 'failed'
+            state.lastRecoveryAction = 'rejoin'
             state.lastRecoveryAt = Date.now()
-            state.lastRecoveryDetail = 'snapshot_restore_empty'
 
             infoLog({
-                message:
-                    'Watchdog orphan session restore produced no tracks; snapshot cleared',
-                data: { guildId, voiceChannelId },
+                message: 'Watchdog orphan session recovered',
+                data: { guildId },
             })
-            return
+        } finally {
+            this.recoveringGuilds.delete(guildId)
         }
-
-        const state = this.ensureState(guildId)
-        state.lastRecoveryAction = 'rejoin'
-        state.lastRecoveryAt = Date.now()
-
-        infoLog({
-            message: 'Watchdog orphan session recovered',
-            data: { guildId },
-        })
     }
 
     getGuildState(guildId: string): WatchdogGuildState {


### PR DESCRIPTION
## Summary
- Guard the `connection` event's session-snapshot restore against an active intentional-stop (kick) flag, so a stale pre-kick track can't override a freshly issued `/play`.
- Add a per-guild in-flight recovery lock shared by `checkAndRecover` and the orphan-session monitor, so a flaky connection can't trigger both reconnect paths at once and produce stacked join/leave cycles.

Found via a multi-agent deep-debug session tracing two user-reported symptoms.

Closes #1948
Closes #1949

## Test plan
- [x] `npx jest src/utils/music/watchdog.spec.ts src/handlers/player/lifecycleHandlers.spec.ts` — 29 passed
- [x] Full monorepo `type:check` (ran via pre-commit hook) — clean
- [ ] Manual repro in a test guild: kick bot mid-song, `/play` a different song, confirm it doesn't revert
- [ ] Manual repro: force a flaky voice connection, confirm no stacked join/leave

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale tracks from overriding a new /play after a kick and stops duplicate voice recoveries that caused repeated join/leave loops.

- **Bug Fixes**
  - Guard snapshot restore on connection when an intentional stop (kick) is active, and add a per‑guild recovery lock shared by `checkAndRecover` and the orphan monitor to stop stacked join/leave; tests cover both fixes and verify the lock releases to avoid stuck recoveries.

<sup>Written for commit 3be30e99fe161399f6cbbe87dcd804cd8c35cb38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

