### PR TITLE
fix(bot): resolve /album text queries to an album url

### DIFF
--- a/packages/backend/src/services/SpotifyAuthService.ts
+++ b/packages/backend/src/services/SpotifyAuthService.ts
@@ -1,4 +1,7 @@
 import { errorLog } from '@lucky/shared/utils'
+// Single implementation lives in shared: the bot needs the same
+// client-credentials token for /album album resolution.
+export { getSpotifyClientToken } from '@lucky/shared/utils'
 
 export type SpotifyTokenResponse = {
     accessToken: string
@@ -83,44 +86,6 @@ export async function exchangeCodeForToken(
     } catch (error) {
         errorLog({
             message: 'Spotify authorization-code token exchange failed',
-            error,
-        })
-        return null
-    }
-}
-
-let cachedClientToken: { token: string; expiresAt: number } | null = null
-
-export async function getSpotifyClientToken(): Promise<string | null> {
-    if (cachedClientToken && Date.now() < cachedClientToken.expiresAt) {
-        return cachedClientToken.token
-    }
-    const clientId = process.env.SPOTIFY_CLIENT_ID
-    const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
-    if (!clientId || !clientSecret) return null
-
-    const auth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
-    try {
-        const data = await fetchJson<{
-            access_token?: string
-            expires_in?: number
-        }>('https://accounts.spotify.com/api/token', {
-            method: 'POST',
-            headers: {
-                Authorization: `Basic ${auth}`,
-                'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            body: 'grant_type=client_credentials',
-        })
-        if (!data?.access_token) return null
-        cachedClientToken = {
-            token: data.access_token,
-            expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000 - 30_000,
-        }
-        return cachedClientToken.token
-    } catch (error) {
-        errorLog({
-            message: 'Spotify client-credentials token request failed',
             error,
         })
         return null

--- a/packages/bot/src/functions/music/commands/album.spec.ts
+++ b/packages/bot/src/functions/music/commands/album.spec.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+jest.mock('discord-player', () => ({
+    QueryType: {
+        AUTO: 'AUTO',
+        SPOTIFY_SEARCH: 'SPOTIFY_SEARCH',
+        SPOTIFY_SONG: 'SPOTIFY_SONG',
+    },
+}))
+
+jest.mock('../../../utils/general/interactionReply', () => ({
+    interactionReply: jest.fn(),
+}))
+
+jest.mock('../../../utils/general/embeds', () => ({
+    createErrorEmbed: jest.fn((title: string, desc?: string) => ({
+        title,
+        description: desc,
+    })),
+    createSuccessEmbed: jest.fn((title: string, desc?: string) => ({
+        title,
+        description: desc,
+    })),
+    createWarningEmbed: jest.fn((title: string, desc?: string) => ({
+        title,
+        description: desc,
+    })),
+}))
+
+jest.mock('../../../services/musicManagement/queueResolver', () => ({
+    resolveGuildQueue: jest.fn(),
+}))
+
+jest.mock('../../../services/musicManagement/queueManipulation', () => ({
+    moveUserTrackToPriority: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/utils/general/errorSanitizer', () => ({
+    createUserFriendlyError: jest.fn(() => 'User friendly error'),
+}))
+
+jest.mock('../../../utils/command/commandValidations', () => ({
+    requireVoiceChannel: jest.fn(async () => true),
+    requireDJRole: jest.fn(async () => true),
+}))
+
+const searchSpotifyAlbumsMock = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    errorLog: jest.fn(),
+    warnLog: jest.fn(),
+    searchSpotifyAlbums: (...args: unknown[]) =>
+        searchSpotifyAlbumsMock(...args),
+}))
+
+jest.mock('@lucky/shared/utils/guards', () => ({
+    assertDefined: jest.fn((value: unknown) => value),
+}))
+
+jest.mock('@lucky/shared/config', () => ({
+    ENVIRONMENT_CONFIG: { PLAYER: { CONNECTION_TIMEOUT: 30_000 } },
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    featureToggleService: { isEnabled: jest.fn(async () => true) },
+}))
+
+import albumCommand from './album'
+import { interactionReply } from '../../../utils/general/interactionReply'
+import { resolveGuildQueue } from '../../../services/musicManagement/queueResolver'
+
+const ALBUM_URL = 'https://open.spotify.com/album/0ETFjACtuP2ADo6LFhL6HN'
+
+const createTrack = (title: string) => ({
+    title,
+    author: 'The Beatles',
+    url: `https://open.spotify.com/track/${encodeURIComponent(title)}`,
+    requestedBy: undefined as unknown,
+})
+
+const createInteraction = (query: string, artist: string | null = null) => ({
+    guildId: 'guild-1',
+    user: { id: 'user-1', username: 'tester' },
+    member: { voice: { channel: { id: 'voice-1' } } },
+    channel: { id: 'text-1' },
+    options: {
+        getString: jest.fn((name: string) =>
+            name === 'artist' ? artist : query,
+        ),
+    },
+    deferReply: jest.fn(async () => undefined),
+})
+
+const lastReply = () =>
+    (interactionReply as jest.Mock).mock.calls.at(-1)?.[0] as {
+        content: { embeds: { title: string; description?: string }[] }
+    }
+
+describe('album command album resolution', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(resolveGuildQueue as jest.Mock).mockReturnValue({
+            queue: { addTrack: jest.fn() },
+        })
+    })
+
+    it('resolves a text query to an album URL before searching', async () => {
+        // Pre-fix this query went to SPOTIFY_SEARCH, which can only return
+        // tracks, so searchResult.playlist was always null and the command
+        // always answered "No album found".
+        searchSpotifyAlbumsMock.mockResolvedValue([
+            {
+                id: 'a1',
+                name: 'Abbey Road',
+                artist: 'The Beatles',
+                url: ALBUM_URL,
+            },
+        ])
+        const search = jest.fn(async () => ({
+            tracks: [createTrack('Come Together'), createTrack('Something')],
+            playlist: { title: 'Abbey Road' },
+        }))
+        const play = jest.fn(async () => ({
+            track: createTrack('Come Together'),
+        }))
+
+        await albumCommand.execute({
+            client: { player: { search, play } },
+            interaction: createInteraction('Abbey Road'),
+        } as never)
+
+        expect(searchSpotifyAlbumsMock).toHaveBeenCalledWith('Abbey Road', 1)
+        expect(search).toHaveBeenCalledTimes(1)
+        expect(search.mock.calls[0][0]).toBe(ALBUM_URL)
+        expect(search.mock.calls[0][1]).toMatchObject({ searchEngine: 'AUTO' })
+        expect(lastReply().content.embeds[0].title).not.toBe('No album found')
+    })
+
+    it('folds the artist option into the album lookup', async () => {
+        searchSpotifyAlbumsMock.mockResolvedValue([
+            {
+                id: 'a1',
+                name: 'Abbey Road',
+                artist: 'The Beatles',
+                url: ALBUM_URL,
+            },
+        ])
+        const search = jest.fn(async () => ({
+            tracks: [createTrack('Come Together')],
+            playlist: { title: 'Abbey Road' },
+        }))
+
+        await albumCommand.execute({
+            client: {
+                player: {
+                    search,
+                    play: jest.fn(async () => ({ track: null })),
+                },
+            },
+            interaction: createInteraction('Abbey Road', 'The Beatles'),
+        } as never)
+
+        expect(searchSpotifyAlbumsMock).toHaveBeenCalledWith(
+            'Abbey Road The Beatles',
+            1,
+        )
+    })
+
+    it('passes a Spotify album URL straight through without a lookup', async () => {
+        const search = jest.fn(async () => ({
+            tracks: [createTrack('Come Together')],
+            playlist: { title: 'Abbey Road' },
+        }))
+
+        await albumCommand.execute({
+            client: {
+                player: {
+                    search,
+                    play: jest.fn(async () => ({ track: null })),
+                },
+            },
+            interaction: createInteraction(ALBUM_URL),
+        } as never)
+
+        expect(searchSpotifyAlbumsMock).not.toHaveBeenCalled()
+        expect(search.mock.calls[0][0]).toBe(ALBUM_URL)
+    })
+
+    it('reports an actionable message when no album matches', async () => {
+        searchSpotifyAlbumsMock.mockResolvedValue([])
+        const search = jest.fn()
+
+        await albumCommand.execute({
+            client: { player: { search, play: jest.fn() } },
+            interaction: createInteraction('zzzz not an album'),
+        } as never)
+
+        expect(search).not.toHaveBeenCalled()
+        const embed = lastReply().content.embeds[0]
+        expect(embed.title).toBe('No album found')
+        // The old copy told users to try "a more specific album search",
+        // which no text query could ever satisfy.
+        expect(embed.description).not.toContain('more specific album search')
+        expect(embed.description).toContain('zzzz not an album')
+    })
+})

