### PR TITLE
ci: guard nested node_modules copies and lift vendor-state budget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,6 +204,9 @@ RUN --mount=type=cache,id=npm-build-stage-v4-${NPM_CACHE_KEY},target=/root/.npm,
 
 FROM deps-production-base AS deps-production-bot
 RUN npm prune --omit=dev --legacy-peer-deps
+# Same guard as deps-production-backend below: nested workspace node_modules
+# can hoist away between installs and COPY --from hard-fails on a missing dir.
+RUN mkdir -p packages/shared/node_modules packages/bot/node_modules
 
 FROM deps-production-base AS deps-production-backend
 RUN npm prune --omit=dev --legacy-peer-deps
@@ -212,7 +215,7 @@ RUN npm prune --omit=dev --legacy-peer-deps
 # installs with no source change (e.g. deepmerge-ts override regen dropped
 # it to zero). COPY --from of a nonexistent dir hard-fails the build, so
 # guarantee the dir exists — empty is harmless, real nested deps still copy.
-RUN mkdir -p packages/backend/node_modules
+RUN mkdir -p packages/backend/node_modules packages/shared/node_modules
 
 # Production stage — bot (full runtime with ffmpeg/opus/yt-dlp)
 FROM base-runtime AS production-bot

--- a/packages/frontend/.size-limit.json
+++ b/packages/frontend/.size-limit.json
@@ -32,7 +32,7 @@
     {
         "name": "Vendor State (gzip)",
         "path": "dist/assets/vendor-state-*.js",
-        "limit": "26.5 KB",
+        "limit": "27 KB",
         "gzip": true
     }
 ]


### PR DESCRIPTION
Refs #2164. Unblocks two of the three real failures on dependabot group #2168 (the third, prisma 7.10.0 mock typings, is a separate PR).

## Build backend

```
failed to calculate checksum of ref '/app/packages/shared/node_modules': not found
```

`Dockerfile` copies `packages/shared/node_modules` from the deps stages at two sites with no guard. Whether npm nests anything there depends on lockfile resolution and flips between installs (3 packages nested on main today; the #2168 lockfile hoists all of them). `deps-production-backend` already has `RUN mkdir -p packages/backend/node_modules` for exactly this reason; this PR extends the same guard to `packages/shared` in both production stages and to `packages/bot`. Empty dir is harmless, real nested deps still copy.

## Size Limit

Vendor State (gzip) is 196 B over its 26.5 KB budget on #2168 after minor bumps in the state vendor chunk. Lifted to 27 KB.

After merge, #2168 needs `@dependabot rebase`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker builds that failed when lockfile hoisting removed nested `node_modules`, and raises the frontend size limit so Dependabot group #2168 can pass.

The build now guards `packages/shared` in both production dependency stages and `packages/bot`; missing directories no longer fail `COPY --from`, empty ones stay harmless, and real nested deps still copy. The Vendor State gzip limit moves from 26.5 KB to 27 KB for the 196 B increase.

**Migration**
- After merge, run `@dependabot rebase` on the group; the Prisma 7.10.0 mock typings failure remains a separate PR.

<sup>Written for commit f2bf34092da709bbdbc6f23963328bb22252921b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

