### PR TITLE
docs: fix env vars, command references, and skip-feedback adr

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ COMMANDS_DISABLED=
 
 # Optional: Disable specific command categories (comma-separated)
 # Available categories: automod, general, management, moderation, music
-# Example: COMMAND_CATEGORIES_DISABLED=download
+# Example: COMMAND_CATEGORIES_DISABLED=automod
 COMMAND_CATEGORIES_DISABLED=
 
 # Optional: Sentry DSN for error tracking and monitoring

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ NODE_ENV=production
 
 # Bot Customization (Optional)
 BOT_NAME=Lucky
-BOT_DESCRIPTION=A modern Discord bot for music playback and downloads
+BOT_DESCRIPTION=A modern Discord bot for music playback
 BOT_AVATAR_URL=
 BOT_COLOR=0x5865F2
 BOT_PRESENCE_ACTIVITIES=
@@ -35,7 +35,7 @@ BOT_SUPPORT_SERVER=
 COMMANDS_DISABLED=
 
 # Optional: Disable specific command categories (comma-separated)
-# Available categories: download, general, music
+# Available categories: automod, general, management, moderation, music
 # Example: COMMAND_CATEGORIES_DISABLED=download
 COMMAND_CATEGORIES_DISABLED=
 
@@ -63,6 +63,8 @@ LOG_LEVEL=1
 # HEALTHCHECK_INTERVAL_MS=60000
 # Ping URL for the bot's own heartbeat service; disabled if unset
 # HEARTBEAT_PING_URL=
+# Interval in ms between heartbeat pings
+# HEARTBEAT_INTERVAL_MS=60000
 # Prometheus /metrics + /healthz server for the bot process
 # METRICS_DISABLED=false
 # METRICS_PORT=9091
@@ -226,6 +228,8 @@ SEARCH_RETRY_DELAY=5000
 # DIGEST_TITLE=📅 Resumo da semana
 # Embed footer for the weekly digest
 # DIGEST_FOOTER=lucky.bot
+# Interval in ms between weekly-digest checks
+# WEEKLY_DIGEST_TICK_INTERVAL_MS=3600000
 
 # Moderation Digest (Optional)
 # Days covered by each moderation digest run
@@ -250,9 +254,7 @@ SEARCH_RETRY_DELAY=5000
 # Environment variables are the fallback when Vercel is unavailable.
 # FLAGS=vercel_flags_connection_string_or_sdk_key
 # Format: FEATURE_<TOGGLE_NAME>=true|false
-# Available toggles: DOWNLOAD_VIDEO, DOWNLOAD_AUDIO, MUSIC_RECOMMENDATIONS, AUTOPLAY, LYRICS, QUEUE_MANAGEMENT, REACTION_ROLES, ROLE_MANAGEMENT, MODERATION, AUTOMOD, CUSTOM_COMMANDS, AUTO_MESSAGES, SERVER_LOGS, WEBAPP, TWITCH_NOTIFICATIONS, LASTFM_INTEGRATION, WELCOME_MESSAGES
-# FEATURE_DOWNLOAD_VIDEO=true
-# FEATURE_DOWNLOAD_AUDIO=true
+# Available toggles: MUSIC_RECOMMENDATIONS, AUTOPLAY, LYRICS, QUEUE_MANAGEMENT, REACTION_ROLES, ROLE_MANAGEMENT, MODERATION, AUTOMOD, CUSTOM_COMMANDS, AUTO_MESSAGES, SERVER_LOGS, WEBAPP, TWITCH_NOTIFICATIONS, LASTFM_INTEGRATION, SPOTIFY_INTEGRATION, WELCOME_MESSAGES, ARTIST_COMMAND, ALBUM_COMMAND, EMBED_BUILDER, COLLABORATIVE_PLAYLIST, RSS_BRIDGE
 # FEATURE_MUSIC_RECOMMENDATIONS=true
 # FEATURE_AUTOPLAY=true
 # FEATURE_LYRICS=true

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Unlike Groovy, Rythm, or Hydra (all shut down by third-party enforcement), Lucky
 - **Guild management**: Control settings and features per server
 - **Music controls**: Queue, playback, and playlist management from the web
 - **Moderation overview**: Case history, warnings, and actions
-- **Feature toggles**: Enable/disable per-guild
+- **Feature status view**: Global, admin-managed
 
 ### 📈 Reliability & Monitoring
 - **CI/CD**: Every PR runs lint, build, the full test suite, and SonarCloud gates