--- a/packages/bot/src/functions/music/commands/album.ts
+++ b/packages/bot/src/functions/music/commands/album.ts
@@ -15,7 +15,7 @@ import {
     createWarningEmbed,
 } from '../../../utils/general/embeds'
 import { interactionReply } from '../../../utils/general/interactionReply'
-import { errorLog } from '@lucky/shared/utils'
+import { errorLog, warnLog, searchSpotifyAlbums } from '@lucky/shared/utils'
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
 import { assertDefined } from '@lucky/shared/utils/guards'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
@@ -111,16 +111,43 @@ export default new Command({
         }
 
         try {
-            const isUrl = isSpotifyAlbumUrl(query)
-            const searchEngine = isUrl
-                ? QueryType.AUTO
-                : QueryType.SPOTIFY_SEARCH
-            const searchQuery =
-                !isUrl && artistFilter ? `${query} ${artistFilter}` : query
+            // A free-text query cannot reach an extractor's album branch: every
+            // search QueryType hits a *track* search and responds with
+            // `createResponse(null, tracks)`, so `searchResult.playlist` was
+            // always null and every text query failed (#2050). Resolve the
+            // query to an album URL first, then run the URL path that works.
+            let albumUrl = isSpotifyAlbumUrl(query) ? query : null
 
-            const searchResult = await client.player.search(searchQuery, {
+            if (!albumUrl) {
+                const albumQuery = artistFilter
+                    ? `${query} ${artistFilter}`
+                    : query
+                const [match] = await searchSpotifyAlbums(albumQuery, 1)
+                if (!match) {
+                    warnLog({
+                        message:
+                            'Album query did not resolve to a Spotify album',
+                        data: { query, artistFilter },
+                    })
+                    await interactionReply({
+                        interaction,
+                        content: {
+                            embeds: [
+                                createErrorEmbed(
+                                    'No album found',
+                                    `No album matched **${query}**${artistFilter ? ` by **${artistFilter}**` : ''}. Try the full album title, or paste a Spotify album URL.`,
+                                ),
+                            ],
+                        },
+                    })
+                    return
+                }
+                albumUrl = match.url
+            }
+
+            const searchResult = await client.player.search(albumUrl, {
                 requestedBy: interaction.user,
-                searchEngine,
+                searchEngine: QueryType.AUTO,
             })
 
             if (!searchResult?.tracks.length) {
@@ -139,13 +166,17 @@ export default new Command({
             }
 
             if (!searchResult.playlist) {
+                warnLog({
+                    message: 'Resolved album URL returned no playlist',
+                    data: { query, albumUrl },
+                })
                 await interactionReply({
                     interaction,
                     content: {
                         embeds: [
                             createErrorEmbed(
                                 'No album found',
-                                'Please provide a Spotify album URL or a more specific album search.',
+                                'Spotify returned tracks but no album listing. Try again, or paste a Spotify album URL.',
                             ),
                         ],
                     },

--- a/packages/shared/src/__tests__/utils/spotify/clientToken.test.ts
+++ b/packages/shared/src/__tests__/utils/spotify/clientToken.test.ts
@@ -1,0 +1,93 @@
+import {
+    beforeEach,
+    afterEach,
+    describe,
+    expect,
+    it,
+    jest,
+} from '@jest/globals'
+
+jest.mock('../../../utils/general/log', () => ({
+    errorLog: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
+import {
+    getSpotifyClientToken,
+    resetSpotifyClientTokenCache,
+} from '../../../utils/spotify/clientToken'
+
+const originalFetch = global.fetch
+
+function mockTokenResponse(token: string, expiresIn = 3600) {
+    return {
+        ok: true,
+        json: async () => ({ access_token: token, expires_in: expiresIn }),
+    } as unknown as Response
+}
+
+describe('getSpotifyClientToken', () => {
+    beforeEach(() => {
+        resetSpotifyClientTokenCache()
+        process.env.SPOTIFY_CLIENT_ID = 'id'
+        process.env.SPOTIFY_CLIENT_SECRET = 'secret'
+    })
+
+    afterEach(() => {
+        global.fetch = originalFetch
+        delete process.env.SPOTIFY_CLIENT_ID
+        delete process.env.SPOTIFY_CLIENT_SECRET
+    })
+
+    it('opens one token exchange for concurrent callers', async () => {
+        // Without in-flight sharing every caller misses the cache before any
+        // of them stores a token, so each opens its own exchange.
+        let resolveFetch: (value: Response) => void = () => {}
+        const pending = new Promise<Response>((resolve) => {
+            resolveFetch = resolve
+        })
+        const fetchMock = jest.fn(() => pending)
+        global.fetch = fetchMock as unknown as typeof fetch
+
+        const calls = Promise.all([
+            getSpotifyClientToken(),
+            getSpotifyClientToken(),
+            getSpotifyClientToken(),
+        ])
+        resolveFetch(mockTokenResponse('tok-1'))
+
+        expect(await calls).toEqual(['tok-1', 'tok-1', 'tok-1'])
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('serves a cached token without refetching', async () => {
+        const fetchMock = jest.fn(async () => mockTokenResponse('tok-1'))
+        global.fetch = fetchMock as unknown as typeof fetch
+
+        expect(await getSpotifyClientToken()).toBe('tok-1')
+        expect(await getSpotifyClientToken()).toBe('tok-1')
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries after a failed exchange instead of caching the failure', async () => {
+        const responses: Response[] = [
+            { ok: false } as unknown as Response,
+            mockTokenResponse('tok-2'),
+        ]
+        const fetchMock = jest.fn(async () => responses.shift() as Response)
+        global.fetch = fetchMock as unknown as typeof fetch
+
+        expect(await getSpotifyClientToken()).toBeNull()
+        expect(await getSpotifyClientToken()).toBe('tok-2')
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns null without a request when credentials are unset', async () => {
+        delete process.env.SPOTIFY_CLIENT_ID
+        const fetchMock = jest.fn()
+        global.fetch = fetchMock as unknown as typeof fetch
+
+        expect(await getSpotifyClientToken()).toBeNull()
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+})

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,5 +1,7 @@
 export * from './general/log'
 export * from './spotify/artistApi'
+export * from './spotify/albumApi'
+export * from './spotify/clientToken'
 export * from './errorHandler'
 export * from './error/errorHandler'
 export * from './monitoring/sentry'

--- a/packages/shared/src/utils/spotify/albumApi.ts
+++ b/packages/shared/src/utils/spotify/albumApi.ts
@@ -1,0 +1,70 @@
+import { getSpotifyClientToken } from './clientToken'
+
+export interface SpotifyAlbumMatch {
+    id: string
+    name: string
+    artist: string
+    url: string
+}
+
+function mapSpotifyAlbum(raw: {
+    id?: string
+    name?: string
+    artists?: { name?: string }[]
+    external_urls?: { spotify?: string }
+}): SpotifyAlbumMatch | null {
+    if (!raw.id || !raw.name) return null
+    const url = raw.external_urls?.spotify
+    if (!url) return null
+    return {
+        id: raw.id,
+        name: raw.name,
+        artist: raw.artists?.[0]?.name ?? 'Unknown Artist',
+        url,
+    }
+}
+
+/**
+ * Resolve a free-text album query to Spotify album URLs.
+ *
+ * `/album` needs this because no discord-player search QueryType can return a
+ * playlist: SPOTIFY_SEARCH (and Apple Music search) hit the track-search API
+ * and build their response with `createResponse(null, tracks)`, so the
+ * extractor's album branch is only reachable via an album URL. Resolving the
+ * URL here lets the command reuse the URL path that already works.
+ */
+export async function searchSpotifyAlbums(
+    query: string,
+    limit = 5,
+): Promise<SpotifyAlbumMatch[]> {
+    if (!query.trim()) return []
+
+    const accessToken = await getSpotifyClientToken()
+    if (!accessToken) return []
+
+    try {
+        const params = new URLSearchParams({
+            q: query,
+            type: 'album',
+            limit: String(Math.min(Math.max(limit, 1), 50)),
+        })
+        const res = await fetch(
+            `https://api.spotify.com/v1/search?${params.toString()}`,
+            {
+                headers: { Authorization: `Bearer ${accessToken}` },
+                signal: AbortSignal.timeout(10_000),
+            },
+        )
+        if (!res.ok) return []
+        const data = (await res.json().catch(() => null)) as {
+            albums?: { items?: unknown[] }
+        } | null
+        return (data?.albums?.items ?? [])
+            .map((a) =>
+                mapSpotifyAlbum(a as Parameters<typeof mapSpotifyAlbum>[0]),
+            )
+            .filter((a): a is SpotifyAlbumMatch => a !== null)
+    } catch {
+        return []
+    }
+}

--- a/packages/shared/src/utils/spotify/clientToken.ts
+++ b/packages/shared/src/utils/spotify/clientToken.ts
@@ -1,0 +1,56 @@
+import { errorLog } from '../general/log'
+
+let cachedClientToken: { token: string; expiresAt: number } | null = null
+
+/**
+ * Client-credentials access token for Spotify's Web API, cached until 30s
+ * before expiry. Returns null when credentials are unset or the request
+ * fails, so callers degrade instead of throwing.
+ *
+ * Lives in shared because both the backend (artist suggestions) and the bot
+ * (`/album` album resolution) need it; a second copy would drift on the
+ * caching and expiry-margin details.
+ */
+export async function getSpotifyClientToken(): Promise<string | null> {
+    if (cachedClientToken && Date.now() < cachedClientToken.expiresAt) {
+        return cachedClientToken.token
+    }
+    const clientId = process.env.SPOTIFY_CLIENT_ID
+    const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
+    if (!clientId || !clientSecret) return null
+
+    const auth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+    try {
+        const res = await fetch('https://accounts.spotify.com/api/token', {
+            method: 'POST',
+            headers: {
+                Authorization: `Basic ${auth}`,
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: 'grant_type=client_credentials',
+            signal: AbortSignal.timeout(10_000),
+        })
+        if (!res.ok) return null
+        const data = (await res.json().catch(() => null)) as {
+            access_token?: string
+            expires_in?: number
+        } | null
+        if (!data?.access_token) return null
+        cachedClientToken = {
+            token: data.access_token,
+            expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000 - 30_000,
+        }
+        return cachedClientToken.token
+    } catch (error) {
+        errorLog({
+            message: 'Spotify client-credentials token request failed',
+            error,
+        })
+        return null
+    }
+}
+
+/** Test seam: drop the cached token so a fresh request is made. */
+export function resetSpotifyClientTokenCache(): void {
+    cachedClientToken = null
+}

--- a/packages/shared/src/utils/spotify/clientToken.ts
+++ b/packages/shared/src/utils/spotify/clientToken.ts
@@ -1,6 +1,7 @@
 import { errorLog } from '../general/log'
 
 let cachedClientToken: { token: string; expiresAt: number } | null = null
+let inFlightRequest: Promise<string | null> | null = null
 
 /**
  * Client-credentials access token for Spotify's Web API, cached until 30s
@@ -15,6 +16,16 @@ export async function getSpotifyClientToken(): Promise<string | null> {
     if (cachedClientToken && Date.now() < cachedClientToken.expiresAt) {
         return cachedClientToken.token
     }
+    // At startup and at expiry every concurrent caller misses the cache
+    // before any of them stores a token, so without this they each open
+    // their own token exchange. Share the in-flight request instead.
+    inFlightRequest ??= requestClientToken().finally(() => {
+        inFlightRequest = null
+    })
+    return inFlightRequest
+}
+
+async function requestClientToken(): Promise<string | null> {
     const clientId = process.env.SPOTIFY_CLIENT_ID
     const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
     if (!clientId || !clientSecret) return null
@@ -53,4 +64,5 @@ export async function getSpotifyClientToken(): Promise<string | null> {
 /** Test seam: drop the cached token so a fresh request is made. */
 export function resetSpotifyClientTokenCache(): void {
     cachedClientToken = null
+    inFlightRequest = null
 }


### PR DESCRIPTION
Closes #2050.

## The bug is bigger than #2050 described

`/album` with a free-text query **never worked**. Not intermittently: no text query could ever succeed.

Trace for `/album abbey road`:

1. Not a URL, so `searchEngine = QueryType.SPOTIFY_SEARCH` (`album.ts:113-117`, pre-fix)
2. The Spotify extractor's text branch ends in `this.createResponse(null, tracks)` — `discord-player-spotify/dist/index.js:823`
3. `createResponse(playlist?, tracks?)` takes the **playlist first** — `discord-player/dist/index.d.ts:3333`. So `searchResult.playlist` is always `null` for a text query.
4. `album.ts:139` checks `if (!searchResult.playlist)` and answers:
   > No album found. Please provide a Spotify album URL or a more specific album search.

That advice is unreachable. No amount of specificity turns a track search into a playlist. Only a Spotify album **URL** ever worked.

**This is why the `/artist` fallback fix (#2052) does not port here.** Adding YouTube/SoundCloud arms would change nothing: every search-type `QueryType` returns tracks. `SPOTIFY_ALBUM`, `APPLE_MUSIC_ALBUM`, `SOUNDCLOUD_PLAYLIST` and `YOUTUBE_PLAYLIST` are all URL types, and Apple Music's `APPLE_MUSIC_SEARCH` branch has the same `createResponse(null, tracks)` shape. Three arms would have failed the same playlist gate.

CHANGELOG line 1009 shipped this as "search and browse albums with track listings". There was no `album.spec.ts`, which is why it went unnoticed.

## Change

- Resolve the text query to an album URL first, via Spotify's search API with `type=album`, then feed that URL through the URL path that already works. Reuses the working branch instead of adding a parallel one.
- The `artist` option folds into the album lookup rather than the track search, so it narrows the album rather than the tracks.
- Both failure points now `warnLog`. Previously neither emitted anything, the same blind spot documented in #2051.
- The "no album found" copy names the query and points at the two things that actually work.

## Shared token fetcher

`getSpotifyClientToken()` (client-credentials, cached to 30s before expiry) moves from `packages/backend/src/services/SpotifyAuthService.ts` into `@lucky/shared/utils/spotify/clientToken.ts`. The bot needs the same token, and a second copy would drift on the caching and expiry-margin details. `SpotifyAuthService` re-exports it, so its three existing callers in `artistSuggestion.ts` are untouched. Backend's local `fetchJson` wrapper is inlined in the moved copy to keep shared free of a backend-only helper.

## Tests

`album.spec.ts` is new: the command had no tests at all. 4 cases, verified **3 fail against the pre-fix code**:

1. resolves a text query to an album URL before searching
2. folds the artist option into the album lookup
3. passes a Spotify album URL straight through without a lookup (the one that passed before)
4. reports an actionable message when no album matches, and no longer suggests "a more specific album search"

Full suites green: 376 bot command tests, 45 backend Spotify tests, 11 shared Spotify tests. Typecheck clean across shared, bot, backend, frontend.

## Note on degradation

`searchSpotifyAlbums` returns `[]` when `SPOTIFY_CLIENT_ID`/`SPOTIFY_CLIENT_SECRET` are unset, so text queries then report "no album found" instead of throwing. URL queries keep working through the extractor's own credentials, which is the same behavior as before this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes /album free‑text queries by resolving them to a Spotify album URL before playback, and deduplicates concurrent Spotify client‑credentials requests. Previously any non‑URL input used a track‑only search and always replied “No album found.”

- Resolves the query (optionally with artist) via `@lucky/shared/utils/spotify/albumApi` `searchSpotifyAlbums`, then searches the resolved album URL with `QueryType.AUTO`.
- Adds warn logs for “no album match” and “URL returned no playlist”, and updates the error copy to include the query and suggest the full title or a Spotify album URL.
- Moves the client‑credentials token to `@lucky/shared/utils/spotify/clientToken`, re‑exported by backend `SpotifyAuthService`; shares the in‑flight token exchange across callers and adds tests for cache/in‑flight/credential paths.
- Adds `album.spec.ts` covering URL resolution, artist narrowing, URL passthrough, and actionable failure messaging.

**Rollout**
- No migrations; backend callers continue via the `SpotifyAuthService` re‑export.
- If `SPOTIFY_CLIENT_ID`/`SPOTIFY_CLIENT_SECRET` are unset, text queries now degrade to “No album found”; direct album URLs still work.

<sup>Written for commit 33cb770fc702c7b46c397bfdc755b2bd8f6651e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

