### PR TITLE
fix: warn on swallowed session, ticket, track errors; fix idle race

### DIFF
--- a/packages/backend/src/middleware/session.ts
+++ b/packages/backend/src/middleware/session.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { mkdirSync } from 'node:fs'
 import session from 'express-session'
 import sessionFileStoreFactory from 'session-file-store'
-import { debugLog, errorLog } from '@lucky/shared/utils'
+import { debugLog, errorLog, warnLog } from '@lucky/shared/utils'
 import type { Express } from 'express'
 import { PrismaSessionStore } from './prismaSessionStore'
 
@@ -129,7 +129,7 @@ function createPrimaryStore(): session.Store | undefined {
     try {
         return new PrismaSessionStore()
     } catch (error) {
-        debugLog({
+        warnLog({
             message:
                 'Postgres session store initialization failed. Using local session store.',
             error,
@@ -180,6 +180,13 @@ export function setupSessionMiddleware(app: Express): void {
         : fallbackStore
 
     const isMemoryFallback = fallbackStore.constructor.name === 'MemoryStore'
+
+    if (isProduction && !primaryStore && isMemoryFallback) {
+        errorLog({
+            message:
+                'Session store falling back to in-memory storage in production. Sessions will not persist across restarts or scale past one instance.',
+        })
+    }
 
     app.use(
         session({

--- a/packages/backend/tests/setup.ts
+++ b/packages/backend/tests/setup.ts
@@ -271,6 +271,10 @@ jest.mock('@lucky/shared/utils', () => ({
     infoLog: jest.fn(),
     warnLog: jest.fn(),
     captureException: jest.fn(),
+    getPrismaClient: jest.fn(() => ({
+        $connect: jest.fn(),
+        $disconnect: jest.fn(),
+    })),
 }))
 
 global.fetch = jest.fn<typeof fetch>() as jest.MockedFunction<typeof fetch>

--- a/packages/backend/tests/unit/middleware/session.test.ts
+++ b/packages/backend/tests/unit/middleware/session.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from '@jest/globals'
+import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import express from 'express'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -142,5 +142,63 @@ describe('Session Middleware', () => {
         expect(source).toContain("sameSite: isProduction ? 'none' : 'lax'")
 
         process.env.NODE_ENV = originalEnv
+    })
+
+    test('warns when Postgres session store initialization fails', async () => {
+        // getPrismaClient is not part of the global @lucky/shared/utils mock,
+        // so PrismaSessionStore always throws in this test environment and
+        // createPrimaryStore falls back to the local store on every run.
+        const { warnLog } = await import('@lucky/shared/utils')
+        const { setupSessionMiddleware } =
+            await import('../../../src/middleware/session')
+
+        setupSessionMiddleware(app)
+
+        expect(warnLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining(
+                    'Postgres session store initialization failed',
+                ),
+                error: expect.anything(),
+            }),
+        )
+    })
+
+    test('errors when production falls back to an in-memory session store', async () => {
+        jest.resetModules()
+        jest.doMock('session-file-store', () =>
+            jest.fn(() => {
+                throw new Error('file store unavailable')
+            }),
+        )
+        jest.doMock('express-session', () => {
+            class Store {}
+            class MemoryStore extends Store {}
+            return Object.assign(
+                () => (_req: unknown, _res: unknown, next: () => void) =>
+                    next(),
+                { Store, MemoryStore },
+            )
+        })
+
+        const { errorLog } = await import('@lucky/shared/utils')
+        const { setupSessionMiddleware } =
+            await import('../../../src/middleware/session')
+
+        const originalEnv = process.env.NODE_ENV
+        process.env.NODE_ENV = 'production'
+
+        setupSessionMiddleware(express())
+
+        expect(errorLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('in-memory'),
+            }),
+        )
+
+        process.env.NODE_ENV = originalEnv
+        jest.dontMock('session-file-store')
+        jest.dontMock('express-session')
+        jest.resetModules()
     })
 })

--- a/packages/backend/tests/unit/middleware/session.test.ts
+++ b/packages/backend/tests/unit/middleware/session.test.ts
@@ -145,9 +145,22 @@ describe('Session Middleware', () => {
     })
 
     test('warns when Postgres session store initialization fails', async () => {
-        // getPrismaClient is not part of the global @lucky/shared/utils mock,
-        // so PrismaSessionStore always throws in this test environment and
-        // createPrimaryStore falls back to the local store on every run.
+        // Force the failure explicitly instead of relying on the global
+        // @lucky/shared/utils mock's accidental omission of getPrismaClient
+        // (that gap is a separate bug — see the mock in tests/setup.ts). This
+        // mocks the PrismaSessionStore module directly, which the other test
+        // in this file relies on too — both want createPrimaryStore to fail
+        // deterministically, so leaving it registered for the rest of the
+        // file matches every remaining test's own precondition.
+        jest.doMock('../../../src/middleware/prismaSessionStore', () => ({
+            PrismaSessionStore: class {
+                constructor() {
+                    throw new Error('database unreachable')
+                }
+            },
+        }))
+        jest.resetModules()
+
         const { warnLog } = await import('@lucky/shared/utils')
         const { setupSessionMiddleware } =
             await import('../../../src/middleware/session')
@@ -165,40 +178,46 @@ describe('Session Middleware', () => {
     })
 
     test('errors when production falls back to an in-memory session store', async () => {
-        jest.resetModules()
-        jest.doMock('session-file-store', () =>
-            jest.fn(() => {
-                throw new Error('file store unavailable')
-            }),
-        )
-        jest.doMock('express-session', () => {
-            class Store {}
-            class MemoryStore extends Store {}
-            return Object.assign(
-                () => (_req: unknown, _res: unknown, next: () => void) =>
-                    next(),
-                { Store, MemoryStore },
-            )
-        })
-
+        const originalEnv = process.env.NODE_ENV
+        // Override the already-registered global mocks in place instead of
+        // doMock/resetModules: session-file-store's default export is a
+        // jest.fn(), so mockImplementationOnce self-cleans after this test's
+        // single call, and MemoryStore's class name is restored in the
+        // finally block below — neither leaves state for later tests.
         const { errorLog } = await import('@lucky/shared/utils')
+        const { default: sessionFileStoreFactory } =
+            await import('session-file-store')
+        const { default: session } = await import('express-session')
         const { setupSessionMiddleware } =
             await import('../../../src/middleware/session')
 
-        const originalEnv = process.env.NODE_ENV
-        process.env.NODE_ENV = 'production'
+        ;(sessionFileStoreFactory as jest.Mock).mockImplementationOnce(() => {
+            throw new Error('file store unavailable')
+        })
 
-        setupSessionMiddleware(express())
+        const MemoryStoreClass = session.MemoryStore
+        const originalMemoryStoreName = MemoryStoreClass.name
 
-        expect(errorLog).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: expect.stringContaining('in-memory'),
-            }),
-        )
+        try {
+            process.env.NODE_ENV = 'production'
+            Object.defineProperty(MemoryStoreClass, 'name', {
+                value: 'MemoryStore',
+                configurable: true,
+            })
 
-        process.env.NODE_ENV = originalEnv
-        jest.dontMock('session-file-store')
-        jest.dontMock('express-session')
-        jest.resetModules()
+            setupSessionMiddleware(express())
+
+            expect(errorLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining('in-memory'),
+                }),
+            )
+        } finally {
+            process.env.NODE_ENV = originalEnv
+            Object.defineProperty(MemoryStoreClass, 'name', {
+                value: originalMemoryStoreName,
+                configurable: true,
+            })
+        }
     })
 })

