### PR TITLE
fix(deps): sync lockfile with undici 7.29.1 so npm ci passes again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11434,6 +11434,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11450,6 +11451,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11466,6 +11468,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -11482,6 +11485,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11498,6 +11502,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11514,6 +11519,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11530,6 +11536,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11546,6 +11553,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11562,6 +11570,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11578,6 +11587,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11594,6 +11604,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11610,6 +11621,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -26997,9 +27009,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+            "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
@@ -28658,9 +28670,9 @@
             }
         },
         "packages/frontend/node_modules/undici": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-            "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+            "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
Every `npm ci` in CI fails since 14:27Z today on every PR, including docs-only ones:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.
npm error Invalid: lock file's undici@7.29.0 does not satisfy undici@7.29.1
```

Cause: undici 7.29.1 was published at 2026-09-04T14:25:11Z (`npm view undici time`). `package.json` overrides undici with the range `^7.29.0`, and npm 11 (CI runs Node 24) validates a ranged override against the newest published version during `npm ci`. No repository change was involved; local npm 10.9.8 does not reproduce it.

Fix: `npm update undici --package-lock-only`, lock entry 7.29.0 -> 7.29.1 (the frontend's nested undici 8.x moves one patch too).

Follow-up: ranged overrides are a repo-wide CI time-bomb under npm 11; tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the lockfile with `undici` 7.29.1 so `npm ci` passes again. The previous lock entry held `undici` 7.29.0, which no longer satisfies the `^7.29.0` override under npm 11 because it validates against the latest published version. Also bumps the frontend's nested `undici` 8.x to 8.10.2 as part of the lockfile update.

<sup>Written for commit 474b474c7d390f9bcf7f0769ed6adbf28452e6ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

