### PR TITLE
fix(ci): run the scripts/ tests, and fix the one that was red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
             # why an untranslated feature is invisible without this gate.
             - name: Verify locale key parity
               run: npm run verify:locales
+            # `scripts/` holds the release-side guards: the broadcast send
+            # ledger, the http probe, the json-import gate. They had tests and
+            # nothing ran them, so the guards on a one-off broadcast to real
+            # servers were never enforced. Plain node, no build, no DB.
+            - name: Test release scripts
+              run: npm run test:scripts
             - name: Type check
               run: npm run type:check
             - name: Check documentation coverage

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "test:ci": "npm run test --workspace=packages/backend -- --ci",
         "test:coverage": "npm run test --workspace=packages/backend -- --coverage",
         "test:e2e": "npm run test:e2e --workspace=packages/frontend",
-        "verify": "npm run lint --workspace=packages/frontend && npm run lint --workspace=packages/backend && npm run build:shared && npm run verify:shared-exports && npm run verify:nginx-routes && npm run verify:locales && npm run type:check && npm run build && npm run test:all && npm run audit:high",
+        "verify": "npm run lint --workspace=packages/frontend && npm run lint --workspace=packages/backend && npm run build:shared && npm run verify:shared-exports && npm run verify:nginx-routes && npm run verify:locales && npm run test:scripts && npm run type:check && npm run build && npm run test:all && npm run audit:high",
         "verify:shared": "npm run lint --workspace=packages/shared && npm run type:check --workspace=packages/shared && npm run build:shared && npm run test:shared",
         "verify:bot": "npm run lint --workspace=packages/bot && npm run type:check --workspace=packages/bot && npm run verify:locales && npm run build:bot && npm run test:bot",
         "verify:backend": "npm run lint --workspace=packages/backend && npm run type:check --workspace=packages/backend && npm run build:backend && npm run test:backend && npm audit --audit-level=high --workspace=packages/backend",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "db:studio": "prisma studio --config prisma/prisma.config.ts",
         "deploy:remote": "./scripts/deploy-remote.sh",
         "deploy:homelab": "./scripts/deploy-remote.sh main",
+        "test:scripts": "node --test scripts/*.test.mjs",
         "test:shared": "npm run test:ci --workspace=packages/shared"
     },
     "lint-staged": {

--- a/scripts/http-probe.test.mjs
+++ b/scripts/http-probe.test.mjs
@@ -1,12 +1,19 @@
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-const repoRoot = new URL('..', import.meta.url)
-const probeScript = new URL('./http-probe.sh', import.meta.url)
+// `fileURLToPath`, not the URL's percent-encoded path property: a repo
+// checked out under a directory containing a space yields
+// `/Volumes/External%20HD/...`. That directory does not exist, spawn fails
+// with ENOENT, and `status` comes back `null` instead of a non-zero exit,
+// which reads as an assertion bug rather than a path bug. CI runners have
+// no space in their checkout path, so CI would never have caught this.
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+const probeScript = fileURLToPath(new URL('./http-probe.sh', import.meta.url))
 
 test('falls back to wget when curl is unavailable', () => {
   const tempDir = mkdtempSync(join(tmpdir(), 'lucky-http-probe-'))
@@ -36,8 +43,8 @@ printf '  HTTP/1.1 200 OK\\n' >&2
       { mode: 0o755 },
     )
 
-    const result = spawnSync('/bin/bash', [probeScript.pathname, 'http://example.test/health'], {
-      cwd: repoRoot.pathname,
+    const result = spawnSync('/bin/bash', [probeScript, 'http://example.test/health'], {
+      cwd: repoRoot,
       env: {
         ...process.env,
         PATH: binDir,


### PR DESCRIPTION
Closes #2116.

## Two problems, one PR

**Nothing ran `scripts/*.test.mjs`.** No `node --test` in `package.json` or any workflow. 21 tests across three files, executing never. The broadcast ones cover the send-ledger classification and the guild-name sanitiser: the logic that decides whether a one-off broadcast to real servers double-posts or silently skips.

**The red one had a different cause than the issue guessed.** Not a harness bug, and not macOS-specific:

```js
const repoRoot = new URL('..', import.meta.url)
spawnSync('/bin/bash', [...], { cwd: repoRoot.pathname })
```

`.pathname` is percent-encoded. This checkout lives under `/Volumes/External HD/` per the storage policy, so `cwd` became `/Volumes/External%20HD/...`, a directory that does not exist. Spawn fails ENOENT, `result.status` is `null` instead of a non-zero exit, and the assertion `null !== 0` reads as a test-logic bug. `fileURLToPath` is the fix.

**Worth being explicit:** this particular test would pass in CI even unfixed, because runner checkout paths (`/home/runner/work/Lucky/Lucky`) have no space. Wiring CI does not protect this test. It protects the other 20.

## Where the step goes

The existing verify job, next to `verify:locales` and `verify:nginx-routes`. Plain node: no build, no DB, no new runner, no added matrix minutes.

## Verification

```
npm run test:scripts
# tests 21
# pass 21
# fail 0
```

`node --test scripts/` (directory form) finds only 1 of the 21, so the script uses the glob.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the 21 `scripts/*.test.mjs` tests in CI and in `npm run verify` for the first time (none ran before) and fixes the one that failed on paths containing spaces.

- Adds the `test:scripts` npm command (`node --test scripts/*.test.mjs`), the step in the existing CI verify job, and the command to the root `npm run verify` aggregate; plain node, no build, no DB. The glob form is required since `node --test scripts/` finds only 1 of the 21 tests.
- These tests cover the broadcast send-ledger and guild-name sanitiser logic, which decide whether a one-off broadcast to real servers double-posts or silently skips.
- The failing http-probe test passed `new URL(...).pathname` as `cwd`, which percent-encodes spaces; a checkout under `/Volumes/External HD/` produced a non-existent path and `spawnSync` returned `null` status instead of a non-zero exit. Switched to `fileURLToPath`.
- CI runner checkout paths have no spaces, so that test would have passed unfixed in CI; the wiring protects the other 20 tests.
- Closes #2116.

<sup>Written for commit ea33af429e1a03b578672cce84a13f8a0957b7dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

