### PR TITLE
ci: ref-scope the docker-publish gha cache

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,8 +97,12 @@ jobs:
                   build-args: |
                       COMMIT_SHA=${{ github.sha }}
                       NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
-                  cache-from: type=gha,scope=${{ matrix.service }}
-                  cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+                  # Ref-scoped, matching .github/actions/docker-build-service.
+                  # A bare service scope is shared with every other workflow
+                  # building the same service, so a mode=max export written by
+                  # one can land in the cache another reads (#2002).
+                  cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.service }}
+                  cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.service }}
 
             - name: Smoke test yt-dlp
               if: matrix.service == 'bot'


### PR DESCRIPTION
Closes #2002.

## What was left

The issue reported both build paths using a bare `scope=<service>`. Half of it is already fixed — `.github/actions/docker-build-service/action.yml:88-89` now uses `format('type=gha,scope={0}-{1}', github.ref_name, inputs.service)`.

`docker-publish.yml:100-101` was still on the bare scope:

```yaml
cache-from: type=gha,scope=${{ matrix.service }}
cache-to: type=gha,mode=max,scope=${{ matrix.service }}
```

That is the last place a `mode=max` export can be written to a scope another workflow reads. Now `${{ github.ref_name }}-${{ matrix.service }}`, matching the PR-side builder.

## Honest scoping of the risk

The concurrent-writer scenario the issue describes is **not currently live** here:

- `docker-publish.yml` declares `concurrency: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, so two runs on the same ref cannot overlap.
- It only triggers on `push: branches: [main]` and `workflow_dispatch`.
- The PR builder already moved to a different scope, so PR builds and main builds no longer share one.

So this is consistency and defence in depth, not an outage fix. Worth doing because the two halves disagreeing is exactly how the original bug got reintroduced, and because a bare scope is the kind of thing a future workflow would copy.

## Cost

One cold build on the next push to `main` — the new scope starts empty. No behaviour change beyond that.

## Verification

`actionlint .github/workflows/docker-publish.yml` passes. Grepped every `type=gha` occurrence in `.github/`; after this change both remaining sites are ref-scoped and no others exist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ref-scopes the BuildKit GHA cache in `docker-publish.yml` to `${{ github.ref_name }}-${{ matrix.service }}` to match the PR build action. This prevents `mode=max` cache exports from one workflow from being read by another.

- Old: `scope=${{ matrix.service }}` (shared across workflows). New: `scope=${{ github.ref_name }}-${{ matrix.service }}`.
- Impact: cache keys change only; expect one cold build on the next push to `main`.
- Safety: workflow concurrency already blocks parallel writers on the same ref; this is defense-in-depth.
- Verification: `actionlint` passes; all remaining `type=gha` cache scopes are ref-scoped.

<sup>Written for commit 72b8fdf4320c0affe7410379b5d5b303a30a375a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

