### PR TITLE
fix(bot): stop autoplay snapshot resurrection after /stop

### DIFF
--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -224,7 +224,7 @@ describe('setupLifecycleHandlers', () => {
         expect(watchdogCheckRecoverMock).not.toHaveBeenCalled()
     })
 
-    it('does NOT call checkAndRecover when disconnect is intentional stop', async () => {
+    it('does NOT save snapshot or call checkAndRecover when disconnect is intentional stop (#2241)', async () => {
         watchdogIsIntentionalStopMock.mockReturnValue(true)
 
         const handlers: Record<string, PlayerEventHandler> = {}
@@ -244,8 +244,58 @@ describe('setupLifecycleHandlers', () => {
 
         await handlers.disconnect(queue)
 
-        expect(saveSnapshotMock).toHaveBeenCalledWith(queue)
+        // Regression: an intentional /stop already deleted the snapshot.
+        // Re-saving it here resurrected it, which the orphan-session monitor
+        // later restored as if it were an accidental disconnect.
+        expect(saveSnapshotMock).not.toHaveBeenCalled()
         expect(watchdogCheckRecoverMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT save snapshot on connectionDestroyed when it is an intentional stop (#2241)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-3b', name: 'Guild 3b' },
+        } as unknown as GuildQueue
+
+        await handlers.connectionDestroyed(queue)
+
+        expect(saveSnapshotMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT save snapshot on emptyChannel when it is an intentional stop (#2241)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-empty', name: 'Guild Empty' },
+        } as unknown as GuildQueue
+
+        await handlers.emptyChannel(queue)
+
+        expect(saveSnapshotMock).not.toHaveBeenCalled()
+        expect(watchdogClearMock).toHaveBeenCalledWith('guild-empty')
     })
 
     it('replenishes queue on emptyQueue when autoplay is enabled', async () => {

--- a/packages/bot/src/handlers/player/lifecycleHandlers.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.ts
@@ -247,14 +247,21 @@ export const setupLifecycleHandlers = (player: {
         })
 
         await voiceStatus.clearStatus(queue)
-        await musicSessionSnapshotService.saveSnapshot(queue)
-        // Queue was explicitly deleted — never attempt recovery here.
+        // Queue was explicitly deleted — never attempt recovery here. An
+        // intentional /stop already deleted the snapshot; re-saving it here
+        // unconditionally resurrected it, which the orphan-session monitor
+        // later restored as if it were an accidental disconnect (#2241).
+        if (!musicWatchdogService.isIntentionalStop(queue.guild.id)) {
+            await musicSessionSnapshotService.saveSnapshot(queue)
+        }
     })
 
     player.events.on('emptyChannel', async (queue: GuildQueue) => {
         infoLog({ message: `Channel is empty in ${queue.guild.name}` })
         await voiceStatus.clearStatus(queue)
-        await musicSessionSnapshotService.saveSnapshot(queue)
+        if (!musicWatchdogService.isIntentionalStop(queue.guild.id)) {
+            await musicSessionSnapshotService.saveSnapshot(queue)
+        }
         musicWatchdogService.clear(queue.guild.id)
     })
 
@@ -283,8 +290,8 @@ export const setupLifecycleHandlers = (player: {
         })
 
         await voiceStatus.clearStatus(queue)
-        await musicSessionSnapshotService.saveSnapshot(queue)
         if (!musicWatchdogService.isIntentionalStop(queue.guild.id)) {
+            await musicSessionSnapshotService.saveSnapshot(queue)
             await musicWatchdogService.checkAndRecover(queue)
         }
     })


### PR DESCRIPTION
## What

Fixes #2241. Bot resumed playing music after an explicit `/stop`, sometimes with tracks unrelated to the current listening session.

`/stop` deletes the session snapshot and marks an intentional stop, then deletes the queue. Deleting the queue fires `connectionDestroyed`, whose handler in `lifecycleHandlers.ts` called `saveSnapshot()` unconditionally — resurrecting the snapshot `/stop` had just removed. `emptyChannel` and `disconnect` had the same unconditional call. Once the 35s intentional-stop window expires, the orphan-session monitor (60s interval) or `checkAndRecover` find the resurrected snapshot, see members still in the voice channel, and restore/resume playback from a session the user had already ended — explaining both the unwanted resume and the stale/out-of-context track choices (they come from the ended session's leftover autoplay queue, not a fresh recommendation).

PR #1998 guarded 4 of 6 known mutation sites with `isIntentionalStop`/`isReplenishSuppressed` but never audited these three `saveSnapshot` calls.

## Fix

Guard the `saveSnapshot` calls in `connectionDestroyed`, `emptyChannel`, and `disconnect` with `!musicWatchdogService.isIntentionalStop(guildId)`, matching the existing pattern already used on sibling handlers in the same file.

## Testing

- Updated `lifecycleHandlers.spec.ts`: the pre-existing `disconnect` intentional-stop test asserted the buggy behavior (`saveSnapshot` called) — flipped to assert it is NOT called.
- Added regression tests for `connectionDestroyed` and `emptyChannel` under intentional stop.
- `npx jest --config packages/bot/jest.config.cjs --testPathPatterns="lifecycleHandlers.spec"` → 28/28 passing.
- `npm run type:check --workspace=packages/bot` clean.

## Test plan

- [ ] `/play` something, `/stop`, wait >60s with someone still in the voice channel, confirm playback does not resume.
- [ ] `/stop` then leave and rejoin the voice channel, confirm no stale autoplay tracks come back.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bot resuming playback after an explicit `/stop` by preventing lifecycle handlers from re-saving the session snapshot. Previously, `/stop` deleted the snapshot and queue, but `connectionDestroyed`, `emptyChannel`, and `disconnect` called `saveSnapshot()` unconditionally, resurrecting the snapshot and causing playback to resume later with stale autoplay tracks from the ended session.

**Bug Fixes**
- Guarded the three `saveSnapshot()` calls with `!musicWatchdogService.isIntentionalStop(guildId)` to match the existing pattern from earlier `isIntentionalStop` guards.
- Updated `lifecycleHandlers.spec.ts` to assert intentional-stop cases no longer save snapshots, adding regression tests for `connectionDestroyed` and `emptyChannel`.

<sup>Written for commit cabb3c27086f0508a65aa1663cf6ecbc286f8372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

