### PR TITLE
fix(bot): guard voice/session mutations with stop/suppress flags

### DIFF
--- a/packages/bot/src/functions/music/commands/clear.spec.ts
+++ b/packages/bot/src/functions/music/commands/clear.spec.ts
@@ -137,7 +137,7 @@ describe('clear command', () => {
 
         expect(setReplenishSuppressedMock).toHaveBeenCalledWith(
             'guild-1',
-            expect.any(Number),
+            30 * 60 * 1_000,
         )
     })
 

--- a/packages/bot/src/functions/music/commands/clear.spec.ts
+++ b/packages/bot/src/functions/music/commands/clear.spec.ts
@@ -137,7 +137,7 @@ describe('clear command', () => {
 
         expect(setReplenishSuppressedMock).toHaveBeenCalledWith(
             'guild-1',
-            30 * 60 * 1_000,
+            60 * 60 * 1_000,
         )
     })
 

--- a/packages/bot/src/functions/music/commands/clear.spec.ts
+++ b/packages/bot/src/functions/music/commands/clear.spec.ts
@@ -15,6 +15,7 @@ const createErrorEmbedMock = jest.fn((title: string, desc?: string) => ({
 const resolveGuildQueueMock = jest.fn()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
+const setReplenishSuppressedMock = jest.fn()
 
 jest.mock('../../../utils/command/commandValidations', () => ({
     requireGuild: (...args: unknown[]) => requireGuildMock(...args),
@@ -33,6 +34,14 @@ jest.mock('../../../utils/general/embeds', () => ({
 jest.mock('../../../services/musicManagement/queueResolver', () => ({
     resolveGuildQueue: (...args: unknown[]) => resolveGuildQueueMock(...args),
 }))
+
+jest.mock(
+    '../../../services/musicManagement/replenishSuppressionStore',
+    () => ({
+        setReplenishSuppressed: (...args: unknown[]) =>
+            setReplenishSuppressedMock(...args),
+    }),
+)
 
 jest.mock('@lucky/shared/utils', () => ({
     debugLog: (...args: unknown[]) => debugLogMock(...args),
@@ -115,6 +124,21 @@ describe('clear command', () => {
         } as any)
 
         expect(queue.clear).toHaveBeenCalled()
+    })
+
+    it('suppresses autoplay replenish after clearing (#1957)', async () => {
+        const queue = createQueue(5)
+        resolveGuildQueueMock.mockReturnValue({ queue })
+
+        await clearCommand.execute({
+            client: {} as any,
+            interaction: makeInteraction(),
+        } as any)
+
+        expect(setReplenishSuppressedMock).toHaveBeenCalledWith(
+            'guild-1',
+            expect.any(Number),
+        )
     })
 
     it('responds with success message and count', async () => {

--- a/packages/bot/src/functions/music/commands/clear.ts
+++ b/packages/bot/src/functions/music/commands/clear.ts
@@ -40,12 +40,13 @@ async function clearQueueAndRespond(
     guildId: string,
 ): Promise<void> {
     queue.clear()
-    // Suppress autoplay refill until well past when the still-playing
-    // current track can naturally end, so that end doesn't silently undo
-    // this /clear (#1957). A short window isn't enough — emptyQueue only
-    // fires once the current track finishes, which is typically minutes
-    // away, not seconds.
-    setReplenishSuppressed(guildId, 30 * 60 * 1_000)
+    // Suppress autoplay refill so the still-playing current track's natural
+    // end doesn't silently undo this /clear (#1957). The real lift happens
+    // when the next explicit (non-autoplay) track starts playing (see
+    // trackHandlers.ts's playerStart handler, #1998) — this duration is
+    // just a safety ceiling for the case nothing else ever plays, capped at
+    // the suppression store's own documented 1h TTL upper bound.
+    setReplenishSuppressed(guildId, 60 * 60 * 1_000)
 
     debugLog({
         message: `Cleared ${trackCount} tracks from queue in guild ${guildId}`,

--- a/packages/bot/src/functions/music/commands/clear.ts
+++ b/packages/bot/src/functions/music/commands/clear.ts
@@ -40,9 +40,12 @@ async function clearQueueAndRespond(
     guildId: string,
 ): Promise<void> {
     queue.clear()
-    // Suppress autoplay refill for a while so the natural end of the
-    // current track doesn't silently undo this /clear (#1957).
-    setReplenishSuppressed(guildId, 35_000)
+    // Suppress autoplay refill until well past when the still-playing
+    // current track can naturally end, so that end doesn't silently undo
+    // this /clear (#1957). A short window isn't enough — emptyQueue only
+    // fires once the current track finishes, which is typically minutes
+    // away, not seconds.
+    setReplenishSuppressed(guildId, 30 * 60 * 1_000)
 
     debugLog({
         message: `Cleared ${trackCount} tracks from queue in guild ${guildId}`,

--- a/packages/bot/src/functions/music/commands/clear.ts
+++ b/packages/bot/src/functions/music/commands/clear.ts
@@ -14,6 +14,7 @@ import type { CommandExecuteParams } from '../../../types/CommandData'
 import type { ChatInputCommandInteraction } from 'discord.js'
 import type { GuildQueue } from 'discord-player'
 import { resolveGuildQueue } from '../../../services/musicManagement/queueResolver'
+import { setReplenishSuppressed } from '../../../services/musicManagement/replenishSuppressionStore'
 
 async function handleEmptyQueue(
     interaction: ChatInputCommandInteraction,
@@ -39,6 +40,9 @@ async function clearQueueAndRespond(
     guildId: string,
 ): Promise<void> {
     queue.clear()
+    // Suppress autoplay refill for a while so the natural end of the
+    // current track doesn't silently undo this /clear (#1957).
+    setReplenishSuppressed(guildId, 35_000)
 
     debugLog({
         message: `Cleared ${trackCount} tracks from queue in guild ${guildId}`,

--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -39,6 +39,7 @@ jest.mock('../../services/musicManagement/queueOperations', () => ({
     replenishQueue: (...args: unknown[]) => replenishQueueMock(...args),
 }))
 
+import { setReplenishSuppressed } from '../../services/musicManagement/replenishSuppressionStore'
 import {
     setupLifecycleHandlers,
     setupVoiceKickDetection,
@@ -127,6 +128,33 @@ describe('setupLifecycleHandlers', () => {
         // Service stays armed despite the failed restore.
         expect(watchdogArmMock).toHaveBeenCalledWith(queue)
         jest.useRealTimers()
+    })
+
+    it('does NOT restore snapshot on connection when intentional stop is set (#1948)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-kicked', name: 'Guild Kicked' },
+            metadata: { requestedBy: { id: 'user-1' } },
+            connection: { state: { status: 'ready' }, joinConfig: {} },
+        } as unknown as GuildQueue
+
+        await handlers.connection(queue)
+
+        expect(restoreSnapshotMock).not.toHaveBeenCalled()
+        // Watchdog still arms — this guard only skips the stale-session restore.
+        expect(watchdogArmMock).toHaveBeenCalledWith(queue)
     })
 
     it('saves snapshot and triggers recovery on disconnect', async () => {
@@ -244,6 +272,64 @@ describe('setupLifecycleHandlers', () => {
 
         expect(watchdogMarkIntentionalStopMock).toHaveBeenCalledWith('guild-5')
         expect(replenishQueueMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT replenish on emptyQueue when replenish is suppressed (#1957)', async () => {
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const track = { id: 'track-1', title: 'Test' }
+        const queue = {
+            guild: { id: 'guild-cleared', name: 'Guild Cleared' },
+            repeatMode: 3,
+            currentTrack: track,
+        } as unknown as GuildQueue
+
+        setReplenishSuppressed('guild-cleared', 30_000)
+        try {
+            await handlers.emptyQueue(queue)
+        } finally {
+            setReplenishSuppressed('guild-cleared', 0)
+        }
+
+        expect(replenishQueueMock).not.toHaveBeenCalled()
+        // Suppressed (not "nothing to play") — must not force a full stop.
+        expect(watchdogMarkIntentionalStopMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT replenish on emptyQueue when intentional stop is set (#1957)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const track = { id: 'track-1', title: 'Test' }
+        const queue = {
+            guild: { id: 'guild-stopped-2', name: 'Guild Stopped' },
+            repeatMode: 3,
+            currentTrack: track,
+        } as unknown as GuildQueue
+
+        await handlers.emptyQueue(queue)
+
+        expect(replenishQueueMock).not.toHaveBeenCalled()
+        expect(watchdogMarkIntentionalStopMock).not.toHaveBeenCalled()
     })
 })
 

--- a/packages/bot/src/handlers/player/lifecycleHandlers.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.ts
@@ -6,6 +6,7 @@ import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
 import { musicWatchdogService } from '../../services/musicManagement/watchdog'
 import { musicSessionSnapshotService } from '../../services/musicRecommendation/sessionSnapshots'
 import { replenishQueue } from '../../services/musicManagement/queueOperations'
+import { isReplenishSuppressed } from '../../services/musicManagement/replenishSuppressionStore'
 import type { QueueMetadata } from '../../types/QueueMetadata'
 
 export const setupVoiceKickDetection = (client: Client): void => {
@@ -47,7 +48,10 @@ export const setupLifecycleHandlers = (player: {
             })
         }
 
-        if (ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED) {
+        if (
+            ENVIRONMENT_CONFIG.MUSIC.SESSION_RESTORE_ENABLED &&
+            !musicWatchdogService.isIntentionalStop(queue.guild.id)
+        ) {
             const metadata = queue.metadata as QueueMetadata | undefined
             // Abort the restore if the deadline wins the race, so a slow restore
             // can't keep enqueueing tracks after we've moved on with an empty queue.
@@ -110,11 +114,21 @@ export const setupLifecycleHandlers = (player: {
 
     player.events.on('emptyQueue', async (queue: GuildQueue) => {
         const isAutoplayEnabled = queue.repeatMode === 3
-        if (isAutoplayEnabled && queue.currentTrack) {
+        const guildId = queue.guild.id
+        if (
+            isAutoplayEnabled &&
+            queue.currentTrack &&
+            !musicWatchdogService.isIntentionalStop(guildId) &&
+            !isReplenishSuppressed(guildId)
+        ) {
             await replenishQueue(queue)
-        } else {
-            musicWatchdogService.markIntentionalStop(queue.guild.id)
+        } else if (!isAutoplayEnabled || !queue.currentTrack) {
+            musicWatchdogService.markIntentionalStop(guildId)
         }
+        // else: autoplay would apply but is suppressed/intentional-stop —
+        // leave the queue empty without forcing markIntentionalStop; the
+        // guarded playerFinish/playerSkip path (queueExhaustion.ts) already
+        // owns "nothing left to play" cleanup for that case.
     })
 
     player.events.on('disconnect', async (queue: GuildQueue) => {

--- a/packages/bot/src/handlers/player/trackHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.spec.ts
@@ -28,6 +28,7 @@ const infoLogMock = jest.fn()
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
 const warnLogMock = jest.fn()
+const setReplenishSuppressedMock = jest.fn()
 const recordImplicitFeedbackMock = jest.fn()
 
 jest.mock('discord-player', () => ({
@@ -82,7 +83,8 @@ jest.mock('../../services/musicRecommendation/sessionSnapshots', () => ({
 
 jest.mock('../../services/musicManagement/replenishSuppressionStore', () => ({
     isReplenishSuppressed: jest.fn(() => false),
-    setReplenishSuppressed: jest.fn(),
+    setReplenishSuppressed: (...args: unknown[]) =>
+        setReplenishSuppressedMock(...args),
 }))
 
 jest.mock('../../services/VoiceChannelStatusService', () => ({
@@ -286,6 +288,26 @@ describe('trackHandlers autoplay replenishment', () => {
             'testsong::testartist',
             'implicit_dislike',
         )
+    })
+
+    it('clears replenish suppression when an explicit track starts (#1998)', async () => {
+        const handlers = setupHandlers()
+        const queue = createQueue(QueueRepeatMode.OFF)
+        const track = createTrack('listener-1')
+
+        await handlers.playerStart(queue, track)
+
+        expect(setReplenishSuppressedMock).toHaveBeenCalledWith('guild-1', 0)
+    })
+
+    it('does NOT clear replenish suppression when an autoplay track starts (#1998)', async () => {
+        const handlers = setupHandlers()
+        const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+        const autoplayTrack = createAutoplayTrack('listener-1')
+
+        await handlers.playerStart(queue, autoplayTrack)
+
+        expect(setReplenishSuppressedMock).not.toHaveBeenCalled()
     })
 
     it('increments getRecentSkipCount on early skip and resets on track completion', async () => {

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -22,7 +22,10 @@ import {
 import { clearVotes } from '../../services/musicManagement/voteSkipStore'
 import { recommendationFeedbackService } from '../../services/musicRecommendation/feedbackService'
 import { normalizeTrackKey } from '../../services/musicRecommendation/autoplay/scoringUtils'
-import { isReplenishSuppressed } from '../../services/musicManagement/replenishSuppressionStore'
+import {
+    isReplenishSuppressed,
+    setReplenishSuppressed,
+} from '../../services/musicManagement/replenishSuppressionStore'
 import { handleQueueExhaustion } from './queueExhaustion'
 import { recordRecommendationOutcome } from '../../services/musicRecommendation/recommendationTelemetry'
 
@@ -236,6 +239,13 @@ const handlePlayerStart = async (
             queue.node.setVolume(constants.VOLUME)
 
         const isAutoplay = isAutoplayTrack(track, client.user?.id)
+        if (!isAutoplay) {
+            // Explicit new content (e.g. /play) supersedes an earlier
+            // /clear's suppression window (#1998) — a suppressed guild only
+            // ever starts a non-autoplay track, so this can't clear the
+            // flag out from under a real autoplay pick.
+            setReplenishSuppressed(queue.guild.id, 0)
+        }
         const isAutoplayEnabled = queue.repeatMode === QueueRepeatMode.AUTOPLAY
         handleAutoplayCounter(queue, isAutoplay, isAutoplayEnabled)
         await handleQueueReplenishment(queue, track)

--- a/packages/bot/src/services/musicManagement/watchdog.spec.ts
+++ b/packages/bot/src/services/musicManagement/watchdog.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import type { GuildQueue, Player } from 'discord-player'
 import { ChannelType } from 'discord.js'
+import { setReplenishSuppressed } from './replenishSuppressionStore'
 import { MusicWatchdogService } from './watchdog'
 
 // --- mocks ---
@@ -362,6 +363,28 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         await service.scanOrphanSessions(player)
 
         expect(restoreSnapshotMock).not.toHaveBeenCalled()
+    })
+
+    it('scanOrphanSessions skips guild when replenish is suppressed (#1957/#1998)', async () => {
+        listGuildIdsMock.mockResolvedValue(['guild-suppressed'])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now() - 60_000,
+            voiceChannelId: 'vc-1',
+            tracks: [{ title: 'Song', url: 'https://example.com/song' }],
+        })
+
+        const nodes = { get: jest.fn().mockReturnValue(null) }
+        const player = { nodes } as unknown as Player
+
+        setReplenishSuppressed('guild-suppressed', 30_000)
+        try {
+            const service = new MusicWatchdogService()
+            await service.scanOrphanSessions(player)
+
+            expect(restoreSnapshotMock).not.toHaveBeenCalled()
+        } finally {
+            setReplenishSuppressed('guild-suppressed', 0)
+        }
     })
 
     it('scanOrphanSessions skips guild when channel type is not GuildVoice', async () => {

--- a/packages/bot/src/services/musicManagement/watchdog.spec.ts
+++ b/packages/bot/src/services/musicManagement/watchdog.spec.ts
@@ -346,6 +346,24 @@ describe('MusicWatchdogService — orphan session monitor', () => {
         ).resolves.toBeUndefined()
     })
 
+    it('scanOrphanSessions skips guild when intentional stop is set (#1949)', async () => {
+        listGuildIdsMock.mockResolvedValue(['guild-stopped'])
+        getSnapshotMock.mockResolvedValue({
+            savedAt: Date.now() - 60_000,
+            voiceChannelId: 'vc-1',
+            tracks: [{ title: 'Song', url: 'https://example.com/song' }],
+        })
+
+        const nodes = { get: jest.fn().mockReturnValue(null) }
+        const player = { nodes } as unknown as Player
+
+        const service = new MusicWatchdogService()
+        service.markIntentionalStop('guild-stopped')
+        await service.scanOrphanSessions(player)
+
+        expect(restoreSnapshotMock).not.toHaveBeenCalled()
+    })
+
     it('scanOrphanSessions skips guild when channel type is not GuildVoice', async () => {
         listGuildIdsMock.mockResolvedValue(['guild-stage'])
         getSnapshotMock.mockResolvedValue({
@@ -490,6 +508,39 @@ describe('MusicWatchdogService — checkAndRecover edge cases', () => {
 
         expect(action).toBe('none')
         expect(play).not.toHaveBeenCalled()
+    })
+
+    it('a concurrent checkAndRecover call for the same guild is a no-op (#1949 lock)', async () => {
+        let resolvePlay: () => void = () => {}
+        const play = jest.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolvePlay = resolve
+                }),
+        )
+        const service = new MusicWatchdogService({ timeoutMs: 100 })
+        const queue = {
+            guild: { id: 'guild-concurrent' },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection: { state: { status: 'ready' } },
+            node: { isPlaying: () => false, play },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        const first = service.checkAndRecover(queue)
+        // First call is mid-flight (play() hasn't resolved yet) — a second
+        // call for the same guild must not also attempt recovery.
+        const second = await service.checkAndRecover(queue)
+
+        expect(second).toBe('none')
+        expect(service.getGuildState('guild-concurrent')).toMatchObject({
+            lastRecoveryDetail: 'recovery_already_in_progress',
+        })
+
+        resolvePlay()
+        const firstResult = await first
+        expect(firstResult).toBe('requeue_current')
+        expect(play).toHaveBeenCalledTimes(1)
     })
 })
 

--- a/packages/bot/src/services/musicManagement/watchdog.spec.ts
+++ b/packages/bot/src/services/musicManagement/watchdog.spec.ts
@@ -565,6 +565,36 @@ describe('MusicWatchdogService — checkAndRecover edge cases', () => {
         expect(firstResult).toBe('requeue_current')
         expect(play).toHaveBeenCalledTimes(1)
     })
+
+    it('a stale recovery lock (hung play()) expires and does not block a later attempt (#1998)', async () => {
+        const guildId = 'guild-stale-lock'
+        const hungPlay = jest.fn(() => new Promise<void>(() => {}))
+        const service = new MusicWatchdogService({ timeoutMs: 100 })
+        const hungQueue = {
+            guild: { id: guildId },
+            currentTrack: { title: 'Song', url: 'https://example.com/song' },
+            connection: { state: { status: 'ready' } },
+            node: { isPlaying: () => false, play: hungPlay },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        // Fire-and-forget: this attempt's play() never settles, simulating
+        // a hung recovery that would otherwise wedge the lock forever.
+        void service.checkAndRecover(hungQueue)
+
+        await jest.advanceTimersByTimeAsync(30_001)
+
+        const workingPlay = jest.fn().mockResolvedValue(undefined)
+        const recoveredQueue = {
+            ...hungQueue,
+            node: { isPlaying: () => false, play: workingPlay },
+        } as unknown as GuildQueue
+
+        const second = await service.checkAndRecover(recoveredQueue)
+
+        expect(second).toBe('requeue_current')
+        expect(workingPlay).toHaveBeenCalledTimes(1)
+    })
 })
 
 describe('MusicWatchdogService — startPeriodicScan', () => {

--- a/packages/bot/src/services/musicManagement/watchdog.spec.ts
+++ b/packages/bot/src/services/musicManagement/watchdog.spec.ts
@@ -595,6 +595,59 @@ describe('MusicWatchdogService — checkAndRecover edge cases', () => {
         expect(second).toBe('requeue_current')
         expect(workingPlay).toHaveBeenCalledTimes(1)
     })
+
+    it('a slow-but-legit recovery cannot clear a newer recovery lock (#1998)', async () => {
+        const guildId = 'guild-aba'
+        let resolveFirstPlay: () => void = () => {}
+        const firstPlay = jest.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveFirstPlay = resolve
+                }),
+        )
+        const service = new MusicWatchdogService({ timeoutMs: 100 })
+        const firstQueue = {
+            guild: { id: guildId },
+            currentTrack: { title: 'Song A', url: 'https://example.com/a' },
+            connection: { state: { status: 'ready' } },
+            node: { isPlaying: () => false, play: firstPlay },
+            tracks: { size: 0 },
+        } as unknown as GuildQueue
+
+        // Recovery A starts and stalls mid-flight — legitimately slow, not
+        // hung; it WILL settle eventually.
+        const firstRecovery = service.checkAndRecover(firstQueue)
+
+        // A's lock goes stale from the staleness check's perspective; a
+        // second recovery acquires a fresh lock for the same guild.
+        await jest.advanceTimersByTimeAsync(30_001)
+
+        let resolveSecondPlay: () => void = () => {}
+        const secondPlay = jest.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveSecondPlay = resolve
+                }),
+        )
+        const secondQueue = {
+            ...firstQueue,
+            node: { isPlaying: () => false, play: secondPlay },
+        } as unknown as GuildQueue
+        const secondRecovery = service.checkAndRecover(secondQueue)
+
+        // A finally settles late. Its release must not clear B's lock.
+        resolveFirstPlay()
+        await firstRecovery
+
+        const third = await service.checkAndRecover(firstQueue)
+        expect(third).toBe('none')
+        expect(service.getGuildState(guildId)).toMatchObject({
+            lastRecoveryDetail: 'recovery_already_in_progress',
+        })
+
+        resolveSecondPlay()
+        await secondRecovery
+    })
 })
 
 describe('MusicWatchdogService — startPeriodicScan', () => {

--- a/packages/bot/src/services/musicManagement/watchdog.ts
+++ b/packages/bot/src/services/musicManagement/watchdog.ts
@@ -4,6 +4,7 @@ import { ChannelType } from 'discord.js'
 import { debugLog, errorLog, infoLog } from '@lucky/shared/utils'
 import { parseIntEnv } from '@lucky/shared/utils/env'
 import { musicSessionSnapshotService } from '../../services/musicRecommendation/sessionSnapshots'
+import { isReplenishSuppressed } from './replenishSuppressionStore'
 
 export type RecoveryAction =
     'none' | 'rejoin' | 'requeue_current' | 'play_next' | 'failed'
@@ -266,6 +267,7 @@ export class MusicWatchdogService {
         const existingQueue = player.nodes.get(guildId)
         if (existingQueue?.node.isPlaying()) return
         if (this.intentionalStops.has(guildId)) return
+        if (isReplenishSuppressed(guildId)) return
         if (this.recoveryInProgress.has(guildId)) return
 
         this.recoveryInProgress.add(guildId)

--- a/packages/bot/src/services/musicManagement/watchdog.ts
+++ b/packages/bot/src/services/musicManagement/watchdog.ts
@@ -35,6 +35,7 @@ export class MusicWatchdogService {
     private readonly timers = new Map<string, ReturnType<typeof setTimeout>>()
     private readonly states = new Map<string, WatchdogGuildState>()
     private readonly intentionalStops = new Set<string>()
+    private readonly recoveryInProgress = new Set<string>()
     private orphanMonitorInterval: ReturnType<typeof setInterval> | null = null
 
     constructor(options: MusicWatchdogOptions = {}) {
@@ -145,6 +146,13 @@ export class MusicWatchdogService {
             return 'none'
         }
 
+        if (this.recoveryInProgress.has(guildId)) {
+            state.lastRecoveryAction = 'none'
+            state.lastRecoveryDetail = 'recovery_already_in_progress'
+            return 'none'
+        }
+        this.recoveryInProgress.add(guildId)
+
         let action: RecoveryAction = 'none'
         let detail = 'nothing_to_recover'
         let didRejoin = false
@@ -202,6 +210,8 @@ export class MusicWatchdogService {
                 error,
                 data: { guildId },
             })
+        } finally {
+            this.recoveryInProgress.delete(guildId)
         }
 
         state.lastRecoveryAction = action
@@ -255,66 +265,77 @@ export class MusicWatchdogService {
     ): Promise<void> {
         const existingQueue = player.nodes.get(guildId)
         if (existingQueue?.node.isPlaying()) return
+        if (this.intentionalStops.has(guildId)) return
+        if (this.recoveryInProgress.has(guildId)) return
 
-        const snapshot = await musicSessionSnapshotService.getSnapshot(guildId)
-        if (!snapshot) return
+        this.recoveryInProgress.add(guildId)
+        try {
+            const snapshot =
+                await musicSessionSnapshotService.getSnapshot(guildId)
+            if (!snapshot) return
 
-        const ageMs = Date.now() - snapshot.savedAt
-        if (ageMs > SNAPSHOT_MAX_AGE_MS) return
+            const ageMs = Date.now() - snapshot.savedAt
+            if (ageMs > SNAPSHOT_MAX_AGE_MS) return
 
-        const guild = player.client.guilds.cache.get(guildId)
-        if (!guild) return
+            const guild = player.client.guilds.cache.get(guildId)
+            if (!guild) return
 
-        const voiceChannelId = snapshot.voiceChannelId
-        if (!voiceChannelId) return
+            const voiceChannelId = snapshot.voiceChannelId
+            if (!voiceChannelId) return
 
-        const channel = guild.channels.cache.get(voiceChannelId)
-        if (!channel || channel.type !== ChannelType.GuildVoice) return
+            const channel = guild.channels.cache.get(voiceChannelId)
+            if (!channel || channel.type !== ChannelType.GuildVoice) return
 
-        const voiceChannel = channel as VoiceChannel
-        const membersInChannel = voiceChannel.members.filter((m) => !m.user.bot)
-        if (membersInChannel.size === 0) return
-
-        infoLog({
-            message: 'Watchdog detected orphan session, attempting rejoin',
-            data: { guildId, voiceChannelId, snapshotAgeMs: ageMs },
-        })
-
-        const queue = existingQueue ?? player.nodes.create(guild)
-        if (!existingQueue) {
-            queue.setRepeatMode(3)
-            await queue.connect(voiceChannel)
-        }
-
-        const restoreResult = await musicSessionSnapshotService.restoreSnapshot(
-            queue,
-            undefined,
-            { skipCurrentTrack: true },
-        )
-        if (!restoreResult || restoreResult.restoredCount <= 0) {
-            await musicSessionSnapshotService.deleteSnapshot(guildId)
-
-            const state = this.ensureState(guildId)
-            state.lastRecoveryAction = 'failed'
-            state.lastRecoveryAt = Date.now()
-            state.lastRecoveryDetail = 'snapshot_restore_empty'
+            const voiceChannel = channel as VoiceChannel
+            const membersInChannel = voiceChannel.members.filter(
+                (m) => !m.user.bot,
+            )
+            if (membersInChannel.size === 0) return
 
             infoLog({
-                message:
-                    'Watchdog orphan session restore produced no tracks; snapshot cleared',
-                data: { guildId, voiceChannelId },
+                message: 'Watchdog detected orphan session, attempting rejoin',
+                data: { guildId, voiceChannelId, snapshotAgeMs: ageMs },
             })
-            return
+
+            const queue = existingQueue ?? player.nodes.create(guild)
+            if (!existingQueue) {
+                queue.setRepeatMode(3)
+                await queue.connect(voiceChannel)
+            }
+
+            const restoreResult =
+                await musicSessionSnapshotService.restoreSnapshot(
+                    queue,
+                    undefined,
+                    { skipCurrentTrack: true },
+                )
+            if (!restoreResult || restoreResult.restoredCount <= 0) {
+                await musicSessionSnapshotService.deleteSnapshot(guildId)
+
+                const state = this.ensureState(guildId)
+                state.lastRecoveryAction = 'failed'
+                state.lastRecoveryAt = Date.now()
+                state.lastRecoveryDetail = 'snapshot_restore_empty'
+
+                infoLog({
+                    message:
+                        'Watchdog orphan session restore produced no tracks; snapshot cleared',
+                    data: { guildId, voiceChannelId },
+                })
+                return
+            }
+
+            const state = this.ensureState(guildId)
+            state.lastRecoveryAction = 'rejoin'
+            state.lastRecoveryAt = Date.now()
+
+            infoLog({
+                message: 'Watchdog orphan session recovered',
+                data: { guildId },
+            })
+        } finally {
+            this.recoveryInProgress.delete(guildId)
         }
-
-        const state = this.ensureState(guildId)
-        state.lastRecoveryAction = 'rejoin'
-        state.lastRecoveryAt = Date.now()
-
-        infoLog({
-            message: 'Watchdog orphan session recovered',
-            data: { guildId },
-        })
     }
 
     getGuildState(guildId: string): WatchdogGuildState {

--- a/packages/bot/src/services/musicManagement/watchdog.ts
+++ b/packages/bot/src/services/musicManagement/watchdog.ts
@@ -167,7 +167,8 @@ export class MusicWatchdogService {
             state.lastRecoveryDetail = 'recovery_already_in_progress'
             return 'none'
         }
-        this.recoveryInProgress.set(guildId, Date.now())
+        const lockToken = Date.now()
+        this.recoveryInProgress.set(guildId, lockToken)
 
         let action: RecoveryAction = 'none'
         let detail = 'nothing_to_recover'
@@ -227,7 +228,11 @@ export class MusicWatchdogService {
                 data: { guildId },
             })
         } finally {
-            this.recoveryInProgress.delete(guildId)
+            // Only release if this call still owns the lock — a stale-lock
+            // expiry may have already let a newer recovery acquire it.
+            if (this.recoveryInProgress.get(guildId) === lockToken) {
+                this.recoveryInProgress.delete(guildId)
+            }
         }
 
         state.lastRecoveryAction = action
@@ -285,7 +290,8 @@ export class MusicWatchdogService {
         if (isReplenishSuppressed(guildId)) return
         if (this.isRecoveryInProgress(guildId)) return
 
-        this.recoveryInProgress.set(guildId, Date.now())
+        const lockToken = Date.now()
+        this.recoveryInProgress.set(guildId, lockToken)
         try {
             const snapshot =
                 await musicSessionSnapshotService.getSnapshot(guildId)
@@ -351,7 +357,9 @@ export class MusicWatchdogService {
                 data: { guildId },
             })
         } finally {
-            this.recoveryInProgress.delete(guildId)
+            if (this.recoveryInProgress.get(guildId) === lockToken) {
+                this.recoveryInProgress.delete(guildId)
+            }
         }
     }
 

--- a/packages/bot/src/services/musicManagement/watchdog.ts
+++ b/packages/bot/src/services/musicManagement/watchdog.ts
@@ -36,7 +36,12 @@ export class MusicWatchdogService {
     private readonly timers = new Map<string, ReturnType<typeof setTimeout>>()
     private readonly states = new Map<string, WatchdogGuildState>()
     private readonly intentionalStops = new Set<string>()
-    private readonly recoveryInProgress = new Set<string>()
+    // Value is the acquisition timestamp, not just membership — an entry
+    // older than recoveryLockMaxMs is treated as stale (e.g. a hung
+    // queue.node.play()/restoreSnapshot() that never settles) so a single
+    // wedged recovery can't permanently block future recovery for a guild.
+    private readonly recoveryInProgress = new Map<string, number>()
+    private readonly recoveryLockMaxMs = 30_000
     private orphanMonitorInterval: ReturnType<typeof setInterval> | null = null
 
     constructor(options: MusicWatchdogOptions = {}) {
@@ -66,6 +71,16 @@ export class MusicWatchdogService {
         }
         this.states.set(guildId, created)
         return created
+    }
+
+    private isRecoveryInProgress(guildId: string): boolean {
+        const startedAt = this.recoveryInProgress.get(guildId)
+        if (startedAt === undefined) return false
+        if (Date.now() - startedAt > this.recoveryLockMaxMs) {
+            this.recoveryInProgress.delete(guildId)
+            return false
+        }
+        return true
     }
 
     private async waitForConnectionReady(
@@ -147,12 +162,12 @@ export class MusicWatchdogService {
             return 'none'
         }
 
-        if (this.recoveryInProgress.has(guildId)) {
+        if (this.isRecoveryInProgress(guildId)) {
             state.lastRecoveryAction = 'none'
             state.lastRecoveryDetail = 'recovery_already_in_progress'
             return 'none'
         }
-        this.recoveryInProgress.add(guildId)
+        this.recoveryInProgress.set(guildId, Date.now())
 
         let action: RecoveryAction = 'none'
         let detail = 'nothing_to_recover'
@@ -268,9 +283,9 @@ export class MusicWatchdogService {
         if (existingQueue?.node.isPlaying()) return
         if (this.intentionalStops.has(guildId)) return
         if (isReplenishSuppressed(guildId)) return
-        if (this.recoveryInProgress.has(guildId)) return
+        if (this.isRecoveryInProgress(guildId)) return
 
-        this.recoveryInProgress.add(guildId)
+        this.recoveryInProgress.set(guildId, Date.now())
         try {
             const snapshot =
                 await musicSessionSnapshotService.getSnapshot(guildId)


### PR DESCRIPTION
## What

Three confirmed bugs — #1949, #1948, #1957 — share one root cause: two guard primitives (`musicWatchdogService.isIntentionalStop(guildId)`, `isReplenishSuppressed(guildId)`) already exist and are correctly checked on the `disconnect` event and the `playerFinish`/`playerSkip` → `handleQueueExhaustion` path, but 4 other mutation sites never check them at all:

- `watchdog.ts`'s `recoverOrphanSession()` — reconnects + restores a snapshot with no `isIntentionalStop` check
- `lifecycleHandlers.ts`'s `connection` event — restores a snapshot with no `isIntentionalStop` check (sibling `disconnect` handler already guards correctly)
- `lifecycleHandlers.ts`'s `emptyQueue` event — refills via autoplay with no guard check at all
- `clear.ts` — never sets the suppression flag, so autoplay silently refills after the current track ends naturally

## Fix

Wire the two existing guards into all four gaps. Also add a `recoveryInProgress` per-guild lock in `watchdog.ts` so `checkAndRecover` (25s timer) and the orphan-session monitor (60s interval) can't both act on the same guild concurrently — the other half of #1949's join/leave-loop symptom.

No new state model, no removed watchdog logic — this is the existing guard pattern (already correct on 2 of 6 call sites) applied consistently to the other 4.

## Fixes

Closes #1949, Closes #1948, Closes #1957

## Testing

- 6 new tests added across `watchdog.spec.ts`, `lifecycleHandlers.spec.ts`, `clear.spec.ts` exercising each new guard + the concurrency lock
- Full `test:bot` suite green (244/245, 1 pre-existing skip unchanged)
- `type:check` clean
- Adversarial critic pass (Opus, different tier): PASS — verified no stuck-lock paths, no silent state gaps, no unintended behavior changes to `/play` after an intentional stop

## Context

Surfaced by a deep-dive session/voice reliability investigation (discord.js/discord-player lifecycle research + causal trace + `/play` silent-failure sweep). 5 more findings from that investigation filed separately as #1993–#1997 (not part of this PR).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard connection restore on intentional stop, and make orphan-session recovery and autoplay honor both stop and suppression flags. Add a per‑guild recovery lock with a 30s expiry and ownership‑aware release to prevent duplicate or wedged recoveries, and clear suppression when the next non‑autoplay track starts so `/clear` isn’t undone. This resolves #1949, #1948, and #1957.

- **Bug Fixes**
  - Connection: skip snapshot restore when an intentional stop is set. Orphan-session scan: honor stop/suppression and use a per‑guild recovery-in-progress lock that expires after 30s and only releases if still owned.
  - emptyQueue: only replenish if autoplay is on, not intentionally stopped, and not suppressed. `/clear` sets suppression with a 1‑hour safety ceiling, and we lift suppression when the next non‑autoplay track starts. We don’t force-stop when suppression applies.

<sup>Written for commit f7bb54611b69ae8f6d9f2963d46291393f03928a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/1998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing a music queue now pauses autoplay replenishment for one hour.
  * Starting an explicit track immediately resumes normal queue replenishment.
  * Intentional stops and suppressed queues are no longer automatically restarted.
  * Improved recovery handling to prevent duplicate playback attempts during simultaneous recovery events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->