### PR TITLE
ci(danger): re-check package.json through the api before failing

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -103,6 +103,28 @@ const DEP_FIELDS = [
 const lockChanged = all.some((p) => p === 'package-lock.json')
 const changedPackageJsons = all.filter((p) => /(^|\/)package\.json$/.test(p))
 
+// Shallow checkouts (the reusable workflow fetches depth 50) can leave the
+// base commit unavailable to local git, so JSONDiffForFile throws on heavily
+// rebased PRs and the old catch-all failed the build on a scripts-only edit
+// (#2182). Before failing, re-read both versions through the API.
+async function depFieldsChangedViaApi(path: string): Promise<boolean> {
+    const { owner, repo } = danger.github.thisPR
+    const slug = `${owner}/${repo}`
+    const [base, head] = await Promise.all([
+        danger.github.utils.fileContents(path, slug, danger.github.pr.base.sha),
+        danger.github.utils.fileContents(path, slug, danger.github.pr.head.sha),
+    ])
+    const parse = (raw: string): Record<string, unknown> =>
+        raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+    const before = parse(base)
+    const after = parse(head)
+    return DEP_FIELDS.some(
+        (f) =>
+            JSON.stringify(before[f] ?? null) !==
+            JSON.stringify(after[f] ?? null),
+    )
+}
+
 async function checkLockfileGuard(): Promise<void> {
     if (changedPackageJsons.length === 0 || lockChanged) return
     for (const path of changedPackageJsons) {
@@ -112,9 +134,15 @@ async function checkLockfileGuard(): Promise<void> {
             // A dependency field appears in the diff only when it changed.
             depFieldChanged = DEP_FIELDS.some((f) => Boolean(diff?.[f]))
         } catch {
-            // If the diff can't be computed (e.g. malformed JSON), fall back
-            // to the conservative guard rather than silently passing.
-            depFieldChanged = true
+            try {
+                depFieldChanged = await depFieldsChangedViaApi(path)
+            } catch (error) {
+                warn(
+                    `Could not diff \`${path}\` locally or through the API ` +
+                        `(${String(error)}); lockfile guard skipped for this file.`,
+                )
+                continue
+            }
         }
         if (depFieldChanged) {
             fail(


### PR DESCRIPTION
## Root cause

The lockfile guard in `dangerfile.ts` was already keyed on dependency fields via `danger.git.JSONDiffForFile`. The false positive on #2178 came from its catch-all: in `danger ci` that call diffs with local git, and the reusable workflow checks out with `fetch-depth: 50`, so on a heavily rebased PR the base commit is missing, the call throws, and the catch set `depFieldChanged = true`. Reproduced the other way round: `danger pr` (API-backed diff) on #2178 passes with the unchanged file.

The issue text said the Dangerfile lives in the org repo; it lives here. Org PR LucasSantana-Dev/.github#16 only added a comment to the workflow and needs no follow-up.

## Change

- On a local diff failure, read base and head `package.json` through `danger.github.utils.fileContents` and compare the same `DEP_FIELDS`.
- Only if that also fails, `warn` and skip that file instead of failing.

## Verification (local `danger pr`, API path forced by making the local diff throw)

| PR | change | result |
|---|---|---|
| #2178 | `scripts` only | passes |
| #2196 | `overrides` changed, lockfile untouched | fails with the lockfile message |

Closes #2182

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2182: the lockfile guard in `dangerfile.ts` no longer fails on scripts-only edits when the local diff is unavailable. Previously, any local diff failure was treated as a dependency change; now the guard re-reads base and head `package.json` via the API and compares the same dependency fields. Only if that API check also fails does it warn and skip the file instead of failing.

<sup>Written for commit 7db8844c1eed88fb0cadcad6a7fb74369031d167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

