### PR TITLE
fix(bot): support yt-dlp cookies file to dodge YouTube 403

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,9 @@ worktrees/
 archive/
 downloads/
 
+# yt-dlp cookies credential (bind-mounted at runtime, never baked into the image)
+secrets/
+
 # Documentation
 docs/
 *.md

--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,13 @@ COMMAND_CATEGORIES_DISABLED=
 # Logging Configuration
 LOG_LEVEL=1
 
+# Optional: path to a Netscape-format cookies.txt for yt-dlp, to avoid
+# YouTube's cookie-less-request 403s (see decisions/2026-06-18-youtube-extraction-reliability.md).
+# docker-compose sets this to /app/secrets/youtube-cookies.txt automatically —
+# see secrets/README.md for how to generate the file. No-ops if unset or the
+# file doesn't exist.
+# YTDLP_COOKIES_FILE=
+
 # Database Configuration
 # For docker compose, set POSTGRES_PASSWORD before `docker compose up`
 # (empty or unset fails the compose guard). Bot-only Redis fallback still works

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ secrets.json
 config.json
 *.secret
 
+# yt-dlp cookies (bot service, ADR 2026-06-18) — bind-mounted at ./secrets
+/secrets/*
+!/secrets/README.md
+
 # Cloudflare Tunnel (credentials; config.example.yml is committed)
 cloudflared/*.json
 cloudflared/config.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,11 @@ services:
             # host path that doesn't exist yet gets autocreated as a directory
             # by Docker, breaking the container. See the `webhook` service's
             # hooks.json comment for the same footgun.
-            - ./secrets:/app/secrets:ro
+            # Read-write (not :ro): yt-dlp's --cookies both reads AND dumps
+            # the refreshed cookie jar back to this file every run; read-only
+            # silently breaks that refresh (confirmed via local repro) and
+            # shortens the cookies' effective lifetime for no benefit.
+            - ./secrets:/app/secrets
         networks:
             - lucky-network
             # Shared monitoring network so the homelab Prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,13 @@ services:
             # the refreshed cookie jar back to this file every run; read-only
             # silently breaks that refresh (confirmed via local repro) and
             # shortens the cookies' effective lifetime for no benefit.
+            # Whole directory, not just the cookies file: a single-file
+            # rw bind to a host path that doesn't exist yet hits the same
+            # autocreate-as-directory footgun noted above, which would break
+            # on first boot before the operator has created the file. This
+            # directory is single-purpose (just the cookies file + a README
+            # excluded from the write concern by not being read by yt-dlp),
+            # so the broader write scope has no real blast radius today.
             - ./secrets:/app/secrets
         networks:
             - lucky-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,9 +128,18 @@ services:
             AI_DEV_TOOLKIT_BOARD_ENABLED: ${AI_DEV_TOOLKIT_BOARD_ENABLED:-false}
             AI_DEV_TOOLKIT_CHANNEL_ID: ${AI_DEV_TOOLKIT_CHANNEL_ID:-}
             GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+            # ADR 2026-06-18: yt-dlp cookies to dodge YouTube's 403 bot
+            # detection. Drop a Netscape-format cookies.txt at
+            # ./secrets/youtube-cookies.txt on the host; no-ops if absent.
+            YTDLP_COOKIES_FILE: ${YTDLP_COOKIES_FILE:-/app/secrets/youtube-cookies.txt}
         volumes:
             - ./downloads:/app/downloads
             - ./logs:/app/logs
+            # Directory mount (not single-file): a single-file bind-mount to a
+            # host path that doesn't exist yet gets autocreated as a directory
+            # by Docker, breaking the container. See the `webhook` service's
+            # hooks.json comment for the same footgun.
+            - ./secrets:/app/secrets:ro
         networks:
             - lucky-network
             # Shared monitoring network so the homelab Prometheus

--- a/packages/bot/src/handlers/player/streamBridge.spec.ts
+++ b/packages/bot/src/handlers/player/streamBridge.spec.ts
@@ -20,8 +20,11 @@ jest.mock('child_process', () => ({
     spawn: (...args: unknown[]) => mockSpawn(...args),
 }))
 const mockStatSync = jest.fn()
+const mockAccessSync = jest.fn()
 jest.mock('fs', () => ({
     statSync: (...args: unknown[]) => mockStatSync(...args),
+    accessSync: (...args: unknown[]) => mockAccessSync(...args),
+    constants: { R_OK: 4 },
 }))
 jest.mock('./soundcloudMatcher', () => ({
     streamViaSoundCloud: (...args: unknown[]) =>
@@ -70,6 +73,7 @@ import {
     createResilientStream,
     getStreamBridgeFallbackLabel,
     STREAM_BRIDGE_FALLBACK_METADATA_KEY,
+    __resetYtdlpCookiesLogStateForTests,
 } from './streamBridge.js'
 
 // ---------------------------------------------------------------------------
@@ -153,15 +157,16 @@ describe('streamViaYtDlp – cookies file', () => {
         return mockSpawn.mock.calls.at(-1)?.[1] as string[]
     }
 
+    beforeEach(() => {
+        __resetYtdlpCookiesLogStateForTests()
+        mockAccessSync.mockReset()
+    })
+
     afterEach(() => {
         if (originalEnv === undefined) delete process.env.YTDLP_COOKIES_FILE
         else process.env.YTDLP_COOKIES_FILE = originalEnv
     })
 
-    // Must run before the other cookies tests below: the missing-file and
-    // applied warn/info logs dedup via module-level flags that persist for
-    // the life of the module (not reset by jest's clearMocks), so this is
-    // the only test that can observe the "first time" transition of each.
     it('logs the missing/applied transition once each, not per call', async () => {
         process.env.YTDLP_COOKIES_FILE = cookiesPath
         mockStatSync.mockImplementation(() => {
@@ -206,9 +211,19 @@ describe('streamViaYtDlp – cookies file', () => {
         expect(await runOnce()).not.toContain('--cookies')
     })
 
-    it('passes --cookies <file> when YTDLP_COOKIES_FILE is a regular file', async () => {
+    it('does not pass --cookies when the file exists but is not readable', async () => {
         process.env.YTDLP_COOKIES_FILE = cookiesPath
         mockStatSync.mockReturnValue({ isFile: () => true })
+        mockAccessSync.mockImplementation(() => {
+            throw new Error('EACCES: permission denied')
+        })
+        expect(await runOnce()).not.toContain('--cookies')
+    })
+
+    it('passes --cookies <file> when YTDLP_COOKIES_FILE is a readable regular file', async () => {
+        process.env.YTDLP_COOKIES_FILE = cookiesPath
+        mockStatSync.mockReturnValue({ isFile: () => true })
+        mockAccessSync.mockReturnValue(undefined)
         const args = await runOnce()
         const idx = args.indexOf('--cookies')
         expect(idx).toBeGreaterThan(-1)

--- a/packages/bot/src/handlers/player/streamBridge.spec.ts
+++ b/packages/bot/src/handlers/player/streamBridge.spec.ts
@@ -19,9 +19,9 @@ const mockCaptureMessage = jest.fn()
 jest.mock('child_process', () => ({
     spawn: (...args: unknown[]) => mockSpawn(...args),
 }))
-const mockExistsSync = jest.fn()
+const mockStatSync = jest.fn()
 jest.mock('fs', () => ({
-    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+    statSync: (...args: unknown[]) => mockStatSync(...args),
 }))
 jest.mock('./soundcloudMatcher', () => ({
     streamViaSoundCloud: (...args: unknown[]) =>
@@ -142,45 +142,77 @@ describe('streamViaYtDlp – URL validation', () => {
 
 describe('streamViaYtDlp – cookies file', () => {
     const validUrl = 'https://www.youtube.com/watch?v=abc123'
+    const cookiesPath = '/app/secrets/youtube-cookies.txt'
     const originalEnv = process.env.YTDLP_COOKIES_FILE
+
+    async function runOnce() {
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        await streamViaYtDlp(validUrl)
+        return mockSpawn.mock.calls.at(-1)?.[1] as string[]
+    }
 
     afterEach(() => {
         if (originalEnv === undefined) delete process.env.YTDLP_COOKIES_FILE
         else process.env.YTDLP_COOKIES_FILE = originalEnv
     })
 
+    // Must run before the other cookies tests below: the missing-file and
+    // applied warn/info logs dedup via module-level flags that persist for
+    // the life of the module (not reset by jest's clearMocks), so this is
+    // the only test that can observe the "first time" transition of each.
+    it('logs the missing/applied transition once each, not per call', async () => {
+        process.env.YTDLP_COOKIES_FILE = cookiesPath
+        mockStatSync.mockImplementation(() => {
+            throw new Error('ENOENT')
+        })
+        await runOnce()
+        await runOnce()
+        expect(mockWarnLog).toHaveBeenCalledTimes(1)
+        expect(mockWarnLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('not a readable file'),
+            }),
+        )
+
+        mockStatSync.mockReturnValue({ isFile: () => true })
+        await runOnce()
+        await runOnce()
+        expect(mockInfoLog).toHaveBeenCalledTimes(1)
+        expect(mockInfoLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Bridge: yt-dlp cookies file applied',
+            }),
+        )
+    })
+
     it('does not pass --cookies when YTDLP_COOKIES_FILE is unset', async () => {
         delete process.env.YTDLP_COOKIES_FILE
-        const proc = makeFakeProc()
-        mockSpawn.mockReturnValue(proc)
-        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
-        await streamViaYtDlp(validUrl)
-        const args = mockSpawn.mock.calls[0][1] as string[]
-        expect(args).not.toContain('--cookies')
+        expect(await runOnce()).not.toContain('--cookies')
     })
 
     it('does not pass --cookies when the configured file does not exist', async () => {
-        process.env.YTDLP_COOKIES_FILE = '/app/secrets/youtube-cookies.txt'
-        mockExistsSync.mockReturnValue(false)
-        const proc = makeFakeProc()
-        mockSpawn.mockReturnValue(proc)
-        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
-        await streamViaYtDlp(validUrl)
-        const args = mockSpawn.mock.calls[0][1] as string[]
-        expect(args).not.toContain('--cookies')
+        process.env.YTDLP_COOKIES_FILE = cookiesPath
+        mockStatSync.mockImplementation(() => {
+            throw new Error('ENOENT')
+        })
+        expect(await runOnce()).not.toContain('--cookies')
     })
 
-    it('passes --cookies <file> when YTDLP_COOKIES_FILE is set and exists', async () => {
-        process.env.YTDLP_COOKIES_FILE = '/app/secrets/youtube-cookies.txt'
-        mockExistsSync.mockReturnValue(true)
-        const proc = makeFakeProc()
-        mockSpawn.mockReturnValue(proc)
-        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
-        await streamViaYtDlp(validUrl)
-        const args = mockSpawn.mock.calls[0][1] as string[]
+    it('does not pass --cookies when the path is a directory', async () => {
+        process.env.YTDLP_COOKIES_FILE = cookiesPath
+        mockStatSync.mockReturnValue({ isFile: () => false })
+        expect(await runOnce()).not.toContain('--cookies')
+    })
+
+    it('passes --cookies <file> when YTDLP_COOKIES_FILE is a regular file', async () => {
+        process.env.YTDLP_COOKIES_FILE = cookiesPath
+        mockStatSync.mockReturnValue({ isFile: () => true })
+        const args = await runOnce()
         const idx = args.indexOf('--cookies')
         expect(idx).toBeGreaterThan(-1)
-        expect(args[idx + 1]).toBe('/app/secrets/youtube-cookies.txt')
+        expect(args[idx + 1]).toBe(cookiesPath)
     })
 })
 

--- a/packages/bot/src/handlers/player/streamBridge.spec.ts
+++ b/packages/bot/src/handlers/player/streamBridge.spec.ts
@@ -19,6 +19,10 @@ const mockCaptureMessage = jest.fn()
 jest.mock('child_process', () => ({
     spawn: (...args: unknown[]) => mockSpawn(...args),
 }))
+const mockExistsSync = jest.fn()
+jest.mock('fs', () => ({
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+}))
 jest.mock('./soundcloudMatcher', () => ({
     streamViaSoundCloud: (...args: unknown[]) =>
         mockStreamViaSoundCloud(...args),
@@ -129,6 +133,54 @@ describe('streamViaYtDlp – URL validation', () => {
         mockSpawn.mockReturnValue(proc)
         setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
         await expect(streamViaYtDlp(url)).resolves.toBeDefined()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// streamViaYtDlp — cookies (#2034 / ADR 2026-06-18)
+// ---------------------------------------------------------------------------
+
+describe('streamViaYtDlp – cookies file', () => {
+    const validUrl = 'https://www.youtube.com/watch?v=abc123'
+    const originalEnv = process.env.YTDLP_COOKIES_FILE
+
+    afterEach(() => {
+        if (originalEnv === undefined) delete process.env.YTDLP_COOKIES_FILE
+        else process.env.YTDLP_COOKIES_FILE = originalEnv
+    })
+
+    it('does not pass --cookies when YTDLP_COOKIES_FILE is unset', async () => {
+        delete process.env.YTDLP_COOKIES_FILE
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        await streamViaYtDlp(validUrl)
+        const args = mockSpawn.mock.calls[0][1] as string[]
+        expect(args).not.toContain('--cookies')
+    })
+
+    it('does not pass --cookies when the configured file does not exist', async () => {
+        process.env.YTDLP_COOKIES_FILE = '/app/secrets/youtube-cookies.txt'
+        mockExistsSync.mockReturnValue(false)
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        await streamViaYtDlp(validUrl)
+        const args = mockSpawn.mock.calls[0][1] as string[]
+        expect(args).not.toContain('--cookies')
+    })
+
+    it('passes --cookies <file> when YTDLP_COOKIES_FILE is set and exists', async () => {
+        process.env.YTDLP_COOKIES_FILE = '/app/secrets/youtube-cookies.txt'
+        mockExistsSync.mockReturnValue(true)
+        const proc = makeFakeProc()
+        mockSpawn.mockReturnValue(proc)
+        setImmediate(() => proc.stdout.emit('data', Buffer.from('bytes')))
+        await streamViaYtDlp(validUrl)
+        const args = mockSpawn.mock.calls[0][1] as string[]
+        const idx = args.indexOf('--cookies')
+        expect(idx).toBeGreaterThan(-1)
+        expect(args[idx + 1]).toBe('/app/secrets/youtube-cookies.txt')
     })
 })
 

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process'
-import { existsSync } from 'fs'
+import { statSync } from 'fs'
 import { PassThrough } from 'stream'
 import type { Readable } from 'stream'
 import type { Track } from 'discord-player'
@@ -49,11 +49,40 @@ function validateYtDlpUrl(url: string): void {
 // at a Netscape-format cookies.txt (exported from a logged-in browser
 // session) to authenticate yt-dlp's requests. Optional — falls back to the
 // prior cookie-less behavior when unset or the file isn't there.
+let loggedCookiesMissing = false
+let loggedCookiesApplied = false
+
 function ytdlpCookiesArgs(): string[] {
     const cookiesFile = process.env.YTDLP_COOKIES_FILE
-    return cookiesFile && existsSync(cookiesFile)
-        ? ['--cookies', cookiesFile]
-        : []
+    if (!cookiesFile) return []
+
+    let isFile: boolean
+    try {
+        isFile = statSync(cookiesFile).isFile()
+    } catch {
+        isFile = false
+    }
+
+    if (!isFile) {
+        if (!loggedCookiesMissing) {
+            loggedCookiesMissing = true
+            warnLog({
+                message:
+                    'Bridge: YTDLP_COOKIES_FILE is set but not a readable file — running cookie-less',
+                data: { cookiesFile },
+            })
+        }
+        return []
+    }
+
+    if (!loggedCookiesApplied) {
+        loggedCookiesApplied = true
+        infoLog({
+            message: 'Bridge: yt-dlp cookies file applied',
+            data: { cookiesFile },
+        })
+    }
+    return ['--cookies', cookiesFile]
 }
 
 export function streamViaYtDlp(url: string): Promise<Readable> {

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process'
+import { existsSync } from 'fs'
 import { PassThrough } from 'stream'
 import type { Readable } from 'stream'
 import type { Track } from 'discord-player'
@@ -43,6 +44,18 @@ function validateYtDlpUrl(url: string): void {
     }
 }
 
+// ADR 2026-06-18 (youtube-extraction-reliability): YouTube's velocity-based
+// bot detection returns 403 on cookie-less requests. Point YTDLP_COOKIES_FILE
+// at a Netscape-format cookies.txt (exported from a logged-in browser
+// session) to authenticate yt-dlp's requests. Optional — falls back to the
+// prior cookie-less behavior when unset or the file isn't there.
+function ytdlpCookiesArgs(): string[] {
+    const cookiesFile = process.env.YTDLP_COOKIES_FILE
+    return cookiesFile && existsSync(cookiesFile)
+        ? ['--cookies', cookiesFile]
+        : []
+}
+
 export function streamViaYtDlp(url: string): Promise<Readable> {
     try {
         validateYtDlpUrl(url)
@@ -64,6 +77,7 @@ export function streamViaYtDlp(url: string): Promise<Readable> {
                 '--no-progress',
                 '--js-runtimes',
                 `node:${process.execPath}`,
+                ...ytdlpCookiesArgs(),
                 url,
             ],
             { stdio: ['ignore', 'pipe', 'pipe'] },
@@ -132,9 +146,7 @@ export function streamViaYtDlpSearch(query: string): Promise<Readable> {
  * happened. Primary yt-dlp resolutions leave the metadata untouched.
  */
 export type StreamBridgeFallbackStage =
