### PR TITLE
fix(frontend): point support link at our own support server

### DIFF
--- a/docs/TOP_GG_SUBMISSION.md
+++ b/docs/TOP_GG_SUBMISSION.md
@@ -4,13 +4,15 @@ Copy-paste artifacts for filing Lucky on https://top.gg. Launch sequence in `~/.
 
 ## 1. Bot identification
 
-| Field          | Value                                                                            |
-| -------------- | -------------------------------------------------------------------------------- |
-| Client ID      | `962198089161134131`                                                             |
-| Invite URL     | `https://lucky.lucassantana.tech/invite`                                         |
-| Website        | `https://lucky.lucassantana.tech`                                                |
-| GitHub         | `https://github.com/LucasSantana-Dev/Lucky`                                      |
-| Support server | _Create a Lucky Discord server first (Phase 0 task #7), then paste invite here._ |
+| Field          | Value                                       |
+| -------------- | ------------------------------------------- |
+| Client ID      | `962198089161134131`                        |
+| Invite URL     | `https://lucky.lucassantana.tech/invite`    |
+| Website        | `https://lucky.lucassantana.tech`           |
+| GitHub         | `https://github.com/LucasSantana-Dev/Lucky` |
+| Support server | `https://discord.gg/f2rxBWvqeR`             |
+
+**Note on the support server**: the invite is permanent by construction ("Expire After: Never", "Max Uses: No limit"). The first invite generated for this server carried `expires_at 2026-09-23` and was discarded: a support link that quietly expires is half of what made #2087 a bug. The single definition lives in `packages/shared/src/constants/support.ts`; do not paste the raw URL into new call sites.
 
 **Note on the invite URL** — do not hardcode a `permissions=` integer here. `https://lucky.lucassantana.tech/invite` redirects to Discord via the backend, which builds the URL from `BOT_INVITE_PERMISSIONS` in `packages/shared/src/constants/invite.ts`, and logs the `utm_*` parameters on the way through so directory clicks are attributable.
 
@@ -132,7 +134,7 @@ Finally, in `packages/bot/src/functions/general/commands/`, add `/voterewards` t
 - [ ] Short description pasted
 - [ ] Long description pasted
 - [ ] 3-8 tags selected
-- [ ] Support server invite link added
+- [x] Support server invite link added
 - [ ] GitHub URL added
 - [ ] Prefix: `/` (slash commands only)
 - [ ] Webhook URL set to `https://api.lucky.lucassantana.tech/webhooks/topgg-votes` (after deploy)

--- a/packages/frontend/src/pages/Docs.tsx
+++ b/packages/frontend/src/pages/Docs.tsx
@@ -2,6 +2,7 @@ import { useMemo, type ReactElement } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
 import { getBotInviteUrl } from '@/lib/discord'
+import { SUPPORT_SERVER_INVITE_URL } from '@lucky/shared/constants'
 import DocsShell, {
     type DocsNavGroup,
     type DocsTocItem,
@@ -64,7 +65,7 @@ const NAV: DocsNavGroup[] = [
             { label: 'Changelog', href: '/changelog' },
             {
                 label: 'Discord support',
-                href: 'https://discord.gg/lucky',
+                href: SUPPORT_SERVER_INVITE_URL,
                 external: true,
             },
         ],
@@ -550,10 +551,9 @@ $EDITOR .env`}</code>
                     <code>POSTGRES_PASSWORD</code> with{' '}
                     <code>openssl rand -hex 24</code> before the first{' '}
                     <code>docker compose up</code>. An empty value fails the
-                    compose guard on purpose. Optional integrations like
-                    Spotify and Last.fm get their own keys. The full list with
-                    notes lives in{' '}
-                    <a href='/docs?page=env'>Environment variables</a>.
+                    compose guard on purpose. Optional integrations like Spotify
+                    and Last.fm get their own keys. The full list with notes
+                    lives in <a href='/docs?page=env'>Environment variables</a>.
                 </p>
                 <p>
                     <code>SESSION_SECRET</code> must be 32+ random bytes.

--- a/packages/frontend/src/pages/Landing.tsx
+++ b/packages/frontend/src/pages/Landing.tsx
@@ -1,5 +1,6 @@
 import { reportError } from '@/lib/sentry'
 import { getBotInviteUrl } from '@/lib/discord'
+import { SUPPORT_SERVER_INVITE_URL } from '@lucky/shared/constants'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '@/stores/authStore'
@@ -758,7 +759,7 @@ function FooterSection() {
                         heading={t('landing.footer.support')}
                         links={[
                             {
-                                href: 'https://discord.gg/lucky',
+                                href: SUPPORT_SERVER_INVITE_URL,
                                 label: t('landing.footer.discord'),
                                 external: true,
                             },

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -6,6 +6,7 @@ export {
     BOT_INVITE_PERMISSIONS,
     buildBotInviteUrl,
 } from './invite'
+export { SUPPORT_SERVER_INVITE_URL } from './support'
 export {
     TOP_GG_BOT_ID,
     TOP_GG_VOTE_TIERS,

--- a/packages/shared/src/constants/support.ts
+++ b/packages/shared/src/constants/support.ts
@@ -1,0 +1,17 @@
+/**
+ * The Lucky support server.
+ *
+ * Lives in shared because the URL had already been copied into two places
+ * (`Landing.tsx` and `Docs.tsx`), which is exactly how the invite-URL drift
+ * started before it reached five divergent copies (#1888, #1894, #1923).
+ *
+ * The previous value pointed at `discord.gg/lucky`, a community that does
+ * not belong to this project, so every visitor who clicked "support" landed
+ * in a stranger's server (#2087).
+ *
+ * The invite is permanent by construction: it was created with
+ * "Expire After: Never" and "Max Uses: No limit". A support link on the
+ * top.gg listing that silently expires is the failure this constant exists
+ * to prevent, so do not replace it with a time-limited invite.
+ */
+export const SUPPORT_SERVER_INVITE_URL = 'https://discord.gg/f2rxBWvqeR'


### PR DESCRIPTION
## What

Creates the Lucky support server invite as a single shared constant and points both call sites at it.

Closes #2087.

## Why

The footer on the landing page and the Docs sidebar both linked to `https://discord.gg/lucky`. That code resolves to a server that is not ours:

```
$ curl -s https://discord.com/api/v10/invites/lucky
{"code":"lucky","guild":{"id":"266985212351741963","name":"LuckyShots Community!", ...}}
```

Anyone clicking "support" landed in a stranger's Discord. Confirmed live, not only in source: the string was present in the deployed lazy-loaded chunk served from `lucky.lucassantana.tech`.

## The support server now exists

`Lucky's Support Server`, guild `1541452011466268704`. Structure was provisioned through the Discord REST API with the bot, then verified by reading the guild back:

```
INFORMATION  [read-only for @everyone]
    📌-start-here      pinned welcome embed
    📣-announcements
    🚀-releases
SUPPORT
    🆘-help
    🐛-issues          pinned embed pointing at GitHub Issues
COMMUNITY
    💬-general         (system channel)
    🔊 Music Lounge
```

Roles `Maintainer` (`#495df3`, the frontend `--primary`) and `Contributor` (`#3ba55d`). Verification level Medium, notifications set to mentions only, explicit content filter on all members, icon from `assets/lucky-logo.png`.

## Single definition, on purpose

The URL goes in `packages/shared/src/constants/support.ts`, not inline. There were already two copies of it, which is exactly how the invite-URL drift began before it reached five divergent values (#1888, #1894, #1923). The constant carries that history in its docblock so the next person does not re-paste it.

## The invite is permanent

The first invite generated for this server carried `expires_at 2026-09-23`:

```
$ curl -s "https://discord.com/api/v10/invites/<first>?with_expiration=true"
  expires_at  2026-09-23T14:20:05+00:00
```

It was discarded and regenerated with "Expire After: Never" and "Max Uses: No limit". Verified:

```
$ curl -s "https://discord.com/api/v10/invites/f2rxBWvqeR?with_expiration=true"
  expires_at  null
```

A support link that silently expires is half of what made #2087 a bug, so this is called out in the constant's docblock and in the submission pack.

## Verification

- `npm run build:shared`, `type:check` (all four workspaces), `lint --workspace=packages/frontend`: pass.
- `npm run verify:shared-exports`: pass, 23 `@lucky/shared` specifiers.

## Note for the reviewer

The 3-line reflow in `Docs.tsx` around line 551 is the repo's own lint-staged `prettier --write` pass on a paragraph that was already non-compliant on `main`. Not a hand edit, and unrelated to the change.

## Not done here

`BOT_SUPPORT_SERVER` and `BOT_WEBSITE` are declared in `.env.example` and read by nothing in the repo. Filed separately rather than fixed inline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points all “Discord support” links to our own support server and centralizes the invite URL to prevent drift. Previously both footer and Docs linked to https://discord.gg/lucky (a different community), sending users to the wrong server.

- Adds SUPPORT_SERVER_INVITE_URL in packages/shared/src/constants/support.ts and re-exports from `@lucky/shared/constants`; invite is permanent.
- Replaces hardcoded links in packages/frontend/src/pages/Landing.tsx and packages/frontend/src/pages/Docs.tsx with the constant.
- Updates docs/TOP_GG_SUBMISSION.md to include the permanent invite and checks the “Support server” item.
- Prettier-only reflow in Docs.tsx paragraph; no behavior change.

<sup>Written for commit 3119b1d3580d15056afbae90a6e9ef79370aebca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

