### PR TITLE
chore(scripts): version the discord support-server ops scripts

### DIFF
--- a/docs/TOP_GG_SUBMISSION.md
+++ b/docs/TOP_GG_SUBMISSION.md
@@ -25,6 +25,11 @@ on it) and the `Appearance` section of the dashboard.
 
 **Note on the support server**: the invite is permanent by construction ("Expire After: Never", "Max Uses: No limit"). The first invite generated for this server carried `expires_at 2026-09-23` and was discarded: a support link that quietly expires is half of what made #2087 a bug. The single definition lives in `packages/shared/src/constants/support.ts`; do not paste the raw URL into new call sites.
 
+The server's channel, role and permission layout is provisioned by
+`scripts/setup-support-server.mjs`, and the GitHub release feed in `#🚀-releases`
+by `scripts/wire-releases-feed.mjs`. Both are idempotent and both need Discord
+permissions granted for the run and revoked after; usage is in their headers.
+
 **Note on the invite URL** — do not hardcode a `permissions=` integer here. `https://lucky.lucassantana.tech/invite` redirects to Discord via the backend, which builds the URL from `BOT_INVITE_PERMISSIONS` in `packages/shared/src/constants/invite.ts`, and logs the `utm_*` parameters on the way through so directory clicks are attributable.
 
 The curated set is `3173504` — View Audit Log, View Channels, Send Messages, Manage Messages, Embed Links, Connect, Speak — per `decisions/2026-06-18-invite-permission-scope.md`. **Never Administrator.** High-alarm permissions (Ban/Kick/ManageRoles/ManageChannels/ManageGuild/ModerateMembers) are escalated on demand rather than requested up front.

--- a/scripts/setup-support-server.mjs
+++ b/scripts/setup-support-server.mjs
@@ -67,6 +67,8 @@ const P = {
     CREATE_PUBLIC_THREADS: 1n << 35n,
     SEND_MESSAGES_IN_THREADS: 1n << 38n,
     ADD_REACTIONS: 1n << 6n,
+    READ_MESSAGE_HISTORY: 1n << 16n,
+    MANAGE_MESSAGES: 1n << 13n,
 }
 
 let calls = 0
