### PR TITLE
fix(docker): decouple deps-production-base from installed-deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,17 +177,26 @@ COPY packages/bot/package*.json ./packages/bot/
 COPY packages/backend/package*.json ./packages/backend/
 COPY packages/frontend/package*.json ./packages/frontend/
 
-# Reuse already-compiled node_modules from the pre-build checkpoint (avoids
-# double @discordjs/opus compilation).
-COPY --from=installed-deps /app/node_modules ./node_modules
-COPY --from=installed-deps /app/packages/shared/node_modules ./packages/shared/node_modules
+# Independent npm ci instead of COPY --from=installed-deps (issue #2015).
+# installed-deps is concurrently extended by a second live branch
+# (source-copied, via FROM inheritance) for the whole rest of this build —
+# COPY --from of it while that's happening hit a BuildKit race ("failed to
+# calculate checksum of ref ...: not found"), non-deterministically but at
+# a very high rate on GH Actions runners, and never resolved by cache
+# tuning or retries alone (#2002, #2013, #2016). Running npm ci here
+# duplicates the @discordjs/opus native compile once — this stage is
+# shared by both deps-production-bot and deps-production-backend below, so
+# it's a one-time cost per build, not per target — but fully decouples this
+# lineage from installed-deps: no more cross-stage read of a stage still
+# being written to elsewhere.
+RUN --mount=type=cache,id=npm-build-stage-v4-${NPM_CACHE_KEY},target=/root/.npm,sharing=locked \
+    YOUTUBE_DL_SKIP_DOWNLOAD=1 \
+    npm ci --legacy-peer-deps --no-audit --no-fund
 
 FROM deps-production-base AS deps-production-bot
-COPY --from=installed-deps /app/packages/bot/node_modules ./packages/bot/node_modules
 RUN npm prune --omit=dev --legacy-peer-deps
 
 FROM deps-production-base AS deps-production-backend
-COPY --from=installed-deps /app/packages/backend/node_modules ./packages/backend/node_modules
 RUN npm prune --omit=dev --legacy-peer-deps
 
 # Production stage — bot (full runtime with ffmpeg/opus/yt-dlp)


### PR DESCRIPTION
## Root cause (issue #2015)

\`installed-deps\` (an empty checkpoint = \`FROM build AS installed-deps\`) is consumed by two different lineages within a single \`docker buildx build\` invocation for any \`production-*\` target:

1. \`source-copied\` (\`FROM installed-deps\`) → \`build-shared\` → \`build-backend\`/\`build-bot\`/\`build-frontend\` — inherits and keeps extending \`installed-deps\`'s filesystem with more COPY/RUN instructions.
2. \`deps-production-base\` did \`COPY --from=installed-deps /app/node_modules ...\` and \`COPY --from=installed-deps /app/packages/shared/node_modules ...\`; \`deps-production-bot\`/\`deps-production-backend\` each did one more \`COPY --from=installed-deps\` for their own package's node_modules.

Both lineages read/extend \`installed-deps\` concurrently — BuildKit parallelizes independent branches of the stage DAG by default. The \`COPY --from\` reads in branch 2 race against branch 1 still actively extending the same stage, and intermittently fail:

\`\`\`
ERROR: failed to calculate checksum of ref ...: "/app/packages/backend/node_modules": not found
\`\`\`

Confirmed **not** a caching issue: reproduced 10/10 recent attempts across #1956 and #1952 with the gha cache fully disabled (#2013), and retries alone don't reliably dodge it even with 5 attempts (#2016).

## Fix

\`deps-production-base\` already branches straight from \`node:${NODE_VERSION}\` (never touches \`installed-deps\` or \`build\`). Give it its own \`npm ci\` instead of copying node_modules out of \`installed-deps\` — this fully removes the cross-stage read of a stage still being concurrently written to. \`deps-production-bot\`/\`deps-production-backend\` no longer need any \`COPY --from=installed-deps\` at all (npm workspaces already installs every workspace's node_modules from the root \`npm ci\`).

Cost: one extra \`@discordjs/opus\` native compile, paid once per build (this stage is shared by both bot and backend production targets) — versus the 3-5 min routinely wasted on exhausted retries recently.

## Verification

Not locally build-verified end-to-end — native C compilation under QEMU cross-arch emulation (amd64 on an arm64 Mac via colima) segfaults GCC independent of this change (\`cc: internal compiler error: Segmentation fault signal terminated program cc1\`), a known QEMU/cross-compile instability class not present on real amd64 hardware. Relying on this PR's own CI (real amd64 runners, matching production) to validate.

## Test plan

- [ ] This PR's own \`docker-build\` matrix (bot/backend/frontend/nginx) passes, ideally on the very first attempt (no retries needed) — confirms the race is actually gone, not just dodged
- [ ] \`Verify native modules load — bot\` step still passes (opus still loads correctly from the independently-installed node_modules)
- [ ] Once merged, rebase #1956 and #1952 and confirm their Docker build check goes green cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples `deps-production-base` from `installed-deps` by running `npm ci` instead of copying `node_modules`. This removes a BuildKit race that intermittently failed production builds with checksum-not-found errors.

- Replaces `COPY --from=installed-deps` with `npm ci` (with cache mount) in `deps-production-base`; removes the per-package `COPY --from=installed-deps` in `deps-production-bot` and `deps-production-backend`; keeps `npm prune --omit=dev`.
- Fixes the root cause: `installed-deps` was read while another branch still extended it, triggering parallel BuildKit races (“failed to calculate checksum of ref …: not found”).
- Impact: one extra `@discordjs/opus` native compile once per build; no runtime changes; workspace `npm ci` still installs all package `node_modules`.
- Rollout: no migrations; CI should pass without retries. Rebase PRs previously failing on issue #2015 after merge.

<sup>Written for commit 1b1a877dd544c1b863fb426ebae672fc509d8654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production container dependency installation and caching.
  * Streamlined separate production builds for bot and backend services.
  * Reduced reliance on shared dependency copies between build stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->