### PR TITLE
fix(bot): refresh the soundcloud client id instead of trusting boot

### DIFF
--- a/packages/bot/src/handlers/player/playerFactory.ts
+++ b/packages/bot/src/handlers/player/playerFactory.ts
@@ -7,11 +7,10 @@ import {
     AttachmentExtractor,
 } from '@discord-player/extractor'
 import { SpotifyExtractor } from 'discord-player-spotify'
-import * as playdl from 'play-dl'
 import type { CustomClient } from '../../types'
 import { errorLog, infoLog, warnLog } from '@lucky/shared/utils'
 import { createResilientStream } from './streamBridge'
-import { withTimeout } from './withTimeout'
+import { refreshSoundCloudClientId } from './soundcloudMatcher'
 import { setExtractorDegraded } from './extractorHealth'
 
 type CreatePlayerParams = {
@@ -130,13 +129,9 @@ const registerRemainingExtractors = async (player: Player): Promise<void> => {
 
 const initPlayDlSoundCloud = async (): Promise<void> => {
     try {
-        const clientId = await withTimeout(
-            playdl.getFreeClientID(),
-            10_000,
-            'play-dl getFreeClientID',
-        )
-        await playdl.setToken({ soundcloud: { client_id: clientId } })
-        infoLog({ message: 'play-dl: SoundCloud client ID initialized' })
+        // Shared with the bridge's per-failure refresh (#2139) so the boot path
+        // and the recovery path cannot drift apart.
+        await refreshSoundCloudClientId()
     } catch (error) {
         warnLog({
             message:

--- a/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
@@ -24,6 +24,7 @@ import {
     streamViaSoundCloud,
     findMatchingSoundCloudResult,
     parseDurationString,
+    __resetSoundCloudRefreshStateForTests,
 } from './soundcloudMatcher.js'
 
 // ---------------------------------------------------------------------------
@@ -253,6 +254,7 @@ describe('findMatchingSoundCloudResult – duration matching', () => {
 describe('streamViaSoundCloud', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        __resetSoundCloudRefreshStateForTests()
         mockStream.mockResolvedValue({ stream: fakeReadable })
         mockGetFreeClientID.mockResolvedValue('fresh-client-id')
         mockSetToken.mockResolvedValue(undefined)
@@ -322,6 +324,7 @@ describe('streamViaSoundCloud', () => {
 describe('streamViaSoundCloud – client id refresh', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        __resetSoundCloudRefreshStateForTests()
         mockStream.mockResolvedValue({ stream: fakeReadable })
         mockGetFreeClientID.mockResolvedValue('fresh-client-id')
         mockSetToken.mockResolvedValue(undefined)
@@ -415,6 +418,24 @@ describe('streamViaSoundCloud – client id refresh', () => {
         releaseScrape('fresh-client-id')
 
         await expect(both).resolves.toEqual([fakeReadable, fakeReadable])
+        expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not scrape a second id for a failure right after a refresh', async () => {
+        // A deleted track or a socket blip lands in the same catch as an expired
+        // token. The first failure may scrape; the ones behind it must not.
+        mockSearch
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValueOnce([makeResult('Song Name', 210)])
+        await streamViaSoundCloud('song name', '3:30')
+        expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
+
+        mockSearch.mockRejectedValue(new Error('404 Not Found'))
+        await expect(streamViaSoundCloud('gone track', '3:30')).rejects.toThrow(
+            '404 Not Found',
+        )
+        // Still 1: the cooldown suppressed a second scrape, and the original
+        // error surfaced untouched instead of paying for a pointless retry.
         expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
     })
 })

--- a/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
@@ -4,10 +4,20 @@ import { PassThrough } from 'stream'
 // --- mocks ---
 const mockSearch = jest.fn()
 const mockStream = jest.fn()
+const mockGetFreeClientID = jest.fn()
+const mockSetToken = jest.fn()
+const mockInfoLog = jest.fn()
+const mockWarnLog = jest.fn()
 
 jest.mock('play-dl', () => ({
     search: (...args: unknown[]) => mockSearch(...args),
     stream: (...args: unknown[]) => mockStream(...args),
+    getFreeClientID: (...args: unknown[]) => mockGetFreeClientID(...args),
+    setToken: (...args: unknown[]) => mockSetToken(...args),
+}))
+jest.mock('@lucky/shared/utils', () => ({
+    infoLog: (...args: unknown[]) => mockInfoLog(...args),
+    warnLog: (...args: unknown[]) => mockWarnLog(...args),
 }))
 
 import {
@@ -242,7 +252,10 @@ describe('findMatchingSoundCloudResult – duration matching', () => {
 
 describe('streamViaSoundCloud', () => {
     beforeEach(() => {
+        jest.clearAllMocks()
         mockStream.mockResolvedValue({ stream: fakeReadable })
+        mockGetFreeClientID.mockResolvedValue('fresh-client-id')
+        mockSetToken.mockResolvedValue(undefined)
     })
 
     it('throws on empty query', async () => {
@@ -298,5 +311,110 @@ describe('streamViaSoundCloud', () => {
 
         // Verify that a stream is returned
         expect(result).toBe(fakeReadable)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// #2139 — the boot-scraped client id expires; the bridge must recover instead
+// of failing every fallback for the rest of the process lifetime.
+// ---------------------------------------------------------------------------
+
+describe('streamViaSoundCloud – client id refresh', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockStream.mockResolvedValue({ stream: fakeReadable })
+        mockGetFreeClientID.mockResolvedValue('fresh-client-id')
+        mockSetToken.mockResolvedValue(undefined)
+    })
+
+    it('refreshes the client id and retries once when search fails', async () => {
+        mockSearch
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValueOnce([makeResult('Song Name', 210)])
+
+        const result = await streamViaSoundCloud('song name', '3:30')
+
+        expect(result).toBe(fakeReadable)
+        expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
+        expect(mockSetToken).toHaveBeenCalledWith({
+            soundcloud: { client_id: 'fresh-client-id' },
+        })
+        expect(mockSearch).toHaveBeenCalledTimes(2)
+    })
+
+    it('refreshes the client id and retries once when stream creation fails', async () => {
+        mockSearch.mockResolvedValue([makeResult('Song Name', 210)])
+        mockStream
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValueOnce({ stream: fakeReadable })
+
+        const result = await streamViaSoundCloud('song name', '3:30')
+
+        expect(result).toBe(fakeReadable)
+        expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
+        expect(mockStream).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not refresh when the search succeeds but genuinely has no results', async () => {
+        mockSearch.mockResolvedValue([])
+
+        await expect(streamViaSoundCloud('song name', '3:30')).rejects.toThrow(
+            'SoundCloud: no results for "song name"',
+        )
+        expect(mockGetFreeClientID).not.toHaveBeenCalled()
+    })
+
+    it('does not refresh when the search succeeds but nothing validates', async () => {
+        mockSearch.mockResolvedValue([makeResult('Completely Different', 300)])
+
+        await expect(streamViaSoundCloud('song name', '3:30')).rejects.toThrow(
+            'SoundCloud: no validated match',
+        )
+        expect(mockGetFreeClientID).not.toHaveBeenCalled()
+    })
+
+    it('surfaces the original failure, not the refresh failure', async () => {
+        mockSearch.mockRejectedValue(new Error('401 Unauthorized'))
+        mockGetFreeClientID.mockRejectedValue(new Error('soundcloud.com down'))
+
+        await expect(streamViaSoundCloud('song name', '3:30')).rejects.toThrow(
+            '401 Unauthorized',
+        )
+        // One attempt only: the retry is skipped when recovery failed.
+        expect(mockSearch).toHaveBeenCalledTimes(1)
+    })
+
+    it('propagates the retry failure when the refreshed id is still rejected', async () => {
+        mockSearch.mockRejectedValue(new Error('401 Unauthorized'))
+
+        await expect(streamViaSoundCloud('song name', '3:30')).rejects.toThrow(
+            '401 Unauthorized',
+        )
+        expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
+        expect(mockSearch).toHaveBeenCalledTimes(2)
+    })
+
+    it('scrapes a single id when concurrent calls fail together', async () => {
+        mockSearch
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValue([makeResult('Song Name', 210)])
+
+        let releaseScrape: (id: string) => void = () => {}
+        mockGetFreeClientID.mockReturnValue(
+            new Promise<string>((resolve) => {
+                releaseScrape = resolve
+            }),
+        )
+
+        const both = Promise.all([
+            streamViaSoundCloud('song name', '3:30'),
+            streamViaSoundCloud('song name', '3:30'),
+        ])
+        await Promise.resolve()
+        releaseScrape('fresh-client-id')
+
+        await expect(both).resolves.toEqual([fakeReadable, fakeReadable])
+        expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
     })
 })

--- a/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.spec.ts
@@ -438,4 +438,22 @@ describe('streamViaSoundCloud – client id refresh', () => {
         // error surfaced untouched instead of paying for a pointless retry.
         expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
     })
+
+    it('throttles the next scrape even when the refresh itself failed', async () => {
+        // The case that matters most: soundcloud.com unreachable. If only a
+        // successful refresh started the cooldown, every following track would
+        // pay another full getFreeClientID timeout.
+        mockGetFreeClientID.mockRejectedValue(new Error('soundcloud.com down'))
+        mockSearch.mockRejectedValue(new Error('401 Unauthorized'))
+
+        await expect(streamViaSoundCloud('song name', '3:30')).rejects.toThrow(
+            '401 Unauthorized',
+        )
+        expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
+
+        await expect(streamViaSoundCloud('other song', '3:30')).rejects.toThrow(
+            '401 Unauthorized',
+        )
+        expect(mockGetFreeClientID).toHaveBeenCalledTimes(1)
+    })
 })

--- a/packages/bot/src/handlers/player/soundcloudMatcher.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.ts
@@ -11,6 +11,7 @@ type SoundCloudSearchResult = {
 
 const TITLE_MATCH_THRESHOLD = 0.75
 const CLIENT_ID_TIMEOUT_MS = 10_000
+const REFRESH_COOLDOWN_MS = 60_000
 
 /**
  * play-dl authenticates SoundCloud with an anonymous client id scraped from
@@ -23,6 +24,7 @@ const CLIENT_ID_TIMEOUT_MS = 10_000
  * otherwise scrape a new id per failure.
  */
 let refreshInFlight: Promise<void> | null = null
+let lastRefreshAt = 0
 
 export async function refreshSoundCloudClientId(): Promise<void> {
     refreshInFlight ??= (async () => {
@@ -33,12 +35,20 @@ export async function refreshSoundCloudClientId(): Promise<void> {
                 'play-dl getFreeClientID',
             )
             await playdl.setToken({ soundcloud: { client_id: clientId } })
+            lastRefreshAt = Date.now()
             infoLog({ message: 'play-dl: SoundCloud client ID initialized' })
         } finally {
             refreshInFlight = null
         }
     })()
     return refreshInFlight
+}
+
+// Test-only: the cooldown above is module-level state, so tests that assert on
+// the refresh path must reset it between cases instead of relying on run order.
+export function __resetSoundCloudRefreshStateForTests(): void {
+    refreshInFlight = null
+    lastRefreshAt = 0
 }
 
 /**
@@ -54,6 +64,16 @@ async function withClientIdRetry<T>(
     try {
         return await op()
     } catch (error) {
+        // Not every rejection is an expired token: a deleted track, a socket
+        // blip or a rate limit lands here too, and scraping a fresh id for each
+        // of those would make a queue of bad tracks pay a 10s stall per track.
+        // Classifying the error by message would be the obvious scope, but that
+        // couples recovery to play-dl's wording and silently stops working when
+        // it changes. A cooldown bounds the waste without reading the error:
+        // a genuinely stale token is fixed by the first refresh, and everything
+        // failing after it rethrows untouched.
+        if (Date.now() - lastRefreshAt < REFRESH_COOLDOWN_MS) throw error
+
         warnLog({
             message: `SoundCloud: ${label} failed, refreshing client ID and retrying once`,
             error,

--- a/packages/bot/src/handlers/player/soundcloudMatcher.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.ts
@@ -35,9 +35,13 @@ export async function refreshSoundCloudClientId(): Promise<void> {
                 'play-dl getFreeClientID',
             )
             await playdl.setToken({ soundcloud: { client_id: clientId } })
-            lastRefreshAt = Date.now()
             infoLog({ message: 'play-dl: SoundCloud client ID initialized' })
         } finally {
+            // Stamp the ATTEMPT, not the success. A refresh that fails (a 10s
+            // getFreeClientID timeout, soundcloud.com unreachable) has to
+            // throttle the next one too, or every following track pays that
+            // same 10s scrape, which is the stall the cooldown exists to stop.
+            lastRefreshAt = Date.now()
             refreshInFlight = null
         }
     })()

--- a/packages/bot/src/handlers/player/soundcloudMatcher.ts
+++ b/packages/bot/src/handlers/player/soundcloudMatcher.ts
@@ -1,5 +1,7 @@
 import * as playdl from 'play-dl'
 import type { Readable } from 'stream'
+import { infoLog, warnLog } from '@lucky/shared/utils'
+import { withTimeout } from './withTimeout'
 
 type SoundCloudSearchResult = {
     name: string
@@ -8,6 +10,63 @@ type SoundCloudSearchResult = {
 }
 
 const TITLE_MATCH_THRESHOLD = 0.75
+const CLIENT_ID_TIMEOUT_MS = 10_000
+
+/**
+ * play-dl authenticates SoundCloud with an anonymous client id scraped from
+ * soundcloud.com, and those ids rotate. #2139: the id was fetched once at boot
+ * and never refreshed, so once it expired every SoundCloud fallback stage
+ * failed for the rest of the process lifetime while the bot still reported
+ * healthy and logged nothing above debug level.
+ *
+ * Single-flight, because a queue that fails several tracks at once would
+ * otherwise scrape a new id per failure.
+ */
+let refreshInFlight: Promise<void> | null = null
+
+export async function refreshSoundCloudClientId(): Promise<void> {
+    refreshInFlight ??= (async () => {
+        try {
+            const clientId = await withTimeout(
+                playdl.getFreeClientID(),
+                CLIENT_ID_TIMEOUT_MS,
+                'play-dl getFreeClientID',
+            )
+            await playdl.setToken({ soundcloud: { client_id: clientId } })
+            infoLog({ message: 'play-dl: SoundCloud client ID initialized' })
+        } finally {
+            refreshInFlight = null
+        }
+    })()
+    return refreshInFlight
+}
+
+/**
+ * Runs a play-dl network call; on failure refreshes the client id once and
+ * retries. Only the play-dl calls are wrapped: the "no results" and "no
+ * validated match" rejections below are raised after a *successful* search, so
+ * a genuine miss never triggers a scrape.
+ */
+async function withClientIdRetry<T>(
+    op: () => Promise<T>,
+    label: string,
+): Promise<T> {
+    try {
+        return await op()
+    } catch (error) {
+        warnLog({
+            message: `SoundCloud: ${label} failed, refreshing client ID and retrying once`,
+            error,
+        })
+        try {
+            await refreshSoundCloudClientId()
+        } catch {
+            // Surface why the call actually failed, not why the recovery did.
+            throw error
+        }
+        return op()
+    }
+}
 
 export async function streamViaSoundCloud(
     query: string,
@@ -17,10 +76,14 @@ export async function streamViaSoundCloud(
         throw new Error('SoundCloud: empty query')
     }
 
-    const results = await playdl.search(query, {
-        source: { soundcloud: 'tracks' },
-        limit: 5,
-    })
+    const results = await withClientIdRetry(
+        () =>
+            playdl.search(query, {
+                source: { soundcloud: 'tracks' },
+                limit: 5,
+            }),
+        'search',
+    )
 
     if (!results.length) {
         throw new Error(`SoundCloud: no results for "${query}"`)
@@ -35,7 +98,10 @@ export async function streamViaSoundCloud(
 
     let scStream: Awaited<ReturnType<typeof playdl.stream>>
     try {
-        scStream = await playdl.stream(match.url)
+        scStream = await withClientIdRetry(
+            () => playdl.stream(match.url),
+            'stream',
+        )
     } catch (err) {
         throw new Error(
             `SoundCloud: stream creation failed for "${match.name}" — ${(err as Error).message}`,


### PR DESCRIPTION
Closes #2139.

## Problem

play-dl authenticates SoundCloud with an anonymous client id scraped from soundcloud.com, and those ids rotate. `playerFactory.ts` fetched one at boot and nothing ever refreshed it, so once it expired every SoundCloud fallback stage failed for the rest of the process lifetime. Since the fallback is what runs whenever yt-dlp misses, `/play` joined the voice channel and streamed nothing.

## Evidence

Prod container, up 34h, 72h of logs:

| line | count |
|---|---|
| `streamed via yt-dlp` | 168 |
| `falling back to SoundCloud` | 34 |
| SoundCloud successes | **0** |

Re-running the boot sequence in that same container with a fresh id worked immediately:

```
INIT_OK    ms=855  idlen=32
SEARCH_OK  ms=756  n=5  first=Michael Jackson - Human Nature
STREAM_OK  ms=527
```

So the code path was correct and only the token was stale.

## Change

`streamViaSoundCloud` refreshes the client id once and retries when a play-dl call fails.

- **Single-flight.** A queue that fails several tracks at once would otherwise scrape a new id per failure.
- **Only the play-dl network calls are wrapped.** The `no results` and `no validated match` rejections are raised *after* a successful search, so a genuine miss never triggers a scrape.
- **The original error survives a failed refresh.** Otherwise the reason the call failed gets replaced by the reason recovery failed, which is the opposite of what #2140 is about.
- **`playerFactory` boot init calls the same function**, so the boot path and the recovery path cannot drift. That orphaned its `play-dl` and `withTimeout` imports; both removed.

## Verification

Unit: 7 new tests. Confirmed they can actually fail: with the retry stubbed out, 4 of them go red (the other 3 are guards asserting a refresh is *not* triggered on a genuine miss, so they pass either way by construction).

Full bot suite: 248 suites, 3214 tests, 0 failures. `tsc --noEmit` clean, eslint clean, prettier clean.

End-to-end against the real failure mode rather than only the mocks. Seeded a deliberately expired id and ran the live play-dl:

```
seeded an expired client id
[WARN] SoundCloud: search failed, refreshing client ID and retrying once
[WARN] Error: Got 401 from the request
[INFO] play-dl: SoundCloud client ID initialized
RECOVERED ms=1983 stream=true
```

The 401 that was invisible in production now logs at warn level, and the bridge recovers in 1.98s.

## Not in this PR

- #2140 raises the fallback stage logs off `debugLog`, which is why this was undiagnosable.
- #2141 covers the 6s yt-dlp timeout that makes the fallback fire 16.8% of the time in the first place.
- #2142 and #2143 are unrelated findings from the same investigation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SoundCloud fallback streams failing permanently once the boot-scraped client ID expires. The bridge now refreshes the client ID once and retries when a play-dl call fails, and boot init uses the same shared refresh.

**Bug Fixes**
- Refresh is single-flight so concurrent failures scrape one ID.
- Only play-dl network calls trigger a refresh; genuine misses do not.
- A failed refresh surfaces the original error.
- Boot and recovery share the same refresh path so they can't drift.
- A 60s cooldown, stamped on the attempt, stops unrelated failures and failed refreshes from each paying for a scrape.

<sup>Written for commit c05f9f6892a6ea4a7536b8fcc11111d4d6964543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

