### PR TITLE
chore(deps): bump prisma, client and adapter-pg to 7.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
             ],
             "dependencies": {
                 "@discord-player/extractor": "^7.2.0",
-                "@prisma/adapter-pg": "^7.8.0",
-                "@prisma/client": "^7.8.0",
+                "@prisma/adapter-pg": "^7.10.0",
+                "@prisma/client": "^7.10.0",
                 "@snazzah/davey": "^0.1.11",
                 "bullmq": "^6",
                 "chalk": "^6.0.0",
@@ -22,7 +22,7 @@
                 "file-type": "^22.0.1",
                 "jintr": "^3.3.1",
                 "minipass-flush": "^2.0.0",
-                "prisma": "^7.8.0",
+                "prisma": "^7.10.0",
                 "prom-client": "^15.1.3",
                 "ws": "^8.21.0"
             },
@@ -6386,24 +6386,24 @@
             }
         },
         "node_modules/@prisma/adapter-pg": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.9.1.tgz",
-            "integrity": "sha512-Ho2RK1KanQxLNSC0sR5bpiiVep10sWPLXCcxK+KXfI/Q69TMRbiafSvLPv3V9snimX72rMCqGlyJ4sBO4lKTAw==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.10.0.tgz",
+            "integrity": "sha512-N7nwSor0HO1Kz6xBv0TPAjAPysKK0fac6p4fVN3ensLOuzc/83Fgmln5k92eK/cvzqdkSR/2kkAqlbcdwVrwpw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/driver-adapter-utils": "7.9.1",
+                "@prisma/driver-adapter-utils": "7.10.0",
                 "@types/pg": "^8.16.0",
                 "pg": "^8.16.3",
                 "postgres-array": "3.0.4"
             }
         },
         "node_modules/@prisma/client": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.9.1.tgz",
-            "integrity": "sha512-+xgrh2EhJVF79wC0yX5G4PI1Rdcm7Qn/nekNQ+t/O153wtNggruHal+fXHSa0QE+Tp/Cw5wvxeCEhZZ59xGm8Q==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.10.0.tgz",
+            "integrity": "sha512-Ubw/QS9JGIBSBUsyxAUQuK/Jcu0Tsva7le7QbLd91Kix9yJvYDdj5QkwgEbbZniH80dd+sziQcALPc+HnvQC8Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/client-runtime-utils": "7.9.1"
+                "@prisma/client-runtime-utils": "7.10.0"
             },
             "engines": {
                 "node": "^20.19 || ^22.12 || >=24.0"
@@ -6422,15 +6422,15 @@
             }
         },
         "node_modules/@prisma/client-runtime-utils": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.9.1.tgz",
-            "integrity": "sha512-mVIBGYdO5CFmK0HvjxrtfIyQQcPdb88pSCeVQriVQPVZyDovIWblpHfOgcS8QO187j3QF0ePArH8qPhp0AU2vg==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.10.0.tgz",
+            "integrity": "sha512-cnCy7lUV8/CctgKVEmqAbSLAmwqJdE/qAlqTBk/0NDk59zEb2cZ0M0M0E4vVPnqbSEYudRroQDvOWfUZH6RIfw==",
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/config": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.1.tgz",
-            "integrity": "sha512-4znKhxTmXmuPye9Z6pbIyYb5VZlkZ05qG1L6Dr4g+7oTwc6V50Bs9XirFBDdjWt+H/AabMn9aUnxBcvj8z05aA==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.10.0.tgz",
+            "integrity": "sha512-Rcg828gIRE3HOQ3pOATFjV5d/P0U9OIobxhd/IMxlfWjA4vru0eGwb0AIwFw0rmcLMVShohZYWPixVxkBHsxUA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "c12": "3.3.4",
@@ -6440,9 +6440,9 @@
             }
         },
         "node_modules/@prisma/debug": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
-            "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.10.0.tgz",
+            "integrity": "sha512-caygJKtltmRIgdJ3jRpkOr7yM4DW6zxo5uOmojKWFb3asnxWoRkQOwZmXBgD8FZp4htrX+nMpcWqDwzlQ1+Y4g==",
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/dev": {
@@ -6469,60 +6469,60 @@
             }
         },
         "node_modules/@prisma/driver-adapter-utils": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.9.1.tgz",
-            "integrity": "sha512-vmHehG7nn/heW32DXXpp13DxxAxVVe6n250oEt3dOL2E/4bt3olktKZN0mzSuxMMronyMSkbeW2uCOn3F4g8RQ==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.10.0.tgz",
+            "integrity": "sha512-u8zkcRLlaryO652T4qavBg0HmzNW5tSKdsCn6hc1PhWAp/J6k0vrxLuUs+b9o+HcjsK7Dfa01o4OFSn0frauJA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.1"
+                "@prisma/debug": "7.10.0"
             }
         },
         "node_modules/@prisma/engines": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.1.tgz",