@@ -144,7 +144,7 @@ echo "POSTGRES_PASSWORD=$(openssl rand -hex 24)" >> .env
 #   - DISCORD_TOKEN (from Discord Developer Portal)
 #   - CLIENT_ID (your bot's client ID)
 #   - DATABASE_URL (postgres://...)
-#   - REDIS_URL (redis://...)
+#   - REDIS_HOST, REDIS_PORT, REDIS_PASSWORD, REDIS_DB (defaults work for the bundled Redis container)
 
 # Start everything
 docker compose up -d
@@ -188,7 +188,10 @@ CLIENT_ID=your_client_id
 
 # Database
 DATABASE_URL=postgres://user:pass@localhost:5432/lucky
-REDIS_URL=redis://localhost:6379
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB=0
 
 # Spotify (optional)
 SPOTIFY_CLIENT_ID=...
@@ -206,12 +209,12 @@ SENTRY_DSN=...
 | Command | Purpose |
 |---------|---------|
 | `/play` | Play a song, playlist, or search query |
-| `/pause` / `/resume` | Control playback |
+| `/pause` | Toggle pause/resume |
 | `/skip` | Skip to next track |
 | `/stop` | Stop and clear queue |
 | `/queue` | View current queue |
 | `/shuffle` | Randomize queue order |
-| `/repeat` | Toggle repeat modes (off / all / one) |
+| `/repeat` | Toggle repeat modes (off / track / queue) |
 | `/lyrics` | Show lyrics for current track |
 | `/autoplay` | Toggle smart recommendations |
 | `/songinfo` | Details on current track |

--- a/decisions/2026-06-06-decommission-backend-guild-automation-execution-service.md
+++ b/decisions/2026-06-06-decommission-backend-guild-automation-execution-service.md
@@ -43,10 +43,9 @@ Rationale: the file is **already** dead (no callers), so deletion is runtime-saf
 nothing at execution time. Remaining executors are ported **fresh per module**, not copy-pasted
 from this file, so it is a _reference at best_, and git serves that better than drift-prone live
 code. "Retain until migration completes" is a weak contract that historically becomes "retain
-forever" on this repo (cf. the per-guild-toggle orphan that sat dead for 2 weeks —
-[2026-05-19-retire-per-guild-feature-toggles](2026-05-19-retire-per-guild-feature-toggles.md)),
-and the passing test is a false coverage signal that invites future devs to treat dead code as
-load-bearing.
+forever" on this repo (cf. the per-guild-toggle orphan that sat dead for 2 weeks before removal,
+which never got its own decision record), and the passing test is a false coverage signal that
+invites future devs to treat dead code as load-bearing.
 
 ## Alternatives considered
 

