### PR TITLE
fix(bot): use metadata setter instead of direct property assignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1185,7 +1185,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
             "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1195,7 +1195,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1229,7 +1229,7 @@
             "version": "7.29.8",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
             "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.8"
@@ -1652,7 +1652,7 @@
             "version": "7.29.8",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
             "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.29.7",
@@ -2370,7 +2370,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
             "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2382,7 +2381,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
             "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2393,7 +2391,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
             "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -9023,7 +9020,7 @@
             "version": "0.34.52",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
             "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@sindresorhus/is": {
@@ -9987,7 +9984,7 @@
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.16.1.tgz",
             "integrity": "sha512-nUaeu91O5QZKrQdaDCHd402ogUIoNOOjpkZNq0UomWK0G6gDaGmLhvddF1/3BXf5O8aLyo6ZPY/aMDWvaJQ/hg==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10232,14 +10229,14 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@swc/types": {
             "version": "0.1.28",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
             "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@swc/counter": "^0.1.3"
@@ -11219,7 +11216,7 @@
             "version": "19.2.4",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
             "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -20396,7 +20393,7 @@
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
             "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.7",
@@ -20939,7 +20936,7 @@
             "version": "3.3.18",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
             "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -22045,7 +22042,7 @@
             "version": "8.5.26",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
             "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -24663,7 +24660,6 @@
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
             "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/tailwindcss-animate": {
@@ -25218,7 +25214,7 @@
             "version": "4.23.12",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
             "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.28.0"
@@ -25487,7 +25483,7 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -26794,7 +26790,7 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
@@ -27037,7 +27033,7 @@
                 "@sentry/node": "^10.68.0",
                 "bullmq": "^6.0.9",
                 "chalk": "^5.6.2",
-                "discord-player": "^7.1.0",
+                "discord-player": "^7.2.0",
                 "discord-player-spotify": "^1.1.9",
                 "discord-player-youtubei": "^3.0.0-beta.4",
                 "discord.js": "^14.27.0",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -28,7 +28,7 @@
         "@sentry/node": "^10.68.0",
         "bullmq": "^6.0.9",
         "chalk": "^5.6.2",
-        "discord-player": "^7.1.0",
+        "discord-player": "^7.2.0",
         "discord-player-spotify": "^1.1.9",
         "discord-player-youtubei": "^3.0.0-beta.4",
         "discord.js": "^14.27.0",

--- a/packages/bot/src/handlers/player/streamBridge.spec.ts
+++ b/packages/bot/src/handlers/player/streamBridge.spec.ts
@@ -102,11 +102,21 @@ function makeTrack(
         url?: string
     } = {},
 ) {
+    let metadata: unknown = null
     return {
         title: overrides.title ?? 'Test Track',
         author: overrides.author ?? 'Test Artist',
         duration: overrides.duration ?? '3:30',
         url: overrides.url ?? 'https://www.youtube.com/watch?v=abc123',
+        // Mirrors discord-player's Track: metadata is a getter-only property
+        // backed by private state, mutated only via setMetadata(). A direct
+        // `track.metadata = x` assignment throws in real usage.
+        get metadata() {
+            return metadata
+        },
+        setMetadata(m: unknown) {
+            metadata = m
+        },
     }
 }
 
@@ -604,10 +614,8 @@ describe('fallback stage stamping', () => {
         mockSpawn.mockReturnValue(proc)
         mockStreamViaSoundCloud.mockResolvedValue(fakeStream)
         setImmediate(() => proc.emit('close', 1))
-        const track = {
-            ...makeTrack(),
-            metadata: { isAutoplay: true },
-        }
+        const track = makeTrack()
+        track.setMetadata({ isAutoplay: true })
         await createResilientStream(track)
         expect(track.metadata).toEqual({
             isAutoplay: true,

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -211,22 +211,27 @@ export function getStreamBridgeFallbackLabel(track: {
 }
 
 function stampFallbackStage(
-    track: Pick<Track, 'title' | 'author' | 'duration' | 'url'>,
+    track: Pick<
+        Track,
+        'title' | 'author' | 'duration' | 'url' | 'metadata' | 'setMetadata'
+    >,
     stage: StreamBridgeFallbackStage,
 ): void {
-    const mutable = track as { metadata?: unknown }
     const existing =
-        typeof mutable.metadata === 'object' && mutable.metadata !== null
-            ? (mutable.metadata as Record<string, unknown>)
+        typeof track.metadata === 'object' && track.metadata !== null
+            ? (track.metadata as Record<string, unknown>)
             : {}
-    mutable.metadata = {
+    track.setMetadata({
         ...existing,
         [STREAM_BRIDGE_FALLBACK_METADATA_KEY]: stage,
-    }
+    })
 }
 
 export async function createResilientStream(
-    track: Pick<Track, 'title' | 'author' | 'duration' | 'url'>,
+    track: Pick<
+        Track,
+        'title' | 'author' | 'duration' | 'url' | 'metadata' | 'setMetadata'
+    >,
     _ext?: unknown,
 ): Promise<Readable> {
     const cleanedTitle = cleanTitle(track.title)


### PR DESCRIPTION
## Summary
- discord-player 7.2.0 made `Track.metadata` a getter-only accessor backed by private state, mutable only via `setMetadata()`
- `stampFallbackStage()` was still assigning `track.metadata` directly, throwing a TypeError right after a SoundCloud fallback stream had already resolved successfully
- This turned a working fallback into a reported "could not extract stream" failure for every track — the bot stopped playing songs entirely

## Fix
- `stampFallbackStage` and `createResilientStream` now use `track.setMetadata()` instead of direct assignment
- Widened the `Pick<Track, ...>` type to include `metadata`/`setMetadata`
- Updated the test's `makeTrack()` mock to mirror discord-player's real getter/setter semantics, and fixed one test that relied on the old plain-property spread pattern

## Test plan
- [x] `npx jest streamBridge.spec.ts` — 36/36 passing
- [x] `tsc --noEmit` — clean
- [ ] Verify song playback works in a live guild after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents playback failures in `discord-player` 7.2.0 by using `Track.setMetadata()` instead of assigning `track.metadata`. Old behavior threw after a SoundCloud fallback and surfaced as "could not extract stream"; the setter keeps fallback stamping and playback working.

- Use `setMetadata()` in `stampFallbackStage` and `createResilientStream`.
- Extend the track type to include `metadata` and `setMetadata`; update tests to mirror getter/setter semantics.
- Bump `discord-player` to `^7.2.0` and sync the lockfile with the new range.

**Migration**
- Replace any `track.metadata = ...` with `track.setMetadata(...)`.

<sup>Written for commit a56d9e1042a9eefeb80999fb9242bfa4107afb97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback stream handling by preserving track metadata through the supported metadata update mechanism.
  * Ensured compatibility with tracks that expose read-only metadata properties.

* **Tests**
  * Updated coverage to verify metadata initialization and preservation during fallback streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->