### PR TITLE
feat(observability): log requested query, fix silent catches

### DIFF
--- a/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.spec.ts
@@ -325,7 +325,11 @@ describe('preferExactMatch', () => {
         expect(result.setTracks).toHaveBeenCalledWith([tracks[1], tracks[0]])
     })
 
-    it('does not stamp requestedQuery for a URL query', async () => {
+    it.each([
+        ['https://open.spotify.com/track/abc123'],
+        ['HTTP://open.spotify.com/track/abc123'],
+        ['  https://open.spotify.com/track/abc123'],
+    ])('does not stamp requestedQuery for a URL query: %s', async (query) => {
         const tracks = [makeMockTrack('Adicto', 'Prince Royce')]
         const result = {
             hasPlaylist: () => false,
@@ -333,9 +337,7 @@ describe('preferExactMatch', () => {
             setTracks: jest.fn(() => result),
         }
 
-        await preferExactMatch('https://open.spotify.com/track/abc123')(
-            result as any,
-        )
+        await preferExactMatch(query)(result as any)
 
         expect(tracks[0].setMetadata).not.toHaveBeenCalled()
     })

--- a/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.spec.ts
@@ -299,11 +299,15 @@ describe('resolveQueryWithFallbacks', () => {
     })
 })
 
+function makeMockTrack(title: string, author: string) {
+    return { title, author, metadata: null, setMetadata: jest.fn() }
+}
+
 describe('preferExactMatch', () => {
     it('promotes a track whose author exactly matches the query', async () => {
         const tracks = [
-            { title: 'Adicto', author: 'Prince Royce' },
-            { title: 'Purple Rain', author: 'Prince' },
+            makeMockTrack('Adicto', 'Prince Royce'),
+            makeMockTrack('Purple Rain', 'Prince'),
         ]
         const result = {
             hasPlaylist: () => false,
@@ -313,16 +317,18 @@ describe('preferExactMatch', () => {
 
         await preferExactMatch('Prince')(result as any)
 
-        expect(result.setTracks).toHaveBeenCalledWith([
-            { title: 'Purple Rain', author: 'Prince' },
-            { title: 'Adicto', author: 'Prince Royce' },
-        ])
+        for (const track of tracks) {
+            expect(track.setMetadata).toHaveBeenCalledWith({
+                requestedQuery: 'Prince',
+            })
+        }
+        expect(result.setTracks).toHaveBeenCalledWith([tracks[1], tracks[0]])
     })
 
     it('promotes a track whose title exactly matches the query', async () => {
         const tracks = [
-            { title: 'Some Other Song', author: 'Someone Else' },
-            { title: 'prince', author: 'A Tribute Band' },
+            makeMockTrack('Some Other Song', 'Someone Else'),
+            makeMockTrack('prince', 'A Tribute Band'),
         ]
         const result = {
             hasPlaylist: () => false,
@@ -332,16 +338,13 @@ describe('preferExactMatch', () => {
 
         await preferExactMatch('Prince')(result as any)
 
-        expect(result.setTracks).toHaveBeenCalledWith([
-            { title: 'prince', author: 'A Tribute Band' },
-            { title: 'Some Other Song', author: 'Someone Else' },
-        ])
+        expect(result.setTracks).toHaveBeenCalledWith([tracks[1], tracks[0]])
     })
 
     it('leaves the result untouched when no exact match exists', async () => {
         const tracks = [
-            { title: 'Bohemian Rhapsody', author: 'Queen' },
-            { title: 'Somebody to Love', author: 'Queen' },
+            makeMockTrack('Bohemian Rhapsody', 'Queen'),
+            makeMockTrack('Somebody to Love', 'Queen'),
         ]
         const result = {
             hasPlaylist: () => false,
@@ -359,8 +362,8 @@ describe('preferExactMatch', () => {
 
     it('leaves the result untouched when the exact match is already first', async () => {
         const tracks = [
-            { title: 'Purple Rain', author: 'Prince' },
-            { title: 'Adicto', author: 'Prince Royce' },
+            makeMockTrack('Purple Rain', 'Prince'),
+            makeMockTrack('Adicto', 'Prince Royce'),
         ]
         const result = {
             hasPlaylist: () => false,
@@ -373,10 +376,10 @@ describe('preferExactMatch', () => {
         expect(result.setTracks).not.toHaveBeenCalled()
     })
 
-    it('skips reordering for playlist results', async () => {
+    it('skips reordering for playlist results but still stamps requestedQuery', async () => {
         const tracks = [
-            { title: 'Adicto', author: 'Prince Royce' },
-            { title: 'Purple Rain', author: 'Prince' },
+            makeMockTrack('Adicto', 'Prince Royce'),
+            makeMockTrack('Purple Rain', 'Prince'),
         ]
         const result = {
             hasPlaylist: () => true,
@@ -387,6 +390,11 @@ describe('preferExactMatch', () => {
         await preferExactMatch('Prince')(result as any)
 
         expect(result.setTracks).not.toHaveBeenCalled()
+        for (const track of tracks) {
+            expect(track.setMetadata).toHaveBeenCalledWith({
+                requestedQuery: 'Prince',
+            })
+        }
     })
 })
 

--- a/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.spec.ts
@@ -325,6 +325,21 @@ describe('preferExactMatch', () => {
         expect(result.setTracks).toHaveBeenCalledWith([tracks[1], tracks[0]])
     })
 
+    it('does not stamp requestedQuery for a URL query', async () => {
+        const tracks = [makeMockTrack('Adicto', 'Prince Royce')]
+        const result = {
+            hasPlaylist: () => false,
+            tracks,
+            setTracks: jest.fn(() => result),
+        }
+
+        await preferExactMatch('https://open.spotify.com/track/abc123')(
+            result as any,
+        )
+
+        expect(tracks[0].setMetadata).not.toHaveBeenCalled()
+    })
+
     it('promotes a track whose title exactly matches the query', async () => {
         const tracks = [
             makeMockTrack('Some Other Song', 'Someone Else'),

--- a/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.ts
@@ -48,8 +48,7 @@ export function preferExactMatch(
         // so a "requestedQuery" full of a raw URL (repeated on every
         // playlist track) would be noise with no requested-vs-delivered
         // signal (#2134 review).
-        const isUrlQuery =
-            query.startsWith('http://') || query.startsWith('https://')
+        const isUrlQuery = /^https?:\/\//i.test(query.trim())
         if (!isUrlQuery) {
             for (const track of result.tracks) {
                 const existingMetadata =

--- a/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.ts
@@ -42,13 +42,25 @@ export function preferExactMatch(
     return async (result) => {
         // Stamps the original query onto every candidate track's metadata so
         // downstream logs can pair requested-vs-resolved title instead of
-        // just scanning resolved titles for remix/edit keywords.
-        for (const track of result.tracks) {
-            const existingMetadata =
-                track.metadata && typeof track.metadata === 'object'
-                    ? (track.metadata as Record<string, unknown>)
-                    : {}
-            track.setMetadata({ ...existingMetadata, requestedQuery: query })
+        // just scanning resolved titles for remix/edit keywords. Skipped for
+        // URL queries (direct link or playlist link) — a URL resolves to an
+        // exact known target, not a text-search that can drift to a remix,
+        // so a "requestedQuery" full of a raw URL (repeated on every
+        // playlist track) would be noise with no requested-vs-delivered
+        // signal (#2134 review).
+        const isUrlQuery =
+            query.startsWith('http://') || query.startsWith('https://')
+        if (!isUrlQuery) {
+            for (const track of result.tracks) {
+                const existingMetadata =
+                    track.metadata && typeof track.metadata === 'object'
+                        ? (track.metadata as Record<string, unknown>)
+                        : {}
+                track.setMetadata({
+                    ...existingMetadata,
+                    requestedQuery: query,
+                })
+            }
         }
 
         if (result.hasPlaylist() || result.tracks.length <= 1) return result

--- a/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.ts
+++ b/packages/bot/src/functions/music/commands/play/handlers/resolveProvider.ts
@@ -40,6 +40,17 @@ export function preferExactMatch(
     const normalizedQuery = query.trim().toLowerCase()
 
     return async (result) => {
+        // Stamps the original query onto every candidate track's metadata so
+        // downstream logs can pair requested-vs-resolved title instead of
+        // just scanning resolved titles for remix/edit keywords.
+        for (const track of result.tracks) {
+            const existingMetadata =
+                track.metadata && typeof track.metadata === 'object'
+                    ? (track.metadata as Record<string, unknown>)
+                    : {}
+            track.setMetadata({ ...existingMetadata, requestedQuery: query })
+        }
+
         if (result.hasPlaylist() || result.tracks.length <= 1) return result
 
         const bestIndex = result.tracks.findIndex((track) => {

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -133,7 +133,14 @@ export function normalizeSoundCloudUrl(url: string): string {
         if (!hasHost(parsed, 'soundcloud.com')) return url
         parsed.searchParams.delete('in')
         return parsed.toString()
-    } catch {
+    } catch (error) {
+        // Same reasoning as expandSoundCloudShortUrl above (#1994): warn, not
+        // debug, so a malformed URL reaching here leaves a trace instead of
+        // silently skipping normalization.
+        warnLog({
+            message: 'SoundCloud URL normalization failed, using original URL',
+            data: { originalUrl: url, error: String(error) },
+        })
         return url
     }
 }
@@ -171,7 +178,11 @@ export function normalizeYouTubeUrl(url: string): string {
         }
 
         return parsed.toString()
-    } catch {
+    } catch (error) {
+        warnLog({
+            message: 'YouTube URL normalization failed, using original URL',
+            data: { originalUrl: url, error: String(error) },
+        })
         return url
     }
 }

--- a/packages/bot/src/handlers/player/trackHandlers.ts
+++ b/packages/bot/src/handlers/player/trackHandlers.ts
@@ -237,8 +237,12 @@ const handlePlayerStart = async (
     try {
         evictOldEntries()
         trackStartTimes.set(trackStartKey(queue.guild.id, track.id), Date.now())
+        const requestedQuery = (
+            track.metadata as { requestedQuery?: string } | null
+        )?.requestedQuery
         infoLog({
             message: `Started playing "${track.title}" in ${queue.guild.name}`,
+            data: requestedQuery ? { requestedQuery } : undefined,
         })
         debugLog({ message: `Track URL: ${track.url}` })
         if (queue.node.volume !== constants.VOLUME)

--- a/packages/bot/src/services/musicManagement/queueRescue.spec.ts
+++ b/packages/bot/src/services/musicManagement/queueRescue.spec.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import type { Track, GuildQueue } from 'discord-player'
 
 const errorLogMock = jest.fn()
+const debugLogMock = jest.fn()
 const replenishQueueMock = jest.fn()
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: (...args: unknown[]) => errorLogMock(...args),
+    debugLog: (...args: unknown[]) => debugLogMock(...args),
 }))
 
 jest.mock('../../services/musicRecommendation/autoplay/replenisher', () => ({
@@ -180,6 +182,11 @@ describe('rescueQueue', () => {
         })
         expect(result.removedTracks).toBe(1)
         expect(result.keptTracks).toBe(0)
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Track resolvability probe failed',
+            }),
+        )
     })
 })
 

--- a/packages/bot/src/services/musicManagement/queueRescue.ts
+++ b/packages/bot/src/services/musicManagement/queueRescue.ts
@@ -1,5 +1,5 @@
 import { QueryType, type Track, type GuildQueue } from 'discord-player'
-import { errorLog } from '@lucky/shared/utils'
+import { errorLog, debugLog } from '@lucky/shared/utils'
 import { replenishQueue } from '../../services/musicRecommendation/autoplay/replenisher'
 
 const HISTORY_SEED_LIMIT = 3
@@ -44,7 +44,16 @@ async function probeTrackResolvable(
             ),
         ])
         return result !== null && result.tracks.length > 0
-    } catch {
+    } catch (error) {
+        // The timeout race resolves to `null` above rather than throwing, so
+        // reaching here means the probe itself errored (network blip,
+        // extractor crash) — not a confirmed "track is gone." Debug, not
+        // warn/error: one probe failing is expected occasionally and the
+        // rescue flow already errorLogs if it fails overall (#2134).
+        debugLog({
+            message: 'Track resolvability probe failed',
+            data: { query, error: String(error) },
+        })
         return false
     } finally {
         if (timeoutId) {

--- a/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
@@ -315,11 +315,13 @@ export async function searchLastFmQuery(
         }
     }
     if (hadError) {
-        // Warn only once all engines are exhausted AND at least one actually
-        // threw — an empty result with no errors is a genuine "no match",
-        // not a failure worth surfacing (#2134).
+        // Warn once engines are exhausted with no result AND at least one
+        // engine actually threw (not just "no match") — an empty result
+        // with zero errors is a genuine "no match", not a failure worth
+        // surfacing (#2134). This can fire when only *some* engines threw
+        // and the rest simply found nothing, hence "at least one", not "all".
         logAndWarn(
-            new Error('All search engines threw for this query'),
+            new Error('No engine produced results; at least one threw'),
             'lastFmSeeder.searchLastFmQuery.exhausted',
             { query },
         )

--- a/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
@@ -1,6 +1,7 @@
 import { QueryType, type Track, type GuildQueue } from 'discord-player'
 import type { User } from 'discord.js'
 import { lastFmLinkService } from '@lucky/shared/services'
+import { logAndSwallow, logAndWarn } from '@lucky/shared/utils/error'
 import {
     consumeLastFmSeedSlice,
     consumeBlendedSeedSlice,
@@ -288,6 +289,7 @@ export async function searchLastFmQuery(
         QueryType.YOUTUBE_SEARCH,
         QueryType.AUTO,
     ]
+    let hadError = false
     for (const engine of engines) {
         try {
             const result = await queue.player.search(query, {
@@ -302,9 +304,25 @@ export async function searchLastFmQuery(
                 )
                 .slice(0, SEARCH_RESULTS_LIMIT)
             if (tracks.length > 0) return tracks
-        } catch {
-            continue
+        } catch (err) {
+            // Debug per engine — a single engine failing while another
+            // succeeds is normal fallback, not worth alerting on.
+            hadError = true
+            logAndSwallow(err, 'lastFmSeeder.searchLastFmQuery', {
+                query,
+                engine: String(engine),
+            })
         }
+    }
+    if (hadError) {
+        // Warn only once all engines are exhausted AND at least one actually
+        // threw — an empty result with no errors is a genuine "no match",
+        // not a failure worth surfacing (#2134).
+        logAndWarn(
+            new Error('All search engines threw for this query'),
+            'lastFmSeeder.searchLastFmQuery.exhausted',
+            { query },
+        )
     }
     return []
 }

--- a/packages/bot/src/utils/music/duplicateDetection/duplicateChecker.ts
+++ b/packages/bot/src/utils/music/duplicateDetection/duplicateChecker.ts
@@ -135,7 +135,10 @@ export async function addTrackToHistory(
             .metadata
         const metadata =
             rawMetadata && typeof rawMetadata === 'object'
-                ? (rawMetadata as { isAutoplay?: boolean })
+                ? (rawMetadata as {
+                      isAutoplay?: boolean
+                      requestedQuery?: string
+                  })
                 : undefined
 
         await trackHistoryService.addTrackToHistory(
@@ -148,6 +151,7 @@ export async function addTrackToHistory(
                         ? track.duration
                         : String(track.duration),
                 url: track.url,
+                requestedQuery: metadata?.requestedQuery,
                 metadata: { isAutoplay: Boolean(metadata?.isAutoplay) },
             },
             guildId,

--- a/packages/shared/src/services/TrackHistoryService.ts
+++ b/packages/shared/src/services/TrackHistoryService.ts
@@ -21,6 +21,10 @@ export interface TrackHistoryInput {
     author: string
     duration: string
     url: string
+    /** Original search query, when known — logged alongside the resolved
+     * title so requested-vs-delivered mismatches (e.g. remix substitution)
+     * can be queried instead of guessed from the title alone. */
+    requestedQuery?: string
     metadata?: { isAutoplay?: boolean }
 }
 
@@ -121,6 +125,9 @@ export class TrackHistoryService {
 
             infoLog({
                 message: `Added track to history: ${track.title} in guild ${guildId}`,
+                data: track.requestedQuery
+                    ? { requestedQuery: track.requestedQuery }
+                    : undefined,
             })
             return true
         } catch (error) {
@@ -409,7 +416,10 @@ export class TrackHistoryService {
                     (trackCounts.get(row.trackId) ?? 0) + 1,
                 )
                 const normalizedArtist = row.author.toLowerCase().trim()
-                artistCounts.set(normalizedArtist, (artistCounts.get(normalizedArtist) ?? 0) + 1)
+                artistCounts.set(
+                    normalizedArtist,
+                    (artistCounts.get(normalizedArtist) ?? 0) + 1,
+                )
             }
 
             const trackIds = new Set<string>()

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -41,7 +41,29 @@ const TRANSITIVE = Symbol('transitive');
  * are accepted, so a new CVE in an already-listed package is not silently
  * inherited by the acceptance.
  */
-const ACCEPTED = {};
+const ACCEPTED = {
+    mysql2: {
+        reason:
+            'Transitive dep of prisma\'s bundled MySQL driver adapter. Lucky only ' +
+            'ever connects to Postgres (prisma/schema.prisma: provider = "postgresql") ' +
+            'so the vulnerable mysql_clear_password auth-downgrade path is never ' +
+            'exercised. No non-major fix exists: prisma@7.9.1 bundles mysql2@3.15.3, ' +
+            "and npm's suggested fix (`prisma@6.19.3`) is a major-version downgrade, " +
+            'not worth taking for a driver this app never uses.',
+        until: 'prisma ships a version bundling mysql2>=3.22.0 (tracked in #2136)',
+        advisories: {
+            1153173:
+                'GHSA-3f6p-5ww8-9rcr: MySQL2 auth plugin downgrade leaks plaintext credentials',
+        },
+    },
+    prisma: {
+        reason:
+            'Reported only as a consequence of the mysql2 finding above ' +
+            '(prisma\'s `via` is ["mysql2"], no advisory of its own).',
+        until: 'clears once mysql2 above is fixed/upgraded',
+        advisories: TRANSITIVE,
+    },
+};
 
 // The policy above is only worth something if every entry actually carries its
 // justification. Enforce it rather than trusting the comment.

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -51,6 +51,10 @@ const ACCEPTED = {
             "and npm's suggested fix (`prisma@6.19.3`) is a major-version downgrade, " +
             'not worth taking for a driver this app never uses.',
         until: 'prisma ships a version bundling mysql2>=3.22.0 (tracked in #2136)',
+        // If another production dependency ever pulls mysql2 in directly,
+        // that's a different exposure than "bundled inside an unused prisma
+        // driver adapter" — re-review before letting the exception cover it.
+        requireTransitive: true,
         advisories: {
             1153173:
                 'GHSA-3f6p-5ww8-9rcr: MySQL2 auth plugin downgrade leaks plaintext credentials',
@@ -120,6 +124,14 @@ for (const [name, vulnerability] of Object.entries(vulnerabilities)) {
 
     if (!entry) {
         blocking.push({ ...summary, why: 'not accepted' });
+        continue;
+    }
+
+    if (entry.requireTransitive && vulnerability.isDirect) {
+        blocking.push({
+            ...summary,
+            why: 'accepted only while transitive, but is now a direct production dependency',
+        });
         continue;
     }
 


### PR DESCRIPTION
## Summary
- Threads the original search query onto track metadata at resolution (`resolveProvider.ts`'s `afterSearch` hook) and into the "Started playing" / "Added track to history" logs, so requested-vs-delivered mismatches (e.g. remix substitution, #2133) can be queried instead of guessed from the resolved title alone.
- Fixes 3 catch blocks that dropped failure signal entirely (#2134): SoundCloud/YouTube URL normalization, last.fm autoplay seeding across all 3 search engines, and the queue-rescue resolvability probe.

Closes #2134. Related: #2133.

## Test plan
- [x] `npx tsc --noEmit` clean on `bot` and `shared`
- [x] `resolveProvider.spec.ts` (19 tests), `queryUtils.spec.ts`, `lastFmSeeder.spec.ts`, `queueRescue.spec.ts`, `duplicateChecker.spec.ts`, `trackHandlers.spec.ts`, `TrackHistoryService.spec.ts` — all passing
- [x] Broader sweep: `musicManagement` + `musicRecommendation` + `play` command specs — 820 passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads the original search query into track metadata and playback/history logs so requested-vs-delivered title mismatches can be queried instead of guessed from the resolved title alone. Also surfaces failures that three catch blocks previously swallowed and unblocks the security gate by accepting the `mysql2`/`prisma` npm audit findings — the vulnerable MySQL driver is never used since Lucky only connects via Postgres, and the acceptance only covers transitive usage (exit condition tracked in #2136). Closes #2134. Related: #2133.

**Bug Fixes**
- SoundCloud/YouTube URL normalization now logs a warning on failure instead of silently falling back to the original URL.
- last.fm autoplay seeding logs a per-engine debug on failure and a warning when no engine produces results and at least one threw.
- The queue-rescue resolvability probe logs a debug message when the probe errors, distinguishing network/extractor failures from confirmed unresolvable tracks.

**New Features**
- Stamps `requestedQuery` onto candidate tracks in `preferExactMatch`, including playlist results, but skips URL queries (matched case-insensitively with leading whitespace trimmed) that resolve to exact known targets.
- "Started playing" and "Added track to history" logs now include `requestedQuery` when available.

<sup>Written for commit ab80661f3e3245a2b63d960127dbbb07546e4095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

