### PR TITLE
fix(ci): bump docker-build retries from 2 to 4 (5 attempts total)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,17 +356,18 @@ jobs:
                   load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
             # Retry on transient failure (buildx setup and build re-run
             # together, matching the previous separate retry steps). Root
-            # cause: BuildKit fails to resolve a COPY --from=<stage>
-            # reference — "failed to calculate checksum of ref ...: not
-            # found" — because cache-from imports a stale/corrupted gha
-            # cache entry for that stage. cache-from is scoped identically
-            # across attempts within the same job, so a retry that reimports
-            # the same entry fails identically instead of getting a fresh
-            # build (confirmed: all retries in one job fail on the exact
-            # same ref hash). use-cache: 'false' skips cache-from on retries
-            # so they build fresh instead of re-hitting the poisoned cache.
-            # Two retries (three attempts total) for headroom against the
-            # ordinary transient case too.
+            # cause (see issue #2015): a local BuildKit race resolving a
+            # COPY --from=<stage> reference — "failed to calculate checksum
+            # of ref ...: not found" — while that shared stage
+            # (installed-deps) is concurrently extended by a second live
+            # branch in the same build DAG. Confirmed NOT a gha-cache issue:
+            # reproduces 6/6 with cache-from AND cache-to fully disabled
+            # (#2013, #2002). use-cache: 'false' is kept on retries anyway
+            # (harmless, avoids any residual cache-side variable) but the
+            # real mitigation here is attempt count — it's a race, not
+            # deterministic, so more attempts raise the odds one lands
+            # clean. Four retries (five attempts total) until #2015's
+            # Dockerfile restructure removes the race itself.
             - name: Build ${{ matrix.service }} - retry 1 on transient failure
               id: build-retry-1
               if: steps.build.outcome == 'failure'
@@ -379,7 +380,29 @@ jobs:
                   load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
                   use-cache: 'false'
             - name: Build ${{ matrix.service }} - retry 2 on transient failure
+              id: build-retry-2
               if: steps.build.outcome == 'failure' && steps.build-retry-1.outcome == 'failure'
+              continue-on-error: true
+              uses: ./.github/actions/docker-build-service
+              with:
+                  service: ${{ matrix.service }}
+                  file: ${{ matrix.file }}
+                  target: ${{ matrix.target }}
+                  load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
+                  use-cache: 'false'
+            - name: Build ${{ matrix.service }} - retry 3 on transient failure
+              id: build-retry-3
+              if: steps.build.outcome == 'failure' && steps.build-retry-1.outcome == 'failure' && steps.build-retry-2.outcome == 'failure'
+              continue-on-error: true
+              uses: ./.github/actions/docker-build-service
+              with:
+                  service: ${{ matrix.service }}
+                  file: ${{ matrix.file }}
+                  target: ${{ matrix.target }}
+                  load: ${{ matrix.service == 'bot' || matrix.service == 'nginx' }}
+                  use-cache: 'false'
+            - name: Build ${{ matrix.service }} - retry 4 on transient failure
+              if: steps.build.outcome == 'failure' && steps.build-retry-1.outcome == 'failure' && steps.build-retry-2.outcome == 'failure' && steps.build-retry-3.outcome == 'failure'
               uses: ./.github/actions/docker-build-service
               with:
                   service: ${{ matrix.service }}


### PR DESCRIPTION
## Context

Follow-up to #2013. That PR gated \`cache-to\` by \`use-cache\` on retries so they run fully cache-free — this definitively ruled out the gha cache as the cause (see #2002's latest comments): the identical \`failed to calculate checksum of ref ...: not found\` error reproduced 6/6 across PR #1956 and #1952 with cache completely disabled.

Real cause is a local BuildKit race (filed as #2015) — not something to fix with another CI-config tweak, needs a Dockerfile restructure.

## Interim mitigation

Since it's a race (not deterministic — some runs the same day succeeded), bump retries from 2 to 4 (5 attempts total) to raise the odds one attempt lands clean while #2015 is worked.

## Test plan

- [ ] This PR's own docker-build check passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase CI docker-build retries from 2 to 4 (5 attempts total) to mitigate a non-deterministic BuildKit race that triggers "failed to calculate checksum of ref ...: not found". Previously we retried twice with cache disabled on retries; now we retry four times, still disabling cache on retries, trading longer worst-case time for higher pass rates until the Dockerfile fix in issue #2015.

- Adds retry steps 2–4 and uses `continue-on-error: true` for the middle attempts to allow progressing to the next retry; the final attempt determines job failure.
- Leaves the first attempt unchanged and keeps `use-cache: 'false'` on all retries.
- No other workflow logic changes; service-specific `load` behavior remains the same.

<sup>Written for commit 1c267f7139d185a51b0fcc6ab8f4fbaa8b36511e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