-            "integrity": "sha512-UprXSMNXx2NF5ow4pqaQtE8OuBz6K78B0wc0tn2L28G5r933iWp1DR9Do2qWrsNvvFIP3x6mpEWnQtckMO0Uhg==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.10.0.tgz",
+            "integrity": "sha512-KNumN6NHFwybvfdYzTee9pqwx5PvknpWAaHn6L5NsbrKdl+SQrsVZs9opKs6U6SAsvB26HDt3WybRjOhgoWOYQ==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.1",
-                "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-                "@prisma/fetch-engine": "7.9.1",
-                "@prisma/get-platform": "7.9.1"
+                "@prisma/debug": "7.10.0",
+                "@prisma/engines-version": "7.10.0-4.0edf323efd1d98336f3f0a68684b56f689b900d3",
+                "@prisma/fetch-engine": "7.10.0",
+                "@prisma/get-platform": "7.10.0"
             }
         },
         "node_modules/@prisma/engines-version": {
-            "version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad.tgz",
-            "integrity": "sha512-2BsPPFksz3CQUXG6af3rVCtJKg6+JJGJTtfgu2fU8DdXhOfkBjulCq8mwybCd6ge0/jhZq2kOtLAbmUDMyI1nA==",
+            "version": "7.10.0-4.0edf323efd1d98336f3f0a68684b56f689b900d3",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.10.0-4.0edf323efd1d98336f3f0a68684b56f689b900d3.tgz",
+            "integrity": "sha512-8OJ6RuZTZ06eFUOtBwxVmv8XMmOW6HWN5F+uxUbZkGxR0Bfab1dfAdXaHPmR5mb59E+fmUo8IOzXlbLY1SClbw==",
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
-            "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.10.0.tgz",
+            "integrity": "sha512-0bra1LFYi8xNw0yqV62bHJNQk4BKleOngZiqPWIQc7a3+9q6rqsnqJ15BuepP8943PFMvtmgnP52juZsyYkA6w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.1"
+                "@prisma/debug": "7.10.0"
             }
         },
         "node_modules/@prisma/fetch-engine": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.1.tgz",
-            "integrity": "sha512-9DwxrNTeT25Orbu9CWh0CZvVlyY1lmscpbaeLZcOnuR7zcuFrt91YSmmOfIm7zJ08YOZ6mVzURKwLoMwEBcK8w==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.10.0.tgz",
+            "integrity": "sha512-Zqyu8DY14t6W/xwmAxUYWCXtHrvQnSvT644EAZSsdM8NSmCS74vJJbBKdVsK3ucFpnUWkEpbO1a0CxJXrg130g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.1",
-                "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-                "@prisma/get-platform": "7.9.1"
+                "@prisma/debug": "7.10.0",
+                "@prisma/engines-version": "7.10.0-4.0edf323efd1d98336f3f0a68684b56f689b900d3",
+                "@prisma/get-platform": "7.10.0"
             }
         },
         "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
-            "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.10.0.tgz",
+            "integrity": "sha512-0bra1LFYi8xNw0yqV62bHJNQk4BKleOngZiqPWIQc7a3+9q6rqsnqJ15BuepP8943PFMvtmgnP52juZsyYkA6w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.9.1"
+                "@prisma/debug": "7.10.0"
             }
         },
         "node_modules/@prisma/get-platform": {
@@ -11434,6 +11434,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11450,6 +11451,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11466,6 +11468,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -11482,6 +11485,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11498,6 +11502,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11514,6 +11519,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11530,6 +11536,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11546,6 +11553,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11562,6 +11570,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11578,6 +11587,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11594,6 +11604,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11610,6 +11621,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -15991,9 +16003,9 @@
             }
         },
         "node_modules/deepmerge-ts": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
-            "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+            "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
             "funding": [
                 {
                     "type": "ko-fi",
@@ -16006,7 +16018,7 @@
             ],
             "license": "BSD-3-Clause",
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=16.9.0"
             }
         },
         "node_modules/default-browser": {
@@ -23362,15 +23374,21 @@
             }
         },
         "node_modules/pkg-types": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-            "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.2.tgz",
+            "integrity": "sha512-v0sVXzj7oPGysr543YYZLYbcJNJsKikSsp/fFzoxQ12ewY3ZZr7oCPC8y7OlmxfYB3QPvriXmuPD8KZggE1vqg==",
             "license": "MIT",
             "dependencies": {
-                "confbox": "^0.2.4",
-                "exsolve": "^1.0.8",
+                "confbox": "^0.3.0",
+                "exsolve": "^1.1.1",
                 "pathe": "^2.0.3"
             }
