### PR TITLE
docs(top.gg): correct the submission pack against the live listing

### DIFF
--- a/docs/TOP_GG_SUBMISSION.md
+++ b/docs/TOP_GG_SUBMISSION.md
@@ -136,7 +136,7 @@ keys it sketched. The real implementation:
 
 Verified reaching the backend in production on v2.39.8:
 
-```
+```console
 $ curl -s -i -X POST -H "Content-Type: application/json" \
     -d '{"type":"test"}' https://lucky-api.lucassantana.tech/webhooks/topgg-votes
 HTTP/2 503
@@ -185,7 +185,8 @@ Done:
 Blocked on approval:
 
 - [ ] Get the webhook token and set `TOPGG_AUTH_TOKEN` in production
-- [ ] Set the webhook URL in top.gg (only after the step above)
+- [ ] Set `TOPGG_TOKEN` in production so `topggStatsScheduler` can post the server count
+- [ ] Set the webhook URL in top.gg (only after `TOPGG_AUTH_TOKEN` is set)
 - [ ] Revisit imagery under the dashboard's `Appearance` section
 - [ ] Announce the listing in the support Discord and a GitHub release note
 

--- a/docs/TOP_GG_SUBMISSION.md
+++ b/docs/TOP_GG_SUBMISSION.md
@@ -1,6 +1,17 @@
 # top.gg Submission Pack
 
-Copy-paste artifacts for filing Lucky on https://top.gg. Launch sequence in `~/.claude/plans/lucky-next-phases-ultraplan.md` Phase 0.
+Reference for the Lucky listing on https://top.gg.
+
+**Status: submitted, awaiting approval.** The dashboard at
+https://top.gg/discord/bots/962198089161134131/dashboard is the authority on
+listing state and reports "Your project is currently in review". Nothing in the
+add-bot wizard does: it renders the static line "Your bot is a draft now and
+whenever you are ready, you can submit it for review" regardless of state, and
+its submit button sits `disabled` with the label "Queued for Review" once the
+listing has been queued. Read the dashboard, not the wizard.
+
+Approval unlocks the public page, ad campaigns (`Promote your Project` is gated
+on it) and the `Appearance` section of the dashboard.
 
 ## 1. Bot identification
 
@@ -21,6 +32,11 @@ The curated set is `3173504` — View Audit Log, View Channels, Send Messages, M
 _Historical note:_ this file previously specified `36970496` and described it as ten permissions summing to 37022784, which is neither that integer nor a set the bot could work with. The real `36970496` is Manage Messages, Use External Emojis, Connect, Speak, Use Voice Activity — with **no** View Channels and **no** Send Messages, so a bot invited with it could not read or post in a channel. It also claimed the README used `permissions=8` (Administrator); that was removed in #1889.
 
 ## 2. Short description (120 char cap)
