### PR TITLE
fix(bot): validate url hosts and warn on spotify search outages

### DIFF
--- a/packages/bot/src/functions/music/commands/play/queryDetector.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryDetector.spec.ts
@@ -19,6 +19,12 @@ describe('detectQueryType', () => {
             expect(detectQueryType('youtube.com/watch?v=abc')).toBe('youtube')
         })
 
+        it('accepts a fully-qualified host with a trailing dot', () => {
+            expect(
+                detectQueryType('https://www.youtube.com./watch?v=abc'),
+            ).toBe('youtube')
+        })
+
         it('does not treat a bare lookalike host as youtube', () => {
             expect(
                 detectQueryType('evil-youtube.com.attacker.tld/watch?v=abc'),

--- a/packages/bot/src/functions/music/commands/play/queryDetector.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryDetector.spec.ts
@@ -19,6 +19,12 @@ describe('detectQueryType', () => {
             expect(detectQueryType('youtube.com/watch?v=abc')).toBe('youtube')
         })
 
+        it('does not treat a bare lookalike host as youtube', () => {
+            expect(
+                detectQueryType('evil-youtube.com.attacker.tld/watch?v=abc'),
+            ).toBe('search')
+        })
+
         it('detects youtube URL even when query also contains spotify.com', () => {
             expect(
                 detectQueryType(

--- a/packages/bot/src/functions/music/commands/play/queryDetector.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryDetector.spec.ts
@@ -26,6 +26,18 @@ describe('detectQueryType', () => {
                 ),
             ).toBe('youtube')
         })
+
+        it('detects a real youtube subdomain', () => {
+            expect(detectQueryType('https://music.youtube.com/watch?v=1')).toBe(
+                'youtube',
+            )
+        })
+
+        it('does not detect a lookalike host as youtube', () => {
+            expect(
+                detectQueryType('https://evil-youtube.com.attacker.tld/x'),
+            ).not.toBe('youtube')
+        })
     })
 
     describe('spotify detection', () => {

--- a/packages/bot/src/functions/music/commands/play/queryDetector.ts
+++ b/packages/bot/src/functions/music/commands/play/queryDetector.ts
@@ -1,3 +1,5 @@
+import { isHost } from '../../../../utils/general/urlHost'
+
 /**
  * Query type detection utilities
  */
@@ -5,15 +7,30 @@
 export function detectQueryType(
     query: string,
 ): 'youtube' | 'spotify' | 'search' | 'url' {
-    if (query.includes('youtube.com') || query.includes('youtu.be')) {
+    const isRealUrl =
+        query.startsWith('http://') || query.startsWith('https://')
+
+    // Real URLs are matched by host only, so a spoofed lookalike
+    // (evil-youtube.com.attacker.tld) is not misdetected as youtube/spotify.
+    // Bare text without a protocol (a user pasting "youtube.com/..." without
+    // https://) keeps the old substring check, since it is not a URL at all
+    // and there is no host to parse.
+    if (
+        isHost(query, 'youtube.com', 'youtu.be') ||
+        (!isRealUrl &&
+            (query.includes('youtube.com') || query.includes('youtu.be')))
+    ) {
         return 'youtube'
     }
 
-    if (query.includes('spotify.com')) {
+    if (
+        isHost(query, 'spotify.com') ||
+        (!isRealUrl && query.includes('spotify.com'))
+    ) {
         return 'spotify'
     }
 
-    if (query.startsWith('http://') || query.startsWith('https://')) {
+    if (isRealUrl) {
         return 'url'
     }
 

--- a/packages/bot/src/functions/music/commands/play/queryDetector.ts
+++ b/packages/bot/src/functions/music/commands/play/queryDetector.ts
@@ -10,23 +10,18 @@ export function detectQueryType(
     const isRealUrl =
         query.startsWith('http://') || query.startsWith('https://')
 
-    // Real URLs are matched by host only, so a spoofed lookalike
-    // (evil-youtube.com.attacker.tld) is not misdetected as youtube/spotify.
+    // Match by host only, so a spoofed lookalike (evil-youtube.com.attacker.tld)
+    // or a path/query segment that merely mentions the host is not misdetected.
     // Bare text without a protocol (a user pasting "youtube.com/..." without
-    // https://) keeps the old substring check, since it is not a URL at all
-    // and there is no host to parse.
-    if (
-        isHost(query, 'youtube.com', 'youtu.be') ||
-        (!isRealUrl &&
-            (query.includes('youtube.com') || query.includes('youtu.be')))
-    ) {
+    // https://) is parsed the same way after prefixing https://, so it gets
+    // the host check instead of a substring match.
+    const candidate = isRealUrl ? query : `https://${query}`
+
+    if (isHost(candidate, 'youtube.com', 'youtu.be')) {
         return 'youtube'
     }
 
-    if (
-        isHost(query, 'spotify.com') ||
-        (!isRealUrl && query.includes('spotify.com'))
-    ) {
+    if (isHost(candidate, 'spotify.com')) {
         return 'spotify'
     }
 

--- a/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.spec.ts
@@ -70,6 +70,7 @@ import {
     normalizeYouTubeUrl,
     normalizeSoundCloudUrl,
     isUrl,
+    isHost,
     executePlayAtTop,
     expandSoundCloudShortUrl,
 } from './queryUtils'
@@ -171,6 +172,24 @@ describe('isUrl', () => {
 
     it('returns false for plain text', () => {
         expect(isUrl('some song title')).toBe(false)
+    })
+})
+
+describe('isHost', () => {
+    it('rejects a lookalike host with the real domain as a suffix', () => {
+        expect(
+            isHost('https://evil-youtube.com.attacker.tld/x', 'youtube.com'),
+        ).toBe(false)
+    })
+
+    it('accepts a real youtube subdomain', () => {
+        expect(
+            isHost('https://music.youtube.com/watch?v=1', 'youtube.com'),
+        ).toBe(true)
+    })
+
+    it('returns false for non-URL strings', () => {
+        expect(isHost('not a url', 'youtube.com')).toBe(false)
     })
 })
 

--- a/packages/bot/src/functions/music/commands/play/queryUtils.ts
+++ b/packages/bot/src/functions/music/commands/play/queryUtils.ts
@@ -20,6 +20,9 @@ import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSaniti
 import { errorLog, debugLog, warnLog } from '@lucky/shared/utils'
 import { withTimeout } from '@lucky/shared/utils/async'
 import { assertDefined } from '@lucky/shared/utils/guards'
+import { isHost } from '../../../../utils/general/urlHost'
+
+export { isHost }
 
 export const DISCORD_UNKNOWN_INTERACTION_CODE = 10062
 
@@ -46,7 +49,7 @@ export function isUrl(query: string): boolean {
  */
 export async function expandSoundCloudShortUrl(url: string): Promise<string> {
     // Fast path: not a short link
-    if (!url.includes('on.soundcloud.com')) {
+    if (!isHost(url, 'on.soundcloud.com')) {
         return url
     }
 

--- a/packages/bot/src/handlers/player/playerFactory.spec.ts
+++ b/packages/bot/src/handlers/player/playerFactory.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals'
 import { withTimeout } from './withTimeout'
+import { isHost } from '../../utils/general/urlHost'
 
 describe('playerFactory', () => {
     describe('withTimeout', () => {
@@ -30,7 +31,7 @@ describe('playerFactory', () => {
     describe('createPlayer', () => {
         it('should identify YouTube URLs correctly', () => {
             const isYouTubeUrl = (url: string): boolean =>
-                url.includes('youtube.com') || url.includes('youtu.be')
+                isHost(url, 'youtube.com', 'youtu.be')
 
             expect(isYouTubeUrl('https://www.youtube.com/watch?v=test')).toBe(
                 true,
@@ -43,6 +44,9 @@ describe('playerFactory', () => {
             expect(isYouTubeUrl('https://music.youtube.com/watch?v=test')).toBe(
                 true,
             )
+            expect(
+                isYouTubeUrl('https://evil-youtube.com.attacker.tld/x'),
+            ).toBe(false)
         })
 
         it('should validate player creation parameters', () => {

--- a/packages/bot/src/handlers/player/streamBridge.ts
+++ b/packages/bot/src/handlers/player/streamBridge.ts
@@ -19,6 +19,7 @@ import {
     safeUrlOrigin,
     scrubUrls,
 } from '../../utils/monitoring/sentry'
+import { isHost } from '../../utils/general/urlHost'
 
 const ALLOWED_YTDLP_DOMAINS = new Set([
     'youtube.com',
@@ -249,7 +250,9 @@ export async function createResilientStream(
 ): Promise<Readable> {
     const cleanedTitle = cleanTitle(track.title)
     const cleanedAuthor = cleanAuthor(track.author)
-    const isSpotifyUrl = track.url?.includes('open.spotify.com') ?? false
+    const isSpotifyUrl = track.url
+        ? isHost(track.url, 'open.spotify.com')
+        : false
 
     debugLog({
         message: 'Bridge: resolving stream',

--- a/packages/bot/src/handlers/player/trackNowPlaying.ts
+++ b/packages/bot/src/handlers/player/trackNowPlaying.ts
@@ -22,6 +22,7 @@ import {
 } from '../../lastfm'
 import { getSkipReasonEmojis } from '../../utils/music/skipReasonMap'
 import { getStreamBridgeFallbackLabel } from './streamBridge'
+import { isHost } from '../../utils/general/urlHost'
 
 /**
  * Track which guilds have logged a skip-reason prefill failure in this session.
@@ -177,10 +178,9 @@ function formatDuration(duration: string) {
 }
 
 function getSource(url: string) {
-    if (url.includes('youtube.com') || url.includes('youtu.be'))
-        return 'YouTube'
-    if (url.includes('spotify.com')) return 'Spotify'
-    if (url.includes('soundcloud.com')) return 'SoundCloud'
+    if (isHost(url, 'youtube.com') || isHost(url, 'youtu.be')) return 'YouTube'
+    if (isHost(url, 'spotify.com')) return 'Spotify'
+    if (isHost(url, 'soundcloud.com')) return 'SoundCloud'
     return 'Unknown'
 }
 

--- a/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.spec.ts
@@ -80,12 +80,13 @@ import {
     searchLastFmQuery,
     collectLastFmCandidates,
     recordSpotifySearchResult,
+    resetSpotifySearchTracking,
 } from './lastFmSeeder'
 
-// Every test starts with a clean rolling window so an accumulated streak from
-// one test's SPOTIFY_SEARCH calls cannot bleed into another's assertions.
+// Every test starts with a clean rolling window and warn cooldown so a streak
+// or a warn from one test cannot bleed into another's assertions.
 beforeEach(() => {
-    recordSpotifySearchResult(true)
+    resetSpotifySearchTracking()
 })
 
 function createTrack(
@@ -233,22 +234,49 @@ describe('recordSpotifySearchResult', () => {
         )
     })
 
-    it('resets the window on a non-empty result', () => {
+    it('keeps successes in the window so the empty rate is a real rate', () => {
         const t = 1_700_100_000_000
+        // 7 empties and 3 hits: 70%, under the 80% threshold.
+        for (let i = 0; i < 7; i++) {
+            recordSpotifySearchResult(false, t)
+        }
+        for (let i = 0; i < 3; i++) {
+            recordSpotifySearchResult(true, t)
+        }
+        expect(warnLogMock).not.toHaveBeenCalled()
+
+        // Four more empties: 11 of 14 is still under 80%.
+        for (let i = 0; i < 4; i++) {
+            recordSpotifySearchResult(false, t)
+        }
+        expect(warnLogMock).not.toHaveBeenCalled()
+
+        // 12 of 15 reaches 80%.
+        recordSpotifySearchResult(false, t)
+        expect(warnLogMock).toHaveBeenCalledTimes(1)
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining(
+                    'Spotify search returned nothing for 12 of the last 15 queries',
+                ),
+            }),
+        )
+    })
+
+    it('drops old samples once the window is full', () => {
+        const t = 1_700_150_000_000
         for (let i = 0; i < 10; i++) {
             recordSpotifySearchResult(false, t)
         }
         expect(warnLogMock).toHaveBeenCalledTimes(1)
-
-        recordSpotifySearchResult(true, t)
         warnLogMock.mockClear()
 
-        // Well outside the cooldown, so this only re-warns if the reset
-        // failed to clear the window (i.e. it would instantly cross
-        // MIN_SAMPLES again instead of needing 10 fresh empties).
-        for (let i = 0; i < 9; i++) {
-            recordSpotifySearchResult(false, t + 60 * 60 * 1000)
+        // 20 hits push every empty out of the 20-sample window; the next
+        // empty (well past the cooldown) is 1 of 20 and must not warn.
+        for (let i = 0; i < 20; i++) {
+            recordSpotifySearchResult(true, t)
         }
+        recordSpotifySearchResult(false, t + 60 * 60 * 1000)
         expect(warnLogMock).not.toHaveBeenCalled()
     })
 

--- a/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.spec.ts
@@ -15,6 +15,11 @@ const calculateRecommendationScoreMock = jest.fn()
 const shouldIncludeCandidateMock = jest.fn()
 const upsertScoredCandidateMock = jest.fn()
 const normalizeTrackKeyMock = jest.fn()
+const warnLogMock = jest.fn()
+
+jest.mock('@lucky/shared/utils', () => ({
+    warnLog: (...args: unknown[]) => warnLogMock(...args),
+}))
 
 jest.mock('discord-player', () => ({
     QueryType: {
@@ -71,7 +76,17 @@ jest.mock('./scoringUtils', () => ({
     normalizeTrackKey: (...args: unknown[]) => normalizeTrackKeyMock(...args),
 }))
 
-import { searchLastFmQuery, collectLastFmCandidates } from './lastFmSeeder'
+import {
+    searchLastFmQuery,
+    collectLastFmCandidates,
+    recordSpotifySearchResult,
+} from './lastFmSeeder'
+
+// Every test starts with a clean rolling window so an accumulated streak from
+// one test's SPOTIFY_SEARCH calls cannot bleed into another's assertions.
+beforeEach(() => {
+    recordSpotifySearchResult(true)
+})
 
 function createTrack(
     title = 'Track',
@@ -189,6 +204,68 @@ describe('searchLastFmQuery', () => {
         const user = createUser()
         const result = await searchLastFmQuery(queue, 'query', user)
         expect(result.length).toBeLessThanOrEqual(8)
+    })
+})
+
+describe('recordSpotifySearchResult', () => {
+    // Each test anchors to its own far-apart timestamp so a warn recorded by
+    // one test can never fall inside another test's 5-minute cooldown window.
+    beforeEach(() => {
+        warnLogMock.mockClear()
+    })
+
+    it('warns once after 10 empty results', () => {
+        const t = 1_700_000_000_000
+        for (let i = 0; i < 9; i++) {
+            recordSpotifySearchResult(false, t)
+        }
+        expect(warnLogMock).not.toHaveBeenCalled()
+
+        recordSpotifySearchResult(false, t)
+
+        expect(warnLogMock).toHaveBeenCalledTimes(1)
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining(
+                    'Spotify search returned nothing for 10 of the last 10 queries',
+                ),
+            }),
+        )
+    })
+
+    it('resets the window on a non-empty result', () => {
+        const t = 1_700_100_000_000
+        for (let i = 0; i < 10; i++) {
+            recordSpotifySearchResult(false, t)
+        }
+        expect(warnLogMock).toHaveBeenCalledTimes(1)
+
+        recordSpotifySearchResult(true, t)
+        warnLogMock.mockClear()
+
+        // Well outside the cooldown, so this only re-warns if the reset
+        // failed to clear the window (i.e. it would instantly cross
+        // MIN_SAMPLES again instead of needing 10 fresh empties).
+        for (let i = 0; i < 9; i++) {
+            recordSpotifySearchResult(false, t + 60 * 60 * 1000)
+        }
+        expect(warnLogMock).not.toHaveBeenCalled()
+    })
+
+    it('suppresses a second warn within the cooldown window', () => {
+        const t = 1_700_200_000_000
+        for (let i = 0; i < 10; i++) {
+            recordSpotifySearchResult(false, t)
+        }
+        expect(warnLogMock).toHaveBeenCalledTimes(1)
+
+        // Still empty, still within the 5-minute cooldown.
+        recordSpotifySearchResult(false, t + 60_000)
+        expect(warnLogMock).toHaveBeenCalledTimes(1)
+
+        // Past the cooldown: allowed to warn again.
+        recordSpotifySearchResult(false, t + 6 * 60 * 1000)
+        expect(warnLogMock).toHaveBeenCalledTimes(2)
     })
 })
 

--- a/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.spec.ts
@@ -190,6 +190,32 @@ describe('searchLastFmQuery', () => {
         expect(result).toContain(goodTrack)
     })
 
+    it('samples the raw spotify count, so over-cap hits are not outage signals', async () => {
+        const longTrack = createTrack()
+        ;(longTrack as unknown as { durationMS: number }).durationMS =
+            15 * 60 * 1000
+        const queue = createQueue({ tracks: [longTrack] })
+        const user = createUser()
+        const t = 1_700_300_000_000
+
+        // 7 empties, then 3 searches whose only hit is filtered out by the
+        // duration cap: 7 of 10 empties if sampled raw (no warn), 10 of 10
+        // if sampled after the filter (warn).
+        for (let i = 0; i < 7; i++) {
+            recordSpotifySearchResult(false, t)
+        }
+        for (let i = 0; i < 3; i++) {
+            await searchLastFmQuery(queue, 'query', user)
+        }
+        expect(warnLogMock).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining(
+                    'Spotify search returned nothing',
+                ),
+            }),
+        )
+    })
+
     it('returns empty array when search returns no tracks', async () => {
         const queue = createQueue({ tracks: [] })
         const user = createUser()

--- a/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
@@ -38,9 +38,8 @@ const SPOTIFY_SEARCH_MIN_SAMPLES = 10
 const SPOTIFY_SEARCH_EMPTY_RATE_THRESHOLD = 0.8
 const SPOTIFY_SEARCH_WARN_COOLDOWN_MS = 5 * 60 * 1000
 
-// Rolling window of recent SPOTIFY_SEARCH outcomes (always empty by
-// construction — see recordSpotifySearchResult below).
-let spotifySearchEmptyResults: boolean[] = []
+// Rolling window of recent SPOTIFY_SEARCH outcomes (true = had results).
+let spotifySearchResults: boolean[] = []
 let spotifySearchWarnedAt = 0
 
 /**
@@ -50,30 +49,27 @@ let spotifySearchWarnedAt = 0
  * `discord-player-spotify`'s `search()` swallows API errors and returns an
  * empty result instead of throwing, so a Spotify outage looks identical to a
  * genuine "no match" and the `engines exhausted` warn below never fires for
- * it (#2134, #2207). This gives that degraded state its own signal: once at
- * least SPOTIFY_SEARCH_MIN_SAMPLES calls have landed in the rolling window
- * and the empty rate crosses SPOTIFY_SEARCH_EMPTY_RATE_THRESHOLD, warn once
- * (rate-limited by SPOTIFY_SEARCH_WARN_COOLDOWN_MS). A non-empty result
- * clears the window — the outage is over, start counting fresh.
+ * it (#2134, #2207). This gives that degraded state its own signal: both
+ * outcomes stay in the rolling window, and once at least
+ * SPOTIFY_SEARCH_MIN_SAMPLES calls have landed and the empty rate crosses
+ * SPOTIFY_SEARCH_EMPTY_RATE_THRESHOLD, warn once (rate-limited by
+ * SPOTIFY_SEARCH_WARN_COOLDOWN_MS). Keeping successes in the window means an
+ * intermittent outage still registers, and a short run of ordinary no-match
+ * queries does not.
  */
 export function recordSpotifySearchResult(
     hadResults: boolean,
     now: number = Date.now(),
 ): void {
-    if (hadResults) {
-        spotifySearchEmptyResults = []
-        return
+    spotifySearchResults.push(hadResults)
+    if (spotifySearchResults.length > SPOTIFY_SEARCH_WINDOW) {
+        spotifySearchResults.shift()
     }
 
-    spotifySearchEmptyResults.push(false)
-    if (spotifySearchEmptyResults.length > SPOTIFY_SEARCH_WINDOW) {
-        spotifySearchEmptyResults.shift()
-    }
-
-    const total = spotifySearchEmptyResults.length
+    const total = spotifySearchResults.length
     if (total < SPOTIFY_SEARCH_MIN_SAMPLES) return
 
-    const emptyCount = spotifySearchEmptyResults.filter((r) => !r).length
+    const emptyCount = spotifySearchResults.filter((r) => !r).length
     if (emptyCount / total < SPOTIFY_SEARCH_EMPTY_RATE_THRESHOLD) return
 
     if (now - spotifySearchWarnedAt < SPOTIFY_SEARCH_WARN_COOLDOWN_MS) return
@@ -82,6 +78,12 @@ export function recordSpotifySearchResult(
     warnLog({
         message: `Autoplay: Spotify search returned nothing for ${emptyCount} of the last ${total} queries`,
     })
+}
+
+/** Test hook: clears the rolling window and the warn cooldown. */
+export function resetSpotifySearchTracking(): void {
+    spotifySearchResults = []
+    spotifySearchWarnedAt = 0
 }
 
 export async function collectLastFmCandidates(

--- a/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
@@ -353,6 +353,11 @@ export async function searchLastFmQuery(
                 requestedBy,
                 searchEngine: engine,
             })
+            if (engine === QueryType.SPOTIFY_SEARCH) {
+                // Raw API count, same meaning as in candidateFallback: a hit
+                // whose tracks all exceed the duration cap is not an outage.
+                recordSpotifySearchResult(result.tracks.length > 0)
+            }
             const tracks = result.tracks
                 .filter(
                     (t) =>
@@ -360,9 +365,6 @@ export async function searchLastFmQuery(
                         t.durationMS <= MAX_AUTOPLAY_DURATION_MS,
                 )
                 .slice(0, SEARCH_RESULTS_LIMIT)
-            if (engine === QueryType.SPOTIFY_SEARCH) {
-                recordSpotifySearchResult(tracks.length > 0)
-            }
             if (tracks.length > 0) return tracks
         } catch (err) {
             if (engine === QueryType.SPOTIFY_SEARCH) {

--- a/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/lastFmSeeder.ts
@@ -2,6 +2,7 @@ import { QueryType, type Track, type GuildQueue } from 'discord-player'
 import type { User } from 'discord.js'
 import { lastFmLinkService } from '@lucky/shared/services'
 import { logAndSwallow, logAndWarn } from '@lucky/shared/utils/error'
+import { warnLog } from '@lucky/shared/utils'
 import {
     consumeLastFmSeedSlice,
     consumeBlendedSeedSlice,
@@ -31,6 +32,57 @@ const MAX_SIMILAR_LOOKUPS = 15
 const SEARCH_RESULTS_LIMIT = 8
 const MAX_AUTOPLAY_DURATION_MS = 10 * 60 * 1000
 const AUTOPLAY_BUFFER_SIZE = 8
+
+const SPOTIFY_SEARCH_WINDOW = 20
+const SPOTIFY_SEARCH_MIN_SAMPLES = 10
+const SPOTIFY_SEARCH_EMPTY_RATE_THRESHOLD = 0.8
+const SPOTIFY_SEARCH_WARN_COOLDOWN_MS = 5 * 60 * 1000
+
+// Rolling window of recent SPOTIFY_SEARCH outcomes (always empty by
+// construction — see recordSpotifySearchResult below).
+let spotifySearchEmptyResults: boolean[] = []
+let spotifySearchWarnedAt = 0
+
+/**
+ * Tracks whether recent SPOTIFY_SEARCH calls (from both `searchLastFmQuery`
+ * and `collectBroadFallbackCandidates`) came back empty.
+ *
+ * `discord-player-spotify`'s `search()` swallows API errors and returns an
+ * empty result instead of throwing, so a Spotify outage looks identical to a
+ * genuine "no match" and the `engines exhausted` warn below never fires for
+ * it (#2134, #2207). This gives that degraded state its own signal: once at
+ * least SPOTIFY_SEARCH_MIN_SAMPLES calls have landed in the rolling window
+ * and the empty rate crosses SPOTIFY_SEARCH_EMPTY_RATE_THRESHOLD, warn once
+ * (rate-limited by SPOTIFY_SEARCH_WARN_COOLDOWN_MS). A non-empty result
+ * clears the window — the outage is over, start counting fresh.
+ */
+export function recordSpotifySearchResult(
+    hadResults: boolean,
+    now: number = Date.now(),
+): void {
+    if (hadResults) {
+        spotifySearchEmptyResults = []
+        return
+    }
+
+    spotifySearchEmptyResults.push(false)
+    if (spotifySearchEmptyResults.length > SPOTIFY_SEARCH_WINDOW) {
+        spotifySearchEmptyResults.shift()
+    }
+
+    const total = spotifySearchEmptyResults.length
+    if (total < SPOTIFY_SEARCH_MIN_SAMPLES) return
+
+    const emptyCount = spotifySearchEmptyResults.filter((r) => !r).length
+    if (emptyCount / total < SPOTIFY_SEARCH_EMPTY_RATE_THRESHOLD) return
+
+    if (now - spotifySearchWarnedAt < SPOTIFY_SEARCH_WARN_COOLDOWN_MS) return
+    spotifySearchWarnedAt = now
+
+    warnLog({
+        message: `Autoplay: Spotify search returned nothing for ${emptyCount} of the last ${total} queries`,
+    })
+}
 
 export async function collectLastFmCandidates(
     ctx: AutoplayContext,
@@ -306,8 +358,14 @@ export async function searchLastFmQuery(
                         t.durationMS <= MAX_AUTOPLAY_DURATION_MS,
                 )
                 .slice(0, SEARCH_RESULTS_LIMIT)
+            if (engine === QueryType.SPOTIFY_SEARCH) {
+                recordSpotifySearchResult(tracks.length > 0)
+            }
             if (tracks.length > 0) return tracks
         } catch (err) {
+            if (engine === QueryType.SPOTIFY_SEARCH) {
+                recordSpotifySearchResult(false)
+            }
             // Debug per engine — a single engine failing while another
             // succeeds is normal fallback, not worth alerting on.
             hadError = true

--- a/packages/bot/src/services/musicRecommendation/candidateFallback.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/candidateFallback.spec.ts
@@ -6,6 +6,7 @@ const getArtistGenresMock = jest.fn()
 const getValidAccessTokenMock = jest.fn()
 const getTagTopTracksMock = jest.fn()
 const searchLastFmQueryMock = jest.fn()
+const recordSpotifySearchResultMock = jest.fn()
 const shouldIncludeCandidateMock = jest.fn()
 const upsertScoredCandidateMock = jest.fn()
 const calculateRecommendationScoreMock = jest.fn()
@@ -43,6 +44,8 @@ jest.mock('../../lastfm', () => ({
 
 jest.mock('./autoplay/lastFmSeeder', () => ({
     searchLastFmQuery: (...args: unknown[]) => searchLastFmQueryMock(...args),
+    recordSpotifySearchResult: (...args: unknown[]) =>
+        recordSpotifySearchResultMock(...args),
 }))
 
 jest.mock('./autoplay/candidateCollector', () => ({
@@ -404,5 +407,58 @@ describe('collectBroadFallbackCandidates', () => {
         })
         await collectBroadFallbackCandidates(ctx, candidates)
         expect(getArtistGenresMock).not.toHaveBeenCalled()
+    })
+
+    it('records a degraded-search sample for every SPOTIFY_SEARCH call', async () => {
+        const foundTrack = {
+            title: 'Song',
+            author: 'Artist',
+            url: 'u2',
+            durationMS: 180_000,
+        }
+        const searchMock = jest.fn().mockResolvedValue({ tracks: [foundTrack] })
+        const queue = { player: { search: searchMock } } as never
+        const currentTrack = {
+            author: 'Artist',
+            title: 'Song',
+            url: 'u1',
+            durationMS: 200_000,
+        } as never
+        const ctx = createAutoplayContext({ queue, currentTrack })
+        await collectBroadFallbackCandidates(ctx, new Map())
+
+        expect(recordSpotifySearchResultMock).toHaveBeenCalledWith(true)
+    })
+
+    it('records an empty sample when the search returns nothing', async () => {
+        const searchMock = jest.fn().mockResolvedValue({ tracks: [] })
+        const queue = { player: { search: searchMock } } as never
+        const currentTrack = {
+            author: 'Artist',
+            title: 'Song',
+            url: 'u1',
+            durationMS: 200_000,
+        } as never
+        const ctx = createAutoplayContext({ queue, currentTrack })
+        await collectBroadFallbackCandidates(ctx, new Map())
+
+        expect(recordSpotifySearchResultMock).toHaveBeenCalledWith(false)
+    })
+
+    it('records an empty sample when the search throws', async () => {
+        const searchMock = jest
+            .fn()
+            .mockRejectedValue(new Error('network error'))
+        const queue = { player: { search: searchMock } } as never
+        const currentTrack = {
+            author: 'Artist',
+            title: 'Song',
+            url: 'u1',
+            durationMS: 200_000,
+        } as never
+        const ctx = createAutoplayContext({ queue, currentTrack })
+        await collectBroadFallbackCandidates(ctx, new Map())
+
+        expect(recordSpotifySearchResultMock).toHaveBeenCalledWith(false)
     })
 })

--- a/packages/bot/src/services/musicRecommendation/candidateFallback.ts
+++ b/packages/bot/src/services/musicRecommendation/candidateFallback.ts
@@ -5,7 +5,10 @@ import { assertDefined } from '@lucky/shared/utils/guards'
 import { spotifyLinkService } from '@lucky/shared/services'
 import type { AutoplayContext } from './autoplay/autoplayContext'
 import { getTagTopTracks } from '../../lastfm'
-import { searchLastFmQuery } from './autoplay/lastFmSeeder'
+import {
+    searchLastFmQuery,
+    recordSpotifySearchResult,
+} from './autoplay/lastFmSeeder'
 import {
     shouldIncludeCandidate,
     upsertScoredCandidate,
@@ -131,6 +134,7 @@ export async function collectBroadFallbackCandidates(
                         t.durationMS <= MAX_AUTOPLAY_DURATION_MS,
                 )
                 .slice(0, SEARCH_RESULTS_LIMIT)
+            recordSpotifySearchResult(tracks.length > 0)
 
             for (const track of tracks) {
                 if (
@@ -185,6 +189,7 @@ export async function collectBroadFallbackCandidates(
                 )
             }
         } catch (err: unknown) {
+            recordSpotifySearchResult(false)
             logAndSwallow(err, 'candidateFallback.spotifySearch', { query })
             continue
         }

--- a/packages/bot/src/services/musicRecommendation/candidateFallback.ts
+++ b/packages/bot/src/services/musicRecommendation/candidateFallback.ts
@@ -127,6 +127,10 @@ export async function collectBroadFallbackCandidates(
                 searchEngine: QueryType.SPOTIFY_SEARCH,
             })
 
+            // Sample the raw API count: a result whose tracks all exceed the
+            // duration cap is a genuine hit, not an outage signal.
+            recordSpotifySearchResult(result.tracks.length > 0)
+
             const tracks = result.tracks
                 .filter(
                     (t: Track) =>
@@ -134,7 +138,6 @@ export async function collectBroadFallbackCandidates(
                         t.durationMS <= MAX_AUTOPLAY_DURATION_MS,
                 )
                 .slice(0, SEARCH_RESULTS_LIMIT)
-            recordSpotifySearchResult(tracks.length > 0)
 
             for (const track of tracks) {
                 if (

--- a/packages/bot/src/utils/general/urlHost.ts
+++ b/packages/bot/src/utils/general/urlHost.ts
@@ -13,7 +13,8 @@
  */
 export function isHost(url: string, ...hosts: string[]): boolean {
     try {
-        const hostname = new URL(url).hostname.toLowerCase()
+        // A fully-qualified host keeps its trailing root dot in URL.hostname.
+        const hostname = new URL(url).hostname.toLowerCase().replace(/\.$/, '')
         return hosts.some((h) => hostname === h || hostname.endsWith(`.${h}`))
     } catch {
         return false

--- a/packages/bot/src/utils/general/urlHost.ts
+++ b/packages/bot/src/utils/general/urlHost.ts
@@ -1,0 +1,21 @@
+/**
+ * True when `url` parses as a URL whose host is one of `hosts` or a subdomain
+ * of one. Unlike a raw `.includes(host)` check, this cannot be spoofed by a
+ * lookalike host (`evil-youtube.com.attacker.tld`) or a query/path segment
+ * that merely mentions the host. Returns false for anything that fails to
+ * parse as a URL.
+ *
+ * Deliberately dependency-free (only the global `URL`): several music
+ * modules across different layers (functions/, handlers/, utils/) need this
+ * check, and pulling it from a module with its own heavy import graph (e.g.
+ * queryUtils.ts) either creates a circular import or drags unrelated
+ * dependencies into call sites that don't otherwise need them.
+ */
+export function isHost(url: string, ...hosts: string[]): boolean {
+    try {
+        const hostname = new URL(url).hostname.toLowerCase()
+        return hosts.some((h) => hostname === h || hostname.endsWith(`.${h}`))
+    } catch {
+        return false
+    }
+}

--- a/packages/bot/src/utils/music/nowPlayingEmbed.ts
+++ b/packages/bot/src/utils/music/nowPlayingEmbed.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder } from 'discord.js'
 import type { Track } from 'discord-player'
 import type { User } from 'discord.js'
 import { COLOR } from '@lucky/shared/constants'
+import { isHost } from '../general/urlHost'
 
 export type PlayResponseKind = 'nowPlaying' | 'addedToQueue' | 'playlistQueued'
 
@@ -72,16 +73,16 @@ export function detectSource(track: {
         return SOURCE_BADGES[sourceHint]
     }
 
-    const url = (track.url ?? '').toLowerCase()
+    const url = track.url ?? ''
     if (!url) return DEFAULT_BADGE
 
-    if (url.includes('spotify.com')) return SOURCE_BADGES.spotify
-    if (url.includes('youtube.com') || url.includes('youtu.be')) {
+    if (isHost(url, 'spotify.com')) return SOURCE_BADGES.spotify
+    if (isHost(url, 'youtube.com') || isHost(url, 'youtu.be')) {
         return SOURCE_BADGES.youtube
     }
-    if (url.includes('soundcloud.com')) return SOURCE_BADGES.soundcloud
-    if (url.includes('music.apple.com')) return SOURCE_BADGES.apple_music
-    if (url.includes('vimeo.com')) return SOURCE_BADGES.vimeo
+    if (isHost(url, 'soundcloud.com')) return SOURCE_BADGES.soundcloud
+    if (isHost(url, 'music.apple.com')) return SOURCE_BADGES.apple_music
+    if (isHost(url, 'vimeo.com')) return SOURCE_BADGES.vimeo
     return DEFAULT_BADGE
 }
 


### PR DESCRIPTION
## Summary

- Adds a dependency-free `isHost(url, ...hosts)` helper (packages/bot/src/utils/general/urlHost.ts) that parses with `new URL` and matches on hostname (or subdomain), and replaces every `.includes('youtube.com')`-style substring host check flagged by CodeQL's `js/incomplete-url-substring-sanitization` rule across queryUtils.ts, queryDetector.ts, nowPlayingEmbed.ts, trackNowPlaying.ts, streamBridge.ts, and playerFactory.spec.ts. `detectQueryType` keeps a bare-text substring fallback for queries pasted without a protocol, since that is not a URL and there is no host to parse.
- Adds a small rolling-window counter in lastFmSeeder.ts (`recordSpotifySearchResult`) that tracks the last 20 SPOTIFY_SEARCH outcomes. `discord-player-spotify` swallows API errors and returns an empty result instead of throwing, so a Spotify outage looks identical to a genuine no-match and the existing "engines exhausted" warn never fires for it. Once at least 10 samples are in the window and the empty rate crosses 80%, warns once (5-minute cooldown), resetting on the next non-empty result. Wired into both `searchLastFmQuery` and `collectBroadFallbackCandidates`.

## Alert locations fixed (13 of 13 in scope)

- `packages/bot/src/functions/music/commands/play/queryUtils.ts:49`
- `packages/bot/src/functions/music/commands/play/queryDetector.ts:8,12`
- `packages/bot/src/utils/music/nowPlayingEmbed.ts:78,79,82,83,84`
- `packages/bot/src/handlers/player/trackNowPlaying.ts:180,182,183`
- `packages/bot/src/handlers/player/streamBridge.ts:252`
- `packages/bot/src/handlers/player/playerFactory.spec.ts:33`

(`packages/frontend/tests/e2e/auth-flow.spec.ts:68` carries the same CodeQL rule but is out of scope for this issue.)

## Test plan

- `npm run type:check` passes clean across all workspaces.
- `npx jest --config packages/bot/jest.config.cjs --testPathPatterns="queryUtils|queryDetector|streamBridge|nowPlayingEmbed|trackNowPlaying|lastFmSeeder|candidateFallback"` → 7 suites, 154 tests, all passing.

Closes #2212
Closes #2207

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces insecure substring host checks with a new `isHost` helper to close CodeQL's `js/incomplete-url-substring-sanitization` alerts, and adds a rolling-window warning so Spotify search outages no longer look like genuine no-matches. Closes #2212 and #2207.

- `isHost(url, ...hosts)` parses with `new URL` and matches the hostname or a subdomain, so lookalike hosts like `evil-youtube.com.attacker.tld` are no longer misdetected as YouTube or Spotify.
- Queries pasted without a protocol get `https://` prefixed before the host check, so no substring fallback remains in `detectQueryType`.
- `recordSpotifySearchResult` tracks the last 20 `SPOTIFY_SEARCH` outcomes and warns once when 10+ samples show an 80%+ empty rate, rate-limited to one warning per 5 minutes.
- Samples use the raw API count before the duration-cap filter, so over-cap hits aren't outage signals; hits and empties both stay in the window, and the check is wired into both `searchLastFmQuery` and `collectBroadFallbackCandidates`.

<sup>Written for commit 3d4459be81bfdbfb10e9a2161777d9c25b383f9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

