### PR TITLE
fix(ci): add a second retry for docker-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,10 +354,30 @@ jobs:
                   file: ${{ matrix.file }}
                   target: ${{ matrix.target }}
                   load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
-            # Retry once on transient failure (buildx setup and build re-run
-            # together, matching the previous separate retry steps).
-            - name: Build ${{ matrix.service }} - retry once on transient failure
+            # Retry on transient failure (buildx setup and build re-run
+            # together, matching the previous separate retry steps). Two
+            # retries (three attempts total) because the failure mode here
+            # isn't a one-off blip: BuildKit intermittently fails to resolve
+            # a COPY --from=<stage> reference — "failed to calculate
+            # checksum of ref ...: not found" — and which specific path it
+            # hits varies run to run (node_modules, dist, prisma, generated
+            # — reproduced across all of them). Disk pressure, GHA cache,
+            # buildx version, and Dockerfile structure were all ruled out
+            # with direct evidence; this reads as upstream BuildKit/runner
+            # flakiness with a high enough per-attempt failure rate that a
+            # single retry isn't reliably enough headroom.
+            - name: Build ${{ matrix.service }} - retry 1 on transient failure
+              id: build-retry-1
               if: steps.build.outcome == 'failure'
+              continue-on-error: true
+              uses: ./.github/actions/docker-build-service
+              with:
+                  service: ${{ matrix.service }}
+                  file: ${{ matrix.file }}
+                  target: ${{ matrix.target }}
+                  load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
+            - name: Build ${{ matrix.service }} - retry 2 on transient failure
+              if: steps.build.outcome == 'failure' && steps.build-retry-1.outcome == 'failure'
               uses: ./.github/actions/docker-build-service
               with:
                   service: ${{ matrix.service }}


### PR DESCRIPTION
## Summary
- Adds a second retry attempt (three total) to the docker-build matrix job for bot/backend/frontend/nginx.

## Why
The failure isn't a one-off blip: BuildKit intermittently fails to resolve a COPY --from=stage reference (failed to calculate checksum of ref ...: not found), and which specific path it hits varies run to run (node_modules, dist, prisma, generated all reproduced across #2005/#2006). Disk pressure, GHA cache staleness, buildx version, and Dockerfile stage structure were all ruled out with direct evidence. This reads as upstream BuildKit/runner flakiness with a high enough per-attempt failure rate that a single retry isn't reliably enough headroom.

## Test plan
- [ ] CI docker-build matrix passes (verifies the new retry step syntax/behavior end to end)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a second retry to the docker-build matrix job (three attempts total) for `bot`, `backend`, `frontend`, and `nginx` to mitigate intermittent BuildKit COPY-from failures and stabilize CI.

<sup>Written for commit 9e0caf0b734c9f29779305a250e9ed1e3a3b23f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

