### PR TITLE
fix(ci): skip gha cache-from on docker-build retries

### DIFF
--- a/.github/actions/docker-build-service/action.yml
+++ b/.github/actions/docker-build-service/action.yml
@@ -15,6 +15,16 @@ inputs:
         description: Load the built image into the local Docker daemon.
         required: false
         default: 'false'
+    use-cache:
+        description: >-
+            Import the gha layer cache for this service. Set to 'false' on
+            retries: BuildKit's "failed to calculate checksum of ref ...:
+            not found" failure comes from a stale/corrupted gha cache entry,
+            and cache-from is scoped identically across retries within the
+            same job, so a retry that reimports it fails identically instead
+            of getting a fresh build.
+        required: false
+        default: 'true'
 runs:
     using: composite
     steps:
@@ -52,7 +62,7 @@ runs:
               tags: lucky-${{ inputs.service }}:ci
               provenance: false
               sbom: false
-              cache-from: type=gha,scope=${{ inputs.service }}
+              cache-from: ${{ inputs.use-cache == 'true' && format('type=gha,scope={0}', inputs.service) || '' }}
               cache-to: type=gha,mode=max,scope=${{ inputs.service }}
               build-args: |
                   COMMIT_SHA=${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,17 +355,18 @@ jobs:
                   target: ${{ matrix.target }}
                   load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
             # Retry on transient failure (buildx setup and build re-run
-            # together, matching the previous separate retry steps). Two
-            # retries (three attempts total) because the failure mode here
-            # isn't a one-off blip: BuildKit intermittently fails to resolve
-            # a COPY --from=<stage> reference — "failed to calculate
-            # checksum of ref ...: not found" — and which specific path it
-            # hits varies run to run (node_modules, dist, prisma, generated
-            # — reproduced across all of them). Disk pressure, GHA cache,
-            # buildx version, and Dockerfile structure were all ruled out
-            # with direct evidence; this reads as upstream BuildKit/runner
-            # flakiness with a high enough per-attempt failure rate that a
-            # single retry isn't reliably enough headroom.
+            # together, matching the previous separate retry steps). Root
+            # cause: BuildKit fails to resolve a COPY --from=<stage>
+            # reference — "failed to calculate checksum of ref ...: not
+            # found" — because cache-from imports a stale/corrupted gha
+            # cache entry for that stage. cache-from is scoped identically
+            # across attempts within the same job, so a retry that reimports
+            # the same entry fails identically instead of getting a fresh
+            # build (confirmed: all retries in one job fail on the exact
+            # same ref hash). use-cache: 'false' skips cache-from on retries
+            # so they build fresh instead of re-hitting the poisoned cache.
+            # Two retries (three attempts total) for headroom against the
+            # ordinary transient case too.
             - name: Build ${{ matrix.service }} - retry 1 on transient failure
               id: build-retry-1
               if: steps.build.outcome == 'failure'
@@ -376,6 +377,7 @@ jobs:
                   file: ${{ matrix.file }}
                   target: ${{ matrix.target }}
                   load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
+                  use-cache: 'false'
             - name: Build ${{ matrix.service }} - retry 2 on transient failure
               if: steps.build.outcome == 'failure' && steps.build-retry-1.outcome == 'failure'
               uses: ./.github/actions/docker-build-service
@@ -384,6 +386,7 @@ jobs:
                   file: ${{ matrix.file }}
                   target: ${{ matrix.target }}
                   load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
+                  use-cache: 'false'
             # A built image is not a working image: the bot's native addons
             # (@discordjs/opus) and the baked Prisma engines only fail at
             # require()-time, which `docker build` never reaches. #1735 shipped a


### PR DESCRIPTION
## Summary
- Skip the gha layer cache import on docker-build retry attempts.

## Why
#2006's own CI run gave the missing piece: all three attempts (build, retry 1, retry 2) failed identically within the same job, each time on the exact same buildx ref hash across multiple unrelated COPY paths (packages/shared/src/generated, packages/shared/dist, packages/bot/dist, prisma). cache-from is scoped identically (type=gha,scope=<service>) across every attempt in a job, so a retry that reimports a stale or corrupted gha cache entry fails identically instead of getting a fresh build. That's why the retry-count fix in #2007 did not save #2006's run.

Adds a `use-cache` input to `docker-build-service` (default true) and sets it to false on both retry steps in ci.yml, so retries skip cache-from and build from scratch. cache-to stays on so a successful retry still writes a fresh cache for the next run.

## Test plan
- [ ] CI docker-build matrix passes on this PR
- [ ] Resync PR 2006 onto main once this merges and confirm its Build - bot / Build - backend go green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip importing the GHA layer cache on docker-build retries to prevent repeated BuildKit failures. Retries now build fresh while still writing a new cache on success.

- **Bug Fixes**
  - Added `use-cache` input to `./.github/actions/docker-build-service` (default `true`); set to `false` on retry steps in `ci.yml` to omit `cache-from`.
  - Keeps `cache-to: type=gha,mode=max` so successful retries repopulate the cache and resolves the "failed to calculate checksum of ref ...: not found" errors from stale `type=gha,scope=<service>` entries.

<sup>Written for commit aee532a0d6f97f3b0f59dbc785f5cbb8450a31f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