--- a/packages/backend/tests/unit/middleware/session.test.ts
+++ b/packages/backend/tests/unit/middleware/session.test.ts
@@ -145,13 +145,10 @@ describe('Session Middleware', () => {
     })
 
     test('warns when Postgres session store initialization fails', async () => {
-        // Force the failure explicitly instead of relying on the global
-        // @lucky/shared/utils mock's accidental omission of getPrismaClient
-        // (that gap is a separate bug — see the mock in tests/setup.ts). This
-        // mocks the PrismaSessionStore module directly, which the other test
-        // in this file relies on too — both want createPrimaryStore to fail
-        // deterministically, so leaving it registered for the rest of the
-        // file matches every remaining test's own precondition.
+        // getPrismaClient is a real function on the global @lucky/shared/utils
+        // mock (tests/setup.ts), so force the failure explicitly here rather
+        // than relying on it being absent — mock PrismaSessionStore itself,
+        // then undo it so the mock never leaks into a later test.
         jest.doMock('../../../src/middleware/prismaSessionStore', () => ({
             PrismaSessionStore: class {
                 constructor() {
@@ -161,63 +158,86 @@ describe('Session Middleware', () => {
         }))
         jest.resetModules()
 
-        const { warnLog } = await import('@lucky/shared/utils')
-        const { setupSessionMiddleware } =
-            await import('../../../src/middleware/session')
+        try {
+            const { warnLog } = await import('@lucky/shared/utils')
+            const { setupSessionMiddleware } =
+                await import('../../../src/middleware/session')
 
-        setupSessionMiddleware(app)
+            setupSessionMiddleware(app)
 
-        expect(warnLog).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: expect.stringContaining(
-                    'Postgres session store initialization failed',
-                ),
-                error: expect.anything(),
-            }),
-        )
+            expect(warnLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'Postgres session store initialization failed',
+                    ),
+                    error: expect.anything(),
+                }),
+            )
+        } finally {
+            jest.dontMock('../../../src/middleware/prismaSessionStore')
+            jest.resetModules()
+        }
     })
 
     test('errors when production falls back to an in-memory session store', async () => {
         const originalEnv = process.env.NODE_ENV
-        // Override the already-registered global mocks in place instead of
-        // doMock/resetModules: session-file-store's default export is a
-        // jest.fn(), so mockImplementationOnce self-cleans after this test's
-        // single call, and MemoryStore's class name is restored in the
-        // finally block below — neither leaves state for later tests.
-        const { errorLog } = await import('@lucky/shared/utils')
-        const { default: sessionFileStoreFactory } =
-            await import('session-file-store')
-        const { default: session } = await import('express-session')
-        const { setupSessionMiddleware } =
-            await import('../../../src/middleware/session')
-
-        ;(sessionFileStoreFactory as jest.Mock).mockImplementationOnce(() => {
-            throw new Error('file store unavailable')
-        })
-
-        const MemoryStoreClass = session.MemoryStore
-        const originalMemoryStoreName = MemoryStoreClass.name
+        // This test's own precondition: force PrismaSessionStore to fail too
+        // (independent of the test above), then undo it the same way.
+        jest.doMock('../../../src/middleware/prismaSessionStore', () => ({
+            PrismaSessionStore: class {
+                constructor() {
+                    throw new Error('database unreachable')
+                }
+            },
+        }))
+        jest.resetModules()
 
         try {
-            process.env.NODE_ENV = 'production'
-            Object.defineProperty(MemoryStoreClass, 'name', {
-                value: 'MemoryStore',
-                configurable: true,
-            })
+            // Override the already-registered global mocks in place:
+            // session-file-store's default export is a jest.fn(), so
+            // mockImplementationOnce self-cleans after this test's single
+            // call, and MemoryStore's class name is restored in the finally
+            // block below — neither leaves state for later tests.
+            const { errorLog } = await import('@lucky/shared/utils')
+            const { default: sessionFileStoreFactory } =
+                await import('session-file-store')
+            const { default: session } = await import('express-session')
+            const { setupSessionMiddleware } =
+                await import('../../../src/middleware/session')
 
-            setupSessionMiddleware(express())
-
-            expect(errorLog).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    message: expect.stringContaining('in-memory'),
-                }),
+            ;(sessionFileStoreFactory as jest.Mock).mockImplementationOnce(
+                () => {
+                    throw new Error('file store unavailable')
+                },
             )
+
+            const MemoryStoreClass = session.MemoryStore
+            const originalMemoryStoreName = MemoryStoreClass.name
+
+            try {
+                process.env.NODE_ENV = 'production'
+                Object.defineProperty(MemoryStoreClass, 'name', {
+                    value: 'MemoryStore',
+                    configurable: true,
+                })
+
+                setupSessionMiddleware(express())
+
+                expect(errorLog).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.stringContaining('in-memory'),
+                    }),
+                )
+            } finally {
+                process.env.NODE_ENV = originalEnv
+                Object.defineProperty(MemoryStoreClass, 'name', {
+                    value: originalMemoryStoreName,
+                    configurable: true,
+                })
+            }
         } finally {
-            process.env.NODE_ENV = originalEnv
-            Object.defineProperty(MemoryStoreClass, 'name', {
-                value: originalMemoryStoreName,
-                configurable: true,
-            })
+            jest.dontMock('../../../src/middleware/prismaSessionStore')
+            jest.resetModules()
         }
     })
 })

