### PR TITLE
fix(bot): surface dead last.fm env session key to sentry

### DIFF
--- a/packages/bot/src/lastfm/deadSessionHandler.spec.ts
+++ b/packages/bot/src/lastfm/deadSessionHandler.spec.ts
@@ -5,6 +5,7 @@ const unlinkMock =
     jest.fn<(discordId: string, sessionKey: string) => Promise<string>>()
 const infoLogMock = jest.fn<(payload: unknown) => void>()
 const warnLogMock = jest.fn<(payload: unknown) => void>()
+const errorLogMock = jest.fn<(payload: unknown) => void>()
 
 jest.mock('@lucky/shared/services', () => ({
     lastFmLinkService: {
@@ -17,6 +18,7 @@ jest.mock('@lucky/shared/services', () => ({
 jest.mock('@lucky/shared/utils', () => ({
     infoLog: (payload: unknown) => infoLogMock(payload),
     warnLog: (payload: unknown) => warnLogMock(payload),
+    errorLog: (payload: unknown) => errorLogMock(payload),
 }))
 
 import {
@@ -43,20 +45,21 @@ describe('handleDeadLastFmSession', () => {
         unlinkMock.mockReset().mockResolvedValue('removed')
         infoLogMock.mockReset()
         warnLogMock.mockReset()
+        errorLogMock.mockReset()
         resetDeadSessionGuards()
     })
 
     it('does nothing without a discordId when env fallback was not used', async () => {
         await handleDeadLastFmSession(undefined, 'key-1', null, OPTS)
         expect(getByDiscordIdMock).not.toHaveBeenCalled()
-        expect(warnLogMock).not.toHaveBeenCalled()
+        expect(errorLogMock).not.toHaveBeenCalled()
     })
 
-    it('warns about the env key when a requester-less env-fallback call fails', async () => {
+    it('errors about the env key (so it reaches Sentry) when a requester-less env-fallback call fails', async () => {
         await handleDeadLastFmSession(undefined, 'key-1', null, ENV_OPTS)
         await handleDeadLastFmSession(undefined, 'key-1', null, ENV_OPTS)
-        expect(warnLogMock).toHaveBeenCalledTimes(1)
-        expect(warnLogMock).toHaveBeenCalledWith(
+        expect(errorLogMock).toHaveBeenCalledTimes(1)
+        expect(errorLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 message: expect.stringContaining('LASTFM_SESSION_KEY'),
             }),
@@ -117,14 +120,14 @@ describe('handleDeadLastFmSession', () => {
         expect(infoLogMock).not.toHaveBeenCalled()
     })
 
-    it('warns once and never unlinks or DMs when the dead key is the env fallback', async () => {
+    it('errors once (for Sentry) and never unlinks or DMs when the dead key is the env fallback', async () => {
         getByDiscordIdMock.mockResolvedValue(null)
         const { client, sendMock, fetchMock } = makeClient()
 
         await handleDeadLastFmSession('user-1', 'key-1', client, ENV_OPTS)
         await handleDeadLastFmSession('user-2', 'key-1', client, ENV_OPTS)
 
-        expect(warnLogMock).toHaveBeenCalledTimes(1)
+        expect(errorLogMock).toHaveBeenCalledTimes(1)
         expect(unlinkMock).not.toHaveBeenCalled()
         expect(fetchMock).not.toHaveBeenCalled()
         expect(sendMock).not.toHaveBeenCalled()
@@ -135,7 +138,7 @@ describe('handleDeadLastFmSession', () => {
 
         await handleDeadLastFmSession('user-1', 'key-1', null, OPTS)
 
-        expect(warnLogMock).not.toHaveBeenCalled()
+        expect(errorLogMock).not.toHaveBeenCalled()
         expect(unlinkMock).not.toHaveBeenCalled()
     })
 

--- a/packages/bot/src/lastfm/deadSessionHandler.ts
+++ b/packages/bot/src/lastfm/deadSessionHandler.ts
@@ -1,6 +1,6 @@
 import type { Client } from 'discord.js'
 import { LRUCache } from 'lru-cache'
-import { infoLog, warnLog } from '@lucky/shared/utils'
+import { errorLog, infoLog, warnLog } from '@lucky/shared/utils'
 import { lastFmLinkService, type LastFmLinkRow } from '@lucky/shared/services'
 
 /**
@@ -21,7 +21,10 @@ interface DeadSessionOptions {
 function warnEnvKeyOnce(via: string): void {
     if (envKeyWarned) return
     envKeyWarned = true
-    warnLog({
+    // errorLog (not warnLog) so this reaches Sentry — a dead env key
+    // otherwise degrades autoplay/radio scrobbling silently forever, see
+    // decisions/2026-08-03-lastfm-dead-session-handling.md "Revisit when".
+    errorLog({
         message:
             'Last.fm env LASTFM_SESSION_KEY is invalid — check deployment config',
         data: { via },


### PR DESCRIPTION
## What

Closes the alerting gap named in `decisions/2026-08-03-lastfm-dead-session-handling.md` ("Revisit when: Env `LASTFM_SESSION_KEY` is rotated/revoked → wire the env-key warning into alerting, not just logs").

`warnEnvKeyOnce` in `packages/bot/src/lastfm/deadSessionHandler.ts` used `warnLog`, which only adds a Sentry breadcrumb — `LogService.warn()` never calls `captureException`/`captureMessage` (`error()` does; `warn()` doesn't, per `packages/shared/src/utils/general/log/service.ts`). So a dead env key degraded requester-less autoplay/radio scrobbling silently, with no way to notice short of grepping container logs.

Switched to `errorLog`, matching every other Sentry-relevant failure path in this file's neighborhood.

## Why now

Found while confirming the Last.fm integration is functioning end-to-end (unrelated ask). Verified live against production: the env `LASTFM_SESSION_KEY` is currently expired (`error 9`, `Invalid session key - Please re-authenticate`) while all 4 real linked-user session keys (DB-stored, used for any requester who ran `/lastfm link`) still work fine. Tracked separately in #2046 — the credential rotation itself needs an interactive Last.fm login and isn't something an agent can do.

## Test plan
- [x] `npx jest deadSessionHandler.spec.ts` — updated the two tests asserting on the env-key-warning path to expect `errorLog` instead of `warnLog`
- [x] Full bot suite: 3145 passed
- [x] `npm run type:check --workspace=@lucky/bot`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces invalid Last.fm env session key errors to Sentry so requester-less autoplay/radio scrobbling no longer degrades silently. Previously this path used `warnLog` (breadcrumb only); now it uses `errorLog` so Sentry captures the event.

- Replaces `warnLog` with `errorLog` in `warnEnvKeyOnce` (`packages/bot/src/lastfm/deadSessionHandler.ts`); preserves the once-only guard.
- No user-facing change: we still never unlink or DM for the env fallback; only visibility to Sentry changes.
- Updates tests in `deadSessionHandler.spec.ts` to expect `errorLog`.

**Rollout**
- No migration needed. If Sentry alerts, rotate `LASTFM_SESSION_KEY` in deployment config.

<sup>Written for commit 3b959e70f0d038371f655ae39dc3e526fc359e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

