### PR TITLE
fix(ci): isolate docker cache scope by branch

### DIFF
--- a/.github/actions/docker-build-service/action.yml
+++ b/.github/actions/docker-build-service/action.yml
@@ -62,8 +62,8 @@ runs:
               tags: lucky-${{ inputs.service }}:ci
               provenance: false
               sbom: false
-              cache-from: ${{ inputs.use-cache == 'true' && format('type=gha,scope={0}', inputs.service) || '' }}
-              cache-to: type=gha,mode=max,scope=${{ inputs.service }}
+              cache-from: ${{ inputs.use-cache == 'true' && format('type=gha,scope={0}-{1}', github.ref_name, inputs.service) || '' }}
+              cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ inputs.service }}
               build-args: |
                   COMMIT_SHA=${{ github.sha }}
                   NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
Fixes the concurrent-PR cache-scope collision tracked in issue #2002.

## Summary
- Scopes GHA cache-from/cache-to by branch name (`github.ref_name`) + service name
- Each branch maintains its own isolated cache namespace
- Prevents cross-PR cache poisoning where PR-A's build layers contaminate PR-B's cache on concurrent runs

## What Changed
Both `cache-from` and `cache-to` in `.github/actions/docker-build-service/action.yml` now include the branch name in the scope:

Before: `scope={service}` (all branches shared same scope)
After: `scope={branch}-{service}` (each branch has isolated scope)

## Why
Previously when two PRs built concurrently:
1. PR-A exports its backend build cache to scope `backend`
2. PR-B tries to import cache for scope `backend`
3. PR-B gets PR-A's cache containing layers from PR-A's code
4. BuildKit hits cache mismatches, or runs with incorrect dependencies

This is now prevented by giving each branch its own scope (e.g., `fix/issue-123-backend`, `main-backend`).

## Related
- Closes #2002 (the cache-scope collision)
- Note: The BuildKit GC race (BuildKit evicting layers mid-build on concurrent builds) is a separate upstream bug (moby/buildkit#4128) already mitigated by retry logic in ci.yml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates Docker BuildKit cache scopes per branch to prevent cross-PR cache collisions. Previously all branches shared `{service}`; now the scope is `{github.ref_name}-{service}`, so each branch uses its own cache.

- Change is in `.github/actions/docker-build-service/action.yml`: `cache-from` and `cache-to` now include `github.ref_name`.
- No workflow or service changes required; `inputs.use-cache` behavior is unchanged.
- Expect a cold cache on the first build of each branch; `main-{service}` will be populated after merge.
- Optional: delete old `gha` caches with scope `{service}` to reclaim space.

<sup>Written for commit b4f001accfd0184c6624eb2da8cc4fe68efc9fa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build caching across branches and release references.
  * Cache reuse remains available only when explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->