--- a/packages/bot/src/functions/general/commands/ticket.spec.ts
+++ b/packages/bot/src/functions/general/commands/ticket.spec.ts
@@ -15,9 +15,12 @@ jest.mock('@lucky/shared/services', () => ({
     guildSettingsService: guildSettingsServiceMock,
     supportSessionService: supportSessionServiceMock,
 }))
+const logAndWarnMock = jest.fn() as jest.MockedFunction<any>
+
 jest.mock('@lucky/shared/utils', () => ({
     infoLog: jest.fn(),
     errorLog: jest.fn(),
+    logAndWarn: (...args: unknown[]) => logAndWarnMock(...args),
 }))
 jest.mock('../../../utils/general/interactionReply', () => ({
     interactionReply: (...args: unknown[]) => interactionReplyMock(...args),
@@ -154,6 +157,34 @@ describe('/ticket command (smoke)', () => {
                 content: {
                     content: expect.stringContaining('already have an open'),
                 },
+            }),
+        )
+    })
+
+    it('close: warns but still resolves when closing the session fails', async () => {
+        const channel = makeChannel()
+        supportSessionServiceMock.getByChannel.mockResolvedValue({
+            id: 's1',
+            status: 'open',
+            requestorId: 'u1',
+        })
+        supportSessionServiceMock.close.mockRejectedValue(
+            new Error('db unavailable'),
+        )
+
+        await ticketCommand.execute({
+            interaction: makeInteraction('close', channel),
+        } as any)
+
+        expect(logAndWarnMock).toHaveBeenCalledWith(
+            expect.any(Error),
+            'ticket.close',
+            { sessionId: 's1' },
+        )
+        expect(channel.delete).toHaveBeenCalled()
+        expect(interactionReplyMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: { content: expect.stringContaining('Closing') },
             }),
         )
     })

