### PR TITLE
feat: add forum discussion cta and autoplay telemetry panel

### DIFF
--- a/packages/frontend/src/components/Music/AutoplayTelemetry.test.tsx
+++ b/packages/frontend/src/components/Music/AutoplayTelemetry.test.tsx
@@ -69,6 +69,41 @@ describe('AutoplayTelemetry', () => {
         ).toBeInTheDocument()
     })
 
+    test('labels a null source as unknown', async () => {
+        vi.mocked(api.recommendations.getHistory).mockResolvedValue({
+            data: {
+                summary: MOCK_HISTORY.summary,
+                perSource: [
+                    {
+                        source: null,
+                        count: 5,
+                        acceptedCount: 2,
+                        rejectedCount: 1,
+                        pendingCount: 2,
+                        acceptanceRate: null,
+                    },
+                ],
+            },
+        } as any)
+
+        render(<AutoplayTelemetry guildId={guildId} />)
+
+        expect(await screen.findByText('Unknown')).toBeInTheDocument()
+        expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    test('shows a failure message when the history request rejects', async () => {
+        vi.mocked(api.recommendations.getHistory).mockRejectedValue(
+            new Error('network error'),
+        )
+
+        render(<AutoplayTelemetry guildId={guildId} />)
+
+        expect(
+            await screen.findByText('Failed to load autoplay acceptance data.'),
+        ).toBeInTheDocument()
+    })
+
     test('refetches with 30 days when the 30d toggle is clicked', async () => {
         vi.mocked(api.recommendations.getHistory).mockResolvedValue({
             data: MOCK_HISTORY,

--- a/packages/frontend/src/components/Music/AutoplayTelemetry.test.tsx
+++ b/packages/frontend/src/components/Music/AutoplayTelemetry.test.tsx
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { api } from '@/services/api'
+
+vi.mock('@/services/api')
+
+import AutoplayTelemetry from './AutoplayTelemetry'
+
+const MOCK_HISTORY = {
+    summary: {
+        totalPicks: 40,
+        accepted: 30,
+        rejected: 10,
+        pending: 0,
+        globalAcceptanceRate: 0.75,
+    },
+    perSource: [
+        {
+            source: 'youtube',
+            count: 25,
+            acceptedCount: 20,
+            rejectedCount: 5,
+            pendingCount: 0,
+            acceptanceRate: 0.8,
+        },
+        {
+            source: 'spotify',
+            count: 15,
+            acceptedCount: 10,
+            rejectedCount: 5,
+            pendingCount: 0,
+            acceptanceRate: 0.67,
+        },
+    ],
+}
+
+describe('AutoplayTelemetry', () => {
+    const guildId = 'guild-1'
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    test('renders the per-source table and overall summary', async () => {
+        vi.mocked(api.recommendations.getHistory).mockResolvedValue({
+            data: MOCK_HISTORY,
+        } as any)
+
+        render(<AutoplayTelemetry guildId={guildId} />)
+
+        expect(await screen.findByText('youtube')).toBeInTheDocument()
+        expect(screen.getByText('spotify')).toBeInTheDocument()
+        expect(screen.getByText('80%')).toBeInTheDocument()
+        expect(
+            screen.getByText(/30 of 40 picks accepted overall/),
+        ).toBeInTheDocument()
+        expect(api.recommendations.getHistory).toHaveBeenCalledWith(guildId, 7)
+    })
+
+    test('shows empty state when perSource is empty', async () => {
+        vi.mocked(api.recommendations.getHistory).mockResolvedValue({
+            data: { summary: MOCK_HISTORY.summary, perSource: [] },
+        } as any)
+
+        render(<AutoplayTelemetry guildId={guildId} />)
+
+        expect(
+            await screen.findByText('No autoplay history yet'),
+        ).toBeInTheDocument()
+    })
+
+    test('refetches with 30 days when the 30d toggle is clicked', async () => {
+        vi.mocked(api.recommendations.getHistory).mockResolvedValue({
+            data: MOCK_HISTORY,
+        } as any)
+
+        render(<AutoplayTelemetry guildId={guildId} />)
+        await screen.findByText('youtube')
+
+        screen.getByRole('button', { name: '30d' }).click()
+
+        await waitFor(() =>
+            expect(api.recommendations.getHistory).toHaveBeenCalledWith(
+                guildId,
+                30,
+            ),
+        )
+    })
+})

--- a/packages/frontend/src/components/Music/AutoplayTelemetry.tsx
+++ b/packages/frontend/src/components/Music/AutoplayTelemetry.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react'
+import { BarChart3 } from 'lucide-react'
+import { reportError } from '@/lib/sentry'
+import Card from '@/components/ui/Card'
+import EmptyState from '@/components/ui/EmptyState'
+import { api } from '@/services/api'
+import type {
+    RecommendationHistory,
+    RecommendationSourceAcceptance,
+} from '@/services/recommendationsApi'
+
+interface AutoplayTelemetryProps {
+    guildId: string
+}
+
+const DAY_WINDOWS = [7, 30] as const
+
+function formatRate(rate: number | null): string {
+    return rate === null ? '—' : `${Math.round(rate * 100)}%`
+}
+
+function sourceLabel(source: string | null): string {
+    return source ?? 'unknown'
+}
+
+export default function AutoplayTelemetry({ guildId }: AutoplayTelemetryProps) {
+    const [days, setDays] = useState<(typeof DAY_WINDOWS)[number]>(7)
+    const [history, setHistory] = useState<RecommendationHistory | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [failed, setFailed] = useState(false)
+
+    useEffect(() => {
+        let mounted = true
+        setLoading(true)
+        setFailed(false)
+
+        api.recommendations
+            .getHistory(guildId, days)
+            .then((res) => {
+                if (mounted) setHistory(res.data)
+            })
+            .catch((error) => {
+                if (!mounted) return
+                reportError('Failed to load recommendation history:', error, {
+                    component: 'AutoplayTelemetry',
+                    action: 'getHistory',
+                })
+                setFailed(true)
+            })
+            .finally(() => {
+                if (mounted) setLoading(false)
+            })
+
+        return () => {
+            mounted = false
+        }
+    }, [guildId, days])
+
+    const perSource: RecommendationSourceAcceptance[] = history?.perSource ?? []
+
+    return (
+        <Card className='overflow-hidden border border-lucky-border p-0'>
+            <div className='flex flex-wrap items-center justify-between gap-3 px-6 py-4 border-b border-lucky-border'>
+                <div className='flex items-center gap-2'>
+                    <BarChart3
+                        className='h-5 w-5 text-lucky-brand'
+                        aria-hidden='true'
+                    />
+                    <h3 className='type-title text-lucky-text-primary'>
+                        Autoplay acceptance
+                    </h3>
+                </div>
+                <div
+                    className='flex gap-1'
+                    role='group'
+                    aria-label='Time window'
+                >
+                    {DAY_WINDOWS.map((window) => (
+                        <button
+                            key={window}
+                            type='button'
+                            onClick={() => setDays(window)}
+                            aria-pressed={days === window}
+                            className={`rounded-md px-2.5 py-1 type-meta transition-colors ${
+                                days === window
+                                    ? 'bg-lucky-brand text-lucky-bg-primary'
+                                    : 'bg-lucky-bg-active text-lucky-text-secondary hover:text-lucky-text-primary'
+                            }`}
+                        >
+                            {window}d
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {loading ? (
+                <p className='px-6 py-8 text-center type-body-sm text-lucky-text-tertiary'>
+                    Loading…
+                </p>
+            ) : failed ? (
+                <p className='px-6 py-8 text-center type-body-sm text-lucky-error'>
+                    Failed to load autoplay acceptance data.
+                </p>
+            ) : perSource.length === 0 ? (
+                <EmptyState
+                    bare
+                    icon={<BarChart3 className='h-8 w-8' aria-hidden='true' />}
+                    title='No autoplay history yet'
+                    description={`No recommendations were recorded for this server in the last ${days} days.`}
+                />
+            ) : (
+                <>
+                    <div className='hidden md:grid grid-cols-[1fr_100px_100px_80px] gap-4 px-6 py-3 border-b border-lucky-border bg-lucky-bg-tertiary/20'>
+                        {['Source', 'Candidates', 'Accepted', 'Rate'].map(
+                            (h) => (
+                                <span
+                                    key={h}
+                                    className='type-meta text-lucky-text-tertiary text-xs uppercase font-semibold tracking-wide'
+                                >
+                                    {h}
+                                </span>
+                            ),
+                        )}
+                    </div>
+                    <div className='divide-y divide-lucky-border/40'>
+                        {perSource.map((row) => (
+                            <div
+                                key={sourceLabel(row.source)}
+                                className='grid grid-cols-2 md:grid-cols-[1fr_100px_100px_80px] gap-2 md:gap-4 px-6 py-3 items-center'
+                            >
+                                <span className='type-body-sm text-lucky-text-primary capitalize'>
+                                    {sourceLabel(row.source)}
+                                </span>
+                                <span className='type-body-sm text-lucky-text-secondary'>
+                                    {row.count}
+                                </span>
+                                <span className='type-body-sm text-lucky-text-secondary'>
+                                    {row.acceptedCount}
+                                </span>
+                                <span className='type-body-sm text-lucky-text-secondary'>
+                                    {formatRate(row.acceptanceRate)}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                    {history?.summary && (
+                        <p className='px-6 py-3 type-body-sm text-lucky-text-tertiary border-t border-lucky-border'>
+                            {history.summary.accepted} of{' '}
+                            {history.summary.totalPicks} picks accepted overall
+                            ({formatRate(history.summary.globalAcceptanceRate)})
+                            in the last {days} days.
+                        </p>
+                    )}
+                </>
+            )}
+        </Card>
+    )
+}

--- a/packages/frontend/src/components/Music/AutoplayTelemetry.tsx
+++ b/packages/frontend/src/components/Music/AutoplayTelemetry.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BarChart3 } from 'lucide-react'
 import { reportError } from '@/lib/sentry'
 import Card from '@/components/ui/Card'
@@ -19,11 +20,8 @@ function formatRate(rate: number | null): string {
     return rate === null ? '—' : `${Math.round(rate * 100)}%`
 }
 
-function sourceLabel(source: string | null): string {
-    return source ?? 'unknown'
-}
-
 export default function AutoplayTelemetry({ guildId }: AutoplayTelemetryProps) {
+    const { t } = useTranslation()
     const [days, setDays] = useState<(typeof DAY_WINDOWS)[number]>(7)
     const [history, setHistory] = useState<RecommendationHistory | null>(null)
     const [loading, setLoading] = useState(true)
@@ -58,6 +56,9 @@ export default function AutoplayTelemetry({ guildId }: AutoplayTelemetryProps) {
 
     const perSource: RecommendationSourceAcceptance[] = history?.perSource ?? []
 
+    const sourceLabel = (source: string | null): string =>
+        source ?? t('music.unknown')
+
     return (
         <Card className='overflow-hidden border border-lucky-border p-0'>
             <div className='flex flex-wrap items-center justify-between gap-3 px-6 py-4 border-b border-lucky-border'>
@@ -67,13 +68,13 @@ export default function AutoplayTelemetry({ guildId }: AutoplayTelemetryProps) {
                         aria-hidden='true'
                     />
                     <h3 className='type-title text-lucky-text-primary'>
-                        Autoplay acceptance
+                        {t('music.autoplayAcceptance')}
                     </h3>
                 </div>
                 <div
                     className='flex gap-1'
                     role='group'
-                    aria-label='Time window'
+                    aria-label={t('music.timeWindow')}
                 >
                     {DAY_WINDOWS.map((window) => (
                         <button
@@ -95,32 +96,37 @@ export default function AutoplayTelemetry({ guildId }: AutoplayTelemetryProps) {
 
             {loading ? (
                 <p className='px-6 py-8 text-center type-body-sm text-lucky-text-tertiary'>
-                    Loading…
+                    {t('music.autoplayLoading')}
                 </p>
             ) : failed ? (
                 <p className='px-6 py-8 text-center type-body-sm text-lucky-error'>
-                    Failed to load autoplay acceptance data.
+                    {t('music.autoplayLoadFailed')}
                 </p>
             ) : perSource.length === 0 ? (
                 <EmptyState
                     bare
                     icon={<BarChart3 className='h-8 w-8' aria-hidden='true' />}
-                    title='No autoplay history yet'
-                    description={`No recommendations were recorded for this server in the last ${days} days.`}
+                    title={t('music.noAutoplayHistoryTitle')}
+                    description={t('music.noAutoplayHistoryDescription', {
+                        days,
+                    })}
                 />
             ) : (
                 <>
-                    <div className='hidden md:grid grid-cols-[1fr_100px_100px_80px] gap-4 px-6 py-3 border-b border-lucky-border bg-lucky-bg-tertiary/20'>
-                        {['Source', 'Candidates', 'Accepted', 'Rate'].map(
-                            (h) => (
-                                <span
-                                    key={h}
-                                    className='type-meta text-lucky-text-tertiary text-xs uppercase font-semibold tracking-wide'
-                                >
-                                    {h}
-                                </span>
-                            ),
-                        )}
+                    <div className='grid grid-cols-2 md:grid-cols-[1fr_100px_100px_80px] gap-2 md:gap-4 px-6 py-3 border-b border-lucky-border bg-lucky-bg-tertiary/20'>
+                        {[
+                            t('music.tableHeaderSource'),
+                            t('music.tableHeaderCandidates'),
+                            t('music.tableHeaderAccepted'),
+                            t('music.tableHeaderRate'),
+                        ].map((h) => (
+                            <span
+                                key={h}
+                                className='type-meta text-lucky-text-tertiary text-xs uppercase font-semibold tracking-wide'
+                            >
+                                {h}
+                            </span>
+                        ))}
                     </div>
                     <div className='divide-y divide-lucky-border/40'>
                         {perSource.map((row) => (
@@ -145,10 +151,14 @@ export default function AutoplayTelemetry({ guildId }: AutoplayTelemetryProps) {
                     </div>
                     {history?.summary && (
                         <p className='px-6 py-3 type-body-sm text-lucky-text-tertiary border-t border-lucky-border'>
-                            {history.summary.accepted} of{' '}
-                            {history.summary.totalPicks} picks accepted overall
-                            ({formatRate(history.summary.globalAcceptanceRate)})
-                            in the last {days} days.
+                            {t('music.autoplayOverallSummary', {
+                                accepted: history.summary.accepted,
+                                total: history.summary.totalPicks,
+                                rate: formatRate(
+                                    history.summary.globalAcceptanceRate,
+                                ),
+                                days,
+                            })}
                         </p>
                     )}
                 </>

--- a/packages/frontend/src/components/Music/ForumThreadCta.test.tsx
+++ b/packages/frontend/src/components/Music/ForumThreadCta.test.tsx
@@ -25,7 +25,7 @@ describe('ForumThreadCta', () => {
         render(<ForumThreadCta guildId={guildId} slug='music' />)
 
         const link = await screen.findByRole('link', {
-            name: /Ver discussão no Discord/,
+            name: /View discussion on Discord/,
         })
         expect(link).toHaveAttribute(
             'href',
@@ -41,7 +41,7 @@ describe('ForumThreadCta', () => {
 
         await waitFor(() => expect(api.forum.getThread).toHaveBeenCalled())
         expect(
-            screen.queryByRole('link', { name: /Ver discussão no Discord/ }),
+            screen.queryByRole('link', { name: /View discussion on Discord/ }),
         ).not.toBeInTheDocument()
     })
 
@@ -52,7 +52,7 @@ describe('ForumThreadCta', () => {
 
         await waitFor(() => expect(api.forum.getThread).toHaveBeenCalled())
         expect(
-            screen.queryByRole('link', { name: /Ver discussão no Discord/ }),
+            screen.queryByRole('link', { name: /View discussion on Discord/ }),
         ).not.toBeInTheDocument()
     })
 })

--- a/packages/frontend/src/components/Music/ForumThreadCta.test.tsx
+++ b/packages/frontend/src/components/Music/ForumThreadCta.test.tsx
@@ -1,0 +1,58 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { api } from '@/services/api'
+
+vi.mock('@/services/api')
+
+import ForumThreadCta from './ForumThreadCta'
+
+describe('ForumThreadCta', () => {
+    const guildId = 'guild-1'
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    test('renders a link when a thread is mapped', async () => {
+        vi.mocked(api.forum.getThread).mockResolvedValue({
+            threadId: 't1',
+            slug: 'music',
+            title: 'Music thread',
+            archived: false,
+            url: 'https://discord.com/channels/guild-1/t1',
+        })
+
+        render(<ForumThreadCta guildId={guildId} slug='music' />)
+
+        const link = await screen.findByRole('link', {
+            name: /Ver discussão no Discord/,
+        })
+        expect(link).toHaveAttribute(
+            'href',
+            'https://discord.com/channels/guild-1/t1',
+        )
+        expect(api.forum.getThread).toHaveBeenCalledWith(guildId, 'music')
+    })
+
+    test('renders nothing when no thread is mapped (404)', async () => {
+        vi.mocked(api.forum.getThread).mockResolvedValue(null)
+
+        render(<ForumThreadCta guildId={guildId} slug='music' />)
+
+        await waitFor(() => expect(api.forum.getThread).toHaveBeenCalled())
+        expect(
+            screen.queryByRole('link', { name: /Ver discussão no Discord/ }),
+        ).not.toBeInTheDocument()
+    })
+
+    test('renders nothing and does not throw on lookup failure', async () => {
+        vi.mocked(api.forum.getThread).mockRejectedValue(new Error('boom'))
+
+        render(<ForumThreadCta guildId={guildId} slug='music' />)
+
+        await waitFor(() => expect(api.forum.getThread).toHaveBeenCalled())
+        expect(
+            screen.queryByRole('link', { name: /Ver discussão no Discord/ }),
+        ).not.toBeInTheDocument()
+    })
+})

--- a/packages/frontend/src/components/Music/ForumThreadCta.tsx
+++ b/packages/frontend/src/components/Music/ForumThreadCta.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { MessageSquare } from 'lucide-react'
 import { reportError } from '@/lib/sentry'
 import { api } from '@/services/api'
@@ -12,6 +13,7 @@ interface ForumThreadCtaProps {
 // is mapped for this guild. Hidden when no thread is mapped (404) or on any
 // other lookup failure.
 export default function ForumThreadCta({ guildId, slug }: ForumThreadCtaProps) {
+    const { t } = useTranslation()
     const [url, setUrl] = useState<string | null>(null)
 
     useEffect(() => {
@@ -47,7 +49,7 @@ export default function ForumThreadCta({ guildId, slug }: ForumThreadCtaProps) {
             className='inline-flex items-center gap-2 self-start rounded-lg border border-lucky-border bg-lucky-bg-active px-3 py-1.5 type-body-sm text-lucky-text-secondary transition-colors hover:bg-lucky-border hover:text-lucky-text-primary'
         >
             <MessageSquare className='h-4 w-4' aria-hidden='true' />
-            Ver discussão no Discord
+            {t('music.viewDiscussion')}
         </a>
     )
 }

--- a/packages/frontend/src/components/Music/ForumThreadCta.tsx
+++ b/packages/frontend/src/components/Music/ForumThreadCta.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import { MessageSquare } from 'lucide-react'
+import { reportError } from '@/lib/sentry'
+import { api } from '@/services/api'
+
+interface ForumThreadCtaProps {
+    guildId: string
+    slug: string
+}
+
+// Renders a link to the guide's official Discord discussion thread, when one
+// is mapped for this guild. Hidden when no thread is mapped (404) or on any
+// other lookup failure.
+export default function ForumThreadCta({ guildId, slug }: ForumThreadCtaProps) {
+    const [url, setUrl] = useState<string | null>(null)
+
+    useEffect(() => {
+        let mounted = true
+        setUrl(null)
+
+        api.forum
+            .getThread(guildId, slug)
+            .then((thread) => {
+                if (mounted) setUrl(thread?.url ?? null)
+            })
+            .catch((error) => {
+                if (!mounted) return
+                reportError('Failed to load forum thread:', error, {
+                    component: 'ForumThreadCta',
+                    action: 'getThread',
+                })
+                setUrl(null)
+            })
+
+        return () => {
+            mounted = false
+        }
+    }, [guildId, slug])
+
+    if (!url) return null
+
+    return (
+        <a
+            href={url}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='inline-flex items-center gap-2 self-start rounded-lg border border-lucky-border bg-lucky-bg-active px-3 py-1.5 type-body-sm text-lucky-text-secondary transition-colors hover:bg-lucky-border hover:text-lucky-text-primary'
+        >
+            <MessageSquare className='h-4 w-4' aria-hidden='true' />
+            Ver discussão no Discord
+        </a>
+    )
+}

--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -770,7 +770,19 @@
         "progressMayBeOutdated": "may be outdated",
         "commandInProgress": "Working on that command…",
         "dismissError": "Dismiss",
-        "playerNotConnected": "Player is not connected"
+        "playerNotConnected": "Player is not connected",
+        "viewDiscussion": "View discussion on Discord",
+        "autoplayAcceptance": "Autoplay acceptance",
+        "timeWindow": "Time window",
+        "tableHeaderSource": "Source",
+        "tableHeaderCandidates": "Candidates",
+        "tableHeaderAccepted": "Accepted",
+        "tableHeaderRate": "Rate",
+        "autoplayLoading": "Loading…",
+        "autoplayLoadFailed": "Failed to load autoplay acceptance data.",
+        "noAutoplayHistoryTitle": "No autoplay history yet",
+        "noAutoplayHistoryDescription": "No recommendations were recorded for this server in the last {{days}} days.",
+        "autoplayOverallSummary": "{{accepted}} of {{total}} picks accepted overall ({{rate}}) in the last {{days}} days."
     },
     "preferredArtists": {
         "noServerSelected": "No Server Selected",

--- a/packages/frontend/src/locales/pt-BR.json
+++ b/packages/frontend/src/locales/pt-BR.json
@@ -766,7 +766,19 @@
         "progressMayBeOutdated": "pode estar desatualizado",
         "commandInProgress": "Executando o comando…",
         "dismissError": "Dispensar",
-        "playerNotConnected": "O player não está conectado"
+        "playerNotConnected": "O player não está conectado",
+        "viewDiscussion": "Ver discussão no Discord",
+        "autoplayAcceptance": "Aceitação do autoplay",
+        "timeWindow": "Janela de tempo",
+        "tableHeaderSource": "Fonte",
+        "tableHeaderCandidates": "Candidatos",
+        "tableHeaderAccepted": "Aceitos",
+        "tableHeaderRate": "Taxa",
+        "autoplayLoading": "Carregando…",
+        "autoplayLoadFailed": "Falha ao carregar os dados de aceitação do autoplay.",
+        "noAutoplayHistoryTitle": "Ainda não há histórico de autoplay",
+        "noAutoplayHistoryDescription": "Nenhuma recomendação foi registrada para este servidor nos últimos {{days}} dias.",
+        "autoplayOverallSummary": "{{accepted}} de {{total}} escolhas aceitas no total ({{rate}}) nos últimos {{days}} dias."
     },
     "preferredArtists": {
         "noServerSelected": "Nenhum Servidor Selecionado",

--- a/packages/frontend/src/pages/Music.test.tsx
+++ b/packages/frontend/src/pages/Music.test.tsx
@@ -19,6 +19,14 @@ vi.mock('@/components/Music/QueueList', () => ({
 vi.mock('@/components/Music/AutoplayGenres', () => ({
     default: () => <div data-testid='autoplay-genres'>AutoplayGenres</div>,
 }))
+vi.mock('@/components/Music/AutoplayTelemetry', () => ({
+    default: () => (
+        <div data-testid='autoplay-telemetry'>AutoplayTelemetry</div>
+    ),
+}))
+vi.mock('@/components/Music/ForumThreadCta', () => ({
+    default: () => <div data-testid='forum-thread-cta'>ForumThreadCta</div>,
+}))
 
 const mockGuild = { id: '123', name: 'Test Guild' }
 
@@ -105,6 +113,8 @@ describe('MusicPage', () => {
         expect(screen.getByTestId('import-playlist')).toBeInTheDocument()
         expect(screen.getByTestId('queue-list')).toBeInTheDocument()
         expect(screen.getByTestId('autoplay-genres')).toBeInTheDocument()
+        expect(screen.getByTestId('autoplay-telemetry')).toBeInTheDocument()
+        expect(screen.getByTestId('forum-thread-cta')).toBeInTheDocument()
     })
 
     test('shows not connected message when no voice channel', () => {

--- a/packages/frontend/src/pages/Music.tsx
+++ b/packages/frontend/src/pages/Music.tsx
@@ -20,6 +20,8 @@ import SearchBar from '@/components/Music/SearchBar'
 import ImportPlaylist from '@/components/Music/ImportPlaylist'
 import QueueList from '@/components/Music/QueueList'
 import AutoplayGenres from '@/components/Music/AutoplayGenres'
+import AutoplayTelemetry from '@/components/Music/AutoplayTelemetry'
+import ForumThreadCta from '@/components/Music/ForumThreadCta'
 import EmptyState from '@/components/ui/EmptyState'
 import type { QueueState } from '@/types'
 import type { MusicActionKey } from '@/hooks/useMusicPlayer'
@@ -92,7 +94,12 @@ export default function MusicPage() {
                         </p>
                     </div>
                 </div>
-                <ConnectionBadge connected={player.isConnected} />
+                <div className='flex items-center gap-3 shrink-0'>
+                    {guildId && (
+                        <ForumThreadCta guildId={guildId} slug='music' />
+                    )}
+                    <ConnectionBadge connected={player.isConnected} />
+                </div>
             </header>
 
             <NowPlayingHero
@@ -138,6 +145,8 @@ export default function MusicPage() {
             </div>
 
             {guildId && <AutoplayGenres guildId={guildId} />}
+
+            {guildId && <AutoplayTelemetry guildId={guildId} />}
 
             <div>
                 <h2 className='type-title text-lucky-text-primary mb-3 px-1'>

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -33,6 +33,8 @@ import { inferApiBase } from './apiBase'
 import { createRolesManageApi } from './rolesManageApi'
 import { createRoleGroupsApi } from './roleGroupsApi'
 import { createBatchJobsApi } from './batchJobsApi'
+import { createForumApi } from './forumApi'
+import { createRecommendationsApi } from './recommendationsApi'
 
 const browserLocation =
     typeof globalThis !== 'undefined' && 'window' in globalThis
@@ -100,8 +102,7 @@ apiClient.interceptors.response.use(
 
         const status: number = error.response.status
         const data = error.response.data as
-            | { error?: string; details?: unknown }
-            | undefined
+            { error?: string; details?: unknown } | undefined
         const message = data?.error || error.message || 'An error occurred'
 
         if (
@@ -455,6 +456,8 @@ export const api = {
     support: createSupportApi(apiClient, NORMALIZED_API_BASE),
     rolesManage: createRolesManageApi(apiClient),
     batchJobs: createBatchJobsApi(apiClient),
+    forum: createForumApi(apiClient),
+    recommendations: createRecommendationsApi(apiClient),
 }
 
 export { ApiError } from './ApiError'

--- a/packages/frontend/src/services/forumApi.test.ts
+++ b/packages/frontend/src/services/forumApi.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect, vi } from 'vitest'
+import type { AxiosInstance } from 'axios'
+import { ApiError } from './ApiError'
+import { createForumApi } from './forumApi'
+
+function makeClient(impl: () => Promise<unknown>): AxiosInstance {
+    return { get: vi.fn(impl) } as unknown as AxiosInstance
+}
+
+describe('createForumApi', () => {
+    test('getThread returns the thread on success', async () => {
+        const thread = {
+            threadId: 't1',
+            slug: 'music',
+            title: 'Music thread',
+            archived: false,
+            url: 'https://discord.com/channels/g1/t1',
+        }
+        const client = makeClient(() => Promise.resolve({ data: thread }))
+        const api = createForumApi(client)
+
+        await expect(api.getThread('g1', 'music')).resolves.toEqual(thread)
+        expect(client.get).toHaveBeenCalledWith('/guilds/g1/threads/music')
+    })
+
+    test('getThread returns null on 404', async () => {
+        const client = makeClient(() =>
+            Promise.reject(new ApiError(404, 'Thread not found')),
+        )
+        const api = createForumApi(client)
+
+        await expect(api.getThread('g1', 'music')).resolves.toBeNull()
+    })
+
+    test('getThread rethrows non-404 errors', async () => {
+        const client = makeClient(() =>
+            Promise.reject(new ApiError(500, 'boom')),
+        )
+        const api = createForumApi(client)
+
+        await expect(api.getThread('g1', 'music')).rejects.toThrow('boom')
+    })
+})

--- a/packages/frontend/src/services/forumApi.ts
+++ b/packages/frontend/src/services/forumApi.ts
@@ -1,0 +1,31 @@
+import type { AxiosInstance } from 'axios'
+import { ApiError } from './ApiError'
+
+export interface ForumThread {
+    threadId: string
+    slug: string
+    title: string
+    archived: boolean
+    url: string
+}
+
+export function createForumApi(client: AxiosInstance) {
+    return {
+        // Resolves a forum-content slug to its Discord thread for a guild.
+        // Returns null when no thread is mapped (guide has no thread yet).
+        getThread: async (
+            guildId: string,
+            slug: string,
+        ): Promise<ForumThread | null> => {
+            try {
+                const res = await client.get<ForumThread>(
+                    `/guilds/${guildId}/threads/${slug}`,
+                )
+                return res.data
+            } catch (err: unknown) {
+                if (err instanceof ApiError && err.isNotFound) return null
+                throw err
+            }
+        },
+    }
+}

--- a/packages/frontend/src/services/recommendationsApi.test.ts
+++ b/packages/frontend/src/services/recommendationsApi.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect, vi } from 'vitest'
+import type { AxiosInstance } from 'axios'
+import { createRecommendationsApi } from './recommendationsApi'
+
+describe('createRecommendationsApi', () => {
+    test('getHistory calls the history endpoint without params by default', async () => {
+        const data = {
+            summary: {
+                totalPicks: 0,
+                accepted: 0,
+                rejected: 0,
+                pending: 0,
+                globalAcceptanceRate: null,
+            },
+            perSource: [],
+        }
+        const get = vi.fn().mockResolvedValue({ data })
+        const client = { get } as unknown as AxiosInstance
+        const api = createRecommendationsApi(client)
+
+        const res = await api.getHistory('g1')
+
+        expect(res.data).toEqual(data)
+        expect(get).toHaveBeenCalledWith(
+            '/guilds/g1/recommendations/history',
+            undefined,
+        )
+    })
+
+    test('getHistory forwards the days param when provided', async () => {
+        const get = vi.fn().mockResolvedValue({ data: {} })
+        const client = { get } as unknown as AxiosInstance
+        const api = createRecommendationsApi(client)
+
+        await api.getHistory('g1', 30)
+
+        expect(get).toHaveBeenCalledWith('/guilds/g1/recommendations/history', {
+            params: { days: 30 },
+        })
+    })
+
+    test('getHistory propagates rejections', async () => {
+        const get = vi.fn().mockRejectedValue(new Error('network error'))
+        const client = { get } as unknown as AxiosInstance
+        const api = createRecommendationsApi(client)
+
+        await expect(api.getHistory('g1')).rejects.toThrow('network error')
+    })
+})

--- a/packages/frontend/src/services/recommendationsApi.ts
+++ b/packages/frontend/src/services/recommendationsApi.ts
@@ -1,0 +1,33 @@
+import type { AxiosInstance } from 'axios'
+
+export interface RecommendationSummary {
+    totalPicks: number
+    accepted: number
+    rejected: number
+    pending: number
+    globalAcceptanceRate: number | null
+}
+
+export interface RecommendationSourceAcceptance {
+    source: string | null
+    count: number
+    acceptedCount: number
+    rejectedCount: number
+    pendingCount: number
+    acceptanceRate: number | null
+}
+
+export interface RecommendationHistory {
+    summary: RecommendationSummary
+    perSource: RecommendationSourceAcceptance[]
+}
+
+export function createRecommendationsApi(client: AxiosInstance) {
+    return {
+        getHistory: (guildId: string, days?: number) =>
+            client.get<RecommendationHistory>(
+                `/guilds/${guildId}/recommendations/history`,
+                days ? { params: { days } } : undefined,
+            ),
+    }
+}

--- a/packages/frontend/tests/e2e/autoplay-telemetry-panel.spec.ts
+++ b/packages/frontend/tests/e2e/autoplay-telemetry-panel.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test'
+import { setupMockApiResponses } from './helpers/api-helpers'
+
+const GUILD_STORAGE = JSON.stringify({
+    id: '111111111111111111',
+    name: 'Test Server 1',
+})
+
+function mockMusicState(page: import('@playwright/test').Page) {
+    return page.route('**/api/guilds/*/music*', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Credentials': 'true',
+            },
+            body: JSON.stringify({
+                isPlaying: false,
+                currentTrack: null,
+                tracks: [],
+                volume: 80,
+                repeatMode: 'off',
+                voiceChannelName: null,
+            }),
+        })
+    })
+}
+
+function mockRecommendationHistory(
+    page: import('@playwright/test').Page,
+    perSource: unknown[],
+) {
+    return page.route(
+        '**/api/guilds/*/recommendations/history**',
+        async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Allow-Credentials': 'true',
+                },
+                body: JSON.stringify({
+                    summary: {
+                        totalPicks: 40,
+                        accepted: 30,
+                        rejected: 10,
+                        pending: 0,
+                        globalAcceptanceRate: 0.75,
+                    },
+                    perSource,
+                }),
+            })
+        },
+    )
+}
+
+test.describe('Autoplay telemetry panel on the Music page', () => {
+    test.beforeEach(async ({ page }) => {
+        await setupMockApiResponses(page)
+        await mockMusicState(page)
+        await page.addInitScript((guild) => {
+            localStorage.setItem('selectedGuild', guild)
+        }, GUILD_STORAGE)
+    })
+
+    test('renders the per-source acceptance table', async ({ page }) => {
+        await mockRecommendationHistory(page, [
+            {
+                source: 'youtube',
+                count: 25,
+                acceptedCount: 20,
+                rejectedCount: 5,
+                pendingCount: 0,
+                acceptanceRate: 0.8,
+            },
+            {
+                source: 'spotify',
+                count: 15,
+                acceptedCount: 10,
+                rejectedCount: 5,
+                pendingCount: 0,
+                acceptanceRate: 0.67,
+            },
+        ])
+
+        await page.goto('/music')
+        await page.waitForLoadState('domcontentloaded')
+
+        const panel = page
+            .getByText('Autoplay acceptance', { exact: false })
+            .locator('xpath=ancestor::*[contains(@class, "surface-card")]')
+        await expect(panel).toBeVisible({ timeout: 10000 })
+        await expect(panel.getByText('youtube', { exact: true })).toBeVisible()
+        await expect(panel.getByText('spotify', { exact: true })).toBeVisible()
+        await expect(panel.getByText('80%', { exact: true })).toBeVisible()
+        await expect(
+            panel.getByText(/30 of 40 picks accepted overall/i),
+        ).toBeVisible()
+    })
+
+    test('shows the empty state when there is no history', async ({ page }) => {
+        await mockRecommendationHistory(page, [])
+
+        await page.goto('/music')
+        await page.waitForLoadState('domcontentloaded')
+
+        await expect(page.getByText('No autoplay history yet')).toBeVisible({
+            timeout: 10000,
+        })
+    })
+})

--- a/packages/frontend/tests/e2e/autoplay-telemetry-panel.spec.ts
+++ b/packages/frontend/tests/e2e/autoplay-telemetry-panel.spec.ts
@@ -1,31 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { setupMockApiResponses } from './helpers/api-helpers'
-
-const GUILD_STORAGE = JSON.stringify({
-    id: '111111111111111111',
-    name: 'Test Server 1',
-})
-
-function mockMusicState(page: import('@playwright/test').Page) {
-    return page.route('**/api/guilds/*/music*', async (route) => {
-        await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Credentials': 'true',
-            },
-            body: JSON.stringify({
-                isPlaying: false,
-                currentTrack: null,
-                tracks: [],
-                volume: 80,
-                repeatMode: 'off',
-                voiceChannelName: null,
-            }),
-        })
-    })
-}
+import { GUILD_STORAGE, mockMusicState } from './helpers/music-state'
 
 function mockRecommendationHistory(
     page: import('@playwright/test').Page,

--- a/packages/frontend/tests/e2e/forum-thread-cta.spec.ts
+++ b/packages/frontend/tests/e2e/forum-thread-cta.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test'
+import { setupMockApiResponses } from './helpers/api-helpers'
+
+const GUILD_STORAGE = JSON.stringify({
+    id: '111111111111111111',
+    name: 'Test Server 1',
+})
+
+function mockMusicState(page: import('@playwright/test').Page) {
+    return page.route('**/api/guilds/*/music*', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Credentials': 'true',
+            },
+            body: JSON.stringify({
+                isPlaying: false,
+                currentTrack: null,
+                tracks: [],
+                volume: 80,
+                repeatMode: 'off',
+                voiceChannelName: null,
+            }),
+        })
+    })
+}
+
+const CTA_NAME = /Ver discussão no Discord/i
+
+test.describe('Forum thread CTA on the Music page', () => {
+    test.beforeEach(async ({ page }) => {
+        await setupMockApiResponses(page)
+        await mockMusicState(page)
+        await page.addInitScript((guild) => {
+            localStorage.setItem('selectedGuild', guild)
+        }, GUILD_STORAGE)
+    })
+
+    test('shows the CTA when a forum thread is mapped', async ({ page }) => {
+        await page.route('**/api/guilds/*/threads/music', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Allow-Credentials': 'true',
+                },
+                body: JSON.stringify({
+                    threadId: '222222222222222222',
+                    slug: 'music',
+                    title: 'Music & autoplay',
+                    archived: false,
+                    url: 'https://discord.com/channels/111111111111111111/222222222222222222',
+                }),
+            })
+        })
+
+        await page.goto('/music')
+        await page.waitForLoadState('domcontentloaded')
+
+        const link = page.getByRole('link', { name: CTA_NAME })
+        await expect(link).toBeVisible({ timeout: 10000 })
+        await expect(link).toHaveAttribute(
+            'href',
+            'https://discord.com/channels/111111111111111111/222222222222222222',
+        )
+    })
+
+    test('hides the CTA when no forum thread is mapped (404)', async ({
+        page,
+    }) => {
+        await page.route('**/api/guilds/*/threads/music', async (route) => {
+            await route.fulfill({
+                status: 404,
+                contentType: 'application/json',
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Allow-Credentials': 'true',
+                },
+                body: JSON.stringify({ error: 'Thread not found' }),
+            })
+        })
+
+        await page.goto('/music')
+        await page.waitForLoadState('domcontentloaded')
+
+        await expect(
+            page.getByRole('heading', { name: /Music Player/i }),
+        ).toBeVisible({ timeout: 10000 })
+        await expect(page.getByRole('link', { name: CTA_NAME })).toHaveCount(0)
+    })
+})

--- a/packages/frontend/tests/e2e/forum-thread-cta.spec.ts
+++ b/packages/frontend/tests/e2e/forum-thread-cta.spec.ts
@@ -1,33 +1,8 @@
 import { test, expect } from '@playwright/test'
 import { setupMockApiResponses } from './helpers/api-helpers'
+import { GUILD_STORAGE, mockMusicState } from './helpers/music-state'
 
-const GUILD_STORAGE = JSON.stringify({
-    id: '111111111111111111',
-    name: 'Test Server 1',
-})
-
-function mockMusicState(page: import('@playwright/test').Page) {
-    return page.route('**/api/guilds/*/music*', async (route) => {
-        await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Credentials': 'true',
-            },
-            body: JSON.stringify({
-                isPlaying: false,
-                currentTrack: null,
-                tracks: [],
-                volume: 80,
-                repeatMode: 'off',
-                voiceChannelName: null,
-            }),
-        })
-    })
-}
-
-const CTA_NAME = /Ver discussão no Discord/i
+const CTA_NAME = /View discussion on Discord/i
 
 test.describe('Forum thread CTA on the Music page', () => {
     test.beforeEach(async ({ page }) => {
@@ -87,7 +62,9 @@ test.describe('Forum thread CTA on the Music page', () => {
         await page.waitForLoadState('domcontentloaded')
 
         await expect(
-            page.getByRole('heading', { name: /Music Player/i }),
+            page
+                .locator('#lucky-main-content')
+                .getByRole('heading', { name: /Music Player/i }),
         ).toBeVisible({ timeout: 10000 })
         await expect(page.getByRole('link', { name: CTA_NAME })).toHaveCount(0)
     })

--- a/packages/frontend/tests/e2e/helpers/music-state.ts
+++ b/packages/frontend/tests/e2e/helpers/music-state.ts
@@ -1,0 +1,30 @@
+import { Page } from '@playwright/test'
+
+// Shared fixtures for specs that render the Music page with a guild
+// selected: the localStorage payload for the selected guild, and a mock
+// for the music player state endpoint it fetches on mount.
+export const GUILD_STORAGE = JSON.stringify({
+    id: '111111111111111111',
+    name: 'Test Server 1',
+})
+
+export function mockMusicState(page: Page) {
+    return page.route('**/api/guilds/*/music*', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Credentials': 'true',
+            },
+            body: JSON.stringify({
+                isPlaying: false,
+                currentTrack: null,
+                tracks: [],
+                volume: 80,
+                repeatMode: 'off',
+                voiceChannelName: null,
+            }),
+        })
+    })
+}

--- a/packages/frontend/tests/e2e/helpers/music-state.ts
+++ b/packages/frontend/tests/e2e/helpers/music-state.ts
@@ -9,7 +9,7 @@ export const GUILD_STORAGE = JSON.stringify({
 })
 
 export function mockMusicState(page: Page) {
-    return page.route('**/api/guilds/*/music*', async (route) => {
+    return page.route('**/api/guilds/*/music/state**', async (route) => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',

--- a/packages/frontend/tests/e2e/music-page.spec.ts
+++ b/packages/frontend/tests/e2e/music-page.spec.ts
@@ -1,31 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { setupMockApiResponses } from './helpers/api-helpers'
-
-const GUILD_STORAGE = JSON.stringify({
-    id: '111111111111111111',
-    name: 'Test Server 1',
-})
-
-function mockMusicState(page: import('@playwright/test').Page) {
-    return page.route('**/api/guilds/*/music*', async (route) => {
-        await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Credentials': 'true',
-            },
-            body: JSON.stringify({
-                isPlaying: false,
-                currentTrack: null,
-                tracks: [],
-                volume: 80,
-                repeatMode: 'off',
-                voiceChannelName: null,
-            }),
-        })
-    })
-}
+import { GUILD_STORAGE, mockMusicState } from './helpers/music-state'
 
 test.describe('Music Page', () => {
     test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary

Implements #2226 and #2227 (ship option). Both backend routes already existed with no frontend caller; this adds the missing API client methods and UI.

- `api.forum.getThread(guildId, slug)` calls `GET /api/guilds/:guildId/threads/:slug`, returning `null` on 404.
- Music page renders a "Ver discussao no Discord" link button for slug `music` when a thread is mapped for the selected guild, hidden on 404/empty/error.
- `api.recommendations.getHistory(guildId, days)` calls `GET /api/guilds/:guildId/recommendations/history`.
- New `AutoplayTelemetry` card on the Music page: a `source | candidates | accepted | rate` table with a 7d/30d toggle and a one-line overall acceptance summary, with an empty state when the guild has no history.

## CTA placement rationale

The spec suggested placing the CTA on the guide/Docs page matching the slug. `Docs.tsx` slugs do match (`music`, `moderation`, etc.), but `Docs.tsx` is a public, unauthenticated page with no guild context (no `guildId`), while the forum-thread route is guild-scoped (`guildId_slug` unique per guild). It cannot be called from Docs.tsx. The Music page is the guild-scoped surface for the same guide topic ("Music & autoplay"), already has `guildId` via `useGuildSelection`, and is where the autoplay telemetry panel from #2227 also lives, so the CTA was placed there with `slug='music'`.

## Testing

- `npm run type:check --workspace=packages/frontend` - pass
- `npm run test --workspace=packages/frontend` - 1047 tests pass (89 files), including new unit tests for `ForumThreadCta` and `AutoplayTelemetry`
- `npm run lint --workspace=packages/frontend` - pass, 0 warnings
- `npx playwright test tests/e2e/forum-thread-cta.spec.ts tests/e2e/autoplay-telemetry-panel.spec.ts tests/e2e/music-page.spec.ts --project=chromium` - 8 passed (includes the pre-existing music-page suite, confirmed unaffected)

No backend changes.

Closes #2226
Closes #2227

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds frontend consumers for two existing backend routes: a forum discussion link on the Music page and an autoplay acceptance panel.

- `api.forum.getThread(guildId, slug)` resolves a guide slug to its Discord thread, returning `null` on 404.
- `api.recommendations.getHistory(guildId, days)` wraps the existing recommendations history endpoint.
- Music page shows a "Ver discussão no Discord" link when a thread is mapped for `music`; hidden on 404 or lookup errors.
- `AutoplayTelemetry` shows a per-source acceptance table with a 7d/30d toggle, overall summary, empty state, and a labeled two-column header on mobile.
- All new copy is localized in `en.json` and `pt-BR.json`.
- Adds unit and e2e tests covering the CTA, telemetry states, and API methods; shared Music page mocks live in `tests/e2e/helpers/music-state.ts`.

**Note on CTA placement**
The CTA lives on the Music page rather than the docs page because `Docs.tsx` is public with no guild context, while the thread route is guild-scoped.

Closes #2226 and #2227.

<sup>Written for commit 1e5dbd85f7fa666a206a1b4a195f0fc8e2b1d5d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

