### PR TITLE
ci: skip dead discord webhook and stale sarif upload

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -165,6 +165,7 @@ jobs:
                 echo "ref=${IMAGE}:${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
 
             - name: Trivy image scan (audit-only)
+              id: trivy-scan
               uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
               with:
                   image-ref: ${{ steps.imgref.outputs.ref }}
@@ -182,7 +183,7 @@ jobs:
                   skip-dirs: /opt/ytdlp/**
 
             - name: Upload Trivy SARIF
-              if: always()
+              if: ${{ always() && steps.trivy-scan.outcome != 'skipped' }}
               uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
               with:
                   sarif_file: trivy-image-${{ matrix.service }}.sarif

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -183,7 +183,7 @@ jobs:
                   skip-dirs: /opt/ytdlp/**
 
             - name: Upload Trivy SARIF
-              if: ${{ always() && steps.trivy-scan.outcome != 'skipped' }}
+              if: ${{ always() && steps.trivy-scan.outcome == 'success' }}
               uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
               with:
                   sarif_file: trivy-image-${{ matrix.service }}.sarif

--- a/.github/workflows/external-pr-notify.yml
+++ b/.github/workflows/external-pr-notify.yml
@@ -123,6 +123,10 @@ jobs:
                               body: JSON.stringify(payload),
                               signal: controller.signal,
                           });
+                          if (res.status === 404) {
+                              core.warning('DISCORD_DEPLOY_ALERT_WEBHOOK returned 404; webhook was deleted on the Discord side, skipping digest');
+                              return;
+                          }
                           if (!res.ok) throw new Error(`Discord webhook failed: ${res.status}`);
                       } finally {
                           clearTimeout(timeout);


### PR DESCRIPTION
## Summary

- `.github/workflows/external-pr-notify.yml` (`digest` job): the scheduled run has failed daily for 7 days with `Discord webhook failed: 404` because the webhook was deleted on the Discord side. Added a check next to the existing `if (!webhook)` guard that treats a 404 response as "webhook gone": logs a `core.warning` and returns without failing the job. Other non-2xx statuses still throw as before.
- `.github/workflows/docker-publish.yml:184-188`: the `Upload Trivy SARIF` step ran on `if: always()` even when the scan step was skipped (for example after an upstream Buildx flake), failing with `Path does not exist`. Gave the `Trivy image scan (audit-only)` step an `id: trivy-scan` and changed the upload condition to `if: ${{ always() && steps.trivy-scan.outcome != 'skipped' }}`.

## Test plan

- [x] `actionlint .github/workflows/external-pr-notify.yml .github/workflows/docker-publish.yml` (exit 0)
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on both files (parses cleanly)
- [ ] Next scheduled `digest` run completes with conclusion `success`
- [ ] Next `docker-publish` run with an earlier step failure shows exactly one failed check, not two

Closes #2216
Closes #2217

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two recurring CI failures: the external PR digest job no longer fails on a deleted Discord webhook, and the Trivy SARIF upload only runs when the scan succeeds.

- Treats a 404 from the Discord webhook as "webhook gone", logs a warning, and exits successfully instead of failing the job.
- Gates the `Upload Trivy SARIF` step on the `Trivy image scan (audit-only)` step's success so a skipped or failed scan doesn't turn into a second failed check.

Closes #2216 and #2217.

<sup>Written for commit 5793a406fbd2ec99113524d70c8beec80d51030d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