--- a/packages/bot/src/functions/general/commands/ticket.ts
+++ b/packages/bot/src/functions/general/commands/ticket.ts
@@ -12,7 +12,7 @@ import {
     guildSettingsService,
     supportSessionService,
 } from '@lucky/shared/services'
-import { infoLog, errorLog } from '@lucky/shared/utils'
+import { infoLog, errorLog, logAndWarn } from '@lucky/shared/utils'
 import { interactionReply } from '../../../utils/general/interactionReply'
 
 // Tickets auto-close 24h after opening (swept by supportSessionScheduler).
@@ -63,7 +63,11 @@ async function handleOpen(
             return
         }
         // Channel was deleted out-of-band — close the orphan row and continue.
-        await supportSessionService.close(existing.id).catch(() => {})
+        await supportSessionService
+            .close(existing.id)
+            .catch((err) =>
+                logAndWarn(err, 'ticket.close', { sessionId: existing.id }),
+            )
     }
 
     let channel: TextChannel
@@ -239,15 +243,21 @@ async function teardownClosedTicket(
 ): Promise<void> {
     const channel = await guild.channels.fetch(channelId).catch(() => null)
     if (!channel) {
-        await supportSessionService.close(sessionId).catch(() => {})
+        await supportSessionService
+            .close(sessionId)
+            .catch((err) => logAndWarn(err, 'ticket.close', { sessionId }))
         return
     }
     try {
         await channel.delete('Support ticket closed')
-        await supportSessionService.close(sessionId).catch(() => {})
+        await supportSessionService
+            .close(sessionId)
+            .catch((err) => logAndWarn(err, 'ticket.close', { sessionId }))
     } catch (error) {
         if ((error as { code?: number })?.code === UNKNOWN_CHANNEL) {
-            await supportSessionService.close(sessionId).catch(() => {})
+            await supportSessionService
+                .close(sessionId)
+                .catch((err) => logAndWarn(err, 'ticket.close', { sessionId }))
             return
         }
         errorLog({

--- a/packages/bot/src/services/musicManagement/idleDisconnect.spec.ts
+++ b/packages/bot/src/services/musicManagement/idleDisconnect.spec.ts
@@ -163,6 +163,35 @@ describe('idleDisconnect', () => {
         expect(() => clearIdleTimer('unknown-guild')).not.toThrow()
     })
 
+    it('two rapid calls before settings resolve leave exactly one timer armed', async () => {
+        const resolvers: Array<
+            (value: { idleTimeoutMinutes: number }) => void
+        > = []
+        mockGetGuildSettings.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolvers.push(resolve)
+                }),
+        )
+        const queue = makeQueue()
+
+        // Both calls run before either settings lookup resolves, reproducing
+        // the race from #2218: the second call's clearIdleTimer used to run
+        // before the first call's idleTimers.set, leaving two timers armed.
+        scheduleIdleDisconnect(queue)
+        scheduleIdleDisconnect(queue)
+
+        resolvers[0]?.({ idleTimeoutMinutes: 5 })
+        resolvers[1]?.({ idleTimeoutMinutes: 5 })
+        await jest.advanceTimersByTimeAsync(0)
+
+        expect(jest.getTimerCount()).toBe(1)
+
+        await jest.advanceTimersByTimeAsync(5 * 60 * 1000)
+
+        expect(queue.delete).toHaveBeenCalledTimes(1)
+    })
+
     it('rescheduling clears any prior timer for the guild', async () => {
         mockGetGuildSettings.mockResolvedValue({ idleTimeoutMinutes: 5 })
         const queue = makeQueue()

--- a/packages/bot/src/services/musicManagement/idleDisconnect.spec.ts
+++ b/packages/bot/src/services/musicManagement/idleDisconnect.spec.ts
@@ -192,6 +192,33 @@ describe('idleDisconnect', () => {
         expect(queue.delete).toHaveBeenCalledTimes(1)
     })
 
+    it('clearIdleTimer before settings resolve leaves zero timers armed', async () => {
+        let resolveSettings: (value: {
+            idleTimeoutMinutes: number
+        }) => void = () => {}
+        mockGetGuildSettings.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveSettings = resolve
+                }),
+        )
+        const queue = makeQueue()
+
+        // playerStart calls clearIdleTimer on playback resume; if the
+        // in-flight settings fetch is not invalidated, its callback can
+        // arm a timer that later kills the now-active playback (#2218 P1).
+        scheduleIdleDisconnect(queue)
+        clearIdleTimer('guild-1')
+        resolveSettings({ idleTimeoutMinutes: 5 })
+        await jest.advanceTimersByTimeAsync(0)
+
+        expect(jest.getTimerCount()).toBe(0)
+
+        await jest.advanceTimersByTimeAsync(5 * 60 * 1000)
+
+        expect(queue.delete).not.toHaveBeenCalled()
+    })
+
     it('rescheduling clears any prior timer for the guild', async () => {
         mockGetGuildSettings.mockResolvedValue({ idleTimeoutMinutes: 5 })
         const queue = makeQueue()

--- a/packages/bot/src/services/musicManagement/idleDisconnect.spec.ts
+++ b/packages/bot/src/services/musicManagement/idleDisconnect.spec.ts
@@ -219,6 +219,39 @@ describe('idleDisconnect', () => {
         expect(queue.delete).not.toHaveBeenCalled()
     })
 
+    it('schedule, clear, reschedule: exactly one timer, belonging to the second schedule', async () => {
+        const resolvers: Array<
+            (value: { idleTimeoutMinutes: number }) => void
+        > = []
+        mockGetGuildSettings.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolvers.push(resolve)
+                }),
+        )
+        const queueA = makeQueue()
+        const queueB = makeQueue()
+
+        // Regression for a fix that deleted the generation entry on clear:
+        // the next schedule then restarted at generation 1 and collided with
+        // A's still-pending captured generation, letting A's callback arm a
+        // second timer once its settings fetch resolved.
+        scheduleIdleDisconnect(queueA)
+        clearIdleTimer('guild-1')
+        scheduleIdleDisconnect(queueB)
+
+        resolvers[0]?.({ idleTimeoutMinutes: 5 })
+        resolvers[1]?.({ idleTimeoutMinutes: 5 })
+        await jest.advanceTimersByTimeAsync(0)
+
+        expect(jest.getTimerCount()).toBe(1)
+
+        await jest.advanceTimersByTimeAsync(5 * 60 * 1000)
+
+        expect(queueA.delete).not.toHaveBeenCalled()
+        expect(queueB.delete).toHaveBeenCalledTimes(1)
+    })
+
     it('rescheduling clears any prior timer for the guild', async () => {
         mockGetGuildSettings.mockResolvedValue({ idleTimeoutMinutes: 5 })
         const queue = makeQueue()

--- a/packages/bot/src/services/musicManagement/idleDisconnect.ts
+++ b/packages/bot/src/services/musicManagement/idleDisconnect.ts
@@ -6,13 +6,24 @@ import { collaborativePlaylistService } from '../musicRecommendation/collaborati
 import type { QueueMetadata } from '../../types/QueueMetadata'
 
 const idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
+// Bumped synchronously on every call so a later scheduleIdleDisconnect call
+// can invalidate an earlier one that is still awaiting guild settings — see
+// #2218 (two rapid calls could otherwise both survive to arm a timer).
+const idleGenerations = new Map<string, number>()
 
 export function scheduleIdleDisconnect(queue: GuildQueue): void {
     const guildId = queue.guild.id
     clearIdleTimer(guildId)
 
+    const generation = (idleGenerations.get(guildId) ?? 0) + 1
+    idleGenerations.set(guildId, generation)
+
     void (async () => {
         const settings = await guildSettingsService.getGuildSettings(guildId)
+        // A newer call superseded this one while settings were loading —
+        // let that call own the timer instead of arming a second one.
+        if (idleGenerations.get(guildId) !== generation) return
+
         const timeoutMinutes = settings?.idleTimeoutMinutes ?? 0
         if (timeoutMinutes <= 0) return
 

--- a/packages/bot/src/services/musicManagement/idleDisconnect.ts
+++ b/packages/bot/src/services/musicManagement/idleDisconnect.ts
@@ -77,7 +77,13 @@ export function clearIdleTimer(guildId: string): void {
     // Invalidate any schedule still awaiting settings, or already armed, for
     // this guild — e.g. playerStart calling this on playback resume must stop
     // a pending idle-disconnect from later killing live playback (#2218).
-    idleGenerations.delete(guildId)
+    //
+    // Advance the counter instead of deleting it: deleting would let the
+    // NEXT scheduleIdleDisconnect restart at generation 1, which can collide
+    // with a still-pending (cleared) call's captured generation and let it
+    // pass the equality check and arm a second timer. Only the identity
+    // guarded releaseGeneration (fire/error paths) may delete the entry.
+    idleGenerations.set(guildId, (idleGenerations.get(guildId) ?? 0) + 1)
     clearArmedTimer(guildId)
 }
 

--- a/packages/bot/src/services/musicManagement/idleDisconnect.ts
+++ b/packages/bot/src/services/musicManagement/idleDisconnect.ts
@@ -11,21 +11,43 @@ const idleTimers = new Map<string, ReturnType<typeof setTimeout>>()
 // #2218 (two rapid calls could otherwise both survive to arm a timer).
 const idleGenerations = new Map<string, number>()
 
+// Deletes the guild's generation entry only if it still matches `generation`,
+// so a completion/cancellation path can never wipe out a newer, still-live
+// generation that superseded it.
+function releaseGeneration(guildId: string, generation: number): void {
+    if (idleGenerations.get(guildId) === generation) {
+        idleGenerations.delete(guildId)
+    }
+}
+
+function clearArmedTimer(guildId: string): void {
+    const timer = idleTimers.get(guildId)
+    if (timer) {
+        clearTimeout(timer)
+        idleTimers.delete(guildId)
+    }
+}
+
 export function scheduleIdleDisconnect(queue: GuildQueue): void {
     const guildId = queue.guild.id
-    clearIdleTimer(guildId)
-
+    // Each call claims the next generation unconditionally (never reusing
+    // clearIdleTimer's own deletion) so two rapid calls always get distinct,
+    // strictly increasing numbers instead of racing back to the same value.
     const generation = (idleGenerations.get(guildId) ?? 0) + 1
     idleGenerations.set(guildId, generation)
+    clearArmedTimer(guildId)
 
     void (async () => {
         const settings = await guildSettingsService.getGuildSettings(guildId)
-        // A newer call superseded this one while settings were loading —
-        // let that call own the timer instead of arming a second one.
+        // A newer call, or an explicit clearIdleTimer, superseded this one
+        // while settings were loading — bail instead of arming a timer.
         if (idleGenerations.get(guildId) !== generation) return
 
         const timeoutMinutes = settings?.idleTimeoutMinutes ?? 0
-        if (timeoutMinutes <= 0) return
+        if (timeoutMinutes <= 0) {
+            releaseGeneration(guildId, generation)
+            return
+        }
 
         debugLog({
             message: 'Idle disconnect scheduled',
@@ -35,6 +57,7 @@ export function scheduleIdleDisconnect(queue: GuildQueue): void {
         const timer = setTimeout(
             () => {
                 idleTimers.delete(guildId)
+                releaseGeneration(guildId, generation)
                 void disconnectIdle(queue)
             },
             timeoutMinutes * 60 * 1000,
@@ -42,6 +65,7 @@ export function scheduleIdleDisconnect(queue: GuildQueue): void {
 
         idleTimers.set(guildId, timer)
     })().catch((error: unknown) => {
+        releaseGeneration(guildId, generation)
         errorLog({
             message: `Failed to schedule idle disconnect in guild ${guildId}`,
             error,
@@ -50,11 +74,11 @@ export function scheduleIdleDisconnect(queue: GuildQueue): void {
 }
 
 export function clearIdleTimer(guildId: string): void {
-    const timer = idleTimers.get(guildId)
-    if (timer) {
-        clearTimeout(timer)
-        idleTimers.delete(guildId)
-    }
+    // Invalidate any schedule still awaiting settings, or already armed, for
+    // this guild — e.g. playerStart calling this on playback resume must stop
+    // a pending idle-disconnect from later killing live playback (#2218).
+    idleGenerations.delete(guildId)
+    clearArmedTimer(guildId)
 }
 
 async function disconnectIdle(queue: GuildQueue): Promise<void> {

--- a/packages/bot/src/utils/music/trackValidator.spec.ts
+++ b/packages/bot/src/utils/music/trackValidator.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from '@jest/globals'
+import { afterEach, describe, expect, it, jest } from '@jest/globals'
 import type { Track, GuildQueue } from 'discord-player'
 import type { TrackManagementOptions } from './types'
 
@@ -23,6 +23,13 @@ const asQueue = (tracks: Track[] = []): GuildQueue =>
 
 describe('validateTrack', () => {
     const options: TrackManagementOptions = {}
+
+    afterEach(() => {
+        // clearMocks (jest.config.cjs) only wipes call data, not a
+        // mockImplementation set on a plain jest.fn() — reset explicitly so
+        // the throw doesn't leak into a later test in this file.
+        calculateTrackQualityMock.mockReset()
+    })
 
     it('rejects and warns when calculateTrackQuality throws', () => {
         const track = asTrack({

--- a/packages/bot/src/utils/music/trackValidator.spec.ts
+++ b/packages/bot/src/utils/music/trackValidator.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import type { Track, GuildQueue } from 'discord-player'
+import type { TrackManagementOptions } from './types'
+
+const warnLogMock = jest.fn()
+const calculateTrackQualityMock = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    warnLog: (...args: unknown[]) => warnLogMock(...args),
+}))
+
+jest.mock('./trackSimilarity', () => ({
+    calculateTrackSimilarity: jest.fn(() => 0),
+    calculateTrackQuality: (...args: unknown[]) =>
+        calculateTrackQualityMock(...args),
+}))
+
+import { validateTrack } from './trackValidator'
+
+const asTrack = (partial: Partial<Track>): Track => partial as Track
+const asQueue = (tracks: Track[] = []): GuildQueue =>
+    ({ tracks: { toArray: () => tracks } }) as unknown as GuildQueue
+
+describe('validateTrack', () => {
+    const options: TrackManagementOptions = {}
+
+    it('rejects and warns when calculateTrackQuality throws', () => {
+        const track = asTrack({
+            title: 'Bad Track',
+            url: 'https://example.com/bad',
+            duration: 120000,
+        })
+        calculateTrackQualityMock.mockImplementation(() => {
+            throw new Error('scoring exploded')
+        })
+
+        const result = validateTrack(track, asQueue(), options)
+
+        expect(result).toEqual({
+            isValid: false,
+            reason: 'Validation error',
+        })
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: expect.any(Error),
+                data: expect.objectContaining({
+                    title: 'Bad Track',
+                    url: 'https://example.com/bad',
+                }),
+            }),
+        )
+    })
+})

--- a/packages/bot/src/utils/music/trackValidator.ts
+++ b/packages/bot/src/utils/music/trackValidator.ts
@@ -1,6 +1,6 @@
 import type { Track, GuildQueue } from 'discord-player'
 import type { TrackValidationResult, TrackManagementOptions } from './types'
-import { debugLog } from '@lucky/shared/utils'
+import { warnLog } from '@lucky/shared/utils'
 import {
     calculateTrackSimilarity,
     calculateTrackQuality,
@@ -53,7 +53,11 @@ export function validateTrack(
 
         return { isValid: true, score: calculateTrackQuality(track) }
     } catch (error) {
-        debugLog({ message: 'Error validating track:', error })
+        warnLog({
+            message: 'Error validating track:',
+            error,
+            data: { title: track?.title, url: track?.url },
+        })
         return { isValid: false, reason: 'Validation error' }
     }
 }


### PR DESCRIPTION
## Summary

Four silent-failure fixes, smallest change per site.

- **#2213** backend session middleware: Postgres session store init failure now logs at `warnLog` (was `debugLog`), and an `errorLog` fires when production ends up on a bare `session.MemoryStore` fallback.
- **#2214** bot ticket command: the four `.catch(() => {})` sites around `supportSessionService.close(...)` now log via `logAndWarn(err, 'ticket.close', { sessionId })` instead of swallowing the error.
- **#2215** bot track validator: an exception from `checkForDuplicates`/`calculateTrackQuality` now logs at `warnLog` with the track title and url (was `debugLog`), track is still rejected.
- **#2218** bot idle disconnect: `scheduleIdleDisconnect` now uses a per-guild generation counter, incremented synchronously at entry, so a call superseded while awaiting guild settings bails instead of arming a second timer.

## Test plan

- [x] `npm run type:check` (root) - passes clean across shared/bot/backend/frontend
- [x] `npx jest --config packages/bot/jest.config.cjs --testPathPatterns="ticket|trackValidator|idleDisconnect"` - 4 suites, 30 tests passed
- [x] `npx jest --config packages/backend/jest.config.cjs --testPathPatterns=session` - 4 suites, 45 tests passed
- [x] Verified the new idleDisconnect race test fails against the pre-fix source (2 timers armed instead of 1), confirming it catches the regression

Closes #2213
Closes #2214
Closes #2215
Closes #2218

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four silent failures where errors were swallowed or only debug-logged, plus races that could leave stale idle-disconnect timers.

**Bug Fixes**
- Postgres session store init failures log at `warnLog`; production falling back to in-memory storage logs `errorLog`.
- Ticket close failures log via `logAndWarn` with the session id instead of being swallowed.
- Track validation failures warn with the track title and url before the track is rejected.
- `scheduleIdleDisconnect` uses a per-guild generation counter so a superseded call can't arm a second timer; `clearIdleTimer` advances that counter so resuming playback invalidates a pending schedule still awaiting settings.

<sup>Written for commit efb93900d22b03aa499361564034cb5176ccc0bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