+
+> **The live listing does not use the copy in §2 and §3.** What was actually
+> submitted is longer and leads on the self-hosting angle. Read and edit it at
+> the dashboard's `Edit Your Page`; treat the text below as the original draft,
+> kept for reference.
 
 ```text
 Self-hosted Discord music bot with autoplay, dashboard, and moderation. TypeScript, open source, no paywall.
@@ -64,79 +80,115 @@ Made with ❤️ in Brazil · Open source under [ISC](https://github.com/LucasSa
 Primary (pick 3): `music`, `moderation`, `dashboard`
 Secondary (add up to 5): `typescript`, `open-source`, `self-hosted`, `autoplay`, `spotify`
 
-## 5. Banner spec
+## 5. Listing fields (as the form actually exists)
 
-- Size: 1000×500 px (top.gg recommendation)
-- Source: adapt existing `assets/lucky-social-preview.png` (currently 252 KB, 1280×640) — crop/resize
-- Must include: "Lucky" wordmark, bot avatar, one-line value prop, subtle link to `lucky.lucassantana.tech`
-- Keep text < 30% of canvas so Discord thumbnail still reads
+**There is no banner upload in the add-bot flow.** The previous version of this
+section specified a 1000x500 banner sourced from `assets/lucky-social-preview.png`;
+top.gg has since changed the listing format and the wizard contains no
+`input[type=file]` at all. Imagery may return under the dashboard's `Appearance`
+section, which is gated on approval, so this cannot be confirmed until then.
 
-## 6. Vote webhook wiring (prep)
+The fields the wizard does have, in order:
 
-Once the listing is live, get your top.gg API token from https://top.gg/bot/962198089161134131/webhooks and add this to `.env`:
+| Field               | Required              | Value used                                                                        |
+| ------------------- | --------------------- | --------------------------------------------------------------------------------- |
+| Headline            | yes, 140 char cap     | leads on self-hosting; see the note in §2                                         |
+| Long Description    | yes, 300 char minimum | Markdown, see §2 note                                                             |
+| Prefix              | yes                   | `/`                                                                               |
+| Categories          | yes, 1+               | Automation, autoplay, Moderation, Music, Spotify, Utility, Web Dashboard, YouTube |
+| Languages           | yes, 1+               | English                                                                           |
+| Note for reviewer   | no                    | empty                                                                             |
+| Invite URL          | no                    | `https://lucky.lucassantana.tech/invite?utm_source=topgg&utm_medium=direct`       |
+| Repository URL      | no                    | `LucasSantana-Dev/Lucky`                                                          |
+| Support URL         | no                    | `f2rxBWvqeR`                                                                      |
+| Website URL         | no                    | `https://lucky.lucassantana.tech`                                                 |
+| Support Server Link | no                    | empty                                                                             |
 
