### PR TITLE
fix(bot): restore youtube-dl-exec, discord-player-youtubei needs it undeclared

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ docker compose logs -f bot
 
 ```bash
 # Install dependencies
-npm install
+# YOUTUBE_DL_SKIP_DOWNLOAD=1 skips youtube-dl-exec's postinstall binary
+# download (yt-dlp is already provided by system/Docker tooling) — without
+# it, plain `npm install` hits the GitHub-API rate limit issue from #874/#1827.
+YOUTUBE_DL_SKIP_DOWNLOAD=1 npm install
 
 # Set up database
 npm run db:migrate

--- a/package-lock.json
+++ b/package-lock.json
@@ -4297,6 +4297,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@kikobeats/time-span": {
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/@kikobeats/time-span/-/time-span-1.0.13.tgz",
+            "integrity": "sha512-CfBK4/EZ73uN/6b5/wOfvWju1Ev/6H+uXqS2Vqd7/dEQTyOsvv4BdOHDqESp4Efa9YyrPPvN3IHU+C4z9FAo3Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/@lucky/backend": {
             "resolved": "packages/backend",
             "link": true
@@ -13051,7 +13060,6 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/binary-version/-/binary-version-7.1.0.tgz",
             "integrity": "sha512-Iy//vPc3ANPNlIWd242Npqc8MK0a/i4kVcHDlDA6HNMv5zMxz4ulIFhOSYJVKw/8AbHdHy0CnGYEt1QqSXxPsw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "execa": "^8.0.1",
@@ -13068,7 +13076,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/binary-version-check/-/binary-version-check-6.1.0.tgz",
             "integrity": "sha512-REKdLKmuViV2WrtWXvNSiPX04KbIjfUV3Cy8batUeOg+FtmowavzJorfFhWq95cVJzINnL/44ixP26TrdJZACA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "binary-version": "^7.1.0",
@@ -13086,7 +13093,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
             "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
@@ -13110,7 +13116,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
             "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=16"
@@ -13123,7 +13128,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
             "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=16.17.0"
@@ -13133,7 +13137,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
             "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -13146,7 +13149,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
             "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^4.0.0"
@@ -13162,7 +13164,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
             "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -13175,7 +13176,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
             "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -14040,7 +14040,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
             "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -14373,6 +14372,15 @@
                 "node": ">=12"
             }
         },
+        "node_modules/dargs": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+            "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/data-uri-to-buffer": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -14464,6 +14472,47 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/debug-logfmt": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/debug-logfmt/-/debug-logfmt-1.4.15.tgz",
+            "integrity": "sha512-tMgdJRAlvf0sv3We8KpVlAnv0V9hnOoB3QqmvkXSGYnYMUJvJTGawqipROgh5WaPKXyt79cdPYx30jSu9aO7Rg==",
+            "license": "MIT",
+            "dependencies": {
+                "@kikobeats/time-span": "~1.0.5",
+                "null-prototype-object": "~1.2.2",
+                "pretty-ms": "~7.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            },
+            "peerDependencies": {
+                "debug": "*"
+            }
+        },
+        "node_modules/debug-logfmt/node_modules/parse-ms": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+            "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/debug-logfmt/node_modules/pretty-ms": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+            "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "parse-ms": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/decimal.js": {
@@ -16318,7 +16367,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
             "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "semver-regex": "^4.0.5",
@@ -16563,7 +16611,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
             "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -18116,6 +18163,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-unix": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/is-unix/-/is-unix-2.0.14.tgz",
+            "integrity": "sha512-ZE+Iq0h1pxZu/IGsBKobH5PZ0L3ylv7WHEmKiRG8kEzue6f+w0i3ckwnDY7Ckej2jjq1c7NDYljEkNqOxv4w9A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/is-weakmap": {
@@ -20352,7 +20408,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
             "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-event": "^6.0.0",
@@ -20370,7 +20425,6 @@
             "version": "4.41.0",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
@@ -20499,7 +20553,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/meriyah": {
@@ -20568,7 +20621,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -21207,6 +21259,15 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
+        "node_modules/null-prototype-object": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/null-prototype-object/-/null-prototype-object-1.2.7.tgz",
+            "integrity": "sha512-pSZWCUew0zed2gxCerA4zdXRGg8ezLiWwvE8RvncezTcROXL0uz3PjSZXl5NsI04Egz0Uu46o1wyX6qr3u/ZWA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -21329,7 +21390,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
             "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^4.0.0"
@@ -21425,7 +21485,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
             "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-timeout": "^6.1.2"
@@ -21486,7 +21545,6 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
             "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14.16"
@@ -23352,7 +23410,6 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
             "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -23365,7 +23422,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-3.0.0.tgz",
             "integrity": "sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.5"
@@ -24355,7 +24411,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
             "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-timeout": "^1.0.1",
@@ -24828,7 +24883,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
             "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "convert-hrtime": "^5.0.0"
@@ -24881,6 +24935,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspawn": {
+            "version": "1.5.9",
+            "resolved": "https://registry.npmjs.org/tinyspawn/-/tinyspawn-1.5.9.tgz",
+            "integrity": "sha512-eTFD3RhtoT+GsCPA+h1YCM1w2qG20Il0vd6oVuyolBe39IWfceKLfEVyJnCexMH57crjkAd5hx65bn0Zz1xkTw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
             }
         },
         "node_modules/tldts": {
@@ -26254,7 +26317,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
             "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
-            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/webidl-conversions": {
@@ -26838,6 +26900,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/youtube-dl-exec": {
+            "version": "3.1.12",
+            "resolved": "https://registry.npmjs.org/youtube-dl-exec/-/youtube-dl-exec-3.1.12.tgz",
+            "integrity": "sha512-S7YwBZ1Kka7TYA/t0eOnHfI2QQMGFxJXp8UFQYOEwqg8sp+OH8MJ5c1c0RgJfoqewP/PGS5j8EtmcXg5E2HM4Q==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-version-check": "~6.1.0",
+                "dargs": "~7.0.0",
+                "debug-logfmt": "~1.4.0",
+                "is-unix": "~2.0.10",
+                "tinyspawn": "~1.5.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/youtubei.js": {
             "version": "17.2.0",
             "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-17.2.0.tgz",
@@ -26970,6 +27049,7 @@
                 "prom-client": "^15.1.3",
                 "rss-parser": "^3.13.0",
                 "ws": "^8.21.0",
+                "youtube-dl-exec": "^3.1.12",
                 "youtubei.js": "^17.2.0"
             },
             "devDependencies": {

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -39,6 +39,7 @@
         "play-dl": "^1.9.7",
         "prom-client": "^15.1.3",
         "ws": "^8.21.0",
+        "youtube-dl-exec": "^3.1.12",
         "youtubei.js": "^17.2.0",
         "rss-parser": "^3.13.0"
     },


### PR DESCRIPTION
## Summary

**Production-breaking regression, urgent.** After #2038's clean node_modules/lockfile regen (needed for the deepmerge-ts security fix) busted a stale Docker npm-install cache layer, YouTube extractor registration now throws on every bot boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'youtube-dl-exec' imported from /app/node_modules/discord-player-youtubei/dist/index.mjs
YouTube extractor unavailable after retries — #play of YouTube URLs will fail until restart. Falling back to SoundCloud/Spotify only.
```