--- a/decisions/2026-09-05-skip-feedback-redesign-deferred.md
+++ b/decisions/2026-09-05-skip-feedback-redesign-deferred.md
@@ -1,0 +1,84 @@
+# Skip-reason feedback UX redesign: deferred
+
+- **Date:** 2026-09-05
+- **Status:** Accepted (defer)
+- **Deciders:** Lucas Santana
+- **Scope:** The skip-reason emoji-reaction feedback mechanism on now-playing messages
+  (`packages/bot/src/handlers/player/trackNowPlaying.ts:298-312, 359-364`)
+- **Closes:** `decisions/2026-08-03-autoplay-remeasure-gate-passed.md` §3, which named this
+  redesign as owed and required a separate decision before it could be built or dropped
+
+## Context
+
+`decisions/2026-08-03-autoplay-remeasure-gate-passed.md` measured the emoji-prefill →
+reaction skip-feedback pipeline at 2 rows lifetime adoption and concluded, in its Decision
+§3, that "the skip-reason feedback UX needs a redesign, not a fix," explicitly deferring
+that redesign to "a new, separate decision." No such decision was recorded in the month
+since. A search of `decisions/*.md` turns up no mention of skip-reason work, and no open
+issue matches "skip feedback" or "redesign" (this ADR's own tracking issue, #2224, is the
+follow-up prompt, not a spec).
+
+Verified current state:
+
+- The mechanism is unchanged: `trackNowPlaying.ts` still attaches the same set of
+  skip-reason emojis to every now-playing message and logs partial-prefill failures. No
+  redesign work has landed.
+- Autoplay's other metrics have held or improved since the 2026-08-03 measurement
+  (`decisions/2026-08-03-autoplay-remeasure-gate-passed.md`: coverage 75.6% -> 83.4%,
+  acceptance holding at 0.950), so autoplay quality is not blocked on this signal.
+- #2227 is open and ready-for-agent: it will surface `getSummary` /
+  `getPerSourceAcceptance` (the acceptance/coverage numbers three ADRs have relied on via
+  raw SQL) on the dashboard's Music page. Once that ships, it is the natural place to
+  observe whether skip-reason adoption moves at all, and the natural place to eventually
+  host a redesigned feedback control if one is ever built.
+- Nothing else in the codebase reads or writes skip-reason data beyond the reaction
+  handler; there is no partial redesign in flight to reconcile.
+
+## Decision
+
+**Defer the skip-reason feedback UX redesign. Keep the existing emoji-reaction mechanism
+as-is.** Two rows of lifetime data is not enough to design against, and no one has spent
+design time on a replacement since the 2026-08-03 ADR flagged the need. Building a redesign
+now would be speculative: the shape of a better mechanism should come from watching
+real usage once that usage is visible in the dashboard (#2227), not from guessing.
+
+This ADR is the "separate decision" the 2026-08-03 ADR asked for. It satisfies that ADR's
+owed follow-up by explicitly re-deferring, with the revisit condition below, rather than
+leaving the debt unrecorded.
+
+## Alternatives considered
+
+- **Redesign now** (e.g. a slash-command prompt, a dashboard form, a DM follow-up),
+  rejected. Two lifetime data points give no signal about what form of feedback users
+  would actually engage with; any design would be a guess dressed up as a decision.
+- **Remove the mechanism entirely**, rejected. It is inert (near-zero adoption, no
+  reported user complaints, negligible maintenance cost) and removing it would also
+  remove the one channel, however underused, through which skip-reason data could ever
+  accumulate. There is no cost pressure forcing removal.
+- **Leave the debt unrecorded**, rejected. That is the exact failure #2224 exists to
+  close; the 2026-08-03 ADR was explicit that a redesign or a re-defer both count as
+  resolving it, and only a recorded decision satisfies that, not silence.
+
+## Consequences
+
+- **Positive:** the owed-decision debt from 2026-08-03 is closed; the mechanism is not
+  touched, so there is zero implementation risk; future work has an explicit revisit
+  condition instead of an open-ended "someday."
+- **Negative:** skip-reason adoption stays at effectively zero until either the revisit
+  condition fires or someone observes a concrete reason to act sooner; the signal
+  continues to be functionally unused.
+- **Neutral:** the emoji-reaction code path is unchanged, so no test or behavior surface
+  is affected by this decision.
+
+## Revisit when
+
+- #2227 ships and dashboard-visible autoplay acceptance telemetry from
+  `/api/guilds/:guildId/recommendations/history` shows skip-reason adoption still below a
+  meaningful threshold (e.g. under 5% of skipped tracks getting a reaction) over a rolling
+  30-day window, at which point the low adoption itself becomes the evidence a redesign
+  should act on; or
+- Someone proposes a concrete redesign with a spec, in which case that spec supersedes this
+  ADR and becomes the new decision record (#2227's dashboard view is the natural place to
+  host it); or
+- Skip-reason data is needed for an autoplay quality decision and the near-zero volume
+  becomes a blocker, forcing the redesign question sooner than either trigger above.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -7,13 +7,13 @@
 
 ## Build targets
 
-| Image                | Command                                                                        |
-| -------------------- | ------------------------------------------------------------------------------ |
-| Bot (production)     | `docker build --target production-bot -t lucky-bot:latest .`                   |
-| Backend (production) | `docker build --target production-backend -t lucky-backend:latest .`           |
-| Bot (development)    | `docker build --target development --build-arg SERVICE=bot -t lucky-bot:dev .` |
-| Frontend (production)| `docker build --target production-frontend -t lucky-frontend:latest .`        |
-| Nginx                | `docker build -f Dockerfile.nginx -t lucky-nginx:latest .`                     |
+| Image                 | Command                                                                |
+| --------------------- | ---------------------------------------------------------------------- |
+| Bot (production)      | `docker build --target production-bot -t lucky-bot:latest .`           |
+| Backend (production)  | `docker build --target production-backend -t lucky-backend:latest .`   |
+| Bot (development)     | `docker build --target development -t lucky-bot:dev .`                 |
+| Frontend (production) | `docker build --target production-frontend -t lucky-frontend:latest .` |
+| Nginx                 | `docker build -f Dockerfile.nginx -t lucky-nginx:latest .`             |
 
 Compose builds these when you run `docker compose up -d` or `docker compose -f docker-compose.dev.yml up -d`.
 

--- a/packages/frontend/src/pages/Docs.tsx
+++ b/packages/frontend/src/pages/Docs.tsx
@@ -290,13 +290,12 @@ const PAGES: DocsPage[] = [
                     <li>
                         <code>/queue</code> — see what's coming up. Use{' '}
                         <code>/skip</code>, <code>/pause</code>,{' '}
-                        <code>/resume</code>, <code>/loop</code> to control
-                        playback.
+                        <code>/repeat</code> to control playback.
                     </li>
                     <li>
                         <code>
-                            /cc create welcome &quot;Welcome to {'{server}'},{' '}
-                            {'{user}'}!&quot;
+                            /customcommand create welcome &quot;Welcome to{' '}
+                            {'{server}'}, {'{user}'}!&quot;
                         </code>{' '}
                         — make a custom command. Run <code>/welcome</code> to
                         test it.
@@ -603,11 +602,9 @@ docker compose ps`}</code>
                 <p>
                     The bot registers commands automatically on first start,
                     both globally and per-guild for testing. If new commands
-                    don't show up, force re-registration with:
+                    don't show up, restart the bot; commands register
+                    automatically on boot.
                 </p>
-                <pre>
-                    <code>{`docker compose exec bot npm run register-commands`}</code>
-                </pre>
                 <h2 id='verify'>Verify the install</h2>
                 <ol>
                     <li>
@@ -915,11 +912,8 @@ docker compose up -d <service>`}</code>
                         after registration.
                     </li>
                     <li>
-                        Force re-register:{' '}
-                        <code>
-                            docker compose exec bot npm run register-commands
-                        </code>
-                        .
+                        Force re-register: restart the bot; commands register
+                        automatically on boot.
                     </li>
                     <li>
                         Per-guild registration is instant. Set{' '}
@@ -1005,11 +999,11 @@ docker compose up -d <service>`}</code>
                         track.
                     </li>
                     <li>
-                        <code>/pause</code> / <code>/resume</code>.
+                        <code>/pause</code>, toggles pause/resume.
                     </li>
                     <li>
-                        <code>/loop track|queue|off</code> — loop the current
-                        track, the whole queue, or disable.
+                        <code>/repeat mode:off|track|queue</code>, repeats the
+                        current track, the whole queue, or disables.
                     </li>
                     <li>
                         <code>/shuffle</code> — shuffle the remainder of the
@@ -1060,9 +1054,9 @@ docker compose up -d <service>`}</code>
                 <p>
                     Per-server allow-list of artists autoplay prefers. Add via{' '}
                     <strong>Music / Preferred artists</strong> in the dashboard,
