### PR TITLE
fix(bot): report a dead autoplay replenish at error level

### DIFF
--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -1,7 +1,7 @@
 import type { Track, GuildQueue } from 'discord-player'
 import { QueueRepeatMode } from 'discord-player'
 import { LRUCache } from 'lru-cache'
-import { infoLog, debugLog, errorLog, warnLog } from '@lucky/shared/utils'
+import { infoLog, debugLog, errorLog } from '@lucky/shared/utils'
 import { addTrackToHistory } from '../../utils/music/duplicateDetection'
 import { replenishQueue } from '../../services/musicManagement/queueOperations'
 import { resetAutoplayCount } from '../../utils/music/autoplayManager'
@@ -207,9 +207,15 @@ async function handleQueueReplenishment(
             setTimeout(() => {
                 replenishQueue(queue, undefined, () =>
                     getRecentSkipCount(queue.guild.id),
-                ).catch((retryErr) => {
-                    warnLog({
-                        message: 'Replenish retry failed',
+                ).catch((retryErr: unknown) => {
+                    // errorLog, not warnLog: this is the second consecutive
+                    // failure, so autoplay has stopped for this guild and will
+                    // not retry again. warn only adds a Sentry breadcrumb,
+                    // which is transmitted solely if some later error fires —
+                    // so the moment autoplay died was invisible (#1995).
+                    errorLog({
+                        message:
+                            'Replenish retry failed — autoplay stopped for this guild',
                         error: retryErr,
                         data: { guildId: queue.guild.id },
                     })


### PR DESCRIPTION
Closes #1995.

## Problem

`trackHandlers.ts:204-214` — when the first replenish fails, a retry is scheduled 5s later. If the retry **also** fails, autoplay has stopped for that guild and nothing will try again. It was only `warnLog`'d.

`warn` never reaches Sentry: `LogService.warn()` only calls `addBreadcrumb` (`shared/src/utils/general/log/service.ts:163-167`), and a breadcrumb is transmitted solely when some *later* error event fires. So the moment autoplay died was invisible unless something unrelated broke afterwards and happened to carry the crumb along.

## Change

Raised to `errorLog`, and the message now states the consequence — `Replenish retry failed — autoplay stopped for this guild` — rather than just naming the failed call. Drops the `warnLog` import this left unused.

Not restructuring the retry itself. The issue floated awaiting it or adding a user-visible notice; both change behaviour (the retry is intentionally detached from the track-start path, and an in-channel notice needs a product decision about noise). Making the failure visible is the part that was unambiguously missing.

## Full bot suite: 3154 passed, 1 skipped. Typecheck and lint clean.

---

## Related: #1996 does not reproduce

While here I checked #1996, which claims `void runSafelyAsync(...)` at `errorHandlers.ts:186-189` silently swallows recovery exceptions. It does not:

```
runSafelyAsync  (errorHandlers.ts:129-139)
  └─ logHandlerFailure  (:113-119)
       └─ safeErrorLog  (:78-88)
            └─ errorLog   ← reaches Sentry
```

The catch already logs at **error** level with the message `Player error event handler failed:`, which is exactly what that issue asks for ("logs at error level (not silently)... so a failed recovery is distinguishable from a successful one"). Commenting there separately rather than folding a no-op change into this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports the second consecutive autoplay replenish failure at error level so Sentry captures the event and we know autoplay stopped for the guild. Previously this logged a warning only, which added a breadcrumb sent only if a later error occurred.

- Logs with `errorLog` (from `@lucky/shared/utils`) and a clearer message: “Replenish retry failed — autoplay stopped for this guild,” including `guildId`.
- Keeps retry behavior unchanged (first failure schedules a retry after 5s; after the second failure, no more retries).
- Removes the unused `warnLog` import.

<sup>Written for commit 94577787e74c6672cdbc0997845d30f0c61fce45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

