### PR TITLE
fix(ci): disable cache-to (not just cache-from) on docker-build retries

### DIFF
--- a/.github/actions/docker-build-service/action.yml
+++ b/.github/actions/docker-build-service/action.yml
@@ -17,12 +17,20 @@ inputs:
         default: 'false'
     use-cache:
         description: >-
-            Import the gha layer cache for this service. Set to 'false' on
-            retries: BuildKit's "failed to calculate checksum of ref ...:
-            not found" failure comes from a stale/corrupted gha cache entry,
-            and cache-from is scoped identically across retries within the
-            same job, so a retry that reimports it fails identically instead
-            of getting a fresh build.
+            Import AND export the gha layer cache for this service. Set to
+            'false' on retries: BuildKit's "failed to calculate checksum of
+            ref ...: not found" failure comes from a stale/corrupted gha
+            cache entry, and cache-from is scoped identically across retries
+            within the same job, so a retry that reimports it fails
+            identically instead of getting a fresh build. Evidence from
+            2026-08-14 (PR #1956, #1952) shows the same error on retries with
+            cache-from already disabled — cache-to's mode=max export also
+            has to "solve" a cache key for every intermediate stage,
+            including the branching installed-deps checkpoint (see Dockerfile
+            comment above that stage), so it can hit the identical
+            checksum-resolution failure on export alone. Disabling cache-to
+            too on retries gives a fully cache-free build for the class of
+            failure caching alone doesn't explain.
         required: false
         default: 'true'
 runs:
@@ -63,7 +71,7 @@ runs:
               provenance: false
               sbom: false
               cache-from: ${{ inputs.use-cache == 'true' && format('type=gha,scope={0}-{1}', github.ref_name, inputs.service) || '' }}
-              cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ inputs.service }}
+              cache-to: ${{ inputs.use-cache == 'true' && format('type=gha,mode=max,scope={0}-{1}', github.ref_name, inputs.service) || '' }}
               build-args: |
                   COMMIT_SHA=${{ github.sha }}
                   NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## Problem

Retries in `.github/workflows/ci.yml`'s `docker-build` job already set `use-cache: 'false'` to skip importing the gha layer cache after a `failed to calculate checksum of ref ...: not found` failure — but `cache-to` (mode=max export) stayed active regardless of `use-cache`.

## Evidence

PR #1956 and #1952 (2026-08-14) both exhausted all 3 attempts (build + 2 retries) with the identical error, even though retry 1 and retry 2 both had `cache-from` disabled:

```
ERROR: failed to calculate checksum of ref ...: "/app/packages/backend/node_modules": not found
```

Cache import being off but the failure persisting identically means the export side alone can trigger the same checksum-resolution failure — `mode=max` has to solve a cache key for every intermediate stage, including the branching `installed-deps` checkpoint that two downstream stages (`source-copied` and `deps-production-base`) read from concurrently.

## Fix

Gate `cache-to` by the same `use-cache` flag so retries run a genuinely cache-free build (no import, no export) instead of only skipping import.

## Test plan

- [ ] This PR's own `docker-build` matrix job (backend/bot/frontend/nginx) passes, validating the composite action change works
- [ ] Once merged, rebase #1956 and #1952 onto main and confirm their `Build — Docker images` required check goes green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `cache-to` on `docker-build` retries when `use-cache` is false to run a fully cache-free build and avoid the BuildKit “failed to calculate checksum of ref …: not found” error. Previously, retries disabled only `cache-from` while still exporting with `mode=max`, which could reproduce the same failure during export.

- Change: In `.github/actions/docker-build-service/action.yml`, gate `cache-to` by `inputs.use-cache` (mirrors `cache-from`). First attempts unchanged; retries now skip both import and export.
- Validate: CI `docker-build` matrix should pass and show no cache writes on retries.
- Follow-up: Rebase #1956 and #1952 and confirm `Build — Docker images` passes.

<sup>Written for commit 33bdce648f61ce4ce49080bbc4d0e95d0e88974f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build caching behavior during retries and cache-resolution failures.
  * Cache export is now disabled when caching is turned off, preventing unnecessary cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->