-```env
-TOPGG_AUTH_TOKEN=<top.gg-provided token>
+**Repository URL and Support URL are prefixed fields.** The form renders
+`https://github.com/` and `https://discord.gg/` as static labels and appends
+what you type. Pasting a full URL produces
+`https://github.com/https://github.com/LucasSantana-Dev/Lucky`, which is what
+the listing shipped with until it was corrected. Type the suffix only.
+
+`Support Server Link` is a dropdown of servers already listed on top.gg, not a
+free invite field. The Lucky support server is not listed there, so it stays
+empty and `Support URL` carries the invite instead.
+
+**Brand asset warning:** do not reach for `assets/lucky-logo.png`. Despite the
+name it contains a NEXUS logo, not Lucky branding (#2094). The real mark is
+`assets/outline-v4-neon.jpeg` (1024x1024) or `packages/frontend/public/lucky-logo.png`.
+
+## 6. Vote webhook
+
+**The endpoint is built and live.** The stub that used to live in this section
+described code that has since shipped, backed by Postgres rather than the Redis
+keys it sketched. The real implementation:
+
+| Piece                        | Where                                                        |
+| ---------------------------- | ------------------------------------------------------------ |
+| `POST /webhooks/topgg-votes` | `packages/backend/src/routes/webhooks.ts`                    |
+| Route registration           | `packages/backend/src/routes/index.ts`                       |
+| Vote + streak storage        | `topggVote` model in `prisma/schema.prisma`                  |
+| Tier definitions             | `packages/shared/src/constants/topgg.ts`                     |
+| `/voterewards` command       | `packages/bot/src/functions/general/commands/voterewards.ts` |
+| Server-count posting         | `packages/bot/src/utils/general/topggStatsScheduler.ts`      |
+| Dashboard badge              | `packages/frontend/src/components/Layout/VoteBadge.tsx`      |
+
+Verified reaching the backend in production on v2.39.8:
+
+```
+$ curl -s -i -X POST -H "Content-Type: application/json" \
+    -d '{"type":"test"}' https://lucky-api.lucassantana.tech/webhooks/topgg-votes
+HTTP/2 503
+content-type: application/json; charset=utf-8
+{"error":"TOPGG_AUTH_TOKEN not configured"}
 ```
 
-Then create the endpoint in `packages/backend/src/routes/`. Stub shape:
+The 503 comes from `verifyTopggAuth` and is the expected state until the token
+is set. Before #2089 this same request returned a `405 Not Allowed` HTML page
+from nginx, because `/webhooks/` had no `location` block and fell through to the
+SPA (#2086). If it ever returns HTML again, that routing regressed, not the
+handler.
 
-```ts
-// packages/backend/src/routes/webhooks.ts
-import { Router } from 'express'
-import { redisClient } from '@lucky/shared/services'
+### Order of operations, once approved
 
-const router = Router()
+The sequence matters. Configuring the webhook URL before the token exists makes
+top.gg receive a 503 and mark the endpoint as failing.
 
-router.post('/webhooks/topgg-votes', async (req, res) => {
-    if (req.headers.authorization !== process.env.TOPGG_AUTH_TOKEN) {
-        return res.status(401).send('unauthorized')
-    }
+1. Get the token from `https://top.gg/bot/962198089161134131/webhooks`.
+2. Set `TOPGG_AUTH_TOKEN` in production (and `TOPGG_TOKEN` for stats posting).
+   Both are declared but commented out in `.env.example`.
+3. Confirm the endpoint now answers `401` rather than `503` for an unauthenticated POST.
+4. Only then paste `https://lucky-api.lucassantana.tech/webhooks/topgg-votes`
+   into top.gg's webhook field.
 
-    const { user: userId, type } = req.body as {
-        user: string
-        type: 'upvote' | 'test'
-    }
+Note the hostname: `lucky-api.lucassantana.tech`. `api.lucky.lucassantana.tech`
+has no DNS record and an earlier version of this doc named it (#2088).
 
-    if (type === 'test') return res.status(200).send('ok')
-
-    // 12h vote window — top.gg allows one vote every 12h
-    const key = `votes:${userId}`
-    await redisClient.set(key, Date.now().toString(), 'EX', 60 * 60 * 12)
-
-    // Streak tracking: increment a counter with 36h expiry (give 12h grace)
-    const streakKey = `votes:streak:${userId}`
-    await redisClient.incr(streakKey)
-    await redisClient.expire(streakKey, 60 * 60 * 36)
-
-    return res.status(200).send('ok')
-})
-
-export default router
-```
-
-Then register this router in `packages/backend/src/routes/index.ts` (or similar central route registration) by importing and mounting it:
-
-```ts
-import webhooksRouter from './webhooks'
-// ... in your Express app setup
-app.use(webhooksRouter)
-```
-
-Finally, in `packages/bot/src/functions/general/commands/`, add `/voterewards` that reads `votes:streak:<user>` and grants tier (e.g. 7+ votes → custom autoplay weighting, 30+ → dashboard badge).
-
-**Security**: the `authorization` header check is the ONLY guard — top.gg sends the token as a plain header. Never log the raw header body.
+**Security**: the `authorization` header is the only guard, sent by top.gg as a
+plain header, and compared with `timingSafeKeyCompare`. Never log the raw header
+or the request body.
 
 ## 7. Submission checklist
 
-- [ ] Bot verified with Discord (`https://discord.com/developers/applications/962198089161134131/bot` → "Server Members Intent" + "Message Content Intent" enabled if used)
-- [ ] Banner rendered at 1000×500
-- [ ] Short description pasted
-- [ ] Long description pasted
-- [ ] 3-8 tags selected
-- [x] Support server invite link added
-- [ ] GitHub URL added
-- [ ] Prefix: `/` (slash commands only)
-- [ ] Webhook URL set to `https://lucky-api.lucassantana.tech/webhooks/topgg-votes` (after deploy)
-- [ ] Webhook auth token pasted in top.gg's field
-- [ ] Announce the listing in the support Discord + a GitHub release note
+Done:
+
+- [x] Bot verified with Discord (`public_flags: 65536`, the `VERIFIED_BOT` bit)
+- [x] Headline and long description filled
+- [x] Categories selected (8) and language set
+- [x] Prefix: `/` (slash commands only)
+- [x] Support server invite added, permanent
+- [x] Repository URL added, and the duplicated-prefix value corrected
+- [x] Website URL added
+- [x] Submitted for review
+
+Blocked on approval:
+
+- [ ] Get the webhook token and set `TOPGG_AUTH_TOKEN` in production
+- [ ] Set the webhook URL in top.gg (only after the step above)
+- [ ] Revisit imagery under the dashboard's `Appearance` section
+- [ ] Announce the listing in the support Discord and a GitHub release note
+
+Not applicable:
+
+- ~~Banner rendered at 1000x500~~: no banner field exists in the flow; see §5.


### PR DESCRIPTION
## What

Corrects `docs/TOP_GG_SUBMISSION.md` against the live listing and the current top.gg wizard. Docs only, no code.

Closes #2091.

## Why

Three things in the pack were wrong, and each one cost time during the actual submission:

**1. It described a submission that had not happened.** It had. The dashboard at `/discord/bots/962198089161134131/dashboard` reports "Your project is currently in review". The add-bot wizard reports nothing useful: it renders "Your bot is a draft now and whenever you are ready, you can submit it for review" as static copy regardless of state, and once queued its submit button sits `disabled` with the label "Queued for Review".

That combination reads exactly like a broken button. Verified it was not:

```js
{ text: "Queued for Review", disabled: true, pointerEvents: "auto", opacity: "1" }
```

Zero network requests fired on click, because the action was already done. The doc now says to read the dashboard and never the wizard.

**2. §5 specified a 1000x500 banner.** top.gg changed the listing format; the wizard has no `input[type=file]` anywhere. Replaced with the field set that does exist, plus the two traps in it:

- `Repository URL` and `Support URL` render `https://github.com/` and `https://discord.gg/` as static prefixes and append what you type. The listing had shipped with `https://github.com/https://github.com/LucasSantana-Dev/Lucky` from a pasted full URL. Corrected during this session; the doc now says to type the suffix only.
- `Support Server Link` is a dropdown of servers already listed on top.gg, not a free invite field. It stays empty; `Support URL` carries the invite.

**3. §6 carried a Redis-backed stub** for an endpoint that has since shipped, backed by Postgres. Replaced with a map of the real implementation across the seven files that make it up, plus the production probe:

```
$ curl -s -i -X POST -d '{"type":"test"}' \
    https://lucky-api.lucassantana.tech/webhooks/topgg-votes
HTTP/2 503
{"error":"TOPGG_AUTH_TOKEN not configured"}
```

That 503 is `verifyTopggAuth` and is the expected state until the token exists. It also documents the ordering constraint that is easy to get backwards: setting the webhook URL in top.gg **before** `TOPGG_AUTH_TOKEN` is set in production makes top.gg receive a 503 and mark the endpoint as failing.

## Also

- Drops the opening pointer to `~/.claude/plans/lucky-next-phases-ultraplan.md`, which is untracked, local-only and no longer exists, so several checklist items deferred to something unreachable (#2091).
- Records that `assets/lucky-logo.png` is a NEXUS logo rather than Lucky branding (#2094), next to the imagery guidance, since that file already caused the wrong mark to be set as the support server icon once.
- Flags that §2 and §3 are the original draft copy and not what is live, rather than leaving them looking authoritative.
- Rewrites §7 into done / blocked-on-approval / not-applicable instead of a flat list of unchecked boxes that were mostly already done.

## Verification

`prettier` clean, `type:check` passes across all four workspaces (husky ran both on commit). No code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated top.gg submission guidance to reflect the current approval status and dashboard workflow.
  * Documented the actual listing fields, URL requirements, support server selection, and brand-asset guidance.
  * Replaced outdated webhook setup instructions with the current configuration and verification steps.
  * Revised the submission checklist to distinguish completed, approval-dependent, and non-applicable items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->