### PR TITLE
fix(bot): pick closest-duration soundcloud fallback match

### DIFF
--- a/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
@@ -198,6 +198,37 @@ describe('findMatchingSoundCloudResult – duration matching', () => {
         expect(match?.name).toBe('Song Name')
     })
 
+    it('picks the first of multiple duration-less candidates when none can be ranked by duration', () => {
+        const results = [makeResult('Song Name'), makeResult('Song Name Live')]
+        const match = findMatchingSoundCloudResult('song name', '3:30', results)
+        expect(match?.name).toBe('Song Name')
+    })
+
+    it('prefers an exact title match with no duration data over a looser title match with duration', () => {
+        // 4 query tokens: 'song name original mix'. The remix result is
+        // missing "original" (3/4 = 75%, just clears the threshold); the
+        // duration-less result matches all 4 tokens (100%).
+        const results = [
+            makeResult('Song Name Mix', 215), // 75% title score, 5s off
+            makeResult('Song Name Original Mix'), // 100% title score, no duration data
+        ]
+        const match = findMatchingSoundCloudResult(
+            'song name original mix',
+            '3:30',
+            results,
+        )
+        expect(match?.name).toBe('Song Name Original Mix')
+    })
+
+    it('at equal title score, prefers the duration-bearing candidate over the duration-less one', () => {
+        const results = [
+            makeResult('Song Name'), // exact title, no duration
+            makeResult('Song Name', 215), // exact title, has duration (5s off)
+        ]
+        const match = findMatchingSoundCloudResult('song name', '3:30', results)
+        expect(match?.durationInSec).toBe(215)
+    })
+
     it('falls back to a candidate with no duration data when it is the only match', () => {
         const results = [makeResult('Song Name')] // no durationInSec at all
         const match = findMatchingSoundCloudResult('song name', '3:30', results)

--- a/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
@@ -187,6 +187,22 @@ describe('findMatchingSoundCloudResult – duration matching', () => {
         const match = findMatchingSoundCloudResult('song name', '3:30', results)
         expect(match?.name).toBe('Song Name')
     })
+
+    it('prefers the closest duration among multiple qualifying candidates, not just the first', () => {
+        const results = [
+            makeResult('Song Name (Sped Up)', 195), // 15s off 3:30 (210s)
+            makeResult('Song Name', 208), // 2s off — closer, but ranked second by SoundCloud
+            makeResult('Song Name (8D Audio)', 225), // 15s off
+        ]
+        const match = findMatchingSoundCloudResult('song name', '3:30', results)
+        expect(match?.name).toBe('Song Name')
+    })
+
+    it('falls back to a candidate with no duration data when it is the only match', () => {
+        const results = [makeResult('Song Name')] // no durationInSec at all
+        const match = findMatchingSoundCloudResult('song name', '3:30', results)
+        expect(match?.name).toBe('Song Name')
+    })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/bot/src/handlers/player/soundcloudMatcher.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.ts
@@ -58,34 +58,55 @@ export function findMatchingSoundCloudResult(
 
     const trackSec = parseDurationString(trackDuration)
 
-    const candidates = results.filter((result) => {
-        const resultNorm = normalizeForMatch(result.name)
-        if (!resultNorm) return false
+    const candidates = results
+        .map((result) => {
+            const resultNorm = normalizeForMatch(result.name)
+            if (!resultNorm) return null
 
-        const matched = tokens.filter((token) =>
-            resultNorm.includes(token),
-        ).length
-        const titleMatch = matched / tokens.length >= TITLE_MATCH_THRESHOLD
-        if (!titleMatch) return false
+            const matched = tokens.filter((token) =>
+                resultNorm.includes(token),
+            ).length
+            const titleScore = matched / tokens.length
+            if (titleScore < TITLE_MATCH_THRESHOLD) return null
 
-        if (trackSec === null || !result.durationInSec) return true
-        return Math.abs(result.durationInSec - trackSec) <= 30
-    })
+            if (
+                trackSec !== null &&
+                result.durationInSec &&
+                Math.abs(result.durationInSec - trackSec) > 30
+            ) {
+                return null
+            }
 
-    if (candidates.length === 0 || trackSec === null) return candidates[0]
+            return { result, titleScore }
+        })
+        .filter(
+            (c): c is { result: SoundCloudSearchResult; titleScore: number } =>
+                c !== null,
+        )
+
+    if (candidates.length === 0) return undefined
+    if (trackSec === null) return candidates[0].result
 
     // The 75%-token threshold lets remixes/speedups/extended edits pass
-    // title matching too. SoundCloud's search order is not a quality
-    // ranking, so among qualifying candidates prefer the closest duration —
-    // the cheapest signal available that a candidate is the original
-    // recording rather than an altered one.
+    // title matching too, and SoundCloud's search order is not a quality
+    // ranking. Prefer the closer title match first — an exact title match
+    // with no duration data is a more trustworthy signal than a near-miss
+    // duration match on a looser title. Only at equal title confidence does
+    // duration closeness break the tie, as the cheapest remaining signal
+    // that a candidate is the original recording rather than an altered one;
+    // missing duration data is treated as neutral there, not disqualifying.
     return candidates.reduce((best, candidate) => {
-        if (!candidate.durationInSec) return best
-        if (!best.durationInSec) return candidate
-        const bestDiff = Math.abs(best.durationInSec - trackSec)
-        const candidateDiff = Math.abs(candidate.durationInSec - trackSec)
+        if (candidate.titleScore !== best.titleScore) {
+            return candidate.titleScore > best.titleScore ? candidate : best
+        }
+        if (!candidate.result.durationInSec) return best
+        if (!best.result.durationInSec) return candidate
+        const bestDiff = Math.abs(best.result.durationInSec - trackSec)
+        const candidateDiff = Math.abs(
+            candidate.result.durationInSec - trackSec,
+        )
         return candidateDiff < bestDiff ? candidate : best
-    }, candidates[0])
+    }, candidates[0]).result
 }
 
 function normalizeForMatch(value: string): string {

--- a/packages/bot/src/handlers/player/soundcloudMatcher.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.ts
@@ -58,7 +58,7 @@ export function findMatchingSoundCloudResult(
 
     const trackSec = parseDurationString(trackDuration)
 
-    return results.find((result) => {
+    const candidates = results.filter((result) => {
         const resultNorm = normalizeForMatch(result.name)
         if (!resultNorm) return false
 
@@ -71,6 +71,21 @@ export function findMatchingSoundCloudResult(
         if (trackSec === null || !result.durationInSec) return true
         return Math.abs(result.durationInSec - trackSec) <= 30
     })
+
+    if (candidates.length === 0 || trackSec === null) return candidates[0]
+
+    // The 75%-token threshold lets remixes/speedups/extended edits pass
+    // title matching too. SoundCloud's search order is not a quality
+    // ranking, so among qualifying candidates prefer the closest duration —
+    // the cheapest signal available that a candidate is the original
+    // recording rather than an altered one.
+    return candidates.reduce((best, candidate) => {
+        if (!candidate.durationInSec) return best
+        if (!best.durationInSec) return candidate
+        const bestDiff = Math.abs(best.durationInSec - trackSec)
+        const candidateDiff = Math.abs(candidate.durationInSec - trackSec)
+        return candidateDiff < bestDiff ? candidate : best
+    }, candidates[0])
 }
 
 function normalizeForMatch(value: string): string {


### PR DESCRIPTION
## What

Part of the investigation in #2048 ("audio not good in some moments"). `findMatchingSoundCloudResult` (`packages/bot/src/handlers/player/soundcloudMatcher.ts`) used `results.find(...)` — the first SoundCloud search result to pass a loose ≥75%-title-token-overlap + ±30s-duration filter. SoundCloud's search-relevance order is not a quality ranking, so a sped-up edit, "8D audio" remix, or extended mix can satisfy that threshold and get picked over the actual original — this is one of two identified contributors to the reported audio-quality complaint (the other, larger contributor was a contaminated cookies file, already fixed same day).

## Fix

Filters to all qualifying candidates first, then picks the one whose duration is closest to the source track — the cheapest available signal (given `SoundCloudSearchResult` only carries `name`/`url`/`durationInSec`) that a candidate is the unaltered original rather than an altered edit.

## Test plan
- [x] `npx jest soundcloudMatcher.spec.ts` — added 2 tests: closest-duration wins among multiple qualifying candidates even when ranked second by SoundCloud; falls back correctly when only one candidate has no duration data at all
- [x] Full bot suite: 3147 passed (2 new)
- [x] `npm run type:check --workspace=@lucky/bot`

## Not in scope here
Whether to also request an explicit stream `quality` tier from `playdl.stream()`/`playdl.search()` — flagged as an open follow-up in #2048, needs verifying play-dl's actual default behavior first rather than guessing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ranks SoundCloud fallback matches by title score before duration closeness to avoid remixes/edits winning. Previously we returned the first result passing ≥75% title-token overlap and ±30s duration; now we choose among all qualifiers, prefer the higher title score, and break ties on smallest duration difference.

- Gates unchanged (≥75% tokens; ±30s when both durations exist); ignore SoundCloud’s order; missing duration is neutral in the duration tiebreak.
- Fallbacks: if source duration is unknown, return the first qualifying candidate; if only duration-less candidates qualify, return the first; prefer an exact-title candidate with no duration over a looser-title candidate with duration; at equal title score, prefer the duration-bearing candidate.
- Touches `packages/bot/src/handlers/player/soundcloudMatcher.ts`; adds tests covering closest-duration selection, duration-less ordering, and title-priority; no API or config changes.

<sup>Written for commit e8bdb3b6fdebc0528aee894c8ac1ffeebd43a38d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SoundCloud result matching to select the qualifying result with the closest duration.
  * Preserved title-only matching when duration information is unavailable.
* **Tests**
  * Added coverage for choosing the closest-duration result and handling candidates without duration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->