+        },
+        "node_modules/pkg-types/node_modules/confbox": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+            "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
+            "license": "MIT"
         },
         "node_modules/play-audio": {
             "version": "0.5.2",
@@ -23652,15 +23670,15 @@
             }
         },
         "node_modules/prisma": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.1.tgz",
-            "integrity": "sha512-aPqePoZIqwlAchbgbFDO/wHqGB+7H1nj9gaM+OsL9h77S5S3TnLd9BgD3LnoeDikULo7cl2HSUrEyQ55Z7DYbg==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.10.0.tgz",
+            "integrity": "sha512-o0ornyJOWgygVAzGCpr8PdXV8EJLHyVGDDUr/voBQt8Azzw8cYTByzzPGcA/m4tCkPcnJA8raEOv2CslsKhPEw==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/config": "7.9.1",
+                "@prisma/config": "7.10.0",
                 "@prisma/dev": "0.24.17",
-                "@prisma/engines": "7.9.1",
+                "@prisma/engines": "7.10.0",
                 "@prisma/studio-core": "0.33.0",
                 "mysql2": "3.15.3",
                 "postgres": "3.4.7"
@@ -23861,12 +23879,12 @@
             }
         },
         "node_modules/rc9": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
-            "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.1.0.tgz",
+            "integrity": "sha512-ufjkNVzbRHKcCOmTahZkmVsyc3W+MSk3jY03m+a7tGHkIsdVMG9l10/3HvFbWkkKzY5VFp3pkRsIo/UYgmFL7Q==",
             "license": "MIT",
             "dependencies": {
-                "defu": "^6.1.6",
+                "defu": "^6.1.7",
                 "destr": "^2.0.5"
             }
         },
@@ -28690,7 +28708,7 @@
             "name": "@lucky/shared",
             "version": "2.17.0",
             "dependencies": {
-                "@prisma/client": "^7.8.0",
+                "@prisma/client": "^7.10.0",
                 "@sentry/node": "^10.68.0",
                 "axios": "^1.18.1",
                 "bullmq": "^6.0.9",

--- a/package.json
+++ b/package.json
@@ -111,8 +111,8 @@
     },
     "dependencies": {
         "@discord-player/extractor": "^7.2.0",
-        "@prisma/adapter-pg": "^7.8.0",
-        "@prisma/client": "^7.8.0",
+        "@prisma/adapter-pg": "^7.10.0",
+        "@prisma/client": "^7.10.0",
         "@snazzah/davey": "^0.1.11",
         "bullmq": "^6",
         "chalk": "^6.0.0",
@@ -120,7 +120,7 @@
         "file-type": "^22.0.1",
         "jintr": "^3.3.1",
         "minipass-flush": "^2.0.0",
-        "prisma": "^7.8.0",
+        "prisma": "^7.10.0",
         "prom-client": "^15.1.3",
         "ws": "^8.21.0"
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -87,7 +87,7 @@
         "lint:fix": "npm run lint -- --fix"
     },
     "dependencies": {
-        "@prisma/client": "^7.8.0",
+        "@prisma/client": "^7.10.0",
         "@sentry/node": "^10.68.0",
         "axios": "^1.18.1",
         "bullmq": "^6.0.9",


### PR DESCRIPTION
Refs #2164. Splits the Prisma part out of dependabot group #2168.

`prisma`, `@prisma/client`, `@prisma/adapter-pg` 7.9.1 -> 7.10.0 (declared `^7.8.0` -> `^7.10.0` in root and `packages/shared`).

## Evidence

With only this change on top of main:
- `packages/shared` tests: 76 suites, 1489 tests pass
- `npm run type:check`: clean across shared, bot, backend, frontend
- backend tests: 85 pass (one pre-existing flaky auth test, unrelated)

The `TS2345` mock failures on #2168 are caused by `jest` 30.4.2 -> 30.5.1, confirmed by installing only jest 30.5.1 on this branch and re-running the two specs (same errors). That gets its own PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `prisma`, `@prisma/client`, and `@prisma/adapter-pg` from 7.9.1 to 7.10.0 (`^7.8.0` -> `^7.10.0`) to isolate the Prisma change from dependabot group #2168.

- `packages/shared` type-checks and its 76 suites / 1489 tests pass.
- The TS2345 mock errors on #2168 are not caused by Prisma.

Refs #2164.

<sup>Written for commit c36c80ebddc63fc7a503239a8e0e65e335fdb639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

