### PR TITLE
ci: bump danger reusable workflow to dependency-key lockfile rule

### DIFF
--- a/.github/workflows/review-tools.yml
+++ b/.github/workflows/review-tools.yml
@@ -62,4 +62,4 @@ jobs:
   # AI review is currently covered by cubic and CodeRabbit, which run as apps
   # rather than workflow jobs.
   danger:
-    uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@ad6776a59b88a798b145e7b555368c39799e23e7 # v1
+    uses: LucasSantana-Dev/.github/.github/workflows/danger.yml@fa22667c1e0b6a5a27e7262c56b412db8b9f7c13 # v1


### PR DESCRIPTION
Closes #2182

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Danger reusable workflow to the latest version, which adds the dependency-key lockfile rule. Closes #2182.

<sup>Written for commit c8c45d3fa2bdda6e3a6ed35c7a0b38bbc2f45b42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

