### PR TITLE
fix(webhooks): read the v1 payload shape, not just the v1 signature

### DIFF
--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -8,7 +8,12 @@ import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { AppError } from '../errors/AppError'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
-import { debugLog, errorLog, getPrismaClient } from '@lucky/shared/utils'
+import {
+    debugLog,
+    errorLog,
+    warnLog,
+    getPrismaClient,
+} from '@lucky/shared/utils'
 import {
     TOP_GG_VOTE_TIERS,
     TOP_GG_VOTE_URL,
@@ -22,12 +27,80 @@ const VOTE_TTL_MILLISECONDS = 60 * 60 * 12 * 1000
 // doesn't lose their streak due to timezone or minor scheduling drift.
 const STREAK_TTL_MILLISECONDS = 60 * 60 * 36 * 1000
 
-type TopggVotePayload = {
+/**
+ * top.gg changed the BODY as well as the auth scheme, and the two are
+ * independent. #2103 implemented v1 signature verification while leaving the v0
+ * payload reader in place, so the first real delivery was rejected with
+ * `400 unsupported vote type`.
+ *
+ * v0: { user: '<discord id>', type: 'upvote' | 'test', isWeekend: bool }
+ * v1: { type: 'vote.create' | 'webhook.test',
+ *       data: { user: { id, platform_id }, weight } }
+ *
+ * The trap is `data.user`. `id` is top.gg's OWN user id; the Discord snowflake
+ * is `platform_id`. Reading `id` would credit votes to a different user, and
+ * only the snowflake check downstream would catch it -- and only by luck, if
+ * the top.gg id happened not to look like a snowflake.
+ *
+ * Weekend double votes moved too: v0 said `isWeekend`, v1 says `weight: 2`.
+ */
+type TopggV0Payload = {
     bot?: string
     user?: string
     type?: 'upvote' | 'test'
     isWeekend?: boolean
     query?: string
+}
+
+type TopggV1Payload = {
+    type?: 'vote.create' | 'webhook.test'
+    data?: {
+        weight?: number
+        user?: { id?: string; platform_id?: string }
+    }
+}
+
+type NormalizedVote =
+    | { kind: 'test' }
+    | { kind: 'vote'; userId: unknown; isWeekend: boolean }
+    | { kind: 'unsupported'; type: unknown }
+
+/**
+ * One place that understands both wire formats, so the handler below never has
+ * to care which one arrived.
+ */
+export function normalizeTopggPayload(body: unknown): NormalizedVote {
+    // Read the wire shape structurally rather than as `V0 & V1`: intersecting
+    // the two literal unions collapses `type` to `undefined` and every case
+    // below becomes uncomparable. The named types above stay as the record of
+    // what each format looks like.
+    const payload = (body ?? {}) as {
+        type?: string
+        user?: unknown
+        isWeekend?: unknown
+        data?: { weight?: unknown; user?: { platform_id?: unknown } }
+    }
+
+    switch (payload.type) {
+        case 'webhook.test':
+        case 'test':
+            return { kind: 'test' }
+        case 'vote.create':
+            return {
+                kind: 'vote',
+                // platform_id, NOT id — see the note above.
+                userId: payload.data?.user?.platform_id,
+                isWeekend: Number(payload.data?.weight ?? 1) >= 2,
+            }
+        case 'upvote':
+            return {
+                kind: 'vote',
+                userId: payload.user,
+                isWeekend: payload.isWeekend === true,
+            }
+        default:
+            return { kind: 'unsupported', type: payload.type }
+    }
 }
 
 function isDiscordSnowflake(value: string): boolean {
@@ -236,22 +309,28 @@ export function setupWebhookPublicRoutes(app: Express): void {
         asyncHandler(async (req: Request, res: Response) => {
             verifyTopggAuth(req)
 
-            const payload = (req.body ?? {}) as TopggVotePayload
+            const event = normalizeTopggPayload(req.body)
 
-            if (payload.type === 'test') {
+            if (event.kind === 'test') {
                 debugLog({ message: 'top.gg webhook test received' })
                 res.status(200).json({ ok: true, test: true })
                 return
             }
 
-            // Only persist genuine upvotes. Unknown/future event types
-            // (e.g. downvotes, if top.gg ever adds them) must not bump the
-            // streak counter.
-            if (payload.type !== 'upvote') {
+            // Only persist genuine votes. Unknown/future event types must not
+            // bump the streak counter. The rejected type is logged because the
+            // first v1 delivery failed here and the log said only "400" -- a
+            // rejection that does not name what it rejected cannot be
+            // diagnosed from the outside.
+            if (event.kind === 'unsupported') {
+                warnLog({
+                    message: 'top.gg webhook: unsupported event type',
+                    data: { type: String(event.type) },
+                })
                 throw AppError.badRequest('unsupported vote type')
             }
 
-            const userId = validateVoteUserId(payload.user)
+            const userId = validateVoteUserId(event.userId)
 
             try {
                 const recordResult = await recordVote(userId)
@@ -270,7 +349,7 @@ export function setupWebhookPublicRoutes(app: Express): void {
                     message: 'top.gg vote recorded',
                     data: {
                         userId,
-                        isWeekend: payload.isWeekend === true,
+                        isWeekend: event.isWeekend,
                     },
                 })
                 res.status(200).json({ ok: true })

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -66,20 +66,19 @@ type NormalizedVote =
     | { kind: 'unsupported'; type: unknown }
 
 /**
+ * A UNION, not an intersection. Intersecting the two collapses `type` to
+ * `undefined` (the literal unions have no overlap) and every case below stops
+ * compiling; as a discriminated union it narrows correctly and both shapes stay
+ * load-bearing instead of decorative.
+ */
+type TopggPayload = TopggV0Payload | TopggV1Payload
+
+/**
  * One place that understands both wire formats, so the handler below never has
  * to care which one arrived.
  */
 export function normalizeTopggPayload(body: unknown): NormalizedVote {
-    // Read the wire shape structurally rather than as `V0 & V1`: intersecting
-    // the two literal unions collapses `type` to `undefined` and every case
-    // below becomes uncomparable. The named types above stay as the record of
-    // what each format looks like.
-    const payload = (body ?? {}) as {
-        type?: string
-        user?: unknown
-        isWeekend?: unknown
-        data?: { weight?: unknown; user?: { platform_id?: unknown } }
-    }
+    const payload = (body ?? {}) as TopggPayload
 
     switch (payload.type) {
         case 'webhook.test':
@@ -90,7 +89,7 @@ export function normalizeTopggPayload(body: unknown): NormalizedVote {
                 kind: 'vote',
                 // platform_id, NOT id — see the note above.
                 userId: payload.data?.user?.platform_id,
-                isWeekend: Number(payload.data?.weight ?? 1) >= 2,
+                isWeekend: (payload.data?.weight ?? 1) >= 2,
             }
         case 'upvote':
             return {

--- a/packages/backend/tests/unit/routes/webhooks.test.ts
+++ b/packages/backend/tests/unit/routes/webhooks.test.ts
@@ -62,6 +62,7 @@ jest.mock(
 import {
     setupWebhookRoutes,
     setupWebhookPublicRoutes,
+    normalizeTopggPayload,
 } from '../../../src/routes/webhooks'
 
 function buildApp(): express.Express {
@@ -726,5 +727,79 @@ describe('webhook auth scheme selection (CodeQL: no user-controlled bypass)', ()
             .send({ type: 'test' })
 
         expect(res.status).toBe(200)
+    })
+})
+
+describe('top.gg payload shapes (v0 and v1)', () => {
+    // The first real v1 delivery was rejected with 400 because #2103 shipped v1
+    // signature verification while still reading the v0 body. These lock both
+    // wire formats down.
+
+    it('reads a v1 vote.create, taking the DISCORD id from platform_id', () => {
+        // data.user.id is top.gg's own id. Reading it would credit the vote to
+        // a different user, and only the snowflake check downstream would
+        // notice -- and only if that id happened not to look like a snowflake.
+        expect(
+            normalizeTopggPayload({
+                type: 'vote.create',
+                data: {
+                    weight: 1,
+                    user: {
+                        id: '808499215864008704',
+                        platform_id: '160105994217586689',
+                    },
+                },
+            }),
+        ).toEqual({
+            kind: 'vote',
+            userId: '160105994217586689',
+            isWeekend: false,
+        })
+    })
+
+    it('treats v1 weight 2 as a weekend vote', () => {
+        const event = normalizeTopggPayload({
+            type: 'vote.create',
+            data: { weight: 2, user: { platform_id: '160105994217586689' } },
+        })
+        expect(event).toEqual({
+            kind: 'vote',
+            userId: '160105994217586689',
+            isWeekend: true,
+        })
+    })
+
+    it('accepts the v1 dashboard test event', () => {
+        expect(normalizeTopggPayload({ type: 'webhook.test' })).toEqual({
+            kind: 'test',
+        })
+    })
+
+    it('still reads the v0 shape', () => {
+        expect(
+            normalizeTopggPayload({
+                type: 'upvote',
+                user: '160105994217586689',
+                isWeekend: true,
+            }),
+        ).toEqual({
+            kind: 'vote',
+            userId: '160105994217586689',
+            isWeekend: true,
+        })
+        expect(normalizeTopggPayload({ type: 'test' })).toEqual({
+            kind: 'test',
+        })
+    })
+
+    it('reports an unknown type rather than guessing', () => {
+        expect(normalizeTopggPayload({ type: 'vote.delete' })).toEqual({
+            kind: 'unsupported',
+            type: 'vote.delete',
+        })
+        expect(normalizeTopggPayload({})).toEqual({
+            kind: 'unsupported',
+            type: undefined,
+        })
     })
 })


### PR DESCRIPTION
Every top.gg vote is currently being rejected with `400`. Production evidence, from the first two real deliveries after the webhook was created:

```
[WARN] 2026-08-27T13:55:44.201Z  POST /webhooks/topgg-votes 400 188ms
[WARN] 2026-08-27T13:55:46.322Z  POST /webhooks/topgg-votes 400   4ms
```

**400, not 401.** That already told us the signature check was working and the body reader was not.

## What I got wrong in #2103

top.gg changed the auth scheme and the payload independently. I implemented v1 signature verification and left the v0 body reader in place.

```
v0: { user: '<discord id>', type: 'upvote' | 'test', isWeekend: bool }
v1: { type: 'vote.create' | 'webhook.test',
      data: { user: { id, platform_id }, weight } }
```

`type` arrives as `vote.create`; the handler tested for `upvote`; every vote bounced.

## The part that would have been worse than a 400

`data.user` has two ids. **`id` is top.gg's own user id. The Discord snowflake is `platform_id`.**

Fixing only the type check and reading `id` would have recorded votes against the wrong user. The only thing standing between that and corrupt streak data is the snowflake regex downstream — and it would have held only by luck, if top.gg's id happened not to look like a snowflake. A 400 is loud; crediting the wrong user is silent.

Weekend doubles moved too: v0 said `isWeekend: true`, v1 says `weight: 2`.

## The fix

`normalizeTopggPayload()` is the single place that understands both wire formats, so the handler no longer knows or cares which arrived. v0 stays supported, because the route still falls back to it when no v1 secret is configured.

An unsupported type is now logged **with the type**. The production log said only `400` — a rejection that does not name what it rejected cannot be diagnosed from outside the box. The payload shape had to come from [top.gg's event reference](https://docs.top.gg/webhooks/events.md) instead of from our own logs.

## Verification

- 36 tests in the webhook suite, 5 of them new, covering both formats
- Mutation-checked: reading `id` instead of `platform_id`, ignoring `weight`, or misspelling `vote.create` each turn them red
- 1,384 backend tests pass

**One caveat, stated rather than buried.** The full backend suite has a pre-existing flake in `tests/unit/routes/twitch.test.ts` — `returns 400 when login query param is missing`. It passes 5/5 in isolation and fails intermittently in the full run. I initially concluded my change had introduced it, on three clean runs of `main`; that was not enough evidence at a ~30% rate. Six more runs of clean `main` produced a failure, so it is **pre-existing and unrelated**. Filed separately.

## Sources

- [Top.gg webhook event reference](https://docs.top.gg/webhooks/events.md)
- [Top.gg webhooks overview](https://docs.top.gg/webhooks/overview)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the top.gg webhook rejecting every vote with a 400 by reading the v1 payload shape alongside the v1 signature, so v1 votes record against the correct Discord user while v0 payloads keep working.

**Bug Fixes**
- v1 nests the Discord snowflake in `data.user.platform_id`, not `data.user.id`; reading `id` would credit votes to the wrong user.
- Weekend doubles moved from `isWeekend: true` to `weight: 2`.
- Unsupported event types are now logged with the type so rejections are diagnosable.
- v0 payloads remain supported as a fallback when no v1 secret is configured.
- Both payload shapes are modeled as a discriminated union so `type` narrows correctly in each case.
- The pre-existing flaky failure in `tests/unit/routes/twitch.test.ts` is unrelated to this change.

<sup>Written for commit 9099e398672e94afa6d8fb591c994acd03e429a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

