### PR TITLE
fix(bot): update a case reason through the service layer

### DIFF
--- a/packages/bot/src/functions/moderation/handlers/caseHandlers.spec.ts
+++ b/packages/bot/src/functions/moderation/handlers/caseHandlers.spec.ts
@@ -7,7 +7,7 @@ import {
 
 const getCaseMock = jest.fn()
 const deactivateCaseMock = jest.fn()
-const prismaUpdateMock = jest.fn()
+const updateCaseReasonMock = jest.fn()
 const interactionReplyMock = jest.fn()
 const infoLogMock = jest.fn()
 
@@ -15,15 +15,11 @@ jest.mock('@lucky/shared/services', () => ({
     moderationService: {
         getCase: (...args: unknown[]) => getCaseMock(...args),
         deactivateCase: (...args: unknown[]) => deactivateCaseMock(...args),
+        updateCaseReason: (...args: unknown[]) => updateCaseReasonMock(...args),
     },
 }))
 
 jest.mock('@lucky/shared/utils', () => ({
-    getPrismaClient: () => ({
-        moderationCase: {
-            update: (...args: unknown[]) => prismaUpdateMock(...args),
-        },
-    }),
     infoLog: (...args: unknown[]) => infoLogMock(...args),
 }))
 
@@ -109,7 +105,7 @@ describe('caseHandlers', () => {
         jest.clearAllMocks()
         getCaseMock.mockResolvedValue(null)
         deactivateCaseMock.mockResolvedValue(undefined)
-        prismaUpdateMock.mockResolvedValue({})
+        updateCaseReasonMock.mockResolvedValue({})
     })
 
     describe('handleCaseView', () => {
@@ -307,7 +303,7 @@ describe('caseHandlers', () => {
                 interaction,
                 content: { content: '❌ Case #999 not found.' },
             })
-            expect(prismaUpdateMock).not.toHaveBeenCalled()
+            expect(updateCaseReasonMock).not.toHaveBeenCalled()
         })
 
         test('updates case reason successfully', async () => {
@@ -321,10 +317,12 @@ describe('caseHandlers', () => {
 
             await handleCaseUpdate(interaction, 42)
 
-            expect(prismaUpdateMock).toHaveBeenCalledWith({
-                where: { id: 'case-123' },
-                data: { reason: 'Updated reason' },
-            })
+            // Asserts the service call, not a direct prisma write: routing
+            // through the service layer is the point of #1972.
+            expect(updateCaseReasonMock).toHaveBeenCalledWith(
+                'case-123',
+                'Updated reason',
+            )
             expect(interactionReplyMock).toHaveBeenCalledWith({
                 interaction,
                 content: {

--- a/packages/bot/src/functions/moderation/handlers/caseHandlers.ts
+++ b/packages/bot/src/functions/moderation/handlers/caseHandlers.ts
@@ -4,12 +4,10 @@ import {
     PermissionFlagsBits,
 } from 'discord.js'
 import { moderationService } from '@lucky/shared/services'
-import { getPrismaClient, infoLog } from '@lucky/shared/utils'
+import { infoLog } from '@lucky/shared/utils'
 import { assertDefined } from '@lucky/shared/utils/guards'
 import { interactionReply } from '../../../utils/general/interactionReply.js'
 import { formatDurationHuman } from '../../../utils/general/formatDuration'
-
-const prisma = getPrismaClient()
 
 const typeColors: Record<string, number> = {
     warn: 0xffa500,
@@ -114,10 +112,7 @@ export async function handleCaseUpdate(
         return
     }
 
-    await prisma.moderationCase.update({
-        where: { id: moderationCase.id },
-        data: { reason: newReason },
-    })
+    await moderationService.updateCaseReason(moderationCase.id, newReason)
 
     const embed = new EmbedBuilder()
         .setColor(0x5865f2)
@@ -142,7 +137,10 @@ export async function handleCaseDelete(
     interaction: ChatInputCommandInteraction,
     caseNumber: number,
 ): Promise<void> {
-    const member = await assertDefined(interaction.guild, 'Guild required for handler').members.fetch(interaction.user.id)
+    const member = await assertDefined(
+        interaction.guild,
+        'Guild required for handler',
+    ).members.fetch(interaction.user.id)
     if (!member.permissions.has(PermissionFlagsBits.Administrator)) {
         await interactionReply({
             interaction,

--- a/packages/shared/src/services/ModerationService.spec.ts
+++ b/packages/shared/src/services/ModerationService.spec.ts
@@ -453,6 +453,18 @@ describe('ModerationService', () => {
             })
         })
 
+        it('updateCaseReason updates only the reason, by id', async () => {
+            const m = setupCaseMock()
+            m.update.mockResolvedValue({})
+
+            await service.updateCaseReason('case-1', 'corrected reason')
+
+            expect(m.update).toHaveBeenCalledWith({
+                where: { id: 'case-1' },
+                data: { reason: 'corrected reason' },
+            })
+        })
+
         it('appealCase records the appeal with reason and timestamp', async () => {
             const m = setupCaseMock()
             m.update.mockResolvedValue({})

--- a/packages/shared/src/services/ModerationService.ts
+++ b/packages/shared/src/services/ModerationService.ts
@@ -209,6 +209,18 @@ export class ModerationService {
         })
     }
 
+    /** Updates the stated reason on an existing moderation case. */
+    async updateCaseReason(
+        caseId: string,
+        reason: string,
+    ): Promise<ModerationCase> {
+        const prisma = getPrismaClient()
+        return await prisma.moderationCase.update({
+            where: { id: caseId },
+            data: { reason },
+        })
+    }
+
     /** Submits an appeal for a moderation case. */
     async appealCase(input: AppealCaseInput): Promise<ModerationCase> {
         const prisma = getPrismaClient()


### PR DESCRIPTION
Closes #1972.

## Problem

`caseHandlers.ts:117` reached past `moderationService` straight into Prisma:

```ts
await prisma.moderationCase.update({
    where: { id: moderationCase.id },
    data: { reason: newReason },
})
```

The same function already used the service for everything else — `moderationService.getCase(...)` a few lines above, `deactivateCase` elsewhere. This was the only direct database write in the handler.

## Change

Adds `updateCaseReason(caseId, reason)` to `ModerationService`, matching the shape of `deactivateCase` and `appealCase` immediately beside it, and switches the handler to it.

That also removes the last reason for the bot handler to hold a Prisma client at all — the `getPrismaClient` import and the module-level `const prisma = getPrismaClient()` are both gone.

## Tests

- New in `ModerationService.spec.ts`: `updateCaseReason` updates **only** the reason, by id (asserts the exact `where`/`data` shape).
- `caseHandlers.spec.ts` asserted the Prisma call shape — which is the bypass being removed. It now asserts `updateCaseReason('case-123', 'Updated reason')`, and its `getPrismaClient` mock is deleted with it. The two tests that broke (`updates case reason successfully`, `handles null old reason correctly`) pass against the service call.

Shared **1412 passed**, bot **3154 passed** + 1 skipped. Typecheck clean across all four packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates case reason through the service layer instead of a direct Prisma write in the bot handler. This centralizes database writes, limits the update to the reason field, and removes the handler’s Prisma client.

- Add `updateCaseReason(caseId, reason)` to `ModerationService` with a spec asserting the exact `where`/`data` shape.
- Switch `handleCaseUpdate` to `moderationService.updateCaseReason` from `@lucky/shared/services`; drop `getPrismaClient` and the module-level client from `@lucky/shared/utils`.
- Update handler tests to mock the service call; remove the Prisma client mock; add a service test for `updateCaseReason`.

<sup>Written for commit 2d9fd851f7f6f64f77c146341534d6b17e6b4e11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