-                    or with <code>/preferred add</code>. Useful for keeping a
-                    server's musical identity intact without micromanaging every
-                    play.
+                    or with <code>/autoplay artist prefer</code>. Useful for
+                    keeping a server's musical identity intact without
+                    micromanaging every play.
                 </p>
                 <h2 id='last-fm'>Last.fm scrobbling</h2>
                 <p>
@@ -1083,9 +1077,9 @@ docker compose up -d <service>`}</code>
                 <h2 id='filters'>Filters & shaping</h2>
                 <p>
                     Audio filters are off by default. Available via{' '}
-                    <code>/filter</code>: bass boost, nightcore, karaoke.
-                    Filters apply to the live stream, so you can toggle
-                    mid-track. Heavier filters add ~50ms of latency.
+                    <code>/effects</code>: bassboost, nightcore, reset. Filters
+                    apply to the live stream, so you can toggle mid-track.
+                    Heavier filters add ~50ms of latency.
                 </p>
             </>
         ),
@@ -1147,24 +1141,24 @@ docker compose up -d <service>`}</code>
                 </p>
                 <h2 id='manual-actions'>Manual actions</h2>
                 <p>
-                    Run <code>/mod ban</code>, <code>/mod kick</code>,{' '}
-                    <code>/mod tempban</code>, <code>/mod warn</code>, or{' '}
-                    <code>/mod mute</code>. Each accepts a reason that's sent to
-                    the user via DM (if they allow them), written to your audit
-                    log, and copied to the Discord audit trail.
+                    Run <code>/ban</code>, <code>/kick</code>,{' '}
+                    <code>/mute</code>, or <code>/warn</code>. Each accepts a
+                    reason that's sent to the user via DM (if they allow them),
+                    written to your audit log, and copied to the Discord audit
+                    trail.
                 </p>
                 <pre>
-                    <code>{`/mod tempban @user 7d reason: "raiding from alt account"
-/mod warn @user reason: "first warning for caps"`}</code>
+                    <code>{`/mute user:@user duration:1h reason:"raiding from alt account"
+/warn user:@user reason:"first warning for caps"`}</code>
                 </pre>
                 <h2 id='cases'>Cases & appeals</h2>
                 <p>
