### PR TITLE
perf(bot): cut yt-dlp timeout from 15s to 6s

### DIFF
--- a/packages/bot/src/handlers/player/streamBridge.spec.ts
+++ b/packages/bot/src/handlers/player/streamBridge.spec.ts
@@ -277,7 +277,7 @@ describe('streamViaYtDlp – process lifecycle', () => {
         mockSpawn.mockReturnValue(proc)
         // never emit stdout data — let the timeout fire
         const promise = streamViaYtDlp(validUrl)
-        jest.advanceTimersByTime(15_000)
+        jest.advanceTimersByTime(6_000)
         await expect(promise).rejects.toThrow('yt-dlp: timed out')
         expect(proc.kill).toHaveBeenCalled()
         jest.useRealTimers()

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -122,10 +122,14 @@ export function streamViaYtDlp(url: string): Promise<Readable> {
             { stdio: ['ignore', 'pipe', 'pipe'] },
         )
 
+        // Kept short: on every attempt this fires, the caller still has to
+        // wait out the full duration before falling back to SoundCloud, so
+        // a long timeout directly taxes perceived playback latency whenever
+        // yt-dlp is degraded (rate-limited/blocked) rather than erroring fast.
         const timeout = setTimeout(() => {
             proc.kill()
             reject(new Error('yt-dlp: timed out waiting for stream start'))
-        }, 15_000)
+        }, 6_000)
 
         const stderrChunks: Buffer[] = []
         assertDefined(proc.stderr, 'stderr guaranteed by stdio config').on(


### PR DESCRIPTION
## Summary
Every stream resolution attempt that hits the yt-dlp timeout blocks the whole fallback chain for its full duration before SoundCloud even gets tried — directly taxing perceived `/play` latency whenever yt-dlp is degraded (currently rate-limited/blocked by YouTube, see the youtube-cookies issue being tracked separately). 15s per attempt was excessive; 6s still gives a real slow-but-working response room while capping the worst-case tax users feel per song.

## Test plan
- [x] `npx jest streamBridge.spec.ts` — 36/36 passing (updated the fake-timers timeout test to match)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the yt-dlp stream-start timeout from 15s to 6s to reduce worst-case /play latency when yt-dlp is slow or rate-limited. Previously fallback to SoundCloud waited 15s; now it fails after 6s and proceeds to fallback sooner.

- Change is in `packages/bot/src/handlers/player/streamBridge.ts`; updated fake-timers expectation in `packages/bot/src/handlers/player/streamBridge.spec.ts`.
- No config or migration changes; only the wait before SoundCloud fallback is shorter in degraded YouTube conditions.

<sup>Written for commit 940e5ddbbee10697c80af593d47acf8ec50d1b22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

