### PR TITLE
ci(danger): read the skip-changelog label from the issue view

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -68,9 +68,10 @@ const userFacingChange = all.some((p) =>
 // Dropped: chore/test/refactor/perf — they often touch user-facing code.
 const TITLE_PREFIX_SKIP =
     /^(chore\(deps(-dev)?\)|ci|build|style|docs)(\([^)]*\))?:\s/
-const hasSkipLabel =
-    pr.labels?.some((l: { name: string }) => l.name === 'skip-changelog') ??
-    false
+// `danger.github.pr` (GitHubPRDSL) has no `labels`; the issue view does.
+const hasSkipLabel = danger.github.issue.labels.some(
+    (l) => l.name === 'skip-changelog',
+)
 if (
     userFacingChange &&
     !changelogTouched &&


### PR DESCRIPTION
`danger.github.pr` is typed as `GitHubPRDSL`, which has no `labels` field, so `pr.labels?.some(...)` only compiled because Danger transpiles the file without type-checking. `danger.github.issue.labels` is the typed source for the same data; behaviour is unchanged.

Verified with `danger@13` installed ad hoc (the reusable workflow installs it the same way):

```
npx tsc --noEmit --ignoreConfig --esModuleInterop --skipLibCheck --strict \
  --target es2022 --module esnext --moduleResolution bundler dangerfile.ts   exit 0
```

Not included: a permanent `type:check` step for the Dangerfile. It would need `danger` as a devDependency (59 packages in the lockfile) since the repo does not depend on it today; that is a separate call.

Closes #2203

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `skip-changelog` label check in the Dangerfile so it type-checks correctly. Reads labels from `danger.github.issue.labels` instead of `pr.labels`, which isn't typed on `GitHubPRDSL`; behavior is unchanged.

Closes #2203.

<sup>Written for commit 0d58f4cf8d63828b93c7a0de8e85da87fbf34564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