@@ -234,19 +236,36 @@ async function main() {
     // enabled. Without it Discord rejects the create with 50035:
     // "Value must be one of {0, 2, 4, 6, 13, 14, 15, 16, 21}".
     const guild = await api('GET', `/guilds/${GUILD_ID}`)
+    const me = await api('GET', '/users/@me')
     const isCommunity = (guild.features ?? []).includes('COMMUNITY')
 
     console.log(`  Guild: ${target.name} (${GUILD_ID})`)
     console.log(`  Manage Channels: ${has(P.MANAGE_CHANNELS) ? 'yes' : 'NO'}`)
     console.log(`  Manage Roles:    ${has(P.MANAGE_ROLES) ? 'yes' : 'NO'}`)
     console.log(
-        `  Manage Guild:    ${has(P.MANAGE_GUILD) ? 'yes' : 'no (server settings will be skipped)'}\n`,
+        `  Manage Guild:    ${has(P.MANAGE_GUILD) ? 'yes' : 'no (server settings will be skipped)'}`,
     )
+    // Pins need both: GET /pins reads history, PUT /pins writes it.
+    console.log(
+        `  Read Msg History:${has(P.READ_MESSAGE_HISTORY) ? 'yes' : 'NO'}`,
+    )
+    console.log(`  Manage Messages: ${has(P.MANAGE_MESSAGES) ? 'yes' : 'NO'}\n`)
 
-    if (!has(P.MANAGE_CHANNELS) || !has(P.MANAGE_ROLES)) {
+    const missing = [
+        ['Manage Channels', P.MANAGE_CHANNELS],
+        ['Manage Roles', P.MANAGE_ROLES],
+        ['Read Message History', P.READ_MESSAGE_HISTORY],
+        ['Manage Messages', P.MANAGE_MESSAGES],
+    ]
+        .filter(([, bit]) => !has(bit))
+        .map(([name]) => name)
+
+    if (missing.length) {
         fail(
-            'Missing Manage Channels and/or Manage Roles in this guild.\n' +
-                '         Server Settings -> Roles -> Lucky -> enable both, then re-run.',
+            `Missing in this guild: ${missing.join(', ')}.\n` +
+                '         Server Settings -> Roles -> Lucky -> enable them, then re-run.\n' +
+                '         Read Message History and Manage Messages are needed for the\n' +
+                '         pinned welcome embeds, not just for channel creation.',
         )
     }
 
@@ -269,24 +288,50 @@ async function main() {
     const created = new Map()
 
     for (const group of STRUCTURE) {
+        // A locked category denies SEND_MESSAGES to @everyone, and the bot
+        // inherits that deny like anyone else. Without an explicit allow it
+        // cannot post the pinned welcome embeds into its own category. A
+        // member overwrite (type 1) avoids resolving the bot's role first.
+        const lockedOverwrites = [
+            {
+                id: GUILD_ID, // the @everyone role id equals the guild id
+                type: 0,
+                allow: String(P.VIEW_CHANNEL | P.ADD_REACTIONS),
+                deny: String(
+                    P.SEND_MESSAGES |
+                        P.CREATE_PUBLIC_THREADS |
+                        P.SEND_MESSAGES_IN_THREADS,
+                ),
+            },
+            {
+                id: me.id,
+                type: 1,
+                allow: String(
+                    P.VIEW_CHANNEL |
+                        P.SEND_MESSAGES |
+                        P.READ_MESSAGE_HISTORY |
+                        P.MANAGE_MESSAGES,
+                ),
+                deny: '0',
+            },
+        ]
+
         let parent = byName.get(group.category)
         if (parent) {
             console.log(`    = ${group.category} already exists, skipping`)
+            // An existing locked category from an older run predates the bot
+            // overwrite above and would still block pinning. Reconcile it.
+            const hasBotAllow = (parent.permission_overwrites ?? []).some(
+                (o) => o.id === me.id,
+            )
+            if (group.locked && !hasBotAllow) {
+                await api('PATCH', `/channels/${parent.id}`, {
+                    permission_overwrites: lockedOverwrites,
+                })
+                console.log('      ~ added the bot overwrite it was missing')
+            }
         } else {
-            const overwrites = group.locked
-                ? [
-                      {
-                          id: GUILD_ID, // the @everyone role id equals the guild id
-                          type: 0,
-                          allow: String(P.VIEW_CHANNEL | P.ADD_REACTIONS),
-                          deny: String(
-                              P.SEND_MESSAGES |
-                                  P.CREATE_PUBLIC_THREADS |
-                                  P.SEND_MESSAGES_IN_THREADS,
-                          ),
-                      },
-                  ]
-                : []
+            const overwrites = group.locked ? lockedOverwrites : []
             parent = await api('POST', `/guilds/${GUILD_ID}/channels`, {
                 name: group.category,
                 type: 4,
@@ -331,6 +376,12 @@ async function main() {
         }
         // Posting is not idempotent on its own: a second run would pin a second
         // copy of the same embed. Match on the embed title already pinned.
+        // In dry-run a freshly "created" channel carries a fabricated id, so a
+        // real GET against it would 404 and abort the whole dry run.
+        if (DRY_RUN && String(channel.id).startsWith('dry-')) {
+            console.log(`    + would pin in ${channelName} (new channel)`)
+            continue
+        }
         const pinned = await api('GET', `/channels/${channel.id}/pins`)
         const items = Array.isArray(pinned) ? pinned : (pinned?.items ?? [])
         const already = items.some((m) =>
@@ -383,7 +434,7 @@ async function main() {
     } else {
         console.log('\n  Server settings skipped (no Manage Guild).')
         console.log(
-            '    Set by hand: name "Lucky", icon assets/lucky-logo.png,',
+            '    Set by hand: name "Lucky", icon assets/outline-v4-neon.jpeg,',
         )
         console.log(
             '    verification level Medium, notifications "Only @mentions".',
@@ -401,9 +452,17 @@ async function main() {
             '    1. Revoke Manage Channels / Manage Roles / Manage Guild from Lucky.',
         )
         console.log(
-            '    2. Create a permanent invite: Expire After = Never, Max Uses = No limit.',
+            '    2. If this is a new server, create a permanent invite:',
         )
-        console.log('    3. Send me the invite code.\n')
+        console.log(
+            '       Expire After = Never, Max Uses = No limit. The Discord default',
+        )
+        console.log(
+            '       expires in 30 days, which silently rots every published link.',
+        )
+        console.log(
+            '    3. Put it in packages/shared/src/constants/support.ts, nowhere else.\n',
+        )
     }
 }
 

--- a/scripts/setup-support-server.mjs
+++ b/scripts/setup-support-server.mjs
@@ -68,7 +68,9 @@ const P = {
     SEND_MESSAGES_IN_THREADS: 1n << 38n,
     ADD_REACTIONS: 1n << 6n,
     READ_MESSAGE_HISTORY: 1n << 16n,
-    MANAGE_MESSAGES: 1n << 13n,
+    // Pinning has needed its own bit since 2026-02-23; MANAGE_MESSAGES
+    // only covers deleting other people's messages.
+    PIN_MESSAGES: 1n << 51n,
 }
 
 let calls = 0
@@ -249,13 +251,13 @@ async function main() {
     console.log(
         `  Read Msg History:${has(P.READ_MESSAGE_HISTORY) ? 'yes' : 'NO'}`,
     )
-    console.log(`  Manage Messages: ${has(P.MANAGE_MESSAGES) ? 'yes' : 'NO'}\n`)
+    console.log(`  Pin Messages:    ${has(P.PIN_MESSAGES) ? 'yes' : 'NO'}\n`)
 
     const missing = [
         ['Manage Channels', P.MANAGE_CHANNELS],
         ['Manage Roles', P.MANAGE_ROLES],
         ['Read Message History', P.READ_MESSAGE_HISTORY],
-        ['Manage Messages', P.MANAGE_MESSAGES],
+        ['Pin Messages', P.PIN_MESSAGES],
     ]
         .filter(([, bit]) => !has(bit))
         .map(([name]) => name)
@@ -264,7 +266,7 @@ async function main() {
         fail(
             `Missing in this guild: ${missing.join(', ')}.\n` +
                 '         Server Settings -> Roles -> Lucky -> enable them, then re-run.\n' +
-                '         Read Message History and Manage Messages are needed for the\n' +
+                '         Read Message History and Pin Messages are needed for the\n' +
                 '         pinned welcome embeds, not just for channel creation.',
         )
     }
@@ -310,7 +312,7 @@ async function main() {
                     P.VIEW_CHANNEL |
                         P.SEND_MESSAGES |
                         P.READ_MESSAGE_HISTORY |
-                        P.MANAGE_MESSAGES,
+                        P.PIN_MESSAGES,
                 ),
                 deny: '0',
             },
@@ -321,14 +323,24 @@ async function main() {
             console.log(`    = ${group.category} already exists, skipping`)
             // An existing locked category from an older run predates the bot
             // overwrite above and would still block pinning. Reconcile it.
-            const hasBotAllow = (parent.permission_overwrites ?? []).some(
-                (o) => o.id === me.id,
-            )
-            if (group.locked && !hasBotAllow) {
+            const botAllow = lockedOverwrites[1]
+            const current = parent.permission_overwrites ?? []
+            const mine = current.find((o) => o.id === me.id)
+            // Existence is not enough: an overwrite that predates PIN_MESSAGES
+            // grants too little and pinning still fails.
+            const needed = BigInt(botAllow.allow)
+            const ok = mine && (BigInt(mine.allow) & needed) === needed
+            if (group.locked && !ok) {
+                // Replace only the bot's entry; anything a human added stays.
                 await api('PATCH', `/channels/${parent.id}`, {
-                    permission_overwrites: lockedOverwrites,
+                    permission_overwrites: [
+                        ...current.filter((o) => o.id !== me.id),
+                        botAllow,
+                    ],
                 })
-                console.log('      ~ added the bot overwrite it was missing')
+                console.log(
+                    `      ~ ${mine ? 'widened' : 'added'} the bot overwrite`,
+                )
             }
         } else {
             const overwrites = group.locked ? lockedOverwrites : []
@@ -449,7 +461,10 @@ async function main() {
     } else {
         console.log('\n  Next, by hand:')
         console.log(
-            '    1. Revoke Manage Channels / Manage Roles / Manage Guild from Lucky.',
+            '    1. Revoke from Lucky what this run needed: Manage Channels,',
+        )
+        console.log(
+            '       Manage Roles, Manage Guild, Read Message History, Pin Messages.',
         )
         console.log(
             '    2. If this is a new server, create a permanent invite:',

--- a/scripts/setup-support-server.mjs
+++ b/scripts/setup-support-server.mjs
@@ -1,0 +1,419 @@
+/**
+ * Idempotent provisioning for the Lucky support server, the one linked from the
+ * site footer, the docs sidebar and the top.gg listing (see
+ * `packages/shared/src/constants/support.ts`).
+ *
+ * Committed because the structure it builds is durable context: it lived only in
+ * /tmp after the server was first set up, so a rebuild would have had nothing to
+ * work from. Re-running is safe; every role and channel is matched by name and
+ * skipped if it already exists.
+ *
+ * Requires, in the target guild only, a Lucky role with:
+ *   Manage Channels  (create categories/channels)
+ *   Manage Roles     (create roles, write permission overwrites)
+ *   Manage Guild     (optional: server settings; skipped cleanly if absent)
+ *
+ * Grant them for the run and revoke afterwards. The invite deliberately does not
+ * carry them, per `decisions/2026-06-18-invite-permission-scope.md`, and
+ * Administrator is never needed.
+ *
+ * Two Discord behaviours this encodes, both found the hard way:
+ *   - Announcement channels (type 5) only exist once the guild has Community
+ *     enabled; otherwise the create is rejected with 50035. Falls back to a plain
+ *     text channel and says so.
+ *   - A bot cannot move a role above its own highest role, and Administrator does
+ *     not bypass role hierarchy. Only the guild owner can. So role ORDER is left
+ *     to a human; this script only creates.
+ *
+ * Usage:
+ *   DRY_RUN=1 GUILD_ID=<id> node scripts/setup-support-server.mjs   # print plan
+ *   GUILD_ID=<id> node scripts/setup-support-server.mjs             # apply
+ *
+ * DISCORD_TOKEN is read from the environment and never printed.
+ */
+
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+const TOKEN = process.env.DISCORD_TOKEN
+const GUILD_ID = process.env.GUILD_ID
+const DRY_RUN = process.env.DRY_RUN === '1'
+// assets/lucky-logo.png is NOT the Lucky mark despite the name: it carries a
+// NEXUS logo (#2094). The real one is the neon cat.
+const LOGO_PATH =
+    process.env.LOGO_PATH ??
+    fileURLToPath(new URL('../assets/outline-v4-neon.jpeg', import.meta.url))
+
+const API = 'https://discord.com/api/v10'
+const REPO = 'https://github.com/LucasSantana-Dev/Lucky'
+const SITE = 'https://lucky.lucassantana.tech'
+const BRAND = 0x495df3 // frontend --primary: 233 88% 62%
+
+function fail(msg) {
+    console.error(`\n  ERROR  ${msg}\n`)
+    process.exit(1)
+}
+
+if (!TOKEN) fail('DISCORD_TOKEN is not set in the environment.')
+if (!GUILD_ID) fail('GUILD_ID is not set. Pass the support server id.')
+
+// Discord permission bits used below.
+const P = {
+    VIEW_CHANNEL: 1n << 10n,
+    SEND_MESSAGES: 1n << 11n,
+    MANAGE_CHANNELS: 1n << 4n,
+    MANAGE_GUILD: 1n << 5n,
+    MANAGE_ROLES: 1n << 28n,
+    CREATE_PUBLIC_THREADS: 1n << 35n,
+    SEND_MESSAGES_IN_THREADS: 1n << 38n,
+    ADD_REACTIONS: 1n << 6n,
+}
+
+let calls = 0
+
+async function api(method, path, body) {
+    if (DRY_RUN && method !== 'GET') {
+        console.log(`      [dry-run] ${method} ${path}`)
+        return {
+            id: `dry-${Math.abs(hash(path + JSON.stringify(body ?? {})))}`,
+        }
+    }
+    for (let attempt = 0; attempt < 5; attempt++) {
+        calls++
+        const res = await fetch(`${API}${path}`, {
+            method,
+            headers: {
+                Authorization: `Bot ${TOKEN}`,
+                'Content-Type': 'application/json',
+            },
+            body: body ? JSON.stringify(body) : undefined,
+        })
+
+        if (res.status === 429) {
+            const retry = Number(res.headers.get('retry-after') ?? 1)
+            console.log(`      rate limited, waiting ${retry}s`)
+            await new Promise((r) => setTimeout(r, (retry + 0.5) * 1000))
+            continue
+        }
+        if (res.status === 401) fail('DISCORD_TOKEN rejected by Discord (401).')
+        if (!res.ok) {
+            const text = await res.text()
+            const err = new Error(`${method} ${path} -> ${res.status} ${text}`)
+            err.status = res.status
+            throw err
+        }
+        return res.status === 204 ? null : await res.json()
+    }
+    throw new Error(`${method} ${path} still rate limited after 5 attempts`)
+}
+
+function hash(s) {
+    let h = 0
+    for (const c of s) h = (h * 31 + c.charCodeAt(0)) | 0
+    return h
+}
+
+// ---------------------------------------------------------------- plan
+
+const ROLES = [
+    {
+        name: 'Maintainer',
+        color: BRAND,
+        hoist: true,
+        mentionable: true,
+        permissions: '0',
+    },
+    {
+        name: 'Contributor',
+        color: 0x3ba55d,
+        hoist: true,
+        mentionable: true,
+        permissions: '0',
+    },
+]
+
+// Category -> channels. `locked` categories deny SEND_MESSAGES to @everyone;
+// children sync with the category, so the deny is written once.
+const STRUCTURE = [
+    {
+        category: 'INFORMATION',
+        locked: true,
+        channels: [
+            {
+                name: '📌-start-here',
+                topic: 'What Lucky is, how to invite it, and where to get help.',
+            },
+            {
+                name: '📣-announcements',
+                announcement: true,
+                topic: 'Product announcements. Follow this channel to get them in your own server.',
+            },
+            {
+                name: '🚀-releases',
+                topic: `Automated release feed from ${REPO}/releases`,
+            },
+        ],
+    },
+    {
+        category: 'SUPPORT',
+        locked: false,
+        channels: [
+            {
+                name: '🆘-help',
+                topic: 'Trouble with a command, playback, or the dashboard? Ask here.',
+            },
+            {
+                name: '🐛-issues',
+                topic: `Bugs and feature requests are tracked on GitHub: ${REPO}/issues`,
+            },
+        ],
+    },
+    {
+        category: 'COMMUNITY',
+        locked: false,
+        channels: [
+            { name: '💬-general', topic: 'Off-topic chat.' },
+            { name: '🔊 Music Lounge', voice: true },
+        ],
+    },
+]
+
+const PINS = {
+    '📌-start-here': {
+        title: 'Welcome to Lucky',
+        description: [
+            '**Lucky** is an open-source Discord music bot with genre-aware autoplay, moderation, and a web dashboard. Self-hostable, free, no paywall.',
+            '',
+            `**Add Lucky to your server** · ${SITE}/invite`,
+            `**Dashboard** · ${SITE}`,
+            `**Source** · ${REPO}`,
+            '',
+            '**Getting help**',
+            'Ask in <#HELP> and include: the command you ran, what you expected, and what happened instead. A screenshot of the error usually saves a round trip.',
+            '',
+            '**Found a bug, or want a feature?**',
+            `Those live on GitHub, not here, so they do not get lost in scrollback: ${REPO}/issues`,
+        ].join('\n'),
+    },
+    '🐛-issues': {
+        title: 'Bugs and feature requests go to GitHub',
+        description: [
+            `This project tracks all work in GitHub Issues: **${REPO}/issues**`,
+            '',
+            'Post here if you want to talk something through first. Once it is confirmed it moves to an issue, so it stays searchable and can be picked up.',
+            '',
+            '**A good report has**',
+            '· what you ran, and in which server',
+            '· what you expected',
+            '· what happened instead, with the exact error text',
+            '· roughly when it happened',
+        ].join('\n'),
+    },
+}
+
+// ---------------------------------------------------------------- run
+
+async function main() {
+    console.log(
+        `\n  Lucky support server setup${DRY_RUN ? '  [DRY RUN, nothing will be changed]' : ''}\n`,
+    )
+
+    // Pre-flight: what can the bot actually do here?
+    const guilds = await api('GET', '/users/@me/guilds')
+    const target = guilds.find((g) => g.id === GUILD_ID)
+    if (!target) {
+        fail(
+            `The bot is not a member of guild ${GUILD_ID}.\n` +
+                '         Invite it first, then re-run.',
+        )
+    }
+    const perms = BigInt(target.permissions)
+    const has = (bit) => (perms & bit) === bit
+
+    // Announcement channels (type 5) only exist once the guild has Community
+    // enabled. Without it Discord rejects the create with 50035:
+    // "Value must be one of {0, 2, 4, 6, 13, 14, 15, 16, 21}".
+    const guild = await api('GET', `/guilds/${GUILD_ID}`)
+    const isCommunity = (guild.features ?? []).includes('COMMUNITY')
+
+    console.log(`  Guild: ${target.name} (${GUILD_ID})`)
+    console.log(`  Manage Channels: ${has(P.MANAGE_CHANNELS) ? 'yes' : 'NO'}`)
+    console.log(`  Manage Roles:    ${has(P.MANAGE_ROLES) ? 'yes' : 'NO'}`)
+    console.log(
+        `  Manage Guild:    ${has(P.MANAGE_GUILD) ? 'yes' : 'no (server settings will be skipped)'}\n`,
+    )
+
+    if (!has(P.MANAGE_CHANNELS) || !has(P.MANAGE_ROLES)) {
+        fail(
+            'Missing Manage Channels and/or Manage Roles in this guild.\n' +
+                '         Server Settings -> Roles -> Lucky -> enable both, then re-run.',
+        )
+    }
+
+    // ---- roles (idempotent by name)
+    console.log('  Roles')
+    const existingRoles = await api('GET', `/guilds/${GUILD_ID}/roles`)
+    for (const role of ROLES) {
+        if (existingRoles.some((r) => r.name === role.name)) {
+            console.log(`    = ${role.name} already exists, skipping`)
+            continue
+        }
+        await api('POST', `/guilds/${GUILD_ID}/roles`, role)
+        console.log(`    + ${role.name}`)
+    }
+
+    // ---- channels (idempotent by name)
+    console.log('\n  Channels')
+    const existing = await api('GET', `/guilds/${GUILD_ID}/channels`)
+    const byName = new Map(existing.map((c) => [c.name, c]))
+    const created = new Map()
+
+    for (const group of STRUCTURE) {
+        let parent = byName.get(group.category)
+        if (parent) {
+            console.log(`    = ${group.category} already exists, skipping`)
+        } else {
+            const overwrites = group.locked
+                ? [
+                      {
+                          id: GUILD_ID, // the @everyone role id equals the guild id
+                          type: 0,
+                          allow: String(P.VIEW_CHANNEL | P.ADD_REACTIONS),
+                          deny: String(
+                              P.SEND_MESSAGES |
+                                  P.CREATE_PUBLIC_THREADS |
+                                  P.SEND_MESSAGES_IN_THREADS,
+                          ),
+                      },
+                  ]
+                : []
+            parent = await api('POST', `/guilds/${GUILD_ID}/channels`, {
+                name: group.category,
+                type: 4,
+                permission_overwrites: overwrites,
+            })
+            console.log(
+                `    + ${group.category}${group.locked ? '  (read-only for @everyone)' : ''}`,
+            )
+        }
+
+        for (const ch of group.channels) {
+            if (byName.has(ch.name)) {
+                console.log(`      = ${ch.name} already exists, skipping`)
+                continue
+            }
+            // 0 text, 2 voice, 5 announcement
+            const wantsAnnouncement = Boolean(ch.announcement) && isCommunity
+            const type = ch.voice ? 2 : wantsAnnouncement ? 5 : 0
+            const made = await api('POST', `/guilds/${GUILD_ID}/channels`, {
+                name: ch.name,
+                type,
+                parent_id: parent.id,
+                ...(ch.topic ? { topic: ch.topic } : {}),
+            })
+            created.set(ch.name, made)
+            const note =
+                ch.announcement && !isCommunity
+                    ? '  (plain text: Community is off, convert later)'
+                    : ''
+            console.log(`      + ${ch.name}${note}`)
+        }
+    }
+
+    // ---- welcome content, pinned
+    console.log('\n  Pinned messages')
+    const helpChannel = created.get('🆘-help') ?? byName.get('🆘-help')
+    for (const [channelName, embed] of Object.entries(PINS)) {
+        const channel = created.get(channelName) ?? byName.get(channelName)
+        if (!channel) {
+            console.log(`    ! ${channelName} not found, skipping pin`)
+            continue
+        }
+        // Posting is not idempotent on its own: a second run would pin a second
+        // copy of the same embed. Match on the embed title already pinned.
+        const pinned = await api('GET', `/channels/${channel.id}/pins`)
+        const items = Array.isArray(pinned) ? pinned : (pinned?.items ?? [])
+        const already = items.some((m) =>
+            (m.message ?? m).embeds?.some((e) => e.title === embed.title),
+        )
+        if (already) {
+            console.log(`    = ${channelName} already pinned, skipping`)
+            continue
+        }
+
+        const description = embed.description.replace(
+            '<#HELP>',
+            helpChannel ? `<#${helpChannel.id}>` : '#help',
+        )
+        const msg = await api('POST', `/channels/${channel.id}/messages`, {
+            embeds: [
+                {
+                    title: embed.title,
+                    description,
+                    color: BRAND,
+                    footer: { text: 'Lucky · open source under ISC' },
+                },
+            ],
+        })
+        await api('PUT', `/channels/${channel.id}/pins/${msg.id}`)
+        console.log(`    + pinned in ${channelName}`)
+    }
+
+    // ---- server settings (only with Manage Guild)
+    if (has(P.MANAGE_GUILD)) {
+        console.log('\n  Server settings')
+        const patch = {
+            name: 'Lucky',
+            verification_level: 2, // registered on Discord for longer than 5 minutes
+            default_message_notifications: 1, // mentions only, not every message
+            explicit_content_filter: 2, // scan media from all members
+        }
+        try {
+            const logo = await readFile(LOGO_PATH)
+            const mime = LOGO_PATH.endsWith('.png') ? 'image/png' : 'image/jpeg'
+            patch.icon = `data:${mime};base64,${logo.toString('base64')}`
+            console.log(`    + icon from ${LOGO_PATH}`)
+        } catch {
+            console.log(`    ! could not read ${LOGO_PATH}, skipping icon`)
+        }
+        await api('PATCH', `/guilds/${GUILD_ID}`, patch)
+        console.log(
+            '    + name, verification level, notification default, content filter',
+        )
+    } else {
+        console.log('\n  Server settings skipped (no Manage Guild).')
+        console.log(
+            '    Set by hand: name "Lucky", icon assets/lucky-logo.png,',
+        )
+        console.log(
+            '    verification level Medium, notifications "Only @mentions".',
+        )
+    }
+
+    console.log(`\n  Done. ${calls} API calls.`)
+    if (DRY_RUN) {
+        console.log(
+            '  This was a dry run. Re-run without DRY_RUN=1 to apply.\n',
+        )
+    } else {
+        console.log('\n  Next, by hand:')
+        console.log(
+            '    1. Revoke Manage Channels / Manage Roles / Manage Guild from Lucky.',
+        )
+        console.log(
+            '    2. Create a permanent invite: Expire After = Never, Max Uses = No limit.',
+        )
+        console.log('    3. Send me the invite code.\n')
+    }
+}
+
+main().catch((e) => {
+    if (e.status === 403) {
+        fail(
+            `Discord refused with 403 Forbidden.\n         ${e.message}\n` +
+                '         The Lucky role is likely missing a permission, or sits below\n' +
+                '         the role it is trying to manage in the role list.',
+        )
+    }
+    fail(e.stack ?? String(e))
+})

--- a/scripts/setup-support-server.mjs
+++ b/scripts/setup-support-server.mjs
@@ -467,6 +467,16 @@ async function main() {
             '       Manage Roles, Manage Guild, Read Message History, Pin Messages.',
         )
         console.log(
+            '       These are per-run grants, not a permanent state: the preflight',
+        )
+        console.log(
+            '       requires them again, so grant them once more before re-running.',
+        )
+        console.log(
+            '       Only the invite set (3173504) is meant to persist, per',
+        )
+        console.log('       decisions/2026-06-18-invite-permission-scope.md.')
+        console.log(
             '    2. If this is a new server, create a permanent invite:',
         )
         console.log(

--- a/scripts/wire-releases-feed.mjs
+++ b/scripts/wire-releases-feed.mjs
@@ -102,30 +102,85 @@ async function main() {
         )
     }
 
-    // hook.token is only returned on create; rebuild the URL either way.
-    if (!hook.token) {
-        fail(
-            'Discord did not return a webhook token, so the URL cannot be rebuilt.\n' +
-                `         Delete webhook ${hook.id} on #${CHANNEL_NAME} and re-run to mint a fresh one.`,
-        )
-    }
-    const discordUrl = `https://discord.com/api/webhooks/${hook.id}/${hook.token}/github`
-
-    // --- GitHub side
+    // Discord returns webhook.token ONLY on creation. On a re-run the GET
+    // above omits it, so the URL cannot be rebuilt. That does not mean the
+    // wiring is broken: if a GitHub hook already points at this webhook id,
+    // the feed is live and there is nothing to rebuild. Check that first,
+    // and only fail when the token is genuinely needed.
     const hooksJson = await gh(['api', `repos/${REPO}/hooks`])
     const hooks = JSON.parse(hooksJson)
     const already = hooks.find((h) =>
         (h.config?.url ?? '').includes(`/webhooks/${hook.id}/`),
     )
+
     if (already) {
-        console.log(
-            `  = GitHub webhook already points at this Discord hook (id ${already.id}), skipping`,
+        // Reconcile rather than assume: a hook that exists but is disabled,
+        // lost the `release` event, or points at the base Discord URL without
+        // the /github suffix delivers nothing, and returning here would report
+        // success while the channel stays empty.
+        const url = already.config?.url ?? ''
+        const needsFix =
+            !already.active ||
+            !already.events?.includes('release') ||
+            !url.endsWith('/github')
+
+        if (!needsFix) {
+            console.log(
+                `  = GitHub webhook already wired (id ${already.id}), nothing to do`,
+            )
+            console.log(
+                `    events: ${already.events.join(', ')}  active: ${already.active}`,
+            )
+            return
+        }
+
+        if (!url.endsWith('/github') && !hook.token) {
+            fail(
+                `GitHub hook ${already.id} points at the Discord webhook without the\n` +
+                    '         /github suffix, and Discord will not hand back the token needed\n' +
+                    `         to rebuild the URL. Delete webhook ${hook.id} on #${CHANNEL_NAME},\n` +
+                    `         delete GitHub hook ${already.id}, then re-run.`,
+            )
+        }
+
+        const patch = JSON.stringify({
+            active: true,
+            events: ['release'],
+            config: {
+                url: url.endsWith('/github') ? url : `${url}/github`,
+                content_type: 'json',
+            },
+        })
+        const fixed = JSON.parse(
+            await gh(
+                [
+                    'api',
+                    `repos/${REPO}/hooks/${already.id}`,
+                    '--method',
+                    'PATCH',
+                    '--input',
+                    '-',
+                ],
+                patch,
+            ),
         )
+        console.log(`  ~ GitHub webhook repaired (id ${fixed.id})`)
         console.log(
-            `    events: ${already.events.join(', ')}  active: ${already.active}`,
+            `    events: ${fixed.events.join(', ')}  active: ${fixed.active}`,
         )
         return
     }
+
+    // No GitHub hook yet, so the URL is genuinely required.
+    if (!hook.token) {
+        fail(
+            'The Discord webhook already exists but Discord only returns its token\n' +
+                '         on creation, so the URL cannot be rebuilt, and no GitHub hook\n' +
+                `         points at it yet. Delete webhook ${hook.id} on #${CHANNEL_NAME}\n` +
+                '         and re-run to mint a fresh one.',
+        )
+    }
+    const discordUrl = `https://discord.com/api/webhooks/${hook.id}/${hook.token}/github`
 
     const payload = JSON.stringify({
         name: 'web',

--- a/scripts/wire-releases-feed.mjs
+++ b/scripts/wire-releases-feed.mjs
@@ -107,8 +107,14 @@ async function main() {
     // wiring is broken: if a GitHub hook already points at this webhook id,
     // the feed is live and there is nothing to rebuild. Check that first,
     // and only fail when the token is genuinely needed.
-    const hooksJson = await gh(['api', `repos/${REPO}/hooks`])
-    const hooks = JSON.parse(hooksJson)
+    // Default page is 30 hooks; a match on a later page would read as absent.
+    const hooksJson = await gh([
+        'api',
+        `repos/${REPO}/hooks`,
+        '--paginate',
+        '--slurp',
+    ])
+    const hooks = JSON.parse(hooksJson).flat()
     const already = hooks.find((h) =>
         (h.config?.url ?? '').includes(`/webhooks/${hook.id}/`),
     )
@@ -134,15 +140,8 @@ async function main() {
             return
         }
 
-        if (!url.endsWith('/github') && !hook.token) {
-            fail(
-                `GitHub hook ${already.id} points at the Discord webhook without the\n` +
-                    '         /github suffix, and Discord will not hand back the token needed\n' +
-                    `         to rebuild the URL. Delete webhook ${hook.id} on #${CHANNEL_NAME},\n` +
-                    `         delete GitHub hook ${already.id}, then re-run.`,
-            )
-        }
-
+        // The stored GitHub URL already contains the token, so the /github
+        // suffix can be appended without Discord handing it back.
         const patch = JSON.stringify({
             active: true,
             events: ['release'],

--- a/scripts/wire-releases-feed.mjs
+++ b/scripts/wire-releases-feed.mjs
@@ -1,0 +1,151 @@
+/**
+ * Wires GitHub release events into the #🚀-releases channel of the Lucky support
+ * server, so that channel fills itself instead of needing a human to repost.
+ *
+ * Two halves:
+ *   1. a Discord webhook on the channel (the bot needs MANAGE_WEBHOOKS)
+ *   2. a GitHub repo webhook posting `release` events to <discord_url>/github,
+ *      Discord's GitHub-compatible endpoint, which renders the payload with no
+ *      code or third-party service in between
+ *
+ * The Discord webhook URL is a bearer credential: anyone holding it can post to
+ * that channel. It is never printed, never passed as an argv, and reaches `gh`
+ * only over stdin.
+ *
+ * Idempotent: re-running finds the existing webhook on each side and skips.
+ *
+ * Verify delivery afterwards with the hook id this prints, rather than trusting
+ * the 201 from creation:
+ *   gh api repos/<owner>/<repo>/hooks/<id>/pings --method POST
+ *   gh api repos/<owner>/<repo>/hooks/<id> -q .last_response
+ *   # 204 / "OK" means Discord accepted it
+ *
+ * Usage:
+ *   GUILD_ID=<id> node scripts/wire-releases-feed.mjs
+ *
+ * DISCORD_TOKEN is read from the environment and never printed. `gh` must be
+ * authenticated with a token carrying `repo` scope.
+ */
+
+import { spawn } from 'node:child_process'
+
+const TOKEN = process.env.DISCORD_TOKEN
+const GUILD_ID = process.env.GUILD_ID
+const REPO = process.env.REPO ?? 'LucasSantana-Dev/Lucky'
+const CHANNEL_NAME = '🚀-releases'
+const WEBHOOK_NAME = 'GitHub Releases'
+const API = 'https://discord.com/api/v10'
+
+if (!TOKEN) fail('DISCORD_TOKEN is not set.')
+if (!GUILD_ID) fail('GUILD_ID is not set.')
+
+function fail(msg) {
+    console.error(`\n  ERROR  ${msg}\n`)
+    process.exit(1)
+}
+
+async function discord(method, path, body) {
+    const res = await fetch(`${API}${path}`, {
+        method,
+        headers: {
+            Authorization: `Bot ${TOKEN}`,
+            'Content-Type': 'application/json',
+        },
+        body: body ? JSON.stringify(body) : undefined,
+    })
+    if (!res.ok)
+        throw new Error(
+            `${method} ${path} -> ${res.status} ${await res.text()}`,
+        )
+    return res.status === 204 ? null : await res.json()
+}
+
+/** Run `gh`, feeding stdin, so no secret ever lands in argv or the shell history. */
+function gh(args, stdin) {
+    return new Promise((resolve, reject) => {
+        const p = spawn('gh', args, { stdio: ['pipe', 'pipe', 'pipe'] })
+        let out = '',
+            err = ''
+        p.stdout.on('data', (d) => (out += d))
+        p.stderr.on('data', (d) => (err += d))
+        p.on('close', (code) =>
+            code === 0
+                ? resolve(out)
+                : reject(
+                      new Error(`gh ${args[0]} exited ${code}: ${err.trim()}`),
+                  ),
+        )
+        if (stdin !== undefined) p.stdin.write(stdin)
+        p.stdin.end()
+    })
+}
+
+async function main() {
+    // --- Discord side
+    const channels = await discord('GET', `/guilds/${GUILD_ID}/channels`)
+    const channel = channels.find((c) => c.name === CHANNEL_NAME)
+    if (!channel)
+        fail(`channel ${CHANNEL_NAME} not found in guild ${GUILD_ID}.`)
+
+    const existing = await discord('GET', `/channels/${channel.id}/webhooks`)
+    let hook = existing.find((w) => w.name === WEBHOOK_NAME)
+    if (hook) {
+        console.log(
+            `  = Discord webhook "${WEBHOOK_NAME}" already exists (id ${hook.id}), reusing`,
+        )
+    } else {
+        hook = await discord('POST', `/channels/${channel.id}/webhooks`, {
+            name: WEBHOOK_NAME,
+        })
+        console.log(
+            `  + Discord webhook created on #${CHANNEL_NAME} (id ${hook.id})`,
+        )
+    }
+
+    // hook.token is only returned on create; rebuild the URL either way.
+    if (!hook.token) {
+        fail(
+            'Discord did not return a webhook token, so the URL cannot be rebuilt.\n' +
+                `         Delete webhook ${hook.id} on #${CHANNEL_NAME} and re-run to mint a fresh one.`,
+        )
+    }
+    const discordUrl = `https://discord.com/api/webhooks/${hook.id}/${hook.token}/github`
+
+    // --- GitHub side
+    const hooksJson = await gh(['api', `repos/${REPO}/hooks`])
+    const hooks = JSON.parse(hooksJson)
+    const already = hooks.find((h) =>
+        (h.config?.url ?? '').includes(`/webhooks/${hook.id}/`),
+    )
+    if (already) {
+        console.log(
+            `  = GitHub webhook already points at this Discord hook (id ${already.id}), skipping`,
+        )
+        console.log(
+            `    events: ${already.events.join(', ')}  active: ${already.active}`,
+        )
+        return
+    }
+
+    const payload = JSON.stringify({
+        name: 'web',
+        active: true,
+        events: ['release'],
+        config: { url: discordUrl, content_type: 'json' },
+    })
+    const created = JSON.parse(
+        await gh(
+            ['api', `repos/${REPO}/hooks`, '--method', 'POST', '--input', '-'],
+            payload,
+        ),
+    )
+    console.log(`  + GitHub webhook created (id ${created.id})`)
+    console.log(
+        `    events: ${created.events.join(', ')}  active: ${created.active}`,
+    )
+    console.log(
+        `    target: https://discord.com/api/webhooks/${hook.id}/<token>/github`,
+    )
+}
+
+main().catch((e) => fail(e.message))


### PR DESCRIPTION
## What

Versions the two Discord ops scripts that built the Lucky support server and its release feed, plus a pointer to them from the submission pack.

- `scripts/setup-support-server.mjs` — categories, channels, roles, permission overwrites, pinned welcome embeds, guild settings
- `scripts/wire-releases-feed.mjs` — the Discord webhook on `#🚀-releases` and the GitHub repo webhook that feeds it

## Why

Both ran during the top.gg submission work and then lived only in `/tmp`. What they build is not throwaway: the support server is linked from the site footer, the docs sidebar and the top.gg listing, via `packages/shared/src/constants/support.ts`. A memory note described the layout, but nothing in the repo could rebuild it. The next `/tmp` clear would have taken the only copy.

No new dependency. Plain `fetch` and `node:` builtins, matching the existing `scripts/*.mjs` convention.

## Changed from the throwaway versions

**Machine-specific path.** `LOGO_PATH` defaulted to an absolute path on one laptop. Now resolved relative to the repo, and pointed at `assets/outline-v4-neon.jpeg` instead of `assets/lucky-logo.png` — the latter carries a NEXUS logo despite its name (#2094) and had already produced a server icon showing another product's mark.

**Pinning was not idempotent.** Everything else matched by name and skipped, but a second run posted and pinned a duplicate welcome embed. It now reads the channel's existing pins and matches on embed title. Verified against the live guild:

```
  Roles
    = Maintainer already exists, skipping
    = Contributor already exists, skipping
  Channels
    = INFORMATION already exists, skipping
      = 📌-start-here already exists, skipping
      ...
  Pinned messages
    = 📌-start-here already pinned, skipping
    = 🐛-issues already pinned, skipping
```

Every phase skips, which is what re-runnable should mean.

**Dropped a fake security measure.** The auth header was assembled with `['Bot', TOKEN].join(' ')` and commented as keeping the token out of source. That only existed to get past local tooling; it reads as a real precaution and is not one. Plain template literal now. The genuine handling stays: `DISCORD_TOKEN` comes from the environment and is never printed, and in `wire-releases-feed.mjs` the Discord webhook URL — a bearer credential for that channel — reaches `gh` over stdin rather than argv.

## Permissions

Neither script takes Administrator. They need Manage Channels, Manage Roles and optionally Manage Guild, granted for the run and revoked after. That is the escalate-on-demand model in `decisions/2026-06-18-invite-permission-scope.md`, which is why the public invite (`3173504`) does not carry them.

## Two Discord behaviours the scripts encode

Both found by hitting them:

- Announcement channels (type 5) only exist once the guild has Community enabled; otherwise the create fails with `50035 Value must be one of {0, 2, 4, 6, 13, 14, 15, 16, 21}`. The script falls back to a plain text channel and logs that it did.
- A bot cannot move a role above its own highest role, and **Administrator does not bypass role hierarchy** — only the guild owner does. `PATCH /guilds/<id>/roles` returns `50013`. Worse, moving a single role returns `200 OK` while Discord clamps the position, so retrying "just to see" silently reorders. The script therefore only creates roles and leaves ordering to a human; the header says so.

## Verification

`node --check` on both, `prettier --check` clean, `eslint` clean, `DRY_RUN` run against the live guild. `type:check` passes across all four workspaces (husky ran it on commit). No runtime code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Versions the Discord ops scripts that provision the support server and wire the `#🚀-releases` feed, making setup idempotent and least‑privileged. Old behavior depended on Administrator, could duplicate pins, and failed to rewire GitHub on reruns; new behavior runs with scoped permissions (including Pin Messages), pins once, and reuses or repairs existing webhooks.

- Adds `scripts/setup-support-server.mjs` (roles, categories/channels, permission overwrites, pinned welcome embeds, guild settings) and `scripts/wire-releases-feed.mjs` (Discord channel webhook + GitHub repo webhook).
- Permissions: requires Manage Channels, Manage Roles, Read Message History, and Pin Messages; optionally Manage Guild for server settings; wiring needs Manage Webhooks. Grant only for the run and revoke after.
- Fixes and idempotency: bot overwrite added and reconciled in locked categories (widened to include Pin Messages where needed); DRY_RUN works on fresh guilds; roles are only created (ordering remains manual); announcement channels fall back to text if Community is off.
- GitHub wiring: paginated lookup, reuses existing Discord/GitHub webhooks, and repairs inactive/misconfigured hooks and missing `/github` suffix without needing the Discord token. Only needs the Discord webhook token when creating a brand‑new GitHub hook; if an old Discord webhook exists with no token and no GitHub hook points to it, delete that Discord webhook and re‑run.
- Secrets: `DISCORD_TOKEN` from env; Discord webhook URL never logged and passed to `gh` over stdin.
- Docs: `docs/TOP_GG_SUBMISSION.md` links to both scripts and clarifies elevated grants are per‑run (re‑runs require re‑granting); the standard invite remains minimal.

<sup>Written for commit ec6afbc9b4697b5d3f11748a70086667aee5f5d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated setup for the Discord support server, including roles, channel organization, permissions, welcome messages, and server settings.
  * Added automated GitHub release notifications to a dedicated Discord channel.
  * Added safe, repeatable setup with dry-run support and rate-limit handling.

* **Documentation**
  * Documented setup scripts, required permissions, and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->