Discovered live on homelab after redeploying #2036 (the yt-dlp-cookies fix for #2034) — the cookies fix itself is correct, but it's moot because `createResilientStream` (the function it patches) never gets wired in at all when this registration fails, since it's passed as `{ createStream: createResilientStream }` at the `player.extractors.register(YoutubeExtractor, ...)` call site (`packages/bot/src/handlers/player/playerFactory.ts:166-169`).

## Root cause

`discord-player-youtubei`'s compiled `dist/index.mjs` has a hard top-level `import youtubeDl from "youtube-dl-exec"` (confirmed: `grep -n youtube-dl-exec node_modules/discord-player-youtubei/dist/index.mjs`) that it never declares anywhere in its own `package.json` (dependencies/optionalDependencies/peerDependencies all empty) — an upstream packaging bug.

`youtube-dl-exec` was a real dependency of ours until `a20a6c29` (5 days ago, "remove the download feature for top.gg compliance", #1956) correctly dropped it since our own `/download` command no longer used it. Nobody knew `discord-player-youtubei` also needed it internally. It kept working in production purely because Docker's npm-install layer (keyed by `package-lock.json` hash) was still cached from before that removal — until #2038's full lockfile regen busted that cache for the first time, surfacing the gap.

## Fix

Re-declare `youtube-dl-exec` in `packages/bot/package.json` — purely as a transitive requirement for `discord-player-youtubei`, no download-feature code restored. `Dockerfile` already sets `YOUTUBE_DL_SKIP_DOWNLOAD=1` (see #1827/#874), so its postinstall binary-download stays skipped as before.

## Test plan

- [x] `node -e "import('discord-player-youtubei').then(...)"` resolves cleanly, `YoutubeExtractor` export present
- [x] `npx jest` (bot package) — 3139/3140 pass (1 pre-existing skip)
- [x] `tsc --noEmit` clean
- [x] `npm run audit:high` clean
- [ ] Deploy + confirm `/play` of a YouTube URL works and the extractor-registration error is gone from logs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `youtube-dl-exec` in `packages/bot` to satisfy `discord-player-youtubei`’s undeclared import and fix the boot-time ERR_MODULE_NOT_FOUND that prevented YouTube extractor registration and playback. Documents `YOUTUBE_DL_SKIP_DOWNLOAD=1` for local installs to avoid postinstall downloads.

- Declares `youtube-dl-exec` in `packages/bot/package.json` only for the extractor; no download feature is restored.
- Behavior: YouTube extractor registers on boot; YouTube URLs play; no other code paths change.
- Docs: README instructs `YOUTUBE_DL_SKIP_DOWNLOAD=1 npm install` for local dev; Docker and CI already skip postinstall.
- Rollout: rebuild and redeploy the bot image. Developers must run `YOUTUBE_DL_SKIP_DOWNLOAD=1 npm install` locally.

<sup>Written for commit 823c1e28a51829c956d5e60c9c583dc0c7922df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving media from YouTube and other supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->