### PR TITLE
fix(nginx): route /webhooks/ to backend so top.gg vote calls land

### DIFF
--- a/docs/TOP_GG_SUBMISSION.md
+++ b/docs/TOP_GG_SUBMISSION.md
@@ -135,6 +135,6 @@ Finally, in `packages/bot/src/functions/general/commands/`, add `/voterewards` t
 - [ ] Support server invite link added
 - [ ] GitHub URL added
 - [ ] Prefix: `/` (slash commands only)
-- [ ] Webhook URL set to `https://api.lucky.lucassantana.tech/webhooks/topgg-votes` (after deploy)
+- [ ] Webhook URL set to `https://lucky-api.lucassantana.tech/webhooks/topgg-votes` (after deploy)
 - [ ] Webhook auth token pasted in top.gg's field
 - [ ] Announce the listing in the support Discord + a GitHub release note

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -79,6 +79,26 @@ server {
         proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
     }
 
+    # top.gg vote callbacks. Registered at the root by the backend
+    # (`setupWebhookPublicRoutes`, packages/backend/src/routes/webhooks.ts),
+    # NOT under /api, so without this block the path fell through to the SPA
+    # catch-all below and nginx answered 405 to every POST. Same
+    # fall-through that silently swallowed /invite in #1888.
+    #
+    # Deliberately NOT the `location /webhook/` block above: that one is the
+    # singular deploy-hook service, rewrites to /hooks/$1 and targets
+    # webhook:9000. Different service entirely.
+    #
+    # Headers come from helmet in the backend, same as /api.
+    location /webhooks/ {
+        proxy_pass $backend_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+    }
+
     location /api {
         proxy_pass $backend_upstream;
         proxy_http_version 1.1;


### PR DESCRIPTION
## What

Adds a `location /webhooks/` block to `nginx/nginx.conf` so top.gg vote callbacks reach the backend, and corrects the webhook hostname in the submission pack.

Closes #2086, closes #2088.

## Why

`POST /webhooks/topgg-votes` never reached Express. Probed against production before the fix:

```
$ curl -s -i -X POST -H "Content-Type: application/json" \
    -d '{"type":"test"}' https://lucky-api.lucassantana.tech/webhooks/topgg-votes

HTTP/2 405
content-type: text/html
server: cloudflare
<html><head><title>405 Not Allowed</title></head>
<body><center><h1>405 Not Allowed</h1></center>
<hr><center>nginx/1.31.4</center></body></html>
```

The response carried the frontend CSP (`script-src 'self'; ... report-uri /api/security/csp-report`), which is the fingerprint of `location /`. The SPA static server was answering, and it rejects POST.

nginx proxied only three paths to the backend:

| block | target | note |
| --- | --- | --- |
| `location /webhook/` | `webhook:9000` | **singular**, deploy hooks, rewrites to `/hooks/$1` |
| `location = /invite` | `backend:3000` | single-color bypass, added by #1888 |
| `location /api` | `$backend_upstream` | blue/green aware |

The backend registers the route at the root, not under `/api`:

- `packages/backend/src/routes/webhooks.ts:187` — `app.post('/webhooks/topgg-votes', ...)`
- mounted at `packages/backend/src/routes/index.ts:112`

`/webhooks/topgg-votes` (plural) matched none of the three, fell through to `location /`, and hit the SPA. Same fall-through class as #1888, where every `/invite` click was silently swallowed.

## Design notes

- **Targets `$backend_upstream`, not the single-color bypass.** `= /invite` hardcodes `http://backend:3000` and carries a NOTE that Phase 1b must route it through `$backend_upstream` before the single-color backend is retired. Following the `/api` precedent instead means this block needs no Phase 1b unwind.
- **No `add_header` directives.** Headers come from helmet in the backend, same rationale as the `/api` block.
- **No conflict with `location /webhook/`.** `/webhooks/topgg-votes` does not match `/webhook/` (the 9th character is `s`, not `/`), and the new prefix is longer regardless.

## Hostname correction

`docs/TOP_GG_SUBMISSION.md` §7 told the operator to configure top.gg with `https://api.lucky.lucassantana.tech/webhooks/topgg-votes`. That host has no DNS record:

```
$ dig +short api.lucky.lucassantana.tech      # (empty)
$ dig +short lucky-api.lucassantana.tech
104.21.55.61
172.67.145.91
```

## Verification

- `nginx -t` runs in CI against the real image (`ci.yml:435`, per `decisions/2026-07-11-bluegreen-web-tier.md`). **I could not run it locally** — no docker daemon and no local nginx binary on this machine. Brace balance and directive termination checked by hand; the block is otherwise a copy of `/api`.
- Post-deploy check: `POST /webhooks/topgg-votes` with no auth header should return backend JSON (401 from `verifyTopggAuth`, or 503 if `TOPGG_AUTH_TOKEN` is unset), not an nginx HTML 405.

## Out of scope

`/health` and `/stats` are also registered at the root and also fall through to the SPA (they return `<!doctype html>` today). `/api/health` works. Left alone deliberately, flagged in #2086 for a separate decision on whether to route them or drop the root-level registration.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `/webhooks/` to the backend so top.gg vote callbacks reach Express instead of the SPA. Previously, `POST /webhooks/topgg-votes` hit the SPA and returned HTML 405; it now proxies via `$backend_upstream`. Also corrects the webhook hostname in the submission docs.

- Added `location /webhooks/` in `nginx/nginx.conf` (mirrors `/api` headers, targets `$backend_upstream`; no conflict with the singular `location /webhook/` deploy-hook service).
- Updated `docs/TOP_GG_SUBMISSION.md` to use `https://lucky-api.lucassantana.tech/webhooks/topgg-votes`.

**Rollout and verification**
- Verify after deploy: `POST /webhooks/topgg-votes` returns backend JSON (401 without auth, or 503 if `TOPGG_AUTH_TOKEN` is unset), not an HTML 405.
- Migration: If top.gg was configured with `https://api.lucky.lucassantana.tech/webhooks/topgg-votes`, change it to `https://lucky-api.lucassantana.tech/webhooks/topgg-votes`.

<sup>Written for commit 88729ed31960a9c96fb0a60776fcca328852493f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for receiving Top.gg vote callbacks through the webhook endpoint.
  * Preserved request headers and routing for reliable callback processing.

* **Documentation**
  * Updated the Top.gg submission checklist with the current webhook URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->