-    | 'soundcloud-full'
-    | 'soundcloud-title'
-    | 'soundcloud-core'
+    'soundcloud-full' | 'soundcloud-title' | 'soundcloud-core'
 
 export const STREAM_BRIDGE_FALLBACK_METADATA_KEY = 'streamBridgeFallbackStage'
 

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process'
-import { statSync } from 'fs'
+import { accessSync, constants, statSync } from 'fs'
 import { PassThrough } from 'stream'
 import type { Readable } from 'stream'
 import type { Track } from 'discord-player'
@@ -52,18 +52,28 @@ function validateYtDlpUrl(url: string): void {
 let loggedCookiesMissing = false
 let loggedCookiesApplied = false
 
+// Test-only: the log-once dedup above is module-level state, so tests that
+// assert on it must reset between cases instead of relying on run order.
+export function __resetYtdlpCookiesLogStateForTests(): void {
+    loggedCookiesMissing = false
+    loggedCookiesApplied = false
+}
+
+function isReadableFile(cookiesFile: string): boolean {
+    try {
+        if (!statSync(cookiesFile).isFile()) return false
+        accessSync(cookiesFile, constants.R_OK)
+        return true
+    } catch {
+        return false
+    }
+}
+
 function ytdlpCookiesArgs(): string[] {
     const cookiesFile = process.env.YTDLP_COOKIES_FILE
     if (!cookiesFile) return []
 
-    let isFile: boolean
-    try {
-        isFile = statSync(cookiesFile).isFile()
-    } catch {
-        isFile = false
-    }
-
-    if (!isFile) {
+    if (!isReadableFile(cookiesFile)) {
         if (!loggedCookiesMissing) {
             loggedCookiesMissing = true
             warnLog({

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,8 +1,11 @@
 # secrets/
 
-Bind-mounted read-only into the `bot` container at `/app/secrets` (see
-`docker-compose.yml`). Nothing in this directory (other than this file) is
-committed — see `.gitignore`.
+Bind-mounted read-write into the `bot` container at `/app/secrets` (see
+`docker-compose.yml` — read-write because yt-dlp refreshes the cookie jar
+in place on every run, not just reads it). Nothing in this directory
+(other than this file) is committed — see `.gitignore`; also excluded from
+the Docker build context via `.dockerignore` so it's never sent to the
+builder.
 
 ## youtube-cookies.txt
 
@@ -10,15 +13,31 @@ Fixes #2034: YouTube blocks yt-dlp's cookie-less requests with HTTP 403
 (velocity-based bot detection, see `decisions/2026-06-18-youtube-extraction-reliability.md`).
 `streamBridge.ts` passes `--cookies <this file>` to yt-dlp when it's present.
 
+**Treat this file as a credential, not a config file.** It contains active
+YouTube session cookies — anyone who gets a copy can act as that account
+(watch history, playlists, etc.) until the session expires or is revoked.
+Use a dedicated low-value account rather than a personal one. If the file
+ever leaks (backup, log capture, compromised host), revoke the session
+(sign that account out of all devices in YouTube's account settings) and
+re-export.
+
 To generate it:
 
-1. Log into youtube.com in a browser with an account you're OK using for
-   this (a regular account works; doesn't need to be the bot's).
+1. Log into youtube.com in a browser with the dedicated account.
 2. Export cookies in Netscape format, e.g. with the "Get cookies.txt LOCALLY"
    browser extension, or `yt-dlp --cookies-from-browser <browser> --cookies youtube-cookies.txt https://youtube.com`
    run locally on a machine with that browser profile.
 3. Copy the resulting file to this directory on the homelab host as
-   `youtube-cookies.txt`, then restart the `bot` service
-   (`docker compose restart bot`) — no rebuild needed.
+   `youtube-cookies.txt`. The `bot` container runs as UID 1001 (see
+   `Dockerfile`) and needs write access to refresh the cookie jar — a plain
+   bind mount does not remap ownership, so if the file isn't already owned
+   by UID 1001 on the host, run `chmod o+w youtube-cookies.txt` (or
+   `chown 1001 youtube-cookies.txt` if you can) after copying it.
+4. Restart the `bot` service (`docker compose restart bot`) — no rebuild
+   needed.
 
-Cookies expire; if 403s return, re-export and re-copy.
+Cookies expire; if 403s return, re-export and re-copy. `streamBridge.ts`
+logs once at startup whether a usable cookies file was found (`Bridge:
+yt-dlp cookies file applied`) or not (`Bridge: YTDLP_COOKIES_FILE is set
+but not a readable file`) — check the bot's logs to confirm the file was
+picked up before assuming 403s mean expired cookies.

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -37,7 +37,9 @@ To generate it:
    needed.
 
 Cookies expire; if 403s return, re-export and re-copy. `streamBridge.ts`
-logs once at startup whether a usable cookies file was found (`Bridge:
-yt-dlp cookies file applied`) or not (`Bridge: YTDLP_COOKIES_FILE is set
-but not a readable file`) — check the bot's logs to confirm the file was
-picked up before assuming 403s mean expired cookies.
+logs once — on the first `/play` after restart, not at boot itself, since
+the check runs lazily on first use — whether a usable cookies file was
+found (`Bridge: yt-dlp cookies file applied`) or not (`Bridge:
+YTDLP_COOKIES_FILE is set but not a readable file`). Play something once
+after restarting and check the bot's logs to confirm the file was picked
+up, rather than assuming 403s mean expired cookies.

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,24 @@
+# secrets/
+
+Bind-mounted read-only into the `bot` container at `/app/secrets` (see
+`docker-compose.yml`). Nothing in this directory (other than this file) is
+committed — see `.gitignore`.
+
+## youtube-cookies.txt
+
+Fixes #2034: YouTube blocks yt-dlp's cookie-less requests with HTTP 403
+(velocity-based bot detection, see `decisions/2026-06-18-youtube-extraction-reliability.md`).
+`streamBridge.ts` passes `--cookies <this file>` to yt-dlp when it's present.
+
+To generate it:
+
+1. Log into youtube.com in a browser with an account you're OK using for
+   this (a regular account works; doesn't need to be the bot's).
+2. Export cookies in Netscape format, e.g. with the "Get cookies.txt LOCALLY"
+   browser extension, or `yt-dlp --cookies-from-browser <browser> --cookies youtube-cookies.txt https://youtube.com`
+   run locally on a machine with that browser profile.
+3. Copy the resulting file to this directory on the homelab host as
+   `youtube-cookies.txt`, then restart the `bot` service
+   (`docker compose restart bot`) — no rebuild needed.
+
+Cookies expire; if 403s return, re-export and re-copy.


### PR DESCRIPTION
## Summary

Fixes #2034 — music playback is 100% broken (2042 "Bridge: all stages exhausted" / 96h, 0 successful plays). Root cause: YouTube's velocity-based bot detection returns HTTP 403 Forbidden on every cookie-less yt-dlp request.

Implements the first step of the data-gated escalation path from `decisions/2026-06-18-youtube-extraction-reliability.md`: cookies-from-browser.

- `streamBridge.ts`: `streamViaYtDlp` now passes `--cookies <file>` to yt-dlp when `YTDLP_COOKIES_FILE` points at a file that exists. No-op (identical to current behavior) when unset or the file's missing — safe to merge/deploy before the cookies file exists.
- `docker-compose.yml`: mounts `./secrets` (read-only) into the `bot` container, defaults `YTDLP_COOKIES_FILE` to `/app/secrets/youtube-cookies.txt`.
- `.gitignore` + `secrets/README.md`: the cookies file itself is never committed; README documents how to generate it (manual — requires a real logged-in YouTube browser session, not automatable).
- `.env.example`: documents the optional var for non-compose setups.

## Manual step still required (can't be automated)

The fix is a no-op until a `youtube-cookies.txt` is placed at `./secrets/youtube-cookies.txt` on the homelab host — see `secrets/README.md` for how to export it, then `docker compose restart bot` (no rebuild needed).

## Test plan

- [x] `npx jest src/handlers/player/streamBridge.spec.ts` (bot package) — 33/33 pass, including 3 new cases for the cookies flag (unset / file missing / file present)
- [x] `tsc --noEmit` clean on bot package
- [x] `eslint` clean on changed files
- [x] `docker-compose -f docker-compose.yml config` validates; confirmed rendered `bot` service has the new volume + env var
- [ ] Operator: drop in `youtube-cookies.txt` on homelab, restart `bot`, verify `/play` works and 403s stop in logs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports a browser-exported cookies file for `yt-dlp` to dodge YouTube 403s and restore playback. Old behavior: cookie-less requests got 403. New behavior: when `YTDLP_COOKIES_FILE` points to a readable regular file, pass `--cookies <file>` and log once when applied or unusable; otherwise no change.

- Review notes
  - `packages/bot/src/handlers/player/streamBridge.ts`: adds `ytdlpCookiesArgs()`; requires `statSync().isFile()` and `accessSync(R_OK)`; injects `--cookies`; one-time info/warn logs; exports `__resetYtdlpCookiesLogStateForTests` for test isolation.
  - Tests: cover unset, missing file, directory path, unreadable file, and present file; verify one-time logging; mock `fs.statSync` and `fs.accessSync`.
  - `docker-compose.yml`: defaults `YTDLP_COOKIES_FILE` to `/app/secrets/youtube-cookies.txt`; mounts `./secrets:/app/secrets` read-write as a directory to allow yt-dlp refresh and avoid single-file bind pitfalls.
  - `.dockerignore`, `.gitignore`, `.env.example`, `secrets/README.md`: exclude `secrets/` from build context, ignore the cookie file in git, document setup, readability/ownership requirements, and that logs appear on first use.

- Rollout
  - No-op until a readable cookies file exists.
  - Action required: export a Netscape-format `cookies.txt` from a logged-in YouTube session to `./secrets/youtube-cookies.txt`, ensure the file is writable by UID 1001 (or `chmod o+w`), then `docker compose restart bot`. Re-export if 403s return; check logs for “yt-dlp cookies file applied.”

<sup>Written for commit 4f2bac66cf58848b71b612fb1d9f5b3c1879e0ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional YouTube cookie-file support to improve yt-dlp streaming compatibility.
  * Added Docker configuration for securely mounting cookie files.
* **Documentation**
  * Documented cookie generation, setup, expiration handling, and bot restart steps.
* **Bug Fixes**
  * Prevented missing or unconfigured cookie files from affecting cookie-free streaming behavior.
* **Tests**
  * Added coverage for configured, missing, and unset cookie-file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->