### PR TITLE
build(ts): drop the removed compiler option that blocks typescript 7

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -2,9 +2,7 @@
     "compilerOptions": {
         "target": "ES2022",
         "module": "ESNext",
-        "lib": [
-            "ES2022"
-        ],
+        "lib": ["ES2022"],
         "moduleResolution": "bundler",
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true,
@@ -14,28 +12,15 @@
         "forceConsistentCasingInFileNames": true,
         "rootDir": "./src",
         "outDir": "./dist",
-        "baseUrl": ".",
         "paths": {
-            "@/*": [
-                "./src/*"
-            ],
-            "@lucky/shared": [
-                "../shared/src/index.ts"
-            ],
-            "@lucky/shared/*": [
-                "../shared/src/*"
-            ]
+            "@/*": ["./src/*"],
+            "@lucky/shared": ["../shared/src/index.ts"],
+            "@lucky/shared/*": ["../shared/src/*"]
         },
         "ignoreDeprecations": "6.0"
     },
-    "include": [
-        "src/**/*"
-    ],
-    "exclude": [
-        "node_modules",
-        "dist",
-        "tests"
-    ],
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "tests"],
     "references": [
         {
             "path": "../shared"

--- a/packages/bot/tsconfig.json
+++ b/packages/bot/tsconfig.json
@@ -2,9 +2,7 @@
     "compilerOptions": {
         "target": "ES2022",
         "module": "ESNext",
-        "lib": [
-            "ES2022"
-        ],
+        "lib": ["ES2022"],
         "moduleResolution": "bundler",
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true,
@@ -14,27 +12,13 @@
         "forceConsistentCasingInFileNames": true,
         "rootDir": "./src",
         "outDir": "./dist",
-        "baseUrl": ".",
         "paths": {
-            "@/*": [
-                "./src/*"
-            ],
-            "@lucky/shared": [
-                "../shared/dist/index.d.ts"
-            ],
-            "@lucky/shared/*": [
-                "../shared/dist/*"
-            ]
+            "@/*": ["./src/*"],
+            "@lucky/shared": ["../shared/dist/index.d.ts"],
+            "@lucky/shared/*": ["../shared/dist/*"]
         },
         "ignoreDeprecations": "6.0"
     },
-    "include": [
-        "src/**/*"
-    ],
-    "exclude": [
-        "node_modules",
-        "dist",
-        "**/*.spec.ts",
-        "**/*.test.ts"
-    ]
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -2,11 +2,7 @@
     "compilerOptions": {
         "target": "ES2022",
         "useDefineForClassFields": true,
-        "lib": [
-            "ES2020",
-            "DOM",
-            "DOM.Iterable"
-        ],
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
         "module": "ESNext",
         "skipLibCheck": true,
         "moduleResolution": "bundler",
@@ -19,17 +15,12 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true,
-        "baseUrl": ".",
         "paths": {
-            "@/*": [
-                "./src/*"
-            ]
+            "@/*": ["./src/*"]
         },
         "ignoreDeprecations": "6.0"
     },
-    "include": [
-        "src"
-    ],
+    "include": ["src"],
     "references": [
         {
             "path": "./tsconfig.node.json"

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,9 +2,7 @@
     "compilerOptions": {
         "target": "ES2022",
         "module": "ESNext",
-        "lib": [
-            "ES2022"
-        ],
+        "lib": ["ES2022"],
         "moduleResolution": "bundler",
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true,
@@ -17,21 +15,11 @@
         "composite": true,
         "outDir": "./dist",
         "rootDir": "./src",
-        "baseUrl": ".",
         "paths": {
-            "@/*": [
-                "./src/*"
-            ]
+            "@/*": ["./src/*"]
         },
         "ignoreDeprecations": "6.0"
     },
-    "include": [
-        "src/**/*"
-    ],
-    "exclude": [
-        "node_modules",
-        "dist",
-        "**/*.spec.ts",
-        "**/*.test.ts"
-    ]
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
         "outDir": "./dist",
         "rootDir": "./src",
         "sourceMap": false,
-        "baseUrl": ".",
         "allowJs": true,
         "incremental": true,
         "tsBuildInfoFile": "./dist/.tsbuildinfo",


### PR DESCRIPTION
Unblocks dependabot #2079 (typescript 6 -> 7), which fails at its first job:

```
Option 'baseUrl' has been removed. Please remove it from your configuration.
tsconfig.json#20
```

`Build — shared` fails, and `Mutation (backend)`, `Mutation (bot)`, `Mutation (shared)` and `Size Limit Check` all fail downstream of it. Five failures, one cause.

## Why removing it is safe on the current TypeScript too

Every `paths` entry in all five tsconfigs is already written relative to its own file:

```json
"@/*":            ["./src/*"]
"@lucky/shared":  ["../shared/src/index.ts"]
```

With `baseUrl` absent, TypeScript resolves `paths` relative to the tsconfig's directory — which is exactly what `baseUrl: "."` pointed at. Same resolution, one fewer removed option.

So this is not a TS7-only workaround, and it is landing on `main` rather than on the bump branch so the next bump does not need it again.

## Verified on TypeScript 6, before pushing

```
npm run type:check          clean across shared, bot, backend, frontend
build --workspace=shared    ok, 65 files
frontend vitest             1038 passed, 86 files
```

The frontend run matters most here: `@/` imports are used throughout its source (`import ErrorBoundary from "@/components/ErrorBoundary"`), so a broken alias would have surfaced there rather than only at type-check time.

## Not claimed

This clears the **first** TS7 failure. Whether typescript 7 surfaces further breakage further down the build is unknown until #2079 re-runs on top of this. I did not run TS7 locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `baseUrl` compiler option from all `tsconfig.json` files to unblock the TypeScript 7 upgrade. Previously `baseUrl: "."`; now omitted. Module resolution is unchanged because all `paths` are already relative to each tsconfig.

- Affects only tsconfig files in `packages/backend`, `packages/bot`, `packages/frontend`, `packages/shared`, and the root.
- Behavior on TypeScript 6 is unchanged; verified via type-check, `shared` build, and frontend tests that use the `@/` alias.
- No migration required; you may need to reload your editor.
- After merge, re-run Dependabot PR #2079 to surface any remaining TS7 issues.

<sup>Written for commit 69b3dc3b33e3a6769911efb66024c607dd96e220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

