### PR TITLE
ci(frontend): raise the vendor radix budget to 50 kb

### DIFF
--- a/packages/frontend/.size-limit.json
+++ b/packages/frontend/.size-limit.json
@@ -20,7 +20,7 @@
     {
         "name": "Vendor Radix (gzip)",
         "path": "dist/assets/vendor-radix-*.js",
-        "limit": "48 KB",
+        "limit": "50 KB",
         "gzip": true
     },
     {


### PR DESCRIPTION
Closes #2010. **Unblocks the release PR #2039**, whose only failing check is `Size Limit Check`.

## The number

| Bundle | Limit | Actual | Headroom |
|---|---|---|---|
| Main | 75 kB | 70.33 | 6.2% |
| Vendor UI | 70 kB | 66.40 | 5.1% |
| Vendor React | 60 kB | 55.63 | 7.3% |
| **Vendor Radix** | **48 kB** | **48.94** | **-2.0% (over by 942 B)** |
| Vendor Forms | 28 kB | 26.35 | 5.9% |
| Vendor State | 26.5 kB | 26.14 | 1.4% |

## I tried to reduce it first

Four Radix packages have **zero imports** in `packages/frontend/src` — `tabs`, `toast`, `tooltip`, `slot` — yet all four are listed in `vite.config.ts` `manualChunks` for `vendor-radix`. That looked like a free win. Removing them drops the chunk to **48.61 kB**, comfortably under the old limit.

**It is a regression.** Measuring the whole output rather than the one chunk:

| | Total JS, gzipped, all 63 chunks |
|---|---|
| current config | **496,709 B** |
| 4 packages removed | **498,088 B** |
| | **+1,379 B worse** |

`@radix-ui/react-slot` is a shared transitive dependency of the other Radix packages. Grouping it into `vendor-radix` **deduplicates** it; splitting it out copies it into every chunk that needs it. So the "fix" shrinks the measured chunk by growing the real bundle — exactly the thing a size budget exists to prevent.

`vite.config.ts` is therefore unchanged.

## So: raise it

With no reduction available that does not make the bundle worse, 48.94 kB is the honest size of what the app actually uses. 50 kB gives ~2.1% headroom, in line with the other five budgets (1.4%–6.6%), and matches the `26 → 26.5 kB` precedent set for Vendor State in #1960.

Verified locally: `npx size-limit` exits **0**, all six budgets pass.

## Follow-up, not done here

`@radix-ui/react-tabs`, `react-toast` and `react-tooltip` have no imports anywhere in `src` and are almost certainly not in the bundle at all (unreachable from the entry, so tree-shaken before chunking). Removing them from `packages/frontend/package.json` is genuine dependency hygiene, but it touches the lockfile and will not change any bundle number — worth its own PR rather than riding along with a release unblock. Say the word and I will file it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the Vendor Radix size-limit from 48 KB to 50 KB to match the actual gzipped chunk size (48.94 kB) and keep CI green. Old behavior: CI failed at 48 KB; new behavior: budget is 50 KB; no runtime or bundling behavior changes.

- No change to `vite.config.ts` or chunking. Removing `@radix-ui/react-tabs`, `@radix-ui/react-toast`, `@radix-ui/react-tooltip`, and `@radix-ui/react-slot` from the `vendor-radix` chunk shrank that chunk but increased total gzipped JS (~1.4 kB) due to duplicated `@radix-ui/react-slot`.
- New headroom is ~2.1%, consistent with other budgets; `npx size-limit` passes locally.
- Single file touched: `packages/frontend/.size-limit.json` (sets "Vendor Radix (gzip)" limit to 50 KB).

<sup>Written for commit 32ad8009d9a6bab654dae6a5233c439ed004cda4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

