### PR TITLE
fix(bot): make three silent /play failures observable

### DIFF
--- a/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
@@ -99,8 +99,20 @@ export async function executePlayHandler({
                     deferredMsg.id,
                     interaction.channelId,
                 )
-            } catch {
-                // Non-fatal — playerStart will send a new message instead
+            } catch (error) {
+                // Non-fatal: playerStart sends its own message if this fails.
+                // Logged because an empty catch made the double failure
+                // (this AND playerStart) indistinguishable from success —
+                // the user got no now-playing message and nothing was
+                // recorded anywhere (#1993).
+                warnLog({
+                    message: 'Failed to register now-playing message',
+                    data: {
+                        guildId: interaction.guildId,
+                        channelId: interaction.channelId,
+                        error: String(error),
+                    },
+                })
             }
         }
 
@@ -218,6 +230,12 @@ export async function executePlayHandler({
 
         // Fire-and-forget: each op is isolated inside runPostPlayBackgroundOps so a
         // single failure never silently skips the others (#1085).
+        //
+        // Not awaited: these are background ops by design and the user-facing
+        // reply has already been sent, so awaiting would hold the command open
+        // on work the user is not waiting for. The catch is what #1997 was
+        // actually missing — anything escaping the internal isolation used to
+        // vanish into an unhandled rejection.
         void runPostPlayBackgroundOps({
             queue,
             guildId: assertDefined(
@@ -227,6 +245,12 @@ export async function executePlayHandler({
             track,
             hadQueueBeforePlay,
             isPlaylist,
+        }).catch((error: unknown) => {
+            errorLog({
+                message: 'Post-play background ops failed',
+                error,
+                data: { guildId: interaction.guildId, track: track?.title },
+            })
         })
     } catch (error) {
         if (isUnknownInteractionError(error)) {

--- a/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
@@ -135,6 +135,29 @@ describe('expandSoundCloudShortUrl', () => {
     beforeEach(() => {
         fetchMock.mockReset()
         debugLogMock.mockReset()
+        warnLogMock.mockReset()
+    })
+
+    it('logs an expansion failure at warn, not debug', async () => {
+        // debug is filtered out in production, so this failure used to leave
+        // no trace: the user saw a generic "No results found" from the
+        // resolver with nothing indicating expansion was the failing step
+        // (#1994).
+        fetchMock.mockRejectedValueOnce(new Error('network down'))
+
+        const shortUrl = 'https://on.soundcloud.com/abc123'
+        const result = await expandSoundCloudShortUrl(shortUrl)
+
+        expect(result).toBe(shortUrl)
+        expect(debugLogMock).not.toHaveBeenCalled()
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining(
+                    'SoundCloud short URL expansion failed',
+                ),
+                data: expect.objectContaining({ originalUrl: shortUrl }),
+            }),
+        )
     })
 
     it('expands on.soundcloud.com short links to full soundcloud.com URLs', async () => {
@@ -172,7 +195,7 @@ describe('expandSoundCloudShortUrl', () => {
         const result = await expandSoundCloudShortUrl(shortUrl)
 
         expect(result).toBe(shortUrl)
-        expect(debugLogMock).toHaveBeenCalledWith(
+        expect(warnLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 message:
                     'SoundCloud short URL expansion failed, using original URL',
@@ -200,7 +223,7 @@ describe('expandSoundCloudShortUrl', () => {
         const result = await expandSoundCloudShortUrl(shortUrl)
 
         expect(result).toBe(shortUrl)
-        expect(debugLogMock).toHaveBeenCalledWith(
+        expect(warnLogMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 message:
                     'SoundCloud short URL expansion failed, using original URL',

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -59,39 +59,30 @@ export async function expandSoundCloudShortUrl(url: string): Promise<string> {
         // Follow redirects with a 5-second timeout, using HEAD first (no body download)
         const expanded = await withTimeout(
             (async () => {
-                try {
-                    const response = await (global.fetch as typeof fetch)(url, {
-                        method: 'HEAD',
-                        redirect: 'follow',
-                    })
-                    const finalUrl = response.url
+                const response = await (global.fetch as typeof fetch)(url, {
+                    method: 'HEAD',
+                    redirect: 'follow',
+                })
+                const finalUrl = response.url
 
-                    // Security check: ensure resolved URL is a soundcloud domain
-                    const finalParsed = new URL(finalUrl)
-                    if (
-                        finalParsed.hostname !== 'soundcloud.com' &&
-                        !finalParsed.hostname?.endsWith('.soundcloud.com')
-                    ) {
-                        // Redirect went somewhere unexpected — reject and fall back
-                        throw new Error(
-                            `Redirect destination is not a soundcloud.com domain: ${finalUrl}`,
-                        )
-                    }
-
-                    debugLog({
-                        message: 'SoundCloud short URL expanded',
-                        data: { originalUrl: url, expandedUrl: finalUrl },
-                    })
-
-                    return finalUrl
-                } catch (innerError) {
-                    debugLog({
-                        message:
-                            'Failed to expand SoundCloud short URL in fetch block',
-                        data: { url, error: String(innerError) },
-                    })
-                    throw innerError
+                // Security check: ensure resolved URL is a soundcloud domain
+                const finalParsed = new URL(finalUrl)
+                if (
+                    finalParsed.hostname !== 'soundcloud.com' &&
+                    !finalParsed.hostname?.endsWith('.soundcloud.com')
+                ) {
+                    // Redirect went somewhere unexpected — reject and fall back
+                    throw new Error(
+                        `Redirect destination is not a soundcloud.com domain: ${finalUrl}`,
+                    )
                 }
+
+                debugLog({
+                    message: 'SoundCloud short URL expanded',
+                    data: { originalUrl: url, expandedUrl: finalUrl },
+                })
+
+                return finalUrl
             })(),
             5000,
             'soundcloud-short-url-expansion',
@@ -99,8 +90,11 @@ export async function expandSoundCloudShortUrl(url: string): Promise<string> {
 
         return expanded
     } catch (error) {
-        // Network error, timeout, or security validation failed — gracefully fall back
-        debugLog({
+        // Network error, timeout, or security validation failed — gracefully
+        // fall back. warn, not debug: debug is filtered out in production, so
+        // the user saw a generic "No results found" from the resolver with no
+        // record that expansion was the step that actually failed (#1994).
+        warnLog({
             message:
                 'SoundCloud short URL expansion failed, using original URL',
             data: {


### PR DESCRIPTION
Closes #1993, #1994, #1997.

Three failure paths in `/play` recorded nothing a production log would show, so each presented to the user as a generic no-result or as success.

## #1993 — empty catch around `registerNowPlayingMessage`

`playHandler.ts:92-104` swallowed the error entirely, with a comment asserting `playerStart` would send a fallback message. Nothing verified that. When both failed, the user got no now-playing message and **nothing was recorded anywhere**. Now warn-logged with guild and channel.

## #1994 — expansion failure logged at `debug`

`queryUtils.ts:100-111` logged SoundCloud short-URL expansion failures at `debug`, which is filtered out in production. Downstream, the unresolvable fallback URL surfaced only as a generic "No results found" from the resolver, with no record that *expansion* was the failing step. Raised to `warn`.

**Also found while fixing it:** that path logged the same failure **twice**. An inner catch (`queryUtils.ts:87-93`) debug-logged and rethrew straight into the outer catch, which logged it again. Since the inner catch only logged and rethrew, it is removed rather than raised — one failure should produce one accurate line. Same double-log shape CodeRabbit caught on #2052.

## #1997 — bare `void` on `runPostPlayBackgroundOps`

`playHandler.ts:219-230` called it as fire-and-forget with no rejection handler, so anything escaping the per-op isolation added by #1085 became an **unhandled rejection**. Now has a `.catch` that error-logs.

**Deliberately not awaited, contrary to the issue's suggested direction.** These are background ops and the user-facing reply has already been sent, so awaiting would hold the command open on work nobody is waiting for, and would make a slow background op look like a slow command. The missing piece was the catch, not the await.

## Tests

- New: an expansion failure logs at `warn` and **not** at `debug` — asserts both halves, so a silent regression to debug is caught.
- Updated: two existing assertions in `queryUtils.spec.ts` moved from `debugLog` to `warnLog`. They cover the non-soundcloud-redirect and domain-suffix-bypass (`soundcloud.com.attacker.com`) paths — those are security rejections and belong at a visible level regardless of this change.

Full bot suite: **3155 passed**, 1 skipped, both test trees (`src/**/*.spec.ts` and `tests/**/*.test.ts`). Typecheck clean across all four packages.

## Not covered

`playHandler.ts` has no spec file, so the #1993 and #1997 changes are not directly unit-tested. Writing one means mocking the entire play flow; it belongs with the untested-command work in #2055 rather than bolted on here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes three silent /play failures observable in production and prevents unhandled rejections. Behavior and latency are unchanged.

- Now-playing registration failure: previously swallowed; now warn-logs guildId, channelId, and error.
- SoundCloud short-URL expansion: previously debug-only and double-logged; removes inner catch; on failure emits a single warn log and falls back to the original URL.
- Post-play background ops: still fire-and-forget; now attaches a .catch that error-logs guildId and track to avoid unhandled rejections; not awaited by design.

**Tests**
- Adds a test that expansion failures log at warn and not at debug; updates two expectations to warn for security-rejection paths.

<sup>Written for commit 8348c916b620692fec30e3bd7ba00f29faa86ca0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

