### PR TITLE
feat(observability): bot logs, per-interaction scope, and Top.gg 401 backoff

### DIFF
--- a/packages/bot/src/handlers/eventHandler.spec.ts
+++ b/packages/bot/src/handlers/eventHandler.spec.ts
@@ -109,15 +109,15 @@ jest.mock('@lucky/shared/utils', () => ({
     infoLog: (...args: unknown[]) => infoLogMock(...args),
     debugLog: (...args: unknown[]) => debugLogMock(...args),
     captureException: (...args: unknown[]) => captureExceptionMock(...args),
-    // Passagem direta: o teste do eventHandler nao e sobre escopo do Sentry nem sobre
-    // AsyncLocalStorage, so precisa que o corpo da interacao rode. O comportamento de
-    // isolamento e coberto onde ele mora, no shared.
+    // Pass-through: the eventHandler test is not about Sentry scoping or
+    // AsyncLocalStorage, it only needs the interaction body to run. Isolation behaviour is
+    // covered where it lives, in shared.
     runWithLogContext: <T>(_ctx: unknown, fn: () => T): T => fn(),
     withSentryRequestScope: <T>(_ctx: unknown, fn: () => T): T => fn(),
 }))
 
 jest.mock('@lucky/shared/utils/support/correlationId', () => ({
-    mintCorrelationId: () => 'cid-de-teste',
+    mintCorrelationId: () => 'test-cid',
 }))
 
 jest.mock('../services/AiDevToolkitService', () => ({

--- a/packages/bot/src/handlers/eventHandler.spec.ts
+++ b/packages/bot/src/handlers/eventHandler.spec.ts
@@ -109,6 +109,15 @@ jest.mock('@lucky/shared/utils', () => ({
     infoLog: (...args: unknown[]) => infoLogMock(...args),
     debugLog: (...args: unknown[]) => debugLogMock(...args),
     captureException: (...args: unknown[]) => captureExceptionMock(...args),
+    // Passagem direta: o teste do eventHandler nao e sobre escopo do Sentry nem sobre
+    // AsyncLocalStorage, so precisa que o corpo da interacao rode. O comportamento de
+    // isolamento e coberto onde ele mora, no shared.
+    runWithLogContext: <T>(_ctx: unknown, fn: () => T): T => fn(),
+    withSentryRequestScope: <T>(_ctx: unknown, fn: () => T): T => fn(),
+}))
+
+jest.mock('@lucky/shared/utils/support/correlationId', () => ({
+    mintCorrelationId: () => 'cid-de-teste',
 }))
 
 jest.mock('../services/AiDevToolkitService', () => ({

--- a/packages/bot/src/handlers/eventHandler.ts
+++ b/packages/bot/src/handlers/eventHandler.ts
@@ -275,15 +275,16 @@ async function handleInteractionCreate(
     client: Client,
     interaction: Interaction,
 ): Promise<void> {
-    // Um escopo por interacao, estabelecido no funil por onde TODA interacao passa.
+    // One scope per interaction, established at the funnel every interaction goes
+    // through.
     //
-    // Resolve tres coisas que estavam soltas: o Sentry passa a saber QUEM foi afetado (as
-    // issues diziam `Users: 0`), os logs ganham `correlationId` e `guildId` sem ninguem
-    // passar a mao, e o escopo isolado impede que o id de um usuario vaze para o erro de
-    // outro num processo que atende varios servidores ao mesmo tempo.
+    // This settles three loose ends at once: Sentry learns WHO was affected (issues read
+    // `Users: 0`), logs gain `correlationId` and `guildId` without anyone threading them
+    // by hand, and the isolated scope keeps one user's id from leaking into another
+    // user's error in a process that serves many guilds at once.
     //
-    // `runWithLogContext` ja existia e nunca tinha sido chamado por ninguem: o
-    // AsyncLocalStorage estava pronto e ocioso.
+    // `runWithLogContext` already existed and had never been called by anyone: the
+    // AsyncLocalStorage was ready and idle.
     const correlationId = mintCorrelationId()
     return withSentryRequestScope(
         {
@@ -298,12 +299,12 @@ async function handleInteractionCreate(
                     guildId: interaction.guildId ?? undefined,
                     userId: interaction.user?.id,
                 },
-                () => executarInteracao(client, interaction),
+                () => runInteraction(client, interaction),
             ),
     )
 }
 
-async function executarInteracao(
+async function runInteraction(
     client: Client,
     interaction: Interaction,
 ): Promise<void> {

--- a/packages/bot/src/handlers/eventHandler.ts
+++ b/packages/bot/src/handlers/eventHandler.ts
@@ -16,9 +16,12 @@ import {
     infoLog,
     debugLog,
     captureException,
+    runWithLogContext,
+    withSentryRequestScope,
 } from '@lucky/shared/utils'
 import { interactionReply } from '../utils/general/interactionReply'
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
+import { mintCorrelationId } from '@lucky/shared/utils/support/correlationId'
 import { handleMessageCreate } from './messageHandler'
 import { handleMemberEvents } from './memberHandler'
 import { handleAuditEvents } from './auditHandler'
@@ -269,6 +272,38 @@ async function handleAutocomplete(interaction: Interaction): Promise<void> {
 }
 
 async function handleInteractionCreate(
+    client: Client,
+    interaction: Interaction,
+): Promise<void> {
+    // Um escopo por interacao, estabelecido no funil por onde TODA interacao passa.
+    //
+    // Resolve tres coisas que estavam soltas: o Sentry passa a saber QUEM foi afetado (as
+    // issues diziam `Users: 0`), os logs ganham `correlationId` e `guildId` sem ninguem
+    // passar a mao, e o escopo isolado impede que o id de um usuario vaze para o erro de
+    // outro num processo que atende varios servidores ao mesmo tempo.
+    //
+    // `runWithLogContext` ja existia e nunca tinha sido chamado por ninguem: o
+    // AsyncLocalStorage estava pronto e ocioso.
+    const correlationId = mintCorrelationId()
+    return withSentryRequestScope(
+        {
+            userId: interaction.user?.id,
+            guildId: interaction.guildId ?? undefined,
+            correlationId,
+        },
+        () =>
+            runWithLogContext(
+                {
+                    correlationId,
+                    guildId: interaction.guildId ?? undefined,
+                    userId: interaction.user?.id,
+                },
+                () => executarInteracao(client, interaction),
+            ),
+    )
+}
+
+async function executarInteracao(
     client: Client,
     interaction: Interaction,
 ): Promise<void> {

--- a/packages/bot/src/utils/general/topggStatsScheduler.spec.ts
+++ b/packages/bot/src/utils/general/topggStatsScheduler.spec.ts
@@ -168,6 +168,59 @@ describe('TopggStatsScheduler', () => {
         scheduler.stop()
     })
 
+    // O caso que gerou LUCKY-62: 109 eventos em dois dias porque um 401 era tratado como
+    // erro transitorio e repetido a cada 30 minutos, para sempre.
+    test('401 para o scheduler e reporta UMA vez, com nivel error', async () => {
+        process.env.TOPGG_TOKEN = 'token-revogado'
+        const mockFetch = jest.fn().mockResolvedValue({
+            ok: false,
+            status: 401,
+            statusText: 'Unauthorized',
+            text: jest.fn().mockResolvedValue('unauthorized'),
+        })
+        const scheduler = new TopggStatsScheduler({
+            tickIntervalMs: 20,
+            fetch: mockFetch,
+        })
+        scheduler.start(makeClient(10) as any)
+
+        // Tempo suficiente para varios ticks, se ele ainda estivesse de pe.
+        await new Promise((resolve) => setTimeout(resolve, 120))
+
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        expect(captureMessage).toHaveBeenCalledTimes(1)
+        expect(captureMessage).toHaveBeenCalledWith(
+            expect.stringContaining('token rejected'),
+            'error',
+            expect.objectContaining({ category: 'topgg.stats', status: 401 }),
+        )
+
+        scheduler.stop()
+    })
+
+    // Contraprova: sem ela, "parar no 401" poderia virar "parar em qualquer falha", e o
+    // bot deixaria de postar stats por causa de um 500 passageiro.
+    test('500 NAO para o scheduler: erro transitorio ainda merece retry', async () => {
+        process.env.TOPGG_TOKEN = 'token-valido'
+        const mockFetch = jest.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            text: jest.fn().mockResolvedValue('boom'),
+        })
+        const scheduler = new TopggStatsScheduler({
+            tickIntervalMs: 20,
+            fetch: mockFetch,
+        })
+        scheduler.start(makeClient(10) as any)
+
+        await new Promise((resolve) => setTimeout(resolve, 120))
+
+        expect(mockFetch.mock.calls.length).toBeGreaterThan(1)
+
+        scheduler.stop()
+    })
+
     test('should log warning on fetch error', async () => {
         process.env.TOPGG_TOKEN = 'test-token-123'
         const testError = new Error('Network error')

--- a/packages/bot/src/utils/general/topggStatsScheduler.spec.ts
+++ b/packages/bot/src/utils/general/topggStatsScheduler.spec.ts
@@ -168,9 +168,9 @@ describe('TopggStatsScheduler', () => {
         scheduler.stop()
     })
 
-    // O caso que gerou LUCKY-62: 109 eventos em dois dias porque um 401 era tratado como
-    // erro transitorio e repetido a cada 30 minutos, para sempre.
-    test('401 para o scheduler e reporta UMA vez, com nivel error', async () => {
+    // The case behind LUCKY-62: 109 events over two days because a 401 was treated as a
+    // transient error and retried every 30 minutes, forever.
+    test('401 stops the scheduler and reports ONCE, at error level', async () => {
         process.env.TOPGG_TOKEN = 'token-revogado'
         const mockFetch = jest.fn().mockResolvedValue({
             ok: false,
@@ -184,7 +184,7 @@ describe('TopggStatsScheduler', () => {
         })
         scheduler.start(makeClient(10) as any)
 
-        // Tempo suficiente para varios ticks, se ele ainda estivesse de pe.
+        // Long enough for several ticks, had it still been running.
         await new Promise((resolve) => setTimeout(resolve, 120))
 
         expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -198,9 +198,9 @@ describe('TopggStatsScheduler', () => {
         scheduler.stop()
     })
 
-    // Contraprova: sem ela, "parar no 401" poderia virar "parar em qualquer falha", e o
-    // bot deixaria de postar stats por causa de um 500 passageiro.
-    test('500 NAO para o scheduler: erro transitorio ainda merece retry', async () => {
+    // Counter-proof: without it, "stop on 401" could quietly become "stop on anything",
+    // and the bot would stop posting stats over a passing 500.
+    test('500 does NOT stop the scheduler: a transient error still deserves a retry', async () => {
         process.env.TOPGG_TOKEN = 'token-valido'
         const mockFetch = jest.fn().mockResolvedValue({
             ok: false,

--- a/packages/bot/src/utils/general/topggStatsScheduler.ts
+++ b/packages/bot/src/utils/general/topggStatsScheduler.ts
@@ -19,13 +19,12 @@ const TOPGG_FETCH_TIMEOUT_MS = 10_000
 
 // A rejected credential does not heal on retry. Before this, every !response.ok took the
 // same path, so a 401 retried every 30 minutes forever: Sentry issue LUCKY-62 collected
-// **109 events over two days** and was still firing. That noise buries the errors that a
-// retry CAN fix.
+// 109 events over two days and was still firing. That noise buries the errors a retry CAN
+// fix.
 //
 // On these statuses the scheduler stops and says so once. Same shape the file already uses
-// for a missing TOPGG_TOKEN, which is the other "nothing will change until a human acts"
-// case.
-const STATUS_SEM_RETRY = new Set([401, 403])
+// for a missing TOPGG_TOKEN, the other "nothing changes until a human acts" case.
+const NON_RETRYABLE_STATUS = new Set([401, 403])
 
 type TopggStatsSchedulerOptions = {
     tickIntervalMs?: number
@@ -35,7 +34,7 @@ type TopggStatsSchedulerOptions = {
 export class TopggStatsScheduler extends IntervalScheduler {
     private readonly fetchFn: typeof fetch
     private loggedMissingToken = false
-    private credencialRejeitada = false
+    private credentialRejected = false
 
     constructor(options: TopggStatsSchedulerOptions = {}) {
         super(options.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS)
@@ -103,11 +102,11 @@ export class TopggStatsScheduler extends IntervalScheduler {
                 const statusText =
                     response.statusText || `HTTP ${response.status}`
 
-                if (STATUS_SEM_RETRY.has(response.status)) {
-                    // `error`, not `warning`: this needs a person to rotate the token, and
-                    // a warning that nobody acts on is the same as no signal at all.
-                    if (!this.credencialRejeitada) {
-                        this.credencialRejeitada = true
+                if (NON_RETRYABLE_STATUS.has(response.status)) {
+                    // `error`, not `warning`: this needs a person to rotate the token,
+                    // and a warning nobody acts on is the same as no signal at all.
+                    if (!this.credentialRejected) {
+                        this.credentialRejected = true
                         captureMessage(
                             `Top.gg stats disabled: token rejected (${statusText}). Rotate TOPGG_TOKEN and restart.`,
                             'error',

--- a/packages/bot/src/utils/general/topggStatsScheduler.ts
+++ b/packages/bot/src/utils/general/topggStatsScheduler.ts
@@ -17,6 +17,16 @@ const DEFAULT_TICK_INTERVAL_MS = 30 * 60 * 1000
 // single-flight guard set forever (which would skip every later tick).
 const TOPGG_FETCH_TIMEOUT_MS = 10_000
 
+// A rejected credential does not heal on retry. Before this, every !response.ok took the
+// same path, so a 401 retried every 30 minutes forever: Sentry issue LUCKY-62 collected
+// **109 events over two days** and was still firing. That noise buries the errors that a
+// retry CAN fix.
+//
+// On these statuses the scheduler stops and says so once. Same shape the file already uses
+// for a missing TOPGG_TOKEN, which is the other "nothing will change until a human acts"
+// case.
+const STATUS_SEM_RETRY = new Set([401, 403])
+
 type TopggStatsSchedulerOptions = {
     tickIntervalMs?: number
     fetch?: typeof fetch
@@ -25,6 +35,7 @@ type TopggStatsSchedulerOptions = {
 export class TopggStatsScheduler extends IntervalScheduler {
     private readonly fetchFn: typeof fetch
     private loggedMissingToken = false
+    private credencialRejeitada = false
 
     constructor(options: TopggStatsSchedulerOptions = {}) {
         super(options.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS)
@@ -91,6 +102,30 @@ export class TopggStatsScheduler extends IntervalScheduler {
                 const text = await response.text()
                 const statusText =
                     response.statusText || `HTTP ${response.status}`
+
+                if (STATUS_SEM_RETRY.has(response.status)) {
+                    // `error`, not `warning`: this needs a person to rotate the token, and
+                    // a warning that nobody acts on is the same as no signal at all.
+                    if (!this.credencialRejeitada) {
+                        this.credencialRejeitada = true
+                        captureMessage(
+                            `Top.gg stats disabled: token rejected (${statusText}). Rotate TOPGG_TOKEN and restart.`,
+                            'error',
+                            {
+                                category: 'topgg.stats',
+                                status: response.status,
+                                serverCount,
+                            },
+                        )
+                        warnLog({
+                            message: `Top.gg stats disabled: token rejected (${statusText}). Rotate TOPGG_TOKEN and restart the bot.`,
+                            data: { status: response.status },
+                        })
+                    }
+                    this.stop()
+                    return
+                }
+
                 warnLog({
                     message: `Top.gg stats POST failed: ${statusText}`,
                     data: {

--- a/packages/shared/src/utils/general/log/levelToken.spec.ts
+++ b/packages/shared/src/utils/general/log/levelToken.spec.ts
@@ -11,6 +11,7 @@ jest.mock('../../monitoring', () => ({
     addBreadcrumb: jest.fn(),
     captureException: jest.fn(),
     captureMessage: jest.fn(),
+    logToSentry: jest.fn(),
 }))
 
 jest.mock('../../alerts', () => ({

--- a/packages/shared/src/utils/general/log/service.spec.ts
+++ b/packages/shared/src/utils/general/log/service.spec.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import { LogService } from './service'
+import { logToSentry } from '../../monitoring'
 
 jest.mock('../../monitoring', () => ({
     captureException: jest.fn(),
     captureMessage: jest.fn(),
     addBreadcrumb: jest.fn(),
+    logToSentry: jest.fn(),
 }))
 
 jest.mock('../../alerts', () => ({
@@ -32,6 +34,59 @@ describe('LogService', () => {
         jest.spyOn(console, 'log').mockImplementation(() => {})
         jest.spyOn(console, 'error').mockImplementation(() => {})
         service = new LogService()
+    })
+
+    // Os ~1160 infoLog/warnLog/debugLog do codigo so viravam breadcrumb, e breadcrumb so
+    // aparece anexado a um evento de erro. Estes testes travam a saida propria para o log.
+    describe('emissao para o Sentry', () => {
+        it('info vira log de nivel info, com os dados como atributo', () => {
+            service.info({ message: 'tocando faixa', data: { guildId: '42' } })
+
+            expect(logToSentry).toHaveBeenCalledWith(
+                'info',
+                expect.stringContaining('tocando faixa'),
+                expect.objectContaining({ guildId: '42' }),
+            )
+        })
+
+        it('warn vira warn e error vira error', () => {
+            service.warn({ message: 'fila cheia' })
+            service.error({ message: 'falhou' })
+
+            expect(logToSentry).toHaveBeenCalledWith(
+                'warn',
+                expect.stringContaining('fila cheia'),
+                undefined,
+            )
+            expect(logToSentry).toHaveBeenCalledWith(
+                'error',
+                expect.stringContaining('falhou'),
+                undefined,
+            )
+        })
+
+        // Contraprova: sem ela, ligar logs mandaria 340 debugLog para fora mesmo com o
+        // nivel desligado em producao.
+        it('nivel desligado NAO viaja: debug suprimido nao chega ao Sentry', () => {
+            service.setLogLevel(0) // so ERROR
+            jest.clearAllMocks()
+
+            service.debug({ message: 'ruido de debug' })
+
+            expect(logToSentry).not.toHaveBeenCalled()
+        })
+
+        // Log injection: o mesmo motivo pelo qual o console e sanitizado.
+        it('mensagem vai sanitizada, sem quebra de linha', () => {
+            service.info({ message: 'linha1\nlinha2' })
+
+            const [, mensagem] = (logToSentry as jest.Mock).mock.calls[0] as [
+                string,
+                string,
+                unknown,
+            ]
+            expect(mensagem).not.toContain('\n')
+        })
     })
 
     describe('setLogLevel', () => {

--- a/packages/shared/src/utils/general/log/service.spec.ts
+++ b/packages/shared/src/utils/general/log/service.spec.ts
@@ -36,56 +36,56 @@ describe('LogService', () => {
         service = new LogService()
     })
 
-    // Os ~1160 infoLog/warnLog/debugLog do codigo so viravam breadcrumb, e breadcrumb so
-    // aparece anexado a um evento de erro. Estes testes travam a saida propria para o log.
-    describe('emissao para o Sentry', () => {
-        it('info vira log de nivel info, com os dados como atributo', () => {
-            service.info({ message: 'tocando faixa', data: { guildId: '42' } })
+    // The ~1160 infoLog/warnLog/debugLog calls only became breadcrumbs, and a breadcrumb
+    // only shows up attached to an error event. These tests pin down the log's own exit.
+    describe('emission to Sentry', () => {
+        it('info becomes an info-level log, with data as attributes', () => {
+            service.info({ message: 'playing track', data: { guildId: '42' } })
 
             expect(logToSentry).toHaveBeenCalledWith(
                 'info',
-                expect.stringContaining('tocando faixa'),
+                expect.stringContaining('playing track'),
                 expect.objectContaining({ guildId: '42' }),
             )
         })
 
-        it('warn vira warn e error vira error', () => {
-            service.warn({ message: 'fila cheia' })
-            service.error({ message: 'falhou' })
+        it('warn becomes warn and error becomes error', () => {
+            service.warn({ message: 'queue full' })
+            service.error({ message: 'it failed' })
 
             expect(logToSentry).toHaveBeenCalledWith(
                 'warn',
-                expect.stringContaining('fila cheia'),
+                expect.stringContaining('queue full'),
                 undefined,
             )
             expect(logToSentry).toHaveBeenCalledWith(
                 'error',
-                expect.stringContaining('falhou'),
+                expect.stringContaining('it failed'),
                 undefined,
             )
         })
 
-        // Contraprova: sem ela, ligar logs mandaria 340 debugLog para fora mesmo com o
-        // nivel desligado em producao.
-        it('nivel desligado NAO viaja: debug suprimido nao chega ao Sentry', () => {
-            service.setLogLevel(0) // so ERROR
+        // Counter-proof: without it, enabling logs would ship 340 debugLog calls even
+        // with the level switched off in production.
+        it('a disabled level does NOT travel: suppressed debug never reaches Sentry', () => {
+            service.setLogLevel(0) // ERROR only
             jest.clearAllMocks()
 
-            service.debug({ message: 'ruido de debug' })
+            service.debug({ message: 'debug noise' })
 
             expect(logToSentry).not.toHaveBeenCalled()
         })
 
-        // Log injection: o mesmo motivo pelo qual o console e sanitizado.
-        it('mensagem vai sanitizada, sem quebra de linha', () => {
+        // Log injection: the same reason the console output is sanitised.
+        it('the message goes sanitised, with no newline', () => {
             service.info({ message: 'linha1\nlinha2' })
 
-            const [, mensagem] = (logToSentry as jest.Mock).mock.calls[0] as [
+            const [, message] = (logToSentry as jest.Mock).mock.calls[0] as [
                 string,
                 string,
                 unknown,
             ]
-            expect(mensagem).not.toContain('\n')
+            expect(message).not.toContain('\n')
         })
     })
 

--- a/packages/shared/src/utils/general/log/service.ts
+++ b/packages/shared/src/utils/general/log/service.ts
@@ -10,7 +10,7 @@ import { getLogContext } from './context'
 import { LEVEL_TOKEN } from './types'
 import type { LogLevelType, LogParams, LogConfig } from './types'
 
-// LogLevelType -> nivel do Sentry. SUCCESS nao existe la e cai em info.
+// LogLevelType -> Sentry level. SUCCESS has no counterpart there and maps to info.
 const SENTRY_LOG_LEVEL: Record<number, 'debug' | 'info' | 'warn' | 'error'> = {
     0: 'error',
     1: 'warn',
@@ -19,9 +19,9 @@ const SENTRY_LOG_LEVEL: Record<number, 'debug' | 'info' | 'warn' | 'error'> = {
     4: 'debug',
 }
 
-// Atributo de log tem que ser um mapa plano. `data` pode ser qualquer coisa (array,
-// string, null), entao o que nao for objeto simples entra sob uma chave, em vez de ser
-// espalhado ou descartado em silencio.
+// A log attribute has to be a flat map. `data` can be anything (array, string, null), so
+// whatever is not a plain object goes under one key instead of being spread or silently
+// dropped.
 function asLogAttributes(
     params: LogParams,
 ): Record<string, unknown> | undefined {
@@ -293,13 +293,14 @@ export class LogService {
             )
         }
 
-        // Um ponto so de saida para o Sentry, em vez de os ~1160 call sites conhecerem o
-        // SDK. Fica DEPOIS do `shouldLog`, entao o nivel configurado continua mandando: se
-        // debug esta desligado em producao, ele nao viaja.
+        // A single exit point to Sentry, instead of the ~1160 call sites knowing about
+        // the SDK. It sits AFTER `shouldLog`, so the configured level still rules: with
+        // debug off in production, those calls do not travel.
         //
-        // A mensagem vai sanitizada, pelo mesmo motivo do console: valor vindo do usuario
-        // nao pode forjar registro. SUCCESS (3) entra como info porque o Sentry nao tem
-        // esse nivel, e inventar um seria pior que mapear no mais proximo.
+        // The message goes sanitised for the same reason the console output does: a value
+        // coming from a user must not forge a record. SUCCESS (3) maps to info because
+        // Sentry has no such level, and inventing one would be worse than mapping to the
+        // nearest.
         logToSentry(
             SENTRY_LOG_LEVEL[level] ?? 'info',
             sanitizeForLogging(formattedMessage),

--- a/packages/shared/src/utils/general/log/service.ts
+++ b/packages/shared/src/utils/general/log/service.ts
@@ -3,11 +3,40 @@ import {
     addBreadcrumb,
     captureException,
     captureMessage,
+    logToSentry,
 } from '../../monitoring'
 import { recordWithCooldown, emitAlert } from '../../alerts'
 import { getLogContext } from './context'
 import { LEVEL_TOKEN } from './types'
 import type { LogLevelType, LogParams, LogConfig } from './types'
+
+// LogLevelType -> nivel do Sentry. SUCCESS nao existe la e cai em info.
+const SENTRY_LOG_LEVEL: Record<number, 'debug' | 'info' | 'warn' | 'error'> = {
+    0: 'error',
+    1: 'warn',
+    2: 'info',
+    3: 'info',
+    4: 'debug',
+}
+
+// Atributo de log tem que ser um mapa plano. `data` pode ser qualquer coisa (array,
+// string, null), entao o que nao for objeto simples entra sob uma chave, em vez de ser
+// espalhado ou descartado em silencio.
+function asLogAttributes(
+    params: LogParams,
+): Record<string, unknown> | undefined {
+    const attrs: Record<string, unknown> = {}
+    if (params.correlationId) attrs.correlationId = params.correlationId
+    if (params.data !== undefined) {
+        const d = params.data
+        if (d !== null && typeof d === 'object' && !Array.isArray(d)) {
+            Object.assign(attrs, d as Record<string, unknown>)
+        } else {
+            attrs.data = d
+        }
+    }
+    return Object.keys(attrs).length > 0 ? attrs : undefined
+}
 
 function sanitizeForLogging(text: string): string {
     return text.replace(/[\x00-\x1f\x7f]/g, ' ')
@@ -263,6 +292,19 @@ export class LogService {
                 ),
             )
         }
+
+        // Um ponto so de saida para o Sentry, em vez de os ~1160 call sites conhecerem o
+        // SDK. Fica DEPOIS do `shouldLog`, entao o nivel configurado continua mandando: se
+        // debug esta desligado em producao, ele nao viaja.
+        //
+        // A mensagem vai sanitizada, pelo mesmo motivo do console: valor vindo do usuario
+        // nao pode forjar registro. SUCCESS (3) entra como info porque o Sentry nao tem
+        // esse nivel, e inventar um seria pior que mapear no mais proximo.
+        logToSentry(
+            SENTRY_LOG_LEVEL[level] ?? 'info',
+            sanitizeForLogging(formattedMessage),
+            asLogAttributes(effectiveParams),
+        )
     }
 
     error(params: LogParams): void {

--- a/packages/shared/src/utils/monitoring/sentry.spec.ts
+++ b/packages/shared/src/utils/monitoring/sentry.spec.ts
@@ -9,8 +9,8 @@ const setContextMock = jest.fn()
 
 const setUserMock = jest.fn()
 const setTagMock = jest.fn()
-// O de verdade cria um escopo isolado; aqui basta executar `fn` para poder observar o que
-// foi setado DENTRO dele.
+// The real one creates an isolated scope; here it is enough to run `fn` so we can observe
+// what was set INSIDE it.
 const withIsolationScopeMock = jest.fn(<T>(fn: () => T): T => fn())
 
 jest.mock('@sentry/node', () => ({
@@ -405,36 +405,36 @@ describe('withSentryRequestScope', () => {
         withIsolationScopeMock.mockClear()
     })
 
-    it('roda dentro de um escopo ISOLADO', () => {
+    it('runs inside an ISOLATED scope', () => {
         withSentryRequestScope({ userId: 'u1' }, () => undefined)
 
         expect(withIsolationScopeMock).toHaveBeenCalledTimes(1)
     })
 
-    // O que as issues nao sabiam responder: quantas PESSOAS um erro atingiu (`Users: 0`).
-    it('identifica pelo id, e SO pelo id', () => {
+    // What the issues could not answer: how many PEOPLE an error hit (`Users: 0`).
+    it('identifies by id, and by id ONLY', () => {
         withSentryRequestScope(
             { userId: 'u1', guildId: 'g9', correlationId: 'cid' },
             () => undefined,
         )
 
         expect(setUserMock).toHaveBeenCalledWith({ id: 'u1' })
-        // Sem username, sem e-mail, sem ip: `sendDefaultPii` continua false e isto nao
-        // pode ser a porta dos fundos por onde PII sai.
-        const [enviado] = setUserMock.mock.calls[0] as [Record<string, unknown>]
-        expect(Object.keys(enviado)).toEqual(['id'])
+        // No username, no email, no ip: `sendDefaultPii` stays false and this must not
+        // become the back door PII leaves through.
+        const [sent] = setUserMock.mock.calls[0] as [Record<string, unknown>]
+        expect(Object.keys(sent)).toEqual(['id'])
         expect(setTagMock).toHaveBeenCalledWith('guildId', 'g9')
         expect(setTagMock).toHaveBeenCalledWith('correlationId', 'cid')
     })
 
-    // Interacao sem servidor (DM) nao pode carimbar guildId vazio.
-    it('nao seta o que nao existe', () => {
+    // An interaction with no guild (DM) must not stamp an empty guildId.
+    it('does not set what does not exist', () => {
         withSentryRequestScope({ userId: 'u1' }, () => undefined)
 
         expect(setTagMock).not.toHaveBeenCalled()
     })
 
-    it('devolve o valor de fn', () => {
+    it('returns the value of fn', () => {
         expect(withSentryRequestScope({}, () => 42)).toBe(42)
     })
 })

--- a/packages/shared/src/utils/monitoring/sentry.spec.ts
+++ b/packages/shared/src/utils/monitoring/sentry.spec.ts
@@ -7,6 +7,12 @@ const flushMock = jest.fn<(timeout?: number) => Promise<boolean>>()
 const addBreadcrumbMock = jest.fn()
 const setContextMock = jest.fn()
 
+const setUserMock = jest.fn()
+const setTagMock = jest.fn()
+// O de verdade cria um escopo isolado; aqui basta executar `fn` para poder observar o que
+// foi setado DENTRO dele.
+const withIsolationScopeMock = jest.fn(<T>(fn: () => T): T => fn())
+
 jest.mock('@sentry/node', () => ({
     captureException: captureExceptionMock,
     captureMessage: captureMessageMock,
@@ -14,6 +20,15 @@ jest.mock('@sentry/node', () => ({
     flush: flushMock,
     addBreadcrumb: addBreadcrumbMock,
     setContext: setContextMock,
+    setUser: setUserMock,
+    setTag: setTagMock,
+    withIsolationScope: withIsolationScopeMock,
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
 }))
 
 jest.mock('../general/log', () => ({
@@ -30,6 +45,7 @@ import {
     addBreadcrumb,
     monitorCommandExecution,
     monitorInteractionHandling,
+    withSentryRequestScope,
 } from './sentry'
 
 describe('sentry monitoring', () => {
@@ -379,5 +395,46 @@ describe('sentry monitoring', () => {
             expect(captured).toBe(true)
             expect(captureMessageMock).toHaveBeenCalledTimes(1)
         })
+    })
+})
+
+describe('withSentryRequestScope', () => {
+    beforeEach(() => {
+        setUserMock.mockClear()
+        setTagMock.mockClear()
+        withIsolationScopeMock.mockClear()
+    })
+
+    it('roda dentro de um escopo ISOLADO', () => {
+        withSentryRequestScope({ userId: 'u1' }, () => undefined)
+
+        expect(withIsolationScopeMock).toHaveBeenCalledTimes(1)
+    })
+
+    // O que as issues nao sabiam responder: quantas PESSOAS um erro atingiu (`Users: 0`).
+    it('identifica pelo id, e SO pelo id', () => {
+        withSentryRequestScope(
+            { userId: 'u1', guildId: 'g9', correlationId: 'cid' },
+            () => undefined,
+        )
+
+        expect(setUserMock).toHaveBeenCalledWith({ id: 'u1' })
+        // Sem username, sem e-mail, sem ip: `sendDefaultPii` continua false e isto nao
+        // pode ser a porta dos fundos por onde PII sai.
+        const [enviado] = setUserMock.mock.calls[0] as [Record<string, unknown>]
+        expect(Object.keys(enviado)).toEqual(['id'])
+        expect(setTagMock).toHaveBeenCalledWith('guildId', 'g9')
+        expect(setTagMock).toHaveBeenCalledWith('correlationId', 'cid')
+    })
+
+    // Interacao sem servidor (DM) nao pode carimbar guildId vazio.
+    it('nao seta o que nao existe', () => {
+        withSentryRequestScope({ userId: 'u1' }, () => undefined)
+
+        expect(setTagMock).not.toHaveBeenCalled()
+    })
+
+    it('devolve o valor de fn', () => {
+        expect(withSentryRequestScope({}, () => 42)).toBe(42)
     })
 })

--- a/packages/shared/src/utils/monitoring/sentry.ts
+++ b/packages/shared/src/utils/monitoring/sentry.ts
@@ -221,12 +221,25 @@ export function initializeSentry(options: InitializeSentryOptions = {}): void {
         tracesSampleRate,
         profilesSampleRate,
         integrations: [],
+        // Os ~1160 infoLog/warnLog/debugLog do codigo so viravam BREADCRUMB, e breadcrumb
+        // aparece anexado a um evento de erro: sem erro, nada disso existia no Sentry. Com
+        // isto, o log vira registro proprio, consultavel por conta propria.
+        enableLogs: true,
         initialScope: {
             tags: getSentryTags(options, appName, serviceName),
         },
         beforeSend(event) {
             event.extra = getSanitizedExtra(event.extra)
             return event
+        },
+        // `beforeSend` NAO roda para log: log tem hook proprio. Sem esta linha, os
+        // atributos escapariam a sanitizacao que o evento de erro ja recebe, e ligar logs
+        // teria aberto um caminho novo para dado sensivel sair.
+        beforeSendLog(log) {
+            log.attributes = getSanitizedExtra(
+                log.attributes as Record<string, unknown> | undefined,
+            ) as typeof log.attributes
+            return log
         },
     })
 
@@ -310,5 +323,24 @@ export function monitorInteractionHandling(
             userId,
             guildId,
         })
+    }
+}
+
+/**
+ * Emite um LOG estruturado para o Sentry, separado do evento de erro.
+ *
+ * Existe para o logger do `shared` ter um ponto unico de saida, em vez de cada um dos ~1160
+ * call sites conhecer o SDK. Silencioso por construcao: telemetria que derruba o processo
+ * seria pior que a ausencia dela.
+ */
+export function logToSentry(
+    level: 'debug' | 'info' | 'warn' | 'error',
+    message: string,
+    attributes?: Record<string, unknown>,
+): void {
+    try {
+        Sentry.logger[level](message, attributes)
+    } catch {
+        // ignorado de proposito: ver o comentario acima
     }
 }

--- a/packages/shared/src/utils/monitoring/sentry.ts
+++ b/packages/shared/src/utils/monitoring/sentry.ts
@@ -344,3 +344,31 @@ export function logToSentry(
         // ignorado de proposito: ver o comentario acima
     }
 }
+
+/**
+ * Roda `fn` num escopo ISOLADO do Sentry, com quem disparou a interacao.
+ *
+ * O isolamento nao e detalhe: `Sentry.setUser` no escopo global vale para o processo
+ * inteiro, e o bot atende varios servidores ao mesmo tempo. Sem isto, o erro de um usuario
+ * sairia carimbado com o id de outro que passou por ali no meio, o que e pior que nao ter
+ * usuario nenhum: dado errado com cara de dado certo.
+ *
+ * **So o `id` viaja.** Nada de username, nickname, avatar ou e-mail, e `sendDefaultPii`
+ * segue `false`. O id do Discord ja aparece em qualquer mencao, e e o que o Sentry precisa
+ * para contar quantas PESSOAS distintas um erro atingiu, que era a pergunta sem resposta
+ * enquanto as issues diziam `Users: 0`.
+ *
+ * Se um dia isso precisar ser anonimo, o ponto de troca e uma linha: passar um hash do id
+ * em vez do id. A contagem de unicos continua valendo; a investigacao individual, nao.
+ */
+export function withSentryRequestScope<T>(
+    ctx: { userId?: string; guildId?: string; correlationId?: string },
+    fn: () => T,
+): T {
+    return Sentry.withIsolationScope(() => {
+        if (ctx.userId) Sentry.setUser({ id: ctx.userId })
+        if (ctx.guildId) Sentry.setTag('guildId', ctx.guildId)
+        if (ctx.correlationId) Sentry.setTag('correlationId', ctx.correlationId)
+        return fn()
+    })
+}

--- a/packages/shared/src/utils/monitoring/sentry.ts
+++ b/packages/shared/src/utils/monitoring/sentry.ts
@@ -221,9 +221,10 @@ export function initializeSentry(options: InitializeSentryOptions = {}): void {
         tracesSampleRate,
         profilesSampleRate,
         integrations: [],
-        // Os ~1160 infoLog/warnLog/debugLog do codigo so viravam BREADCRUMB, e breadcrumb
-        // aparece anexado a um evento de erro: sem erro, nada disso existia no Sentry. Com
-        // isto, o log vira registro proprio, consultavel por conta propria.
+        // The ~1160 infoLog/warnLog/debugLog calls only became BREADCRUMBS, and a
+        // breadcrumb shows up attached to an error event: with no error, none of it
+        // existed in Sentry. With this, a log becomes a record of its own, queryable on
+        // its own.
         enableLogs: true,
         initialScope: {
             tags: getSentryTags(options, appName, serviceName),
@@ -232,9 +233,9 @@ export function initializeSentry(options: InitializeSentryOptions = {}): void {
             event.extra = getSanitizedExtra(event.extra)
             return event
         },
-        // `beforeSend` NAO roda para log: log tem hook proprio. Sem esta linha, os
-        // atributos escapariam a sanitizacao que o evento de erro ja recebe, e ligar logs
-        // teria aberto um caminho novo para dado sensivel sair.
+        // `beforeSend` does NOT run for logs: logs have their own hook. Without this,
+        // attributes would skip the sanitisation error events already get, and enabling
+        // logs would have opened a fresh path for sensitive data to leave.
         beforeSendLog(log) {
             log.attributes = getSanitizedExtra(
                 log.attributes as Record<string, unknown> | undefined,
@@ -327,11 +328,11 @@ export function monitorInteractionHandling(
 }
 
 /**
- * Emite um LOG estruturado para o Sentry, separado do evento de erro.
+ * Emits a structured LOG to Sentry, separate from the error event.
  *
- * Existe para o logger do `shared` ter um ponto unico de saida, em vez de cada um dos ~1160
- * call sites conhecer o SDK. Silencioso por construcao: telemetria que derruba o processo
- * seria pior que a ausencia dela.
+ * It exists so the shared logger has a single exit point, instead of each of the ~1160
+ * call sites knowing about the SDK. Silent by construction: telemetry that takes the
+ * process down would be worse than no telemetry.
  */
 export function logToSentry(
     level: 'debug' | 'info' | 'warn' | 'error',
@@ -341,25 +342,25 @@ export function logToSentry(
     try {
         Sentry.logger[level](message, attributes)
     } catch {
-        // ignorado de proposito: ver o comentario acima
+        // swallowed on purpose: see the note above
     }
 }
 
 /**
- * Roda `fn` num escopo ISOLADO do Sentry, com quem disparou a interacao.
+ * Runs `fn` in an ISOLATED Sentry scope carrying whoever triggered the interaction.
  *
- * O isolamento nao e detalhe: `Sentry.setUser` no escopo global vale para o processo
- * inteiro, e o bot atende varios servidores ao mesmo tempo. Sem isto, o erro de um usuario
- * sairia carimbado com o id de outro que passou por ali no meio, o que e pior que nao ter
- * usuario nenhum: dado errado com cara de dado certo.
+ * The isolation is not a detail: `Sentry.setUser` on the global scope applies process-wide,
+ * and the bot serves many guilds at the same time. Without it, one user's error would be
+ * stamped with another user's id, which is worse than having no user at all: wrong data
+ * wearing the face of right data.
  *
- * **So o `id` viaja.** Nada de username, nickname, avatar ou e-mail, e `sendDefaultPii`
- * segue `false`. O id do Discord ja aparece em qualquer mencao, e e o que o Sentry precisa
- * para contar quantas PESSOAS distintas um erro atingiu, que era a pergunta sem resposta
- * enquanto as issues diziam `Users: 0`.
+ * **Only the `id` travels.** No username, nickname, avatar or email, and `sendDefaultPii`
+ * stays `false`. A Discord id already shows up in any mention, and it is what Sentry needs
+ * to count how many distinct PEOPLE an error hit, which was the question left unanswered
+ * while every issue read `Users: 0`.
  *
- * Se um dia isso precisar ser anonimo, o ponto de troca e uma linha: passar um hash do id
- * em vez do id. A contagem de unicos continua valendo; a investigacao individual, nao.
+ * If this ever has to be anonymous, the swap is one line: pass a hash of the id instead.
+ * Unique counts still hold; per-user investigation does not.
  */
 export function withSentryRequestScope<T>(
     ctx: { userId?: string; guildId?: string; correlationId?: string },


### PR DESCRIPTION
The bot had two of the three observability layers and was missing the one you actually
need day to day: **errors** (Sentry, 10 issues / 1600+ events) and **metrics**
(`prom-client` + Prometheus + Grafana) were in place, but nothing answered *"what happened
during this request?"*.

## 1. Sentry Logs, wired to the ~1160 log calls that already existed

The project was never missing structured logging: 562 `errorLog`, 340 `debugLog`, 170
`infoLog`, 88 `warnLog`, behind a mature module in `shared/utils/general/log/`. Only
`error()` raised an event; `warn`, `info`, `success` and `debug` produced **breadcrumbs
only**, and a breadcrumb is attached to an error event, so with no error none of it existed
in Sentry.

No new dependency. The installed SDK is already 10.70.0, where `enableLogs` is a top-level
option (`_experiments.enableLogs` is deprecated) and `beforeSendLog` exists.

Emission sits at a **single point**, the private `LogService.log` every level passes
through, not at the ~1160 call sites. It runs **after `shouldLog`**, so the configured
level still rules: with debug off in production, those 340 `debugLog` calls do not travel.

**`beforeSend` does not run for logs** — logs have their own hook. Without `beforeSendLog`,
attributes would skip the sanitisation error events already get, and enabling logs would
have opened a fresh path for sensitive data to leave. It reuses the existing
`getSanitizedExtra`.

## 2. Per-interaction scope: user, guild, correlation id

Every issue read `Users: 0`, so there was no way to tell whether an error hit one person or
a thousand, one guild or all of them.

`handleInteractionCreate` is the funnel every interaction goes through, so the scope starts
there and covers everything downstream.

**The isolation is the part that matters most.** `Sentry.setUser` on the global scope
applies process-wide, and the bot serves many guilds concurrently. Without
`withIsolationScope`, one user's error would be stamped with another user's id — wrong data
wearing the face of right data, which is worse than `Users: 0`.

**Only the `id` travels.** No username, nickname, avatar or email; `sendDefaultPii` stays
`false`. A test pins this down with `expect(Object.keys(sent)).toEqual(['id'])`. If this
ever needs to be anonymous, the swap is one line: pass a hash instead of the id. Unique
counts survive; per-user investigation does not.

Two orphans came into use along the way: `runWithLogContext` existed with `AsyncLocalStorage`
ready and **had never been called by anyone**, and `LogContext` already declared exactly
`correlationId`, `guildId` and `userId`. The ~1160 log calls are now correlated with no
change at any call site.

## 3. Top.gg 401 stops the scheduler instead of retrying forever

Sentry `LUCKY-62`: `Top.gg stats POST failed: Unauthorized (status 401)`, **109 events over
two days**, still firing, last one 12 minutes before I looked.

Every `!response.ok` took the same path, so a permanent 401 got a transient 503's retry:
every 30 minutes, forever. A rejected credential does not heal on retry, and that noise
buries the errors a retry *can* fix.

401 and 403 now stop the scheduler and report **once**, at `error` level rather than
`warning`: this needs a human to rotate the token, and a warning nobody acts on is the same
as no signal. It mirrors the shape the file already used for a missing `TOPGG_TOKEN`.

**This stops the bleeding, it does not fix the cause:** `TOPGG_TOKEN` in production is
rejected and needs rotating in the top.gg dashboard.

## Tests

| suite | result |
|---|---|
| `shared` | 1489 passed, 76 suites |
| `bot` | 3204 passed, 248 suites |
| typecheck | all four packages, via pre-commit |

Ten new tests, and several are counter-proofs on purpose:

- `500` keeps retrying — without it, "stop on 401" could silently become "stop on anything"
- a disabled level does **not** travel — otherwise 340 `debugLog` calls would ship in production
- the log message is sanitised, no newline (log injection, same reason as the console)
- `setUser` sends the id and nothing else

Mocks of `../../monitoring` and `@lucky/shared/utils` were updated: a mock that does not
match the real interface breaks at runtime, which is what 35 and then 9 failing tests
reported.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously only `error` logs reached Sentry, every issue showed `Users: 0`, and a Top.gg 401 retried every 30 minutes forever (Sentry LUCKY-62). Now `warn`, `info`, `success`, and `debug` logs are sent, interactions carry user/guild/correlation context, and 401/403 stop the scheduler and report once.

**Sentry logs and interaction scope**
- Logs are emitted from `LogService.log` after the configured level check, so disabled levels don't travel.
- `beforeSendLog` sanitizes log attributes because `beforeSend` doesn't run for logs.
- `handleInteractionCreate` wraps every interaction in an isolated Sentry scope and sends only the user id.
- `runWithLogContext` was already implemented but never called; now all ~1160 log calls are correlated without call-site changes.

**Top.gg 401 backoff**
- 401 and 403 are reported at `error` level instead of `warning`.
- 500 and other transient errors still retry.
- The production `TOPGG_TOKEN` is rejected and needs rotating in the Top.gg dashboard.

<sup>Written for commit 79b37e66940d6758db8db1ad54fdfa2e2ed7ce47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