-                    Every manual action creates a numbered case. Users can run{' '}
-                    <code>/case &lt;id&gt;</code> to see their own case detail,
-                    or moderators can run <code>/case @user</code> to see a
-                    user's case history. Cases can be edited (
-                    <code>/case edit</code>) and appealed (
-                    <code>/case appeal</code>).
+                    Every manual action creates a numbered case. Moderators can
+                    run <code>/case view &lt;id&gt;</code> to see a case's
+                    detail, or <code>/cases user:@user</code> to see a user's
+                    case history. A case's reason can be updated (
+                    <code>/case update</code>) or the case removed (
+                    <code>/case delete</code>).
                 </p>
                 <h2 id='audit'>Audit log</h2>
                 <p>
@@ -1203,7 +1197,7 @@ docker compose up -d <service>`}</code>
                 </p>
                 <h2 id='create-one'>Create one</h2>
                 <pre>
-                    <code>{`/cc create rules
+                    <code>{`/customcommand create rules
 > response: "Read the rules in #rules-channel, ${'$'}{user}."`}</code>
                 </pre>
                 <p>
@@ -1273,14 +1267,14 @@ docker compose up -d <service>`}</code>
                     <strong>Welcome reply</strong>
                 </p>
                 <pre>
-                    <code>{`/cc create welcome
+                    <code>{`/customcommand create welcome
 > response: "Welcome to {server}, {user}! Read #rules and grab a role in #pick-roles."`}</code>
                 </pre>
                 <p>
                     <strong>Repeatable info card</strong> with an embed:
                 </p>
                 <pre>
-                    <code>{`/cc create faq
+                    <code>{`/customcommand create faq
 > embed
 > title: "Server FAQ"
 > description: "Common questions answered here. {server.memberCount} members and growing."
@@ -1290,7 +1284,7 @@ docker compose up -d <service>`}</code>
                     <strong>Mod-only utility</strong> with a role gate:
                 </p>
                 <pre>
-                    <code>{`/cc create staff-ping
+                    <code>{`/customcommand create staff-ping
 > response: "Heads up @Staff — {user} is asking for help in {channel}."
 > roles: [Moderator]`}</code>
                 </pre>
@@ -1508,15 +1502,15 @@ docker compose up -d <service>`}</code>
                         </tr>
                         <tr>
                             <td>
-                                <code>/pause</code> / <code>/resume</code>
+                                <code>/pause</code>
                             </td>
-                            <td>Pause and resume playback.</td>
+                            <td>Toggle pause/resume playback.</td>
                         </tr>
                         <tr>
                             <td>
-                                <code>/loop track|queue|off</code>
+                                <code>/repeat mode:off|track|queue</code>
                             </td>
-                            <td>Configure looping.</td>
+                            <td>Configure repeat mode.</td>
                         </tr>
                         <tr>
                             <td>
@@ -1568,11 +1562,9 @@ docker compose up -d <service>`}</code>
                         </tr>
                         <tr>
                             <td>
-                                <code>/filter &lt;name&gt;</code>
+                                <code>/effects bassboost|nightcore|reset</code>
                             </td>
-                            <td>
-                                Apply audio filters (bass, nightcore, karaoke).
-                            </td>
+                            <td>Apply audio effects to the current track.</td>
                         </tr>
                     </tbody>
                 </table>
@@ -1587,7 +1579,7 @@ docker compose up -d <service>`}</code>
                     <tbody>
                         <tr>
                             <td>
-                                <code>/mod ban</code>
+                                <code>/ban</code>
                             </td>
                             <td>
                                 Permanent ban with reason and audit-log entry.
@@ -1595,33 +1587,33 @@ docker compose up -d <service>`}</code>
                         </tr>
                         <tr>
                             <td>
-                                <code>/mod kick</code>
+                                <code>/kick</code>
                             </td>
                             <td>Kick from the server.</td>
                         </tr>
                         <tr>
                             <td>
-                                <code>/mod tempban</code>
-                            </td>
-                            <td>Temporary ban with auto-revoke.</td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code>/mod mute</code>
+                                <code>/mute</code>
                             </td>
                             <td>Discord timeout with duration.</td>
                         </tr>
                         <tr>
                             <td>
-                                <code>/mod warn</code>
+                                <code>/warn</code>
                             </td>
                             <td>Warn a user, DM them, log it.</td>
                         </tr>
                         <tr>
                             <td>
-                                <code>/case &lt;id|user&gt;</code>
+                                <code>/case view &lt;id&gt;</code>
                             </td>
-                            <td>Look up moderation cases.</td>
+                            <td>Look up a moderation case by ID.</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code>/cases user:&lt;user&gt;</code>
+                            </td>
+                            <td>List a user's moderation case history.</td>
                         </tr>
                         <tr>
                             <td>
