### PR TITLE
fix(i18n): add the json import attribute that crash-looped the bot

### DIFF
--- a/packages/bot/src/i18n/index.ts
+++ b/packages/bot/src/i18n/index.ts
@@ -4,9 +4,18 @@ import {
     DEFAULT_BOT_LANGUAGE,
     type BotLanguage,
 } from '@lucky/shared/constants'
-import en from '../locales/en.json'
-import ptBR from '../locales/pt-BR.json'
-import es from '../locales/es.json'
+// `with { type: 'json' }` is REQUIRED, not decoration. This package is
+// "type": "module", so the built output is real ESM and Node refuses a JSON
+// import without the attribute:
+//   ERR_IMPORT_ATTRIBUTE_MISSING: Module ".../dist/locales/en.json" needs an
+//   import attribute of "type: json"
+// It shipped in v2.40.0 and crash-looped the bot at boot. Nothing in CI runs
+// the built output: jest transpiles to CJS, where a bare JSON import is legal,
+// and `npm run build` compiles without executing. A static gate for this class
+// is in #2114.
+import en from '../locales/en.json' with { type: 'json' }
+import ptBR from '../locales/pt-BR.json' with { type: 'json' }
+import es from '../locales/es.json' with { type: 'json' }
 
 /**
  * Bot-side i18n.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -449,7 +449,13 @@ run_health_checks() {
         fi
         if [[ "$bot_health" == "unhealthy" ]]; then
             log "HEALTH: bot container unhealthy (Discord gateway not connected)"
-            docker logs lucky-bot --tail=40 --no-color 2>/dev/null || true
+            # `--no-color` is a `docker compose logs` flag; `docker logs`
+            # rejects it with "unknown flag", and 2>/dev/null || true swallowed
+            # that. This line is the ONLY explanation of a failed bot deploy and
+            # it printed nothing on every auto-rollback since it was written --
+            # the v2.40.0 logs had to be recovered from Loki instead. Keep
+            # stderr: a broken diagnostic must be loud.
+            docker logs lucky-bot --tail=60 2>&1 || true
             return 1
         fi
         sleep 5


### PR DESCRIPTION
Fixes #2113. Supersedes the production fix in #2114.

**Two files, both from the incident. Nothing else.**

## The crash

v2.40.0 deployed, the bot failed its Discord gateway health check, and the homelab auto-rolled back to 2.39.8. Production never went down, but nothing merged on 2026-08-26 is live.

Recovered from Loki (`{container_name="lucky-bot"}`, 23:32:00–23:32:56):

```
TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module
"file:///app/packages/bot/dist/locales/en.json" needs an import attribute of "type: json"
    at validateAttributes (node:internal/modules/esm/assert:99:15)
```

`packages/bot` is `"type": "module"`, so the built output is real ESM and Node refuses a JSON import without `with { type: 'json' }`. The bot died on that line at boot and restarted every six seconds — the deploy log shows it re-running `prisma migrate` at 23:32:30, :35, :41, :48, once per restart.

## Why every check was green

Nothing in CI runs the built output.

- jest transpiles to CJS, where a bare JSON import is legal — all 3,202 bot tests passed
- `npm run build` compiles and stops; it never loads what it produced
- tsc emits the import verbatim, so the difference exists only in a real Node ESM load

Verified both directions rather than reasoning about it: with the attribute, `import('./dist/i18n/index.js')` loads and translates; without it, the production error reproduces exactly.

For the record, my first hypothesis was wrong — I assumed `tsc` had not copied the locale JSON into `dist`. A clean rebuild disproved that; `resolveJsonModule` emits all three. The JSON was there, Node just refused to load it.

## The second file

`scripts/deploy.sh:452` is the one line that exists to explain a failed bot deploy:

```bash
docker logs lucky-bot --tail=40 --no-color 2>/dev/null || true
```

`--no-color` belongs to `docker compose logs`. `docker logs` rejects it with `unknown flag`, `2>/dev/null` hides that, and `|| true` swallows the exit code. **It has printed nothing on every auto-rollback since it was written**, which is why these logs came from Loki instead of from the deploy that failed.

Now `docker logs lucky-bot --tail=60 2>&1`, keeping stderr. Audited the other two `--no-color` uses in the repo (`deploy.sh:130`, `deploy-staging.sh:145`) — both are `docker compose logs`, both correct.

## Why this is not #2114

#2114 has the same fix plus a static gate for the whole class. That gate is worth having, but it has now taken **five review rounds** — three false positives, one false negative, a duplicated implementation, and unrun tests — while production sits on the previous release.

The gate is defensive work. Getting the bot booting is not. Coupling them was my scope error; this PR is the correction. #2114 keeps the gate and can iterate at its own pace.

## Verification

- 248 suites / 3,202 tests pass
- `tsc --noEmit` clean across all four workspaces; the attribute survives emit
- Built module executed under real Node ESM — the check that was missing
- `bash -n scripts/deploy.sh` clean

## Known and tracked, not in scope here

- **#2115** — CI compiles the bot but never boots it. This fix closes one instance; the class stays open.
- **#2116** — no test under `scripts/` has ever run in CI, and one of them is already red.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `with { type: 'json' }` import attribute to `packages/bot`'s locale imports so the bot boots under ESM instead of crash-looping, and fixes the deploy script's broken `docker logs` call that silently swallowed container logs on every failed deploy.

**Bug Fixes**

- v2.40.0 died at boot with `ERR_IMPORT_ATTRIBUTE_MISSING` because `packages/bot` builds to real ESM; the container restarted every six seconds until the auto-rollback.
- CI missed it because nothing runs the built output: jest transpiles to CJS where a bare JSON import is legal, and `npm run build` compiles without loading what it produced.
- `scripts/deploy.sh` called `docker logs --no-color`, a flag that only exists on `docker compose logs`; the error was hidden by `2>/dev/null || true`, so the one line meant to explain a failed bot deploy printed nothing. It now uses `--tail=60 2>&1` and keeps stderr.
- Verified the real built module directly: with the attribute it loads and translates, without it the production error reproduces exactly.
- The static CI gate for this bug class stays in a separate PR and is intentionally out of scope here.

<sup>Written for commit b8a67afbe71f87d416fef7c0765307e3b01d16b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

