### PR TITLE
fix(docker): scope the apk upgrade to libexpat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,16 @@ FROM node:${NODE_VERSION} AS base-runtime
 # yt-dlp is installed into a dedicated venv at /opt/ytdlp so we avoid
 # `--break-system-packages` (Alpine's PEP 668 marker). The venv binary
 # is symlinked into /usr/local/bin so callers don't need to know the path.
+# `apk upgrade` patches Alpine OS packages already present in the base image
+# (e.g. libexpat, pulled in as a python3 dependency) to the current package
+# index, closing CVE-2026-76641 / CVE-2026-66046 (libexpat < 2.8.4-r0).
 RUN apk add --no-cache \
     python3 \
     py3-pip \
     ffmpeg \
     opus \
     opus-tools \
+    && apk upgrade --no-cache \
     && python3 -m venv /opt/ytdlp \
     && /opt/ytdlp/bin/pip install --no-cache-dir --upgrade pip yt-dlp \
     && ln -s /opt/ytdlp/bin/yt-dlp /usr/local/bin/yt-dlp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,16 +35,16 @@ FROM node:${NODE_VERSION} AS base-runtime
 # yt-dlp is installed into a dedicated venv at /opt/ytdlp so we avoid
 # `--break-system-packages` (Alpine's PEP 668 marker). The venv binary
 # is symlinked into /usr/local/bin so callers don't need to know the path.
-# `apk upgrade` patches Alpine OS packages already present in the base image
-# (e.g. libexpat, pulled in as a python3 dependency) to the current package
-# index, closing CVE-2026-76641 / CVE-2026-66046 (libexpat < 2.8.4-r0).
+# libexpat is pulled in as a python3 dependency; upgrade only that package
+# to the current index to close CVE-2026-76641 / CVE-2026-66046
+# (libexpat < 2.8.4-r0) without floating the rest of the digest-pinned base.
 RUN apk add --no-cache \
     python3 \
     py3-pip \
     ffmpeg \
     opus \
     opus-tools \
-    && apk upgrade --no-cache \
+    && apk upgrade --no-cache libexpat \
     && python3 -m venv /opt/ytdlp \
     && /opt/ytdlp/bin/pip install --no-cache-dir --upgrade pip yt-dlp \
     && ln -s /opt/ytdlp/bin/yt-dlp /usr/local/bin/yt-dlp \


### PR DESCRIPTION
Follow-up to #2183, which auto-merged while its cubic thread was being addressed.

`apk upgrade` with no package argument floats every Alpine OS package in the digest-pinned `node:24-alpine` base at build time, which the rest of the Dockerfile deliberately avoids. This scopes it to `apk upgrade --no-cache libexpat`, the only package the two CVEs (CVE-2026-76641, CVE-2026-66046, libexpat < 2.8.4-r0) touch.

Refs #2159.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the base image's `apk upgrade` to only `libexpat` so the rest of the digest-pinned Alpine packages stay pinned.

- Upgrading all packages floated every OS package in the `node:24-alpine` base, which the Dockerfile otherwise avoids.
- Only `libexpat` is affected by the two CVEs (CVE-2026-76641, CVE-2026-66046, libexpat < 2.8.4-r0).

<sup>Written for commit e4e7a613b1ba020318d0331ed2561c285e99d599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