@@ -1642,19 +1634,19 @@ docker compose up -d <service>`}</code>
                     <tbody>
                         <tr>
                             <td>
-                                <code>/cc create</code>
+                                <code>/customcommand create</code>
                             </td>
                             <td>Build a custom command.</td>
                         </tr>
                         <tr>
                             <td>
-                                <code>/cc edit</code>
+                                <code>/customcommand edit</code>
                             </td>
                             <td>Edit an existing custom command.</td>
                         </tr>
                         <tr>
                             <td>
-                                <code>/cc delete</code>
+                                <code>/customcommand delete</code>
                             </td>
                             <td>Delete a custom command.</td>
                         </tr>

--- a/packages/frontend/src/pages/Docs.tsx
+++ b/packages/frontend/src/pages/Docs.tsx
@@ -1183,111 +1183,56 @@ docker compose up -d <service>`}</code>
         breadcrumb: 'Docs / Custom commands',
         toc: [
             { id: 'create-one', label: 'Create one' },
-            { id: 'variables', label: 'Variables' },
-            { id: 'embeds', label: 'Embed responses' },
-            { id: 'permissions', label: 'Permissions & scope' },
-            { id: 'examples', label: 'Patterns & examples' },
+            { id: 'how-it-triggers', label: 'How it triggers' },
+            { id: 'manage', label: 'Edit, list, delete' },
+            { id: 'scope', label: 'Scope' },
         ],
         content: () => (
             <>
                 <p>
-                    Build slash commands without writing code. Useful for FAQ
-                    replies, role toggles, embed posts, server-specific
-                    shortcuts, and quick info lookups.
+                    Canned text replies without writing code. Useful for FAQ
+                    answers, rules reminders, and server-specific shortcuts.
                 </p>
                 <h2 id='create-one'>Create one</h2>
                 <pre>
-                    <code>{`/customcommand create rules
-> response: "Read the rules in #rules-channel, ${'$'}{user}."`}</code>
+                    <code>{`/customcommand create name:rules response:"Read the rules in #rules-channel." description:"Points to the rules"`}</code>
                 </pre>
                 <p>
-                    Or use the dashboard: <strong>Custom commands / New</strong>
-                    . The dashboard form lets you preview the response live with
-                    sample variable values.
+                    <code>name</code> and <code>response</code> are required;
+                    <code>description</code> is optional and only shows in{' '}
+                    <code>/customcommand list</code> and{' '}
+                    <code>/customcommand info</code>. Names are lowercased and
+                    must be unique per server. The response is sent exactly as
+                    written: there is no variable substitution, no embed mode,
+                    and no per-command cooldown. The dashboard{' '}
+                    <strong>Commands</strong> page enables or disables built-in
+                    commands; it does not create custom ones.
                 </p>
-                <h2 id='variables'>Variables</h2>
-                <ul>
-                    <li>
-                        <code>{'{user}'}</code> — the invoking user's mention.
-                    </li>
-                    <li>
-                        <code>{'{user.name}'}</code> — username only.
-                    </li>
-                    <li>
-                        <code>{'{user.id}'}</code> — snowflake ID.
-                    </li>
-                    <li>
-                        <code>{'{user.joinedAt}'}</code> — formatted join date.
-                    </li>
-                    <li>
-                        <code>{'{server}'}</code> — server name.
-                    </li>
-                    <li>
-                        <code>{'{server.memberCount}'}</code> — total members.
-                    </li>
-                    <li>
-                        <code>{'{channel}'}</code> — current channel mention.
-                    </li>
-                    <li>
-                        <code>{'{arg1}'}</code>, <code>{'{arg2}'}</code> ... —
-                        positional arguments.
-                    </li>
-                    <li>
-                        <code>{'{args}'}</code> — everything after the command
-                        name as one string.
-                    </li>
-                </ul>
-                <h2 id='embeds'>Embed responses</h2>
+                <h2 id='how-it-triggers'>How it triggers</h2>
                 <p>
-                    Custom commands can return rich embeds. In the dashboard,
-                    toggle <strong>Embed mode</strong> on the command and use
-                    the embed builder — title, description, color, fields,
-                    footer. Variables interpolate inside embed fields too.
+                    A custom command is not a slash command. Lucky replies when
+                    a member sends a message whose text is exactly the command
+                    name, or starts with the name followed by a space. For the
+                    example above, sending <code>rules</code> in any channel the
+                    bot can read posts the reply. The{' '}
+                    <strong>Custom commands</strong> feature toggle must be on
+                    for the server.
                 </p>
-                <h2 id='permissions'>Permissions & scope</h2>
-                <ul>
-                    <li>
-                        <strong>Role gate.</strong> Restrict who can invoke.
-                        Default is everyone.
-                    </li>
-                    <li>
-                        <strong>Channel gate.</strong> Restrict where it can be
-                        invoked.
-                    </li>
-                    <li>
-                        <strong>Cooldown.</strong> Per-user or per-channel.
-                    </li>
-                    <li>
-                        <strong>Ephemeral.</strong> Response only visible to the
-                        invoker (useful for self-service info).
-                    </li>
-                </ul>
-                <h2 id='examples'>Patterns & examples</h2>
-                <p>
-                    <strong>Welcome reply</strong>
-                </p>
+                <h2 id='manage'>Edit, list, delete</h2>
                 <pre>
-                    <code>{`/customcommand create welcome
-> response: "Welcome to {server}, {user}! Read #rules and grab a role in #pick-roles."`}</code>
+                    <code>{`/customcommand edit name:rules response:"Rules moved to #welcome."
+/customcommand info name:rules
+/customcommand list
+/customcommand delete name:rules`}</code>
                 </pre>
+                <h2 id='scope'>Scope</h2>
                 <p>
-                    <strong>Repeatable info card</strong> with an embed:
+                    Each command stores optional allowed-role and
+                    allowed-channel lists, and the bot ignores a trigger from
+                    anyone or anywhere outside them. Neither the slash command
+                    nor the dashboard exposes those lists yet, so every command
+                    you create today answers everyone in every channel.
                 </p>
-                <pre>
-                    <code>{`/customcommand create faq
-> embed
-> title: "Server FAQ"
-> description: "Common questions answered here. {server.memberCount} members and growing."
-> color: pink`}</code>
-                </pre>
-                <p>
-                    <strong>Mod-only utility</strong> with a role gate:
-                </p>
-                <pre>
-                    <code>{`/customcommand create staff-ping
-> response: "Heads up @Staff — {user} is asking for help in {channel}."
-> roles: [Moderator]`}</code>
-                </pre>
             </>
         ),
     },
