### PR TITLE
fix(bot): stop warning on url normalization for plain-text queries

### DIFF
--- a/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
@@ -429,3 +429,55 @@ describe('normalizeYouTubeUrl', () => {
         ).toBe('https://www.youtube.com/watch?v=x')
     })
 })
+
+describe('normalization logging behavior', () => {
+    beforeEach(() => {
+        warnLogMock.mockReset()
+    })
+
+    describe('normalizeSoundCloudUrl', () => {
+        it('produces no warnLog for plain text queries', () => {
+            normalizeSoundCloudUrl('bohemian rhapsody queen')
+            expect(warnLogMock).not.toHaveBeenCalled()
+        })
+
+        it('produces no warnLog for non-URL strings', () => {
+            normalizeSoundCloudUrl('not a url at all')
+            expect(warnLogMock).not.toHaveBeenCalled()
+        })
+
+        it('still warns for malformed http URLs', () => {
+            // soundcloud.com/... without protocol looks like a URL (could be
+            // user pasting), so attempting to parse it should warn when it fails
+            normalizeSoundCloudUrl('http://invalid[url')
+            expect(warnLogMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message:
+                        'SoundCloud URL normalization failed, using original URL',
+                }),
+            )
+        })
+    })
+
+    describe('normalizeYouTubeUrl', () => {
+        it('produces no warnLog for plain text queries', () => {
+            normalizeYouTubeUrl('never gonna give you up')
+            expect(warnLogMock).not.toHaveBeenCalled()
+        })
+
+        it('produces no warnLog for non-URL strings', () => {
+            normalizeYouTubeUrl('youtube not a url here')
+            expect(warnLogMock).not.toHaveBeenCalled()
+        })
+
+        it('still warns for malformed http URLs', () => {
+            normalizeYouTubeUrl('https://[invalid-url')
+            expect(warnLogMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message:
+                        'YouTube URL normalization failed, using original URL',
+                }),
+            )
+        })
+    })
+})

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -128,6 +128,8 @@ function hasHost(url: URL, ...domains: string[]): boolean {
  * SoundCloud extractor cannot resolve. The bare track URL resolves correctly.
  */
 export function normalizeSoundCloudUrl(url: string): string {
+    if (!isUrl(url)) return url
+
     try {
         const parsed = new URL(url)
         if (!hasHost(parsed, 'soundcloud.com')) return url
@@ -163,6 +165,8 @@ export function normalizeSoundCloudUrl(url: string): string {
  * equivalent `?in=` playlist context.
  */
 export function normalizeYouTubeUrl(url: string): string {
+    if (!isUrl(url)) return url
+
     try {
         const parsed = new URL(url)
         if (!hasHost(parsed, 'youtube.com', 'youtu.be')) return url


### PR DESCRIPTION
## Before

Every `/play` with a plain-text query logged two warnings, because `normalizeSoundCloudUrl` and `normalizeYouTubeUrl` in `packages/bot/src/functions/music/commands/play/queryUtils.ts` called `new URL(query)` unconditionally and hit the catch:

```
[WARN] SoundCloud URL normalization failed, using original URL  { query: "homebody ebk jaaybo" }
[WARN] YouTube URL normalization failed, using original URL     { query: "homebody ebk jaaybo" }
```

## After

Both functions return early when the query is not URL-shaped (`isUrl`), so the warning fires only for inputs that looked like a URL and still failed to parse. Behaviour for real URLs and for malformed URLs is unchanged.

## Tests

`queryUtils.spec.ts` gains a logging block: plain text and non-URL strings produce no `warnLog`; a malformed `http` URL still warns.

```
npx jest --config packages/bot/jest.config.cjs --testPathPatterns=queryUtils   41 passed
npm run type:check                                                              clean (husky pre-commit)
```

Closes #2181

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `/play` with plain-text queries from logging two spurious "normalization failed" warnings. `normalizeSoundCloudUrl` and `normalizeYouTubeUrl` now return early when the input isn't URL-shaped, so the warning only fires for inputs that looked like a URL and still failed to parse. Behavior for real and malformed URLs is unchanged.

**Tests**

- Adds logging coverage to `queryUtils.spec.ts`: plain text and non-URL strings produce no warning, malformed `http` URLs still warn.

<sup>Written for commit b958d2c3371aa66488298b82169e24bffac500fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

