### PR TITLE
fix(bot): stop reporting an outage when the fallbacks found nothing

### DIFF
--- a/packages/bot/src/functions/music/commands/play/handlers/playErrorMessage.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/playErrorMessage.spec.ts
@@ -21,10 +21,50 @@ describe('resolvePlayErrorMessage', () => {
             'No results found for "some song" (Extractor: com.discord-player.youtube)',
         )
 
-        expect(resolvePlayErrorMessage(error)).toBe(
+        expect(
+            resolvePlayErrorMessage(
+                error,
+                'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            ),
+        ).toBe(
             'Music sources are currently unreachable. Please try again in a few minutes.',
         )
         expect(isExtractorDegradedMock).toHaveBeenCalledWith('youtube')
+    })
+
+    it('does not claim an outage for a text search that found nothing (#2000)', () => {
+        // A text search falls through to Spotify and SoundCloud. If it still
+        // finds nothing, the healthy engines answered correctly — saying
+        // "unreachable" reported an outage that did not happen.
+        isExtractorDegradedMock.mockReturnValue(true)
+        const error = new Error(
+            'No results found for "asdkjhasd" (Extractor: com.discord-player.soundcloudextractor)',
+        )
+
+        expect(resolvePlayErrorMessage(error, 'asdkjhasd')).not.toBe(
+            'Music sources are currently unreachable. Please try again in a few minutes.',
+        )
+    })
+
+    it('does not claim an outage for a spotify url while youtube is degraded', () => {
+        isExtractorDegradedMock.mockReturnValue(true)
+        const error = new Error('No results found for "track"')
+
+        expect(
+            resolvePlayErrorMessage(
+                error,
+                'https://open.spotify.com/track/abc',
+            ),
+        ).not.toBe(
+            'Music sources are currently unreachable. Please try again in a few minutes.',
+        )
+    })
+
+    it('stays generic when no query is supplied rather than guessing an outage', () => {
+        isExtractorDegradedMock.mockReturnValue(true)
+        const error = new Error('No results found for "some song"')
+
+        expect(resolvePlayErrorMessage(error)).toContain('No results found')
     })
 
     it('falls back to the sanitized message for a no-results error when youtube is healthy', () => {

--- a/packages/bot/src/functions/music/commands/play/handlers/playErrorMessage.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/playErrorMessage.ts
@@ -1,13 +1,33 @@
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
 import { isExtractorDegraded } from '../../../../../handlers/player/extractorHealth'
+import { detectQueryType } from '../queryDetector'
 
 // "No results found" is misleading when it's actually a degraded extractor
 // (e.g. YouTube session init silently failed but registration still
 // reported success) — say so instead (#1929).
-export function resolvePlayErrorMessage(error: unknown): string {
+//
+// Scoped to queries only the degraded extractor could have served (#2000).
+// A text search falls through resolveQueryWithFallbacks to Spotify and
+// SoundCloud, so if it still finds nothing, the healthy engines answered and
+// genuinely found nothing — calling that "unreachable" told users an outage
+// had happened when the fallbacks had worked correctly.
+export function resolvePlayErrorMessage(
+    error: unknown,
+    query?: string,
+): string {
     const isNoResultsError =
         error instanceof Error && /no results found/i.test(error.message)
-    if (isNoResultsError && isExtractorDegraded('youtube')) {
+
+    // Without a query we cannot tell the two cases apart, so fall back to the
+    // accurate generic message rather than guessing "outage".
+    const onlyYoutubeCouldServe =
+        query !== undefined && detectQueryType(query) === 'youtube'
+
+    if (
+        isNoResultsError &&
+        onlyYoutubeCouldServe &&
+        isExtractorDegraded('youtube')
+    ) {
         return 'Music sources are currently unreachable. Please try again in a few minutes.'
     }
     return createUserFriendlyError(error)

--- a/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/playHandler.ts
@@ -250,7 +250,7 @@ export async function executePlayHandler({
                     embeds: [
                         createErrorEmbed(
                             'Play Error',
-                            resolvePlayErrorMessage(error),
+                            resolvePlayErrorMessage(error, query),
                         ),
                     ],
                     ephemeral: true,


### PR DESCRIPTION
Closes #2000.

## Problem

`playErrorMessage.ts:10` replaced **any** "no results found" error with "Music sources are currently unreachable" whenever the YouTube extractor was flagged degraded:

```ts
if (isNoResultsError && isExtractorDegraded('youtube')) {
    return 'Music sources are currently unreachable. Please try again in a few minutes.'
}
```

It keyed only on that global flag plus a message regex — nothing tied the error to the extractor that actually produced it.

But a text search does not stop at YouTube. `resolveQueryWithFallbacks` tries Spotify, then SoundCloud. So a user searching a song that genuinely does not exist got told the sources were unreachable, when the healthy fallback engines had answered normally and correctly found nothing.

## Change

Scoped to queries **only the degraded extractor could have served**, using the `detectQueryType` helper that already exists in `play/queryDetector.ts` — the discriminator the issue said was missing:

- `youtube.com` / `youtu.be` URL + YouTube degraded → genuinely unreachable for that user, keep the outage message. This is #1929's original case.
- Text search, Spotify URL, anything else → the fallbacks could and did answer, so return the accurate message.

With no query supplied the two cases are indistinguishable, so it returns the generic message rather than guessing an outage. The parameter is optional, so no other caller breaks.

## Why not discriminate on the extractor id in the error

The error reaching this function is whatever the **last** fallback arm threw — SoundCloud's — even when the query is a YouTube URL that only YouTube could serve. Production confirms the id is in the message (`... (Extractor: com.discord-player.itsmaat.spotifyextractor)`), but it names the arm that failed last, not the capability that was missing. Keying on the query type answers the actual question: *could a healthy engine have served this at all?*

## Tests

7 total, **3 new and all verified failing before this change**:

- text search that found nothing does **not** claim an outage
- Spotify URL while YouTube is degraded does **not** claim an outage
- no query supplied stays generic instead of guessing

The original YouTube case is kept and now passes a YouTube URL, so the #1929 behaviour is still pinned.

Full bot suite: **3157 passed**, 1 skipped. Typecheck clean across all four packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops misreporting an outage on “no results found” when healthy fallbacks answered. Before: any “no results found” while YouTube was degraded showed an outage. Now: only YouTube URLs that only YouTube could serve show the outage; text searches and non‑YouTube URLs return the accurate sanitized message.

- Scopes the outage message in resolvePlayErrorMessage using detectQueryType; triggers only for YouTube queries when isExtractorDegraded('youtube') is true.
- Adds an optional query?: string to resolvePlayErrorMessage and passes it from playHandler; other call sites remain valid. Without a query, returns the generic sanitized message from `@lucky/shared/utils/general/errorSanitizer`.
- Adds tests for text search, Spotify URL, and no‑query paths; keeps the original YouTube URL case.

<sup>Written for commit 8be638d90ecbae9ef75eebb74478a673e907d74e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music playback error messages during YouTube service disruptions.
  * YouTube outage guidance now appears only for applicable YouTube links.
  * Text searches, Spotify links, and missing queries now receive a generic helpful error instead of an inaccurate outage message.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->