### PR TITLE
fix(docker): bump bot image base to clear two high cves

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,16 @@ FROM node:${NODE_VERSION} AS base-runtime
 # yt-dlp is installed into a dedicated venv at /opt/ytdlp so we avoid
 # `--break-system-packages` (Alpine's PEP 668 marker). The venv binary
 # is symlinked into /usr/local/bin so callers don't need to know the path.
+# `apk upgrade` patches Alpine OS packages already present in the base image
+# (e.g. libexpat, pulled in as a python3 dependency) to the current package
+# index, closing CVE-2026-76641 / CVE-2026-66046 (libexpat < 2.8.4-r0).
 RUN apk add --no-cache \
     python3 \
     py3-pip \
     ffmpeg \
     opus \
     opus-tools \
+    && apk upgrade --no-cache \
     && python3 -m venv /opt/ytdlp \
     && /opt/ytdlp/bin/pip install --no-cache-dir --upgrade pip yt-dlp \
     && ln -s /opt/ytdlp/bin/yt-dlp /usr/local/bin/yt-dlp \


### PR DESCRIPTION
Closes #2159

Two open HIGH container-scan alerts on `lucassantana-dev/lucky-bot`:

- CVE-2026-76641
- CVE-2026-66046

## Investigation

```
gh api 'repos/LucasSantana-Dev/Lucky/code-scanning/alerts?state=open&severity=high&per_page=100' \
  --jq '.[]|select(.rule.id|test("76641|66046"))|{n:.number,rule:.rule.id,path:.most_recent_instance.location.path,msg:.most_recent_instance.message.text}'
```

Both alerts point at the same package:

```
Package: libexpat
Installed Version: 2.8.3-r0
Fixed Version: 2.8.4-r0
```

`libexpat` is an Alpine OS package, not an npm dependency, so `npm audit`/the audit gate never sees it. It is not `apk add`ed directly; it comes in transitively as a dependency of `python3`, which `base-runtime` installs (yt-dlp needs it). `production-bot` (the stage that becomes the `lucky-bot` image, per `.github/workflows/docker-publish.yml` and `ci.yml`) derives from `base-runtime`, so this is the image that ships the vulnerable package.

## Before / after

| | before | after |
|---|---|---|
| libexpat | 2.8.3-r0 | 2.8.4-r0 (current Alpine package index) |

## Fix

Added `apk upgrade --no-cache` to `base-runtime`'s existing `apk add` RUN layer in the root `Dockerfile`. This patches libexpat (and any other already-installed Alpine OS package) to the current package index at build time, without a base-image digest bump. This mirrors the identical fix already in the same `Dockerfile`'s `production-frontend` stage and in `Dockerfile.nginx`, both of which run `apk upgrade --no-cache` for the same class of Alpine OS-package CVE drift.

`deploy/fly/Dockerfile` does not exist in this repo; the only Dockerfile that builds the bot image is the root `Dockerfile` (`production-bot` target).

## Verification

Pulled the pinned base digest (`node:24-alpine@sha256:d32cdf6...`, the exact `NODE_VERSION` this Dockerfile uses) and confirmed the current Alpine package index already serves the fixed version, on both platforms CI/the homelab use:

```
docker run --rm node:24-alpine@sha256:d32cdf6... sh -c \
  "apk add --no-cache python3 py3-pip ffmpeg opus opus-tools; apk upgrade --no-cache; apk info libexpat"
# libexpat-2.8.4-r0
```
Reproduced on both `linux/arm64` and `linux/amd64` (`--platform linux/amd64`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `lucky-bot` image’s `base-runtime` stage to run `apk upgrade --no-cache`, replacing vulnerable Alpine `libexpat` 2.8.3-r0 with 2.8.4-r0 and clearing CVE-2026-76641 and CVE-2026-66046. The upgrade also patches other installed Alpine packages at build time without changing the base-image digest.

- `libexpat` is pulled in transitively by `python3`, so `npm audit` does not detect it.
- Verified `libexpat-2.8.4-r0` on both `linux/amd64` and `linux/arm64`.
- Closes #2159.

<sup>Written for commit f25b606cc906e6c7dbed3603d64ed17da748a00e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

