### PR TITLE
fix(bot): stop autoplay overriding clear/kick, race in watchdog recovery

### DIFF
--- a/packages/bot/src/functions/music/commands/clear.spec.ts
+++ b/packages/bot/src/functions/music/commands/clear.spec.ts
@@ -15,6 +15,7 @@ const createErrorEmbedMock = jest.fn((title: string, desc?: string) => ({
 const resolveGuildQueueMock = jest.fn()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
+const setReplenishSuppressedMock = jest.fn()
 
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireGuild: (...args: unknown[]) => requireGuildMock(...args),
@@ -32,6 +33,11 @@ jest.mock('../../../utils/general/embeds', () => ({
 
 jest.mock('../../../utils/music/queueResolver', () => ({
     resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
+}))
+
+jest.mock('../../../utils/music/replenishSuppressionStore', () => ({
+    setReplenishSuppressed: (...args: unknown[]) =>
+        setReplenishSuppressedMock(...args),
 }))
 
 jest.mock('@lucky/shared/utils', () => ({
@@ -115,6 +121,33 @@ describe('clear command', () => {
         } as any)
 
         expect(queue.clear).toHaveBeenCalled()
+    })
+
+    it('suppresses autoplay replenish after clearing so it cannot silently refill the queue', async () => {
+        const queue = createQueue(5)
+        resolveGuildQueueMock.mockReturnValue({ queue })
+
+        await clearCommand.execute({
+            client: {} as any,
+            interaction: makeInteraction(),
+        } as any)
+
+        expect(setReplenishSuppressedMock).toHaveBeenCalledWith(
+            'guild-1',
+            expect.any(Number),
+        )
+    })
+
+    it('does not suppress replenish when queue was already empty', async () => {
+        const queue = createQueue(0)
+        resolveGuildQueueMock.mockReturnValue({ queue })
+
+        await clearCommand.execute({
+            client: {} as any,
+            interaction: makeInteraction(),
+        } as any)
+
+        expect(setReplenishSuppressedMock).not.toHaveBeenCalled()
     })
 
     it('responds with success message and count', async () => {

--- a/packages/bot/src/functions/music/commands/clear.ts
+++ b/packages/bot/src/functions/music/commands/clear.ts
@@ -1,5 +1,8 @@
 import { SlashCommandBuilder } from '@discordjs/builders'
-import { createErrorEmbed, createSuccessEmbed } from '../../../utils/general/embeds'
+import {
+    createErrorEmbed,
+    createSuccessEmbed,
+} from '../../../utils/general/embeds'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import { debugLog, errorLog } from '@lucky/shared/utils'
 import Command from '../../../models/Command'
@@ -11,6 +14,12 @@ import type { CommandExecuteParams } from '../../../types/CommandData'
 import type { ChatInputCommandInteraction } from 'discord.js'
 import type { GuildQueue } from 'discord-player'
 import { resolveGuildQueue } from '../../../utils/music/queueResolver'
+import { setReplenishSuppressed } from '../../../utils/music/replenishSuppressionStore'
+
+// Same window queueExhaustion.ts uses when the queue runs dry with nothing
+// left to recover — keeps /clear from being silently undone by autoplay
+// refilling the queue the moment the current track ends.
+const CLEAR_REPLENISH_SUPPRESSION_MS = 35_000
 
 async function handleEmptyQueue(
     interaction: ChatInputCommandInteraction,
@@ -19,7 +28,10 @@ async function handleEmptyQueue(
         interaction,
         content: {
             embeds: [
-                createErrorEmbed('Empty queue', '🗑️ The queue is already empty!'),
+                createErrorEmbed(
+                    'Empty queue',
+                    '🗑️ The queue is already empty!',
+                ),
             ],
             ephemeral: true,
         },
@@ -33,6 +45,7 @@ async function clearQueueAndRespond(
     guildId: string,
 ): Promise<void> {
     queue.clear()
+    setReplenishSuppressed(guildId, CLEAR_REPLENISH_SUPPRESSION_MS)
 
     debugLog({
         message: `Cleared ${trackCount} tracks from queue in guild ${guildId}`,

--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -93,7 +93,7 @@ describe('setupLifecycleHandlers', () => {
         expect(watchdogArmMock).toHaveBeenCalledWith(queue)
     })
 
-    it('skips snapshot restore on connection when disconnect was intentional (#1948)', async () => {
+    it('does NOT restore snapshot on connection when the guild is an intentional stop (post-kick /play)', async () => {
         watchdogIsIntentionalStopMock.mockReturnValue(true)
 
         const handlers: Record<string, PlayerEventHandler> = {}
@@ -118,8 +118,8 @@ describe('setupLifecycleHandlers', () => {
 
         await handlers.connection(queue)
 
+        // #1948: a stale pre-kick snapshot must not override the fresh /play.
         expect(restoreSnapshotMock).not.toHaveBeenCalled()
-        // A kick/leave reconnect should still arm the watchdog for the fresh session.
         expect(watchdogArmMock).toHaveBeenCalledWith(queue)
     })
 
@@ -234,31 +234,6 @@ describe('setupLifecycleHandlers', () => {
         expect(watchdogCheckRecoverMock).not.toHaveBeenCalled()
     })
 
-    it('replenishes queue on emptyQueue when autoplay is enabled', async () => {
-        const handlers: Record<string, PlayerEventHandler> = {}
-        const player = {
-            events: {
-                on: jest.fn((event: string, handler: PlayerEventHandler) => {
-                    handlers[event] = handler
-                }),
-            },
-        }
-
-        setupLifecycleHandlers(player)
-
-        const track = { id: 'track-1', title: 'Test' }
-        const queue = {
-            guild: { id: 'guild-5', name: 'Guild 5' },
-            repeatMode: 3,
-            currentTrack: track,
-        } as unknown as GuildQueue
-
-        await handlers.emptyQueue(queue)
-
-        expect(replenishQueueMock).toHaveBeenCalledWith(queue)
-        expect(watchdogMarkIntentionalStopMock).not.toHaveBeenCalled()
-    })
-
     it('does NOT replenish on emptyQueue when disconnect was intentional (e.g. mid-restore kick)', async () => {
         watchdogIsIntentionalStopMock.mockReturnValue(true)
 
@@ -312,6 +287,31 @@ describe('setupLifecycleHandlers', () => {
         await handlers.emptyQueue(queue)
 
         expect(replenishQueueMock).not.toHaveBeenCalled()
+    })
+
+    it('replenishes queue on emptyQueue when autoplay is enabled', async () => {
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const track = { id: 'track-1', title: 'Test' }
+        const queue = {
+            guild: { id: 'guild-5', name: 'Guild 5' },
+            repeatMode: 3,
+            currentTrack: track,
+        } as unknown as GuildQueue
+
+        await handlers.emptyQueue(queue)
+
+        expect(replenishQueueMock).toHaveBeenCalledWith(queue)
+        expect(watchdogMarkIntentionalStopMock).not.toHaveBeenCalled()
     })
 
     it('marks intentional stop on emptyQueue when autoplay is disabled', async () => {

--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -11,6 +11,7 @@ const watchdogClearMock = jest.fn()
 const watchdogMarkIntentionalStopMock = jest.fn()
 const watchdogIsIntentionalStopMock = jest.fn(() => false)
 const replenishQueueMock = jest.fn()
+const isReplenishSuppressedMock = jest.fn(() => false)
 
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: (...args: unknown[]) => debugLogMock(...args),
@@ -39,6 +40,11 @@ jest.mock('../../utils/music/queueOperations', () => ({
     replenishQueue: (...args: unknown[]) => replenishQueueMock(...args),
 }))
 
+jest.mock('../../utils/music/replenishSuppressionStore', () => ({
+    isReplenishSuppressed: (...args: unknown[]) =>
+        isReplenishSuppressedMock(...args),
+}))
+
 import {
     setupLifecycleHandlers,
     setupVoiceKickDetection,
@@ -53,6 +59,7 @@ describe('setupLifecycleHandlers', () => {
         saveSnapshotMock.mockResolvedValue(null)
         watchdogCheckRecoverMock.mockResolvedValue('none')
         watchdogIsIntentionalStopMock.mockReturnValue(false)
+        isReplenishSuppressedMock.mockReturnValue(false)
     })
 
     it('restores snapshot and arms watchdog on connection', async () => {
@@ -83,6 +90,36 @@ describe('setupLifecycleHandlers', () => {
             expect.objectContaining({ id: 'user-1' }),
             expect.objectContaining({ signal: expect.anything() }),
         )
+        expect(watchdogArmMock).toHaveBeenCalledWith(queue)
+    })
+
+    it('skips snapshot restore on connection when disconnect was intentional (#1948)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-1', name: 'Guild 1' },
+            metadata: { requestedBy: { id: 'user-1' } },
+            connection: {
+                state: { status: 'ready' },
+                joinConfig: {},
+            },
+        } as unknown as GuildQueue
+
+        await handlers.connection(queue)
+
+        expect(restoreSnapshotMock).not.toHaveBeenCalled()
+        // A kick/leave reconnect should still arm the watchdog for the fresh session.
         expect(watchdogArmMock).toHaveBeenCalledWith(queue)
     })
 
@@ -220,6 +257,61 @@ describe('setupLifecycleHandlers', () => {
 
         expect(replenishQueueMock).toHaveBeenCalledWith(queue)
         expect(watchdogMarkIntentionalStopMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT replenish on emptyQueue when disconnect was intentional (e.g. mid-restore kick)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const track = { id: 'track-1', title: 'Test' }
+        const queue = {
+            guild: { id: 'guild-5', name: 'Guild 5' },
+            repeatMode: 3,
+            currentTrack: track,
+        } as unknown as GuildQueue
+
+        await handlers.emptyQueue(queue)
+
+        expect(replenishQueueMock).not.toHaveBeenCalled()
+        // Autoplay wanted to replenish, it was just suppressed — don't re-mark
+        // intentional stop on top of the existing suppression.
+        expect(watchdogMarkIntentionalStopMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT replenish on emptyQueue when /clear suppressed autoplay', async () => {
+        isReplenishSuppressedMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const track = { id: 'track-1', title: 'Test' }
+        const queue = {
+            guild: { id: 'guild-5', name: 'Guild 5' },
+            repeatMode: 3,
+            currentTrack: track,
+        } as unknown as GuildQueue
+
+        await handlers.emptyQueue(queue)
+
+        expect(replenishQueueMock).not.toHaveBeenCalled()
     })
 
     it('marks intentional stop on emptyQueue when autoplay is disabled', async () => {

--- a/packages/bot/src/handlers/player/lifecycleHandlers.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.ts
@@ -6,6 +6,7 @@ import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 import { musicWatchdogService } from '../../utils/music/watchdog'
 import { musicSessionSnapshotService } from '../../utils/music/sessionSnapshots'
 import { replenishQueue } from '../../utils/music/queueOperations'
+import { isReplenishSuppressed } from '../../utils/music/replenishSuppressionStore'
 import type { QueueMetadata } from '../../types/QueueMetadata'
 
 export const setupVoiceKickDetection = (client: Client): void => {
@@ -47,7 +48,10 @@ export const setupLifecycleHandlers = (player: {
             })
         }
 
-        if (ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED) {
+        if (
+            ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED &&
+            !musicWatchdogService.isIntentionalStop(queue.guild.id)
+        ) {
             const metadata = queue.metadata as QueueMetadata | undefined
             // Abort the restore if the deadline wins the race, so a slow restore
             // can't keep enqueueing tracks after we've moved on with an empty queue.
@@ -110,10 +114,15 @@ export const setupLifecycleHandlers = (player: {
 
     player.events.on('emptyQueue', async (queue: GuildQueue) => {
         const isAutoplayEnabled = queue.repeatMode === 3
-        if (isAutoplayEnabled && queue.currentTrack) {
+        const guildId = queue.guild.id
+        const wantsReplenish = isAutoplayEnabled && Boolean(queue.currentTrack)
+        const suppressed =
+            musicWatchdogService.isIntentionalStop(guildId) ||
+            isReplenishSuppressed(guildId)
+        if (wantsReplenish && !suppressed) {
             await replenishQueue(queue)
-        } else {
-            musicWatchdogService.markIntentionalStop(queue.guild.id)
+        } else if (!wantsReplenish) {
+            musicWatchdogService.markIntentionalStop(guildId)
         }
     })
 

--- a/packages/bot/src/utils/music/watchdog.spec.ts
+++ b/packages/bot/src/utils/music/watchdog.spec.ts
@@ -84,36 +84,6 @@ describe('MusicWatchdogService', () => {
         expect(rejoin).not.toHaveBeenCalled()
         expect(play).not.toHaveBeenCalled()
     })
-
-    it('skips a concurrent checkAndRecover call for the same guild already in flight (#1949)', async () => {
-        const connection = { state: { status: 'ready' } }
-        let resolvePlay: () => void = () => {}
-        const play = jest.fn(
-            () => new Promise<void>((resolve) => (resolvePlay = resolve)),
-        )
-        const service = new MusicWatchdogService({ timeoutMs: 1_000 })
-        const queue = {
-            guild: { id: 'guild-race' },
-            currentTrack: { title: 'Song', url: 'https://example.com/song' },
-            connection,
-            node: { isPlaying: () => false, play },
-            tracks: { size: 0 },
-        } as unknown as GuildQueue
-
-        const first = service.checkAndRecover(queue)
-        const second = await service.checkAndRecover(queue)
-
-        expect(second).toBe('none')
-        expect(service.getGuildState('guild-race')).toEqual(
-            expect.objectContaining({
-                lastRecoveryDetail: 'recovery_already_in_flight',
-            }),
-        )
-        expect(play).toHaveBeenCalledTimes(1)
-
-        resolvePlay()
-        await first
-    })
 })
 
 describe('MusicWatchdogService — orphan session monitor', () => {
@@ -270,15 +240,30 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         )
     })
 
-    it('skips recoverOrphanSession when checkAndRecover already holds the lock for the guild (#1949)', async () => {
-        const guildId = 'guild-coordination'
+    it('skips orphan recovery for a guild already being recovered by checkAndRecover (#1949)', async () => {
+        const guildId = 'guild-lock-cross'
+        const connection = { state: { status: 'ready' } }
+        // Never resolves, so checkAndRecover's recovery lock stays held for
+        // the duration of this test.
+        const play = jest.fn(() => new Promise(() => {}))
+        const queue = {
+            guild: { id: guildId },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection,
+            node: { isPlaying: () => false, play },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const service = new MusicWatchdogService()
+        void service.checkAndRecover(queue) // fire-and-forget: holds the lock
+        await Promise.resolve()
+
         listGuildIdsMock.mockResolvedValue([guildId])
         getSnapshotMock.mockResolvedValue({
-            savedAt: Date.now() - 60_000,
+            savedAt: Date.now(),
             voiceChannelId: 'vc-active',
             tracks: [{ title: 'Song', url: 'https://example.com/song' }],
         })
-
         const voiceChannel = {
             type: ChannelType.GuildVoice,
             members: { filter: jest.fn().mockReturnValue({ size: 2 }) },
@@ -288,39 +273,62 @@ describe('MusicWatchdogService — orphan session monitor', () => {
                 cache: { get: jest.fn().mockReturnValue(voiceChannel) },
             },
         }
+        const nodes = {
+            get: jest.fn().mockReturnValue(queue),
+            create: jest.fn(),
+        }
         const client = {
             guilds: { cache: { get: jest.fn().mockReturnValue(guild) } },
         }
-
-        let resolvePlay: () => void = () => {}
-        const watchdogQueue = {
-            guild: { id: guildId },
-            currentTrack: { title: 'Song', url: 'https://example.com/song' },
-            connection: { state: { status: 'ready' } },
-            node: {
-                isPlaying: () => false,
-                play: jest.fn(
-                    () =>
-                        new Promise<void>((resolve) => (resolvePlay = resolve)),
-                ),
-            },
-            tracks: { size: 0 },
-        } as unknown as GuildQueue
-
-        const nodes = { get: jest.fn().mockReturnValue(null) }
         const player = { nodes, client } as unknown as Player
 
-        const service = new MusicWatchdogService({ timeoutMs: 1_000 })
-
-        // checkAndRecover (watchdog timer path) grabs the lock first and hangs mid-recovery...
-        const recoverPromise = service.checkAndRecover(watchdogQueue)
-        // ...so the orphan monitor's independent 60s-interval pass must back off.
         await service.scanOrphanSessions(player)
 
         expect(restoreSnapshotMock).not.toHaveBeenCalled()
+        expect(nodes.create).not.toHaveBeenCalled()
+    })
 
-        resolvePlay()
-        await recoverPromise
+    // Mutation testing (PR #1950 follow-up): same gap as checkAndRecover's
+    // lock release, for the orphan-monitor side of the lock.
+    it('releases the orphan-recovery lock after completion so a later scan can run', async () => {
+        listGuildIdsMock.mockResolvedValue(['guild-recover-twice'])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now() - 60_000,
+            voiceChannelId: 'vc-active',
+            tracks: [{ title: 'Song', url: 'https://example.com/song' }],
+        })
+        restoreSnapshotMock.mockResolvedValue({
+            restoredCount: 1,
+            sessionSnapshotId: 'snapshot-recover',
+        })
+
+        const voiceChannel = {
+            type: ChannelType.GuildVoice,
+            members: { filter: jest.fn().mockReturnValue({ size: 2 }) },
+        }
+        const queue = {
+            setRepeatMode: jest.fn(),
+            connect: jest.fn().mockResolvedValue(undefined),
+        }
+        const guild = {
+            channels: {
+                cache: { get: jest.fn().mockReturnValue(voiceChannel) },
+            },
+        }
+        const nodes = {
+            get: jest.fn().mockReturnValue(null),
+            create: jest.fn().mockReturnValue(queue),
+        }
+        const client = {
+            guilds: { cache: { get: jest.fn().mockReturnValue(guild) } },
+        }
+        const player = { nodes, client } as unknown as Player
+
+        const service = new MusicWatchdogService()
+        await service.scanOrphanSessions(player)
+        await service.scanOrphanSessions(player)
+
+        expect(restoreSnapshotMock).toHaveBeenCalledTimes(2)
     })
 
     it('reuses existing queue during orphan recovery and avoids creating a new queue', async () => {
@@ -573,6 +581,52 @@ describe('MusicWatchdogService — checkAndRecover edge cases', () => {
 
         expect(action).toBe('none')
         expect(play).not.toHaveBeenCalled()
+    })
+
+    // #1949: overlapping checkAndRecover calls for the same guild must not
+    // both drive playback recovery — that's what stacked the join/leave cycles.
+    it('does not run two checkAndRecover recoveries concurrently for the same guild', async () => {
+        const play = jest.fn().mockResolvedValue(undefined)
+        const service = new MusicWatchdogService({ timeoutMs: 100 })
+        const queue = {
+            guild: { id: 'guild-concurrent' },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection: { state: { status: 'ready' } },
+            node: { isPlaying: () => false, play },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const [firstAction, secondAction] = await Promise.all([
+            service.checkAndRecover(queue),
+            service.checkAndRecover(queue),
+        ])
+
+        expect([firstAction, secondAction].sort()).toEqual([
+            'none',
+            'requeue_current',
+        ])
+        expect(play).toHaveBeenCalledTimes(1)
+    })
+
+    // Mutation testing (PR #1950 follow-up): the finally-block lock release
+    // had no coverage proving it actually runs — a stuck lock would
+    // permanently block recovery for that guild.
+    it('releases the recovery lock after completion so a later call can run', async () => {
+        const play = jest.fn().mockResolvedValue(undefined)
+        const service = new MusicWatchdogService({ timeoutMs: 100 })
+        const queue = {
+            guild: { id: 'guild-lock-release' },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection: { state: { status: 'ready' } },
+            node: { isPlaying: () => false, play },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        await service.checkAndRecover(queue)
+        const secondAction = await service.checkAndRecover(queue)
+
+        expect(secondAction).toBe('requeue_current')
+        expect(play).toHaveBeenCalledTimes(2)
     })
 })
 

--- a/packages/bot/src/utils/music/watchdog.spec.ts
+++ b/packages/bot/src/utils/music/watchdog.spec.ts
@@ -84,6 +84,36 @@ describe('MusicWatchdogService', () => {
         expect(rejoin).not.toHaveBeenCalled()
         expect(play).not.toHaveBeenCalled()
     })
+
+    it('skips a concurrent checkAndRecover call for the same guild already in flight (#1949)', async () => {
+        const connection = { state: { status: 'ready' } }
+        let resolvePlay: () => void = () => {}
+        const play = jest.fn(
+            () => new Promise<void>((resolve) => (resolvePlay = resolve)),
+        )
+        const service = new MusicWatchdogService({ timeoutMs: 1_000 })
+        const queue = {
+            guild: { id: 'guild-race' },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection,
+            node: { isPlaying: () => false, play },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const first = service.checkAndRecover(queue)
+        const second = await service.checkAndRecover(queue)
+
+        expect(second).toBe('none')
+        expect(service.getGuildState('guild-race')).toEqual(
+            expect.objectContaining({
+                lastRecoveryDetail: 'recovery_already_in_flight',
+            }),
+        )
+        expect(play).toHaveBeenCalledTimes(1)
+
+        resolvePlay()
+        await first
+    })
 })
 
 describe('MusicWatchdogService — orphan session monitor', () => {
@@ -238,6 +268,59 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         expect(service.getGuildState('guild-recover')).toEqual(
             expect.objectContaining({ lastRecoveryAction: 'rejoin' }),
         )
+    })
+
+    it('skips recoverOrphanSession when checkAndRecover already holds the lock for the guild (#1949)', async () => {
+        const guildId = 'guild-coordination'
+        listGuildIdsMock.mockResolvedValue([guildId])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now() - 60_000,
+            voiceChannelId: 'vc-active',
+            tracks: [{ title: 'Song', url: 'https://example.com/song' }],
+        })
+
+        const voiceChannel = {
+            type: ChannelType.GuildVoice,
+            members: { filter: jest.fn().mockReturnValue({ size: 2 }) },
+        }
+        const guild = {
+            channels: {
+                cache: { get: jest.fn().mockReturnValue(voiceChannel) },
+            },
+        }
+        const client = {
+            guilds: { cache: { get: jest.fn().mockReturnValue(guild) } },
+        }
+
+        let resolvePlay: () => void = () => {}
+        const watchdogQueue = {
+            guild: { id: guildId },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection: { state: { status: 'ready' } },
+            node: {
+                isPlaying: () => false,
+                play: jest.fn(
+                    () =>
+                        new Promise<void>((resolve) => (resolvePlay = resolve)),
+                ),
+            },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const nodes = { get: jest.fn().mockReturnValue(null) }
+        const player = { nodes, client } as unknown as Player
+
+        const service = new MusicWatchdogService({ timeoutMs: 1_000 })
+
+        // checkAndRecover (watchdog timer path) grabs the lock first and hangs mid-recovery...
+        const recoverPromise = service.checkAndRecover(watchdogQueue)
+        // ...so the orphan monitor's independent 60s-interval pass must back off.
+        await service.scanOrphanSessions(player)
+
+        expect(restoreSnapshotMock).not.toHaveBeenCalled()
+
+        resolvePlay()
+        await recoverPromise
     })
 
     it('reuses existing queue during orphan recovery and avoids creating a new queue', async () => {

--- a/packages/bot/src/utils/music/watchdog.ts
+++ b/packages/bot/src/utils/music/watchdog.ts
@@ -40,11 +40,14 @@ export class MusicWatchdogService {
     private readonly states = new Map<string, WatchdogGuildState>()
     private readonly intentionalStops = new Set<string>()
     private orphanMonitorInterval: ReturnType<typeof setInterval> | null = null
+    // Prevents checkAndRecover (watchdog timer / disconnect event) and
+    // recoverOrphanSession (60s orphan monitor) from both driving reconnects
+    // for the same guild at once, which stacks join/leave cycles (#1949).
+    private readonly recoveryInFlight = new Set<string>()
 
     constructor(options: MusicWatchdogOptions = {}) {
         this.timeoutMs =
-            options.timeoutMs ??
-            parseIntEnv('MUSIC_WATCHDOG_TIMEOUT_MS', 25000)
+            options.timeoutMs ?? parseIntEnv('MUSIC_WATCHDOG_TIMEOUT_MS', 25000)
         this.recoveryWaitTimeoutMs =
             options.recoveryWaitTimeoutMs ??
             parseIntEnv('MUSIC_WATCHDOG_RECOVERY_WAIT_MS', 5000)
@@ -150,6 +153,13 @@ export class MusicWatchdogService {
             return 'none'
         }
 
+        if (this.recoveryInFlight.has(guildId)) {
+            state.lastRecoveryAction = 'none'
+            state.lastRecoveryDetail = 'recovery_already_in_flight'
+            return 'none'
+        }
+        this.recoveryInFlight.add(guildId)
+
         let action: RecoveryAction = 'none'
         let detail = 'nothing_to_recover'
         let didRejoin = false
@@ -207,6 +217,8 @@ export class MusicWatchdogService {
                 error,
                 data: { guildId },
             })
+        } finally {
+            this.recoveryInFlight.delete(guildId)
         }
 
         state.lastRecoveryAction = action
@@ -280,46 +292,54 @@ export class MusicWatchdogService {
         const membersInChannel = voiceChannel.members.filter((m) => !m.user.bot)
         if (membersInChannel.size === 0) return
 
-        infoLog({
-            message: 'Watchdog detected orphan session, attempting rejoin',
-            data: { guildId, voiceChannelId, snapshotAgeMs: ageMs },
-        })
+        if (this.recoveryInFlight.has(guildId)) return
+        this.recoveryInFlight.add(guildId)
 
-        const queue = existingQueue ?? player.nodes.create(guild)
-        if (!existingQueue) {
-            queue.setRepeatMode(3)
-            await queue.connect(voiceChannel)
-        }
+        try {
+            infoLog({
+                message: 'Watchdog detected orphan session, attempting rejoin',
+                data: { guildId, voiceChannelId, snapshotAgeMs: ageMs },
+            })
 
-        const restoreResult = await musicSessionSnapshotService.restoreSnapshot(
-            queue,
-            undefined,
-            { skipCurrentTrack: true },
-        )
-        if (!restoreResult || restoreResult.restoredCount <= 0) {
-            await musicSessionSnapshotService.deleteSnapshot(guildId)
+            const queue = existingQueue ?? player.nodes.create(guild)
+            if (!existingQueue) {
+                queue.setRepeatMode(3)
+                await queue.connect(voiceChannel)
+            }
+
+            const restoreResult =
+                await musicSessionSnapshotService.restoreSnapshot(
+                    queue,
+                    undefined,
+                    { skipCurrentTrack: true },
+                )
+            if (!restoreResult || restoreResult.restoredCount <= 0) {
+                await musicSessionSnapshotService.deleteSnapshot(guildId)
+
+                const state = this.ensureState(guildId)
+                state.lastRecoveryAction = 'failed'
+                state.lastRecoveryAt = Date.now()
+                state.lastRecoveryDetail = 'snapshot_restore_empty'
+
+                infoLog({
+                    message:
+                        'Watchdog orphan session restore produced no tracks; snapshot cleared',
+                    data: { guildId, voiceChannelId },
+                })
+                return
+            }
 
             const state = this.ensureState(guildId)
-            state.lastRecoveryAction = 'failed'
+            state.lastRecoveryAction = 'rejoin'
             state.lastRecoveryAt = Date.now()
-            state.lastRecoveryDetail = 'snapshot_restore_empty'
 
             infoLog({
-                message:
-                    'Watchdog orphan session restore produced no tracks; snapshot cleared',
-                data: { guildId, voiceChannelId },
+                message: 'Watchdog orphan session recovered',
+                data: { guildId },
             })
-            return
+        } finally {
+            this.recoveryInFlight.delete(guildId)
         }
-
-        const state = this.ensureState(guildId)
-        state.lastRecoveryAction = 'rejoin'
-        state.lastRecoveryAt = Date.now()
-
-        infoLog({
-            message: 'Watchdog orphan session recovered',
-            data: { guildId },
-        })
     }
 
     getGuildState(guildId: string): WatchdogGuildState {

--- a/packages/bot/src/utils/music/watchdog.ts
+++ b/packages/bot/src/utils/music/watchdog.ts
@@ -40,10 +40,11 @@ export class MusicWatchdogService {
     private readonly states = new Map<string, WatchdogGuildState>()
     private readonly intentionalStops = new Set<string>()
     private orphanMonitorInterval: ReturnType<typeof setInterval> | null = null
-    // Prevents checkAndRecover (watchdog timer / disconnect event) and
-    // recoverOrphanSession (60s orphan monitor) from both driving reconnects
-    // for the same guild at once, which stacks join/leave cycles (#1949).
-    private readonly recoveryInFlight = new Set<string>()
+    // Guards checkAndRecover and recoverOrphanSession from running concurrently
+    // for the same guild — without this, a flaky connection can trigger both
+    // the watchdog's rejoin cycle and the orphan monitor's fresh connect() at
+    // once, producing stacked join/leave cycles.
+    private readonly recoveringGuilds = new Set<string>()
 
     constructor(options: MusicWatchdogOptions = {}) {
         this.timeoutMs =
@@ -153,12 +154,11 @@ export class MusicWatchdogService {
             return 'none'
         }
 
-        if (this.recoveryInFlight.has(guildId)) {
-            state.lastRecoveryAction = 'none'
-            state.lastRecoveryDetail = 'recovery_already_in_flight'
+        if (this.recoveringGuilds.has(guildId)) {
+            state.lastRecoveryDetail = 'recovery_already_in_progress'
             return 'none'
         }
-        this.recoveryInFlight.add(guildId)
+        this.recoveringGuilds.add(guildId)
 
         let action: RecoveryAction = 'none'
         let detail = 'nothing_to_recover'
@@ -218,7 +218,7 @@ export class MusicWatchdogService {
                 data: { guildId },
             })
         } finally {
-            this.recoveryInFlight.delete(guildId)
+            this.recoveringGuilds.delete(guildId)
         }
 
         state.lastRecoveryAction = action
@@ -292,8 +292,8 @@ export class MusicWatchdogService {
         const membersInChannel = voiceChannel.members.filter((m) => !m.user.bot)
         if (membersInChannel.size === 0) return
 
-        if (this.recoveryInFlight.has(guildId)) return
-        this.recoveryInFlight.add(guildId)
+        if (this.recoveringGuilds.has(guildId)) return
+        this.recoveringGuilds.add(guildId)
 
         try {
             infoLog({
@@ -338,7 +338,7 @@ export class MusicWatchdogService {
                 data: { guildId },
             })
         } finally {
-            this.recoveryInFlight.delete(guildId)
+            this.recoveringGuilds.delete(guildId)
         }
     }
 


### PR DESCRIPTION
## Summary

Root-caused the "autoplay overrides commands / bot comes back on its own after disconnect" reports (open ~6 months).

**Reconciled with #1950** (open since 2026-08-05, not yet merged): it already fixes #1948 and #1949 with an equivalent implementation (same guard, same per-guild lock pattern, independently converged). Rather than ship a competing duplicate, this PR now adopts #1950's `lifecycleHandlers.ts`/`watchdog.ts` verbatim and adds only what #1950 doesn't touch:

- `/clear` never suppressed autoplay replenish (unlike `/stop`/`/leave`) — the queue silently refilled once the current track ended. `clear.ts` now calls `setReplenishSuppressed()`, reusing the window `queueExhaustion.ts` already uses.
- The `emptyQueue` player-event handler called `replenishQueue()` directly, bypassing the `isIntentionalStop`/`isReplenishSuppressed` guards its sibling `playerFinish`/`playerSkip` path respects. Now checks both — filed as #1957.

**Once #1950 merges**, this PR's diff on `lifecycleHandlers.ts`/`watchdog.ts` should be empty (rebase will show no conflict) and only the `clear.ts` + `emptyQueue` fix for #1957 remains as net-new content. Recommend merging #1950 first.

YouTube extractor: code itself checked clean (search/playlist/error-handling paths). The "extractor has issues" complaint maps to already-open #1929 (extractor silently degrades — registers truthy but non-functional on YouTube-side session failures); its fix (Prometheus metric + user-facing wording) is a distinct, larger scoped task, left as a follow-up rather than bolted on here.

## Blocked on a repo-wide CI issue (not this PR)

Both this PR and #1950 currently fail the required **Security** check — this is **not caused by either PR's diff**. Root cause: `package.json`'s `overrides` pins `undici` to exactly `7.28.0` (itself now a vulnerable version — advisory range `7.0.0–7.28.0`) and floors `ip-address` at `>=10.1.1` with no ceiling past its vulnerable range (`<=10.3.0`). Confirmed pre-existing on clean `main` via `git stash` + `node scripts/audit-gate.mjs`.

I attempted a fix (bump the override pins to `undici: 7.29.0`, `ip-address: >=10.3.1`, add `fast-uri: >=3.1.5`) but `npm install` did not consistently re-resolve the root-level packages to the new floors even after a full reinstall, and the local tree showed additional drift (`nanoid` findings appearing/disappearing between runs, a pre-existing `react-router` advisory-id mismatch unrelated to my changes). This needs a careful, dedicated lockfile-health pass with full CI verification — not something to force through inline here. Did not commit a half-verified `package-lock.json`.

Closes #1957

## Test plan
- [x] `npx jest clear.spec.ts lifecycleHandlers.spec.ts watchdog.spec.ts` — 50 passed (watchdog/lifecycleHandlers tests are now #1950's, adopted as-is; new emptyQueue suppression tests added)
- [x] `tsc --noEmit` clean on all touched files
- [x] `eslint` clean