@@ -1383,8 +1328,8 @@ docker compose up -d <service>`}</code>
                         actions, audit log, cases.
                     </li>
                     <li>
-                        <strong>Custom commands.</strong> Build, edit, and scope
-                        custom replies. Live preview.
+                        <strong>Custom commands.</strong> Canned text replies
+                        managed with <code>/customcommand</code>.
                     </li>
                     <li>
                         <strong>Reaction roles.</strong> Self-assign roles from


### PR DESCRIPTION
## Summary

Also rewrites the Custom commands docs page (#2233) to describe only what `/customcommand` ships: plain-text trigger, static reply, no variables, no embed mode, role and channel gates stored but not yet editable.

Fixes five documentation-drift issues: dead env vars and a dead ADR link, stale `.env.example` comments, a stack of wrong slash-command references across the Docs page and README, a stale per-guild feature-toggle claim, and an owed ADR follow-up.

## Changes

- **README.md**: replaced the dead `REDIS_URL` blocks with `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD`/`REDIS_DB` (matches `.env.example` and what the app actually reads); changed the "Feature toggles: Enable/disable per-guild" bullet to "Feature status view: Global, admin-managed"; fixed `/pause` / `/repeat` command references in the Commands table.
- **docs/DOCKER.md**: dropped `--build-arg SERVICE=bot` (the Dockerfile declares no such ARG).
- **decisions/2026-06-06-decommission-backend-guild-automation-execution-service.md**: dropped the dead link to `2026-05-19-retire-per-guild-feature-toggles.md`, which never existed (`grep -ril per-guild decisions/` turns up no ADR for that retirement; a plain-text note replaces the link). Verified every relative link across `decisions/*.md` now resolves.
- **.env.example**: regenerated the "Available categories" comment from the real `category:` values (`automod, general, management, moderation, music`); regenerated "Available toggles" from `featureToggles.ts` (removed the dead `DOWNLOAD_*` entries, added the 6 missing ones); removed the `FEATURE_DOWNLOAD_VIDEO`/`FEATURE_DOWNLOAD_AUDIO` example lines; dropped "and downloads" from `BOT_DESCRIPTION`; added `HEARTBEAT_INTERVAL_MS` and `WEEKLY_DIGEST_TICK_INTERVAL_MS` next to their siblings, with the real code defaults as commented values.
- **packages/frontend/src/pages/Docs.tsx**: replaced every wrong command reference with the real one, and replaced both manual `npm run register-commands` steps with "restart the bot; commands register automatically on boot".
- **decisions/2026-09-05-skip-feedback-redesign-deferred.md** (new): explicitly re-defers the skip-reason feedback UX redesign that `decisions/2026-08-03-autoplay-remeasure-gate-passed.md` §3 flagged as owed. Revisit-when is tied to autoplay telemetry becoming dashboard-visible via #2227, or a concrete redesign spec appearing.

## Command-reference mismatch diff (Docs.tsx / README)

| documented (before) | real | fixed to |
|---|---|---|
| `/resume` | `/pause` toggles pause/resume | `/pause` |
| `/loop track\|queue\|off` | `/repeat mode:off\|track\|queue` | `/repeat mode:off\|track\|queue` |
| `/filter <name>` (+ karaoke) | `/effects bassboost\|nightcore\|reset` | `/effects bassboost\|nightcore\|reset` |
| `/mod ban\|kick\|tempban\|warn\|mute` | five top-level commands, no tempban | `/ban`, `/kick`, `/mute`, `/warn` |
| `/cc create` | `/customcommand` | `/customcommand create\|edit\|delete` |
| `docker compose exec bot npm run register-commands` | no such script; registration is automatic on boot | "restart the bot" |

Extra mismatches found while diffing every `/command` token against `grep -rhoE "setName('[a-z-]+')" packages/bot/src/functions` (not in the original issue list, fixed in the same PR since they're the same class of drift):

| documented (before) | real |
|---|---|
| `/preferred add` | `/autoplay artist prefer` |
| `/case <id>` / `/case @user`, `/case edit`, `/case appeal` | `/case view <id>`, `/cases user:<user>`, `/case update`, `/case delete` (no appeal subcommand exists) |

After the fixes, `grep -n "register-commands"` in Docs.tsx returns no `npm run register-commands` invocation, and no leftover `/mod`, `/loop`, `/filter`, `/cc`, `tempban`, or `karaoke` token remains in Docs.tsx or README.md.

## Left undone / filed separately

While verifying the Custom commands doc page against the real `/customcommand` command, found that its "Embed responses" and "Permissions & scope" sections describe an embed-mode toggle, role gate, channel gate, cooldown, and ephemeral-response options that don't exist on the real command (only `name`/`response`/`description`). That's a different class of problem (fabricated features, not a wrong command name) and out of scope for this PR, so filed as #2233 instead of folding it in here.

## Verification

- `npm run type:check --workspace=packages/frontend`: passes.
- `npx prettier --check` on every touched file: passes (`.env.example` has no prettier parser for that extension, pre-existing, unrelated to this change).
- Re-ran the setName diff after the fixes: zero mismatches remain.

Closes #2220
Closes #2221
Closes #2222
Closes #2223
Closes #2224
Closes #2233

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes documentation drift across the README, docs, and `.env.example`, and rewrites the Custom commands page to describe only what `/customcommand` actually ships: plain-text trigger, static reply, no variables or embed mode, and role/channel gates stored but not yet editable.

**Documentation fixes**
- Replaces dead `REDIS_URL` references with `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, and `REDIS_DB`.
- Corrects every wrong slash-command reference: `/resume` → `/pause`, `/loop` → `/repeat`, `/filter` → `/effects`, `/mod` subcommands → separate `/ban`, `/kick`, `/mute`, `/warn`, `/cc` → `/customcommand`, `/preferred` → `/autoplay artist prefer`, and `/case` → its real `view`/`update`/`delete` subcommands.
- Removes the nonexistent `npm run register-commands` instructions in favor of restarting the bot; commands register automatically on boot.
- Regenerates `.env.example` toggle and category comments from real sources, uses a real category (`automod`) in the disabled-categories example, drops the removed `DOWNLOAD_*` toggles and "and downloads" from the description, and documents `HEARTBEAT_INTERVAL_MS` and `WEEKLY_DIGEST_TICK_INTERVAL_MS`.
- Drops the undeclared `--build-arg SERVICE=bot` from `docs/DOCKER.md` and replaces a dead ADR link with a plain-text note.
- Drops the fabricated variables, embed mode, cooldowns, and ephemeral features from the Custom commands page, documenting the real plain-text behavior and the stored-but-unexposed scope lists.

**New ADR**
- Adds `decisions/2026-09-05-skip-feedback-redesign-deferred.md`, which explicitly re-defers the skip-reason feedback UX redesign owed by the autoplay remeasure ADR, with a revisit condition tied to dashboard telemetry.

<sup>Written for commit 3fec2f90ae68ad27b023db9fbbd35a27783251e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

