### PR TITLE
fix(bot): log the autoplay source breakdown on an empty pool

### DIFF
--- a/packages/bot/src/services/musicRecommendation/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/replenisher.spec.ts
@@ -226,6 +226,66 @@ describe('replenishQueue', () => {
         await result
     })
 
+    // #2146: production runs LOG_LEVEL=2, so the per-source breakdown that
+    // used to sit on the debug line below this warn was invisible exactly
+    // when it was needed. These pin it to the warn.
+    it('reports the per-source breakdown when no candidates are selected', async () => {
+        const { warnLog } = require('@lucky/shared/utils')
+        const queue = createGuildQueue()
+
+        await replenishQueue(queue)
+
+        const call = warnLog.mock.calls.find(
+            ([arg]: [{ message: string }]) =>
+                arg.message ===
+                'Autoplay: no candidates selected — queue may stall',
+        )
+        expect(call).toBeDefined()
+        expect(call[0].data).toEqual(
+            expect.objectContaining({
+                candidatePoolSize: 0,
+                sources: {
+                    recommendation: 0,
+                    seedSimilar: 0,
+                    lastfm: 0,
+                    fallback: 0,
+                    genre: 0,
+                },
+                hasRequester: false,
+            }),
+        )
+    })
+
+    it('distinguishes a collector that ran and found nothing from a skipped one', async () => {
+        const { warnLog } = require('@lucky/shared/utils')
+        const {
+            collectRecommendationCandidates,
+        } = require('./candidateCollector')
+        // Pool is non-empty, but nothing survives selection. Proves the
+        // breakdown reports real counts rather than a hardcoded zero.
+        collectRecommendationCandidates.mockResolvedValue(
+            new Map([
+                ['a', { track: createTrack() }],
+                ['b', { track: createTrack() }],
+            ]),
+        )
+        const queue = createGuildQueue({
+            metadata: { requestedBy: { id: 'u1' } },
+        } as Partial<GuildQueue>)
+
+        await replenishQueue(queue)
+
+        const call = warnLog.mock.calls.find(
+            ([arg]: [{ message: string }]) =>
+                arg.message ===
+                'Autoplay: no candidates selected — queue may stall',
+        )
+        expect(call).toBeDefined()
+        expect(call[0].data.candidatePoolSize).toBe(2)
+        expect(call[0].data.sources.recommendation).toBe(2)
+        expect(call[0].data.hasRequester).toBe(true)
+    })
+
     it('should serialize concurrent calls with locks', async () => {
         const queue = createGuildQueue()
 

--- a/packages/bot/src/services/musicRecommendation/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/replenisher.spec.ts
@@ -269,6 +269,9 @@ describe('replenishQueue', () => {
                 ['b', { track: createTrack() }],
             ]),
         )
+        const {
+            collectSeedSimilarCandidates,
+        } = require('./seedSimilarityCollector')
         const queue = createGuildQueue({
             metadata: { requestedBy: { id: 'u1' } },
         } as Partial<GuildQueue>)
@@ -281,8 +284,16 @@ describe('replenishQueue', () => {
                 'Autoplay: no candidates selected — queue may stall',
         )
         expect(call).toBeDefined()
+        // Counts are real, not hardcoded zeros.
         expect(call[0].data.candidatePoolSize).toBe(2)
         expect(call[0].data.sources.recommendation).toBe(2)
+
+        // And this is the distinction the breakdown exists to make. The seed
+        // collector is gated on a requester; here one is present, so it ran and
+        // legitimately found nothing. Its 0 therefore means "empty", not
+        // "skipped" — and hasRequester is what tells the two apart in the log.
+        expect(collectSeedSimilarCandidates).toHaveBeenCalled()
+        expect(call[0].data.sources.seedSimilar).toBe(0)
         expect(call[0].data.hasRequester).toBe(true)
     })
 

--- a/packages/bot/src/services/musicRecommendation/autoplay/replenisher.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/replenisher.ts
@@ -578,11 +578,21 @@ async function _replenishQueue(
         }
 
         if (enriched.length === 0) {
+            // The per-source breakdown has to ride on this warn, not on the
+            // debug below it: production runs LOG_LEVEL=2, so the debug is
+            // suppressed and an empty pool was indistinguishable from "which
+            // of the five collectors came back dry" (#2146).
             warnLog({
                 message: 'Autoplay: no candidates selected — queue may stall',
                 data: {
                     guildId: queue.guild.id,
                     candidatePoolSize: candidates.size,
+                    sources: sourcesCounts,
+                    autoplayMode,
+                    // Four of the five collectors are gated on a requester, so
+                    // a zero count means "skipped" rather than "found nothing"
+                    // when this is false. Without it the breakdown is ambiguous.
+                    hasRequester: Boolean(requestedBy),
                 },
             })
             replenishCounters.set(guildId, replenishCount + 1)


### PR DESCRIPTION
Refs #2146. Unblocks the diagnosis rather than fixing autoplay itself.

## Problem

`_replenishQueue` already tracks which of the five collectors contributed:

```ts
const sourcesCounts = { recommendation: 0, seedSimilar: 0, lastfm: 0, fallback: 0, genre: 0 }
```

but it was only emitted on the **success** path, at `debugLog`. Production runs `LOG_LEVEL=2`, so on the failure path the entire log was:

```
Autoplay: no candidates selected - queue may stall
{ guildId, candidatePoolSize: 0 }
```

Over 72h of production that warning fired **86 times, every one with a pool of exactly 0**, and there was no way to narrow it further from logs.

## Change

`sourcesCounts` and `autoplayMode` now ride on the warn itself.

Also adds `hasRequester`. Four of the five collectors are gated behind a resolvable requester (`replenisher.ts` lines 436, 455, 474, 554, plus the Spotify token at 352), so without it a zero is ambiguous between "the collector ran and found nothing" and "the collector was skipped" - which is the first fork anyone reading this log has to resolve.

## Tests

Two, **both confirmed to fail without the change** (removed the added fields, re-ran: `2 failed, 30 passed`).

The second one matters more than the first: it drives a **non-empty** pool that still yields no selection, so it pins the breakdown to real counts instead of passing on hardcoded zeros.

```
Test Suites: 2 passed
Tests:       32 passed
```

Full bot suite: 248 suites, 3210 tests, 0 failures. `tsc --noEmit` clean.

## Scope

Does not touch the stale `candidatePoolSize` local reported in #2147 (eslint already flags it as `no-useless-assignment`). The failure path reads `candidates.size` directly, so the numbers logged here are correct as-is.

Does not attempt to fix autoplay. The next step is to let this run for a day, read which collector reports 0, and fix that one - #2146 stays open until then.

## Note on merge order

The `Security` check will fail on this PR until #2148 lands. That failure is unrelated to this change; it hits every open PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2146 by moving the autoplay source breakdown onto the empty-pool warning so production logs (`LOG_LEVEL=2`, where the old debug log was suppressed) now show which collector came back dry.

Also adds `hasRequester` to the warning data: four of the five collectors are gated behind a resolvable requester, so without it a zero count was ambiguous between "ran and found nothing" and "was skipped".

Two tests cover the new fields; one drives a non-empty pool that still yields no selection, so it pins the breakdown to real counts and asserts a zero from a collector that ran rather than one that was skipped.

<sup>Written for commit f1f11bb8d9206d6ae6d4a0b2115c63d404fb2de1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

