### PR TITLE
fix(bot): accept uppercase schemes in the url guard

### DIFF
--- a/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
@@ -481,3 +481,17 @@ describe('normalization logging behavior', () => {
         })
     })
 })
+
+describe('uppercase scheme', () => {
+    it('isUrl accepts an uppercase scheme', () => {
+        expect(isUrl('HTTPS://SOUNDCLOUD.COM/artist/track')).toBe(true)
+    })
+
+    it('normalizeSoundCloudUrl still strips playlist context', () => {
+        expect(
+            normalizeSoundCloudUrl(
+                'HTTPS://SOUNDCLOUD.COM/artist/track?in=artist/sets/mix',
+            ),
+        ).not.toContain('in=')
+    })
+})

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -33,7 +33,7 @@ export function isUnknownInteractionError(error: unknown): boolean {
 }
 
 export function isUrl(query: string): boolean {
-    return query.startsWith('http://') || query.startsWith('https://')
+    return /^https?:\/\//i.test(query)
 }
 
 /**


### PR DESCRIPTION
Follow-up to #2198. The cubic review there flagged that `isUrl` compares the scheme case-sensitively, so a query like `HTTPS://SOUNDCLOUD.COM/artist/track?in=x` skipped normalization that `new URL()` used to handle. #2198 auto-merged the moment its thread was resolved, before the fix commit reached the PR, so this PR carries it.

- `isUrl` now tests `/^https?:\/\//i`.
- Spec: an uppercase scheme is recognised and still has its `?in=` playlist context stripped.

```
npx jest --config packages/bot/jest.config.cjs --testPathPatterns=queryUtils   43 passed
npm run type:check                                                              clean (husky)
```

Refs #2181

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `isUrl` guard in `queryUtils` to accept uppercase URL schemes. Previously, `isUrl` compared `http://` and `https://` case-sensitively, so a query like `HTTPS://SOUNDCLOUD.COM/artist/track?in=...` skipped normalization. Now `isUrl` matches `/^https?:\/\//i`, so uppercase-scheme SoundCloud URLs still get their `?in=` playlist context stripped.

<sup>Written for commit 73dd668d3dcaf26681e6103b44af95273627b610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

