### PR TITLE
fix(backend): close guild settings/autoplay access-control gap

### DIFF
--- a/packages/backend/src/middleware/guildAccess.ts
+++ b/packages/backend/src/middleware/guildAccess.ts
@@ -30,7 +30,7 @@ function resolveRequiredMode(req: Request, mode: RequiredMode): AccessMode {
 }
 
 export function requireGuildModuleAccess(
-    module: ModuleKey,
+    module: ModuleKey | ((req: AuthenticatedRequest) => ModuleKey),
     mode: RequiredMode = 'auto',
 ) {
     return async (
@@ -54,6 +54,9 @@ export function requireGuildModuleAccess(
                 throw AppError.badRequest('Guild id is required')
             }
 
+            const resolvedModule =
+                typeof module === 'function' ? module(req) : module
+
             // Note: resolveGuildContext uses a 30-second TTL cache on the user's
             // Discord guild list. A membership revocation between getSession() and
             // resolveGuildContext() may transiently grant access until the cache
@@ -72,9 +75,15 @@ export function requireGuildModuleAccess(
             }
 
             const requiredMode = resolveRequiredMode(req, mode)
-            if (!guildAccessService.hasAccess(context, module, requiredMode)) {
+            if (
+                !guildAccessService.hasAccess(
+                    context,
+                    resolvedModule,
+                    requiredMode,
+                )
+            ) {
                 throw AppError.forbidden(
-                    `Requires ${requiredMode} access to ${module}`,
+                    `Requires ${requiredMode} access to ${resolvedModule}`,
                 )
             }
 

--- a/packages/backend/src/middleware/guildAccess.ts
+++ b/packages/backend/src/middleware/guildAccess.ts
@@ -30,7 +30,7 @@ function resolveRequiredMode(req: Request, mode: RequiredMode): AccessMode {
 }
 
 export function requireGuildModuleAccess(
-    module: ModuleKey | ((req: AuthenticatedRequest) => ModuleKey),
+    module: ModuleKey,
     mode: RequiredMode = 'auto',
 ) {
     return async (
@@ -54,9 +54,6 @@ export function requireGuildModuleAccess(
                 throw AppError.badRequest('Guild id is required')
             }
 
-            const resolvedModule =
-                typeof module === 'function' ? module(req) : module
-
             // Note: resolveGuildContext uses a 30-second TTL cache on the user's
             // Discord guild list. A membership revocation between getSession() and
             // resolveGuildContext() may transiently grant access until the cache
@@ -75,15 +72,9 @@ export function requireGuildModuleAccess(
             }
 
             const requiredMode = resolveRequiredMode(req, mode)
-            if (
-                !guildAccessService.hasAccess(
-                    context,
-                    resolvedModule,
-                    requiredMode,
-                )
-            ) {
+            if (!guildAccessService.hasAccess(context, module, requiredMode)) {
                 throw AppError.forbidden(
-                    `Requires ${requiredMode} access to ${resolvedModule}`,
+                    `Requires ${requiredMode} access to ${module}`,
                 )
             }
 

--- a/packages/backend/src/routes/guildSettings.ts
+++ b/packages/backend/src/routes/guildSettings.ts
@@ -5,11 +5,7 @@ import { validateBody, validateParams } from '../middleware/validate'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { managementSchemas as s } from '../schemas/management'
-import {
-    guildSettingsService,
-    RBAC_MODULES,
-    type ModuleKey,
-} from '@lucky/shared/services'
+import { guildSettingsService, RBAC_MODULES } from '@lucky/shared/services'
 import { SUPPORTED_BOT_LANGUAGES } from '@lucky/shared/constants'
 import { z } from 'zod'
 import { paramToString as p } from '../utils/paramCoerce'
@@ -37,13 +33,15 @@ export const settingsBody = z
     })
     .strict()
 
+// `slug` selects which module's settings UI is calling this endpoint, but the
+// handler below reads/writes the whole GuildSettings record regardless of it
+// (guildSettingsService has no per-module field scoping) — so authorization
+// gates on 'settings' access, matching what the endpoint actually exposes,
+// not the requested module. A 'music:manage' grant must not imply write
+// access to unrelated fields like prefix or embedColor.
 const moduleSlugParam = s.guildIdParam.extend({
     slug: z.enum(RBAC_MODULES),
 })
-
-function slugModule(req: AuthenticatedRequest): ModuleKey {
-    return req.params.slug as ModuleKey
-}
 
 const moduleSettingsBody = z.record(z.string(), z.unknown())
 
@@ -92,7 +90,7 @@ export function setupGuildSettingsRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/modules/:slug/settings',
         requireAuth,
-        requireGuildModuleAccess(slugModule, 'view'),
+        requireGuildModuleAccess('settings', 'view'),
         validateParams(moduleSlugParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
@@ -105,7 +103,7 @@ export function setupGuildSettingsRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/modules/:slug/settings',
         requireAuth,
-        requireGuildModuleAccess(slugModule, 'manage'),
+        requireGuildModuleAccess('settings', 'manage'),
         writeLimiter,
         validateParams(moduleSlugParam),
         validateBody(moduleSettingsBody),

--- a/packages/backend/src/routes/guildSettings.ts
+++ b/packages/backend/src/routes/guildSettings.ts
@@ -1,10 +1,15 @@
 import type { Express, Response } from 'express'
 import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
+import { requireGuildModuleAccess } from '../middleware/guildAccess'
 import { validateBody, validateParams } from '../middleware/validate'
 import { writeLimiter } from '../middleware/rateLimit'
 import { asyncHandler } from '../middleware/asyncHandler'
 import { managementSchemas as s } from '../schemas/management'
-import { guildSettingsService } from '@lucky/shared/services'
+import {
+    guildSettingsService,
+    RBAC_MODULES,
+    type ModuleKey,
+} from '@lucky/shared/services'
 import { SUPPORTED_BOT_LANGUAGES } from '@lucky/shared/constants'
 import { z } from 'zod'
 import { paramToString as p } from '../utils/paramCoerce'
@@ -33,8 +38,12 @@ export const settingsBody = z
     .strict()
 
 const moduleSlugParam = s.guildIdParam.extend({
-    slug: z.string().min(1).max(50),
+    slug: z.enum(RBAC_MODULES),
 })
+
+function slugModule(req: AuthenticatedRequest): ModuleKey {
+    return req.params.slug as ModuleKey
+}
 
 const moduleSettingsBody = z.record(z.string(), z.unknown())
 
@@ -54,6 +63,7 @@ export function setupGuildSettingsRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/settings',
         requireAuth,
+        requireGuildModuleAccess('settings', 'view'),
         validateParams(s.guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
@@ -68,6 +78,7 @@ export function setupGuildSettingsRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/settings',
         requireAuth,
+        requireGuildModuleAccess('settings', 'manage'),
         writeLimiter,
         validateParams(s.guildIdParam),
         validateBody(settingsBody),
@@ -81,6 +92,7 @@ export function setupGuildSettingsRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/modules/:slug/settings',
         requireAuth,
+        requireGuildModuleAccess(slugModule, 'view'),
         validateParams(moduleSlugParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = p(req.params.guildId)
@@ -93,6 +105,7 @@ export function setupGuildSettingsRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/modules/:slug/settings',
         requireAuth,
+        requireGuildModuleAccess(slugModule, 'manage'),
         writeLimiter,
         validateParams(moduleSlugParam),
         validateBody(moduleSettingsBody),

--- a/packages/backend/src/routes/music/autoplayRoutes.ts
+++ b/packages/backend/src/routes/music/autoplayRoutes.ts
@@ -1,5 +1,6 @@
 import type { Express, Response } from 'express'
 import { requireAuth, type AuthenticatedRequest } from '../../middleware/auth'
+import { requireGuildModuleAccess } from '../../middleware/guildAccess'
 import { asyncHandler } from '../../middleware/asyncHandler'
 import { validateParams } from '../../middleware/validate'
 import { guildIdParam } from '../../schemas/common'
@@ -11,6 +12,7 @@ export function setupAutoplayRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/autoplay/genres',
         requireAuth,
+        requireGuildModuleAccess('music', 'view'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -25,6 +27,7 @@ export function setupAutoplayRoutes(app: Express): void {
     app.put(
         '/api/guilds/:guildId/autoplay/genres',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)

--- a/packages/backend/tests/integration/routes/autoplay.test.ts
+++ b/packages/backend/tests/integration/routes/autoplay.test.ts
@@ -111,6 +111,22 @@ describe('Autoplay Routes', () => {
                 mockGuildSettingsService.getGuildSettings,
             ).not.toHaveBeenCalled()
         })
+
+        it('returns 403 for a user without music:view access to this guild (IDOR regression, #2243)', async () => {
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            const res = await request(app)
+                .get('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(403)
+            expect(
+                mockGuildSettingsService.getGuildSettings,
+            ).not.toHaveBeenCalled()
+        })
     })
 
     describe('PUT /api/guilds/:guildId/autoplay/genres', () => {

--- a/packages/backend/tests/integration/routes/autoplay.test.ts
+++ b/packages/backend/tests/integration/routes/autoplay.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import request from 'supertest'
-import type { Express, Request, Response, NextFunction } from 'express'
+import type { Express } from 'express'
 import express from 'express'
-import type { AuthenticatedRequest } from '../../../src/middleware/auth'
 
 interface MockGuildSettingsService {
     getGuildSettings: jest.Mock<Promise<unknown>>
@@ -18,28 +17,32 @@ jest.mock('@lucky/shared/services', () => ({
     guildSettingsService: mockGuildSettingsService,
 }))
 
-jest.mock('../../../src/middleware/auth', () => ({
-    requireAuth: (
-        req: AuthenticatedRequest,
-        _res: Response,
-        next: NextFunction,
-    ) => {
-        req.user = {
-            id: 'test-discord-id',
-            username: 'test',
-            discriminator: '0000',
-            avatar: null,
-        }
-        next()
-    },
-}))
-
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
     debugLog: jest.fn(),
+    warnLog: jest.fn(),
+    infoLog: jest.fn(),
 }))
 
+jest.mock('../../../src/services/SessionService', () => ({
+    sessionService: {
+        getSession: jest.fn(),
+    },
+}))
+
+jest.mock('../../../src/services/GuildAccessService', () => ({
+    guildAccessService: {
+        resolveGuildContext: jest.fn(),
+        hasAccess: jest.fn(),
+    },
+}))
+
+import { setupSessionMiddleware } from '../../../src/middleware/session'
 import { setupAutoplayRoutes } from '../../../src/routes/music/autoplayRoutes'
+import { errorHandler } from '../../../src/middleware/errorHandler'
+import { sessionService } from '../../../src/services/SessionService'
+import { guildAccessService } from '../../../src/services/GuildAccessService'
+import { MOCK_SESSION_DATA, MOCK_GUILD_CONTEXT } from '../../fixtures/mock-data'
 
 describe('Autoplay Routes', () => {
     let app: Express
@@ -48,16 +51,31 @@ describe('Autoplay Routes', () => {
         jest.clearAllMocks()
         app = express()
         app.use(express.json())
+        setupSessionMiddleware(app)
         setupAutoplayRoutes(app)
+        app.use(errorHandler)
+
+        const mockSessionService = sessionService as jest.Mocked<
+            typeof sessionService
+        >
+        mockSessionService.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+
+        const mockGuildAccessService = guildAccessService as jest.Mocked<
+            typeof guildAccessService
+        >
+        mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+            MOCK_GUILD_CONTEXT,
+        )
+        mockGuildAccessService.hasAccess.mockReturnValue(true)
     })
 
     describe('GET /api/guilds/:guildId/autoplay/genres', () => {
         it('returns empty genres when no settings exist', async () => {
             mockGuildSettingsService.getGuildSettings.mockResolvedValue(null)
 
-            const res = await request(app).get(
-                '/api/guilds/123456789012345678/autoplay/genres',
-            )
+            const res = await request(app)
+                .get('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
 
             expect(res.status).toBe(200)
             expect(res.body).toEqual({ genres: [] })
@@ -68,14 +86,30 @@ describe('Autoplay Routes', () => {
                 autoplayGenres: ['rock', 'indie', 'jazz'],
             })
 
-            const res = await request(app).get(
-                '/api/guilds/123456789012345678/autoplay/genres',
-            )
+            const res = await request(app)
+                .get('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
 
             expect(res.status).toBe(200)
             expect(res.body).toEqual({
                 genres: ['rock', 'indie', 'jazz'],
             })
+        })
+
+        it('returns 403 for a user with no access to this guild (IDOR regression, #2243)', async () => {
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.resolveGuildContext.mockResolvedValue(null)
+
+            const res = await request(app)
+                .get('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(403)
+            expect(
+                mockGuildSettingsService.getGuildSettings,
+            ).not.toHaveBeenCalled()
         })
     })
 
@@ -85,6 +119,7 @@ describe('Autoplay Routes', () => {
 
             const res = await request(app)
                 .put('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
                 .send({ genres: ['rock', 'pop'] })
 
             expect(res.status).toBe(200)
@@ -99,6 +134,7 @@ describe('Autoplay Routes', () => {
         it('rejects when genres is not an array', async () => {
             const res = await request(app)
                 .put('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
                 .send({ genres: 'rock' })
 
             expect(res.status).toBe(400)
@@ -108,6 +144,7 @@ describe('Autoplay Routes', () => {
         it('rejects when more than 5 genres', async () => {
             const res = await request(app)
                 .put('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
                 .send({
                     genres: [
                         'rock',
@@ -128,6 +165,7 @@ describe('Autoplay Routes', () => {
 
             const res = await request(app)
                 .put('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
                 .send({ genres: ['Rock', 'ROCK', '  rock  ', 'pop'] })
 
             expect(res.status).toBe(200)
@@ -141,10 +179,28 @@ describe('Autoplay Routes', () => {
 
             const res = await request(app)
                 .put('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
                 .send({ genres: ['rock'] })
 
             expect(res.status).toBe(500)
             expect(res.body.error).toBe('Update failed')
+        })
+
+        it('returns 403 for a user without manage access to this guild (IDOR regression, #2243)', async () => {
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            const res = await request(app)
+                .put('/api/guilds/123456789012345678/autoplay/genres')
+                .set('Cookie', ['sessionId=valid_session_id'])
+                .send({ genres: ['rock'] })
+
+            expect(res.status).toBe(403)
+            expect(
+                mockGuildSettingsService.updateGuildSettings,
+            ).not.toHaveBeenCalled()
         })
     })
 })

--- a/packages/backend/tests/integration/routes/guildSettings.test.ts
+++ b/packages/backend/tests/integration/routes/guildSettings.test.ts
@@ -8,12 +8,20 @@ import {
 } from '../../../src/routes/guildSettings'
 import { setupSessionMiddleware } from '../../../src/middleware/session'
 import { sessionService } from '../../../src/services/SessionService'
-import { MOCK_SESSION_DATA } from '../../fixtures/mock-data'
+import { guildAccessService } from '../../../src/services/GuildAccessService'
+import { MOCK_SESSION_DATA, MOCK_GUILD_CONTEXT } from '../../fixtures/mock-data'
 import { GUILD_SETTINGS_EDITABLE_FIELDS } from '@lucky/shared/services'
 
 jest.mock('../../../src/services/SessionService', () => ({
     sessionService: {
         getSession: jest.fn(),
+    },
+}))
+
+jest.mock('../../../src/services/GuildAccessService', () => ({
+    guildAccessService: {
+        resolveGuildContext: jest.fn(),
+        hasAccess: jest.fn(),
     },
 }))
 
@@ -38,6 +46,14 @@ describe('Guild Settings Routes', () => {
         setupGuildSettingsRoutes(app)
         app.use(errorHandler)
         jest.clearAllMocks()
+
+        const mockGuildAccessService = guildAccessService as jest.Mocked<
+            typeof guildAccessService
+        >
+        mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+            MOCK_GUILD_CONTEXT,
+        )
+        mockGuildAccessService.hasAccess.mockReturnValue(true)
     })
 
     const GUILD_ID = '111111111111111111'
@@ -97,6 +113,25 @@ describe('Guild Settings Routes', () => {
 
             expect(res.status).toBe(401)
         })
+
+        test('returns 403 for a user with no access to this guild (IDOR regression, #2243)', async () => {
+            const mockSession = sessionService as jest.Mocked<
+                typeof sessionService
+            >
+            mockSession.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.resolveGuildContext.mockResolvedValue(null)
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/settings`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(403)
+            expect(mockGetSettings).not.toHaveBeenCalled()
+        })
     })
 
     describe('POST /api/guilds/:guildId/settings', () => {
@@ -153,6 +188,26 @@ describe('Guild Settings Routes', () => {
 
             expect(res.status).toBe(400)
         })
+
+        test('returns 403 for a user without manage access to this guild (IDOR regression, #2243)', async () => {
+            const mockSession = sessionService as jest.Mocked<
+                typeof sessionService
+            >
+            mockSession.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            const res = await request(app)
+                .post(`/api/guilds/${GUILD_ID}/settings`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+                .send({ prefix: '!' })
+
+            expect(res.status).toBe(403)
+            expect(mockSetSettings).not.toHaveBeenCalled()
+        })
     })
 
     describe('settingsBody schema / editable field list agreement', () => {
@@ -183,6 +238,41 @@ describe('Guild Settings Routes', () => {
             expect(res.status).toBe(200)
             expect(res.body.settings).toEqual(settings)
         })
+
+        test('checks access against the requested slug, not a hardcoded module (IDOR regression, #2243)', async () => {
+            const mockSession = sessionService as jest.Mocked<
+                typeof sessionService
+            >
+            mockSession.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+            mockGetSettings.mockResolvedValue({})
+
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+
+            await request(app)
+                .get(`/api/guilds/${GUILD_ID}/modules/moderation/settings`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(mockGuildAccessService.hasAccess).toHaveBeenCalledWith(
+                MOCK_GUILD_CONTEXT,
+                'moderation',
+                'view',
+            )
+        })
+
+        test('returns 400 for a slug that is not a real module', async () => {
+            const mockSession = sessionService as jest.Mocked<
+                typeof sessionService
+            >
+            mockSession.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+
+            const res = await request(app)
+                .get(`/api/guilds/${GUILD_ID}/modules/not-a-module/settings`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+
+            expect(res.status).toBe(400)
+        })
     })
 
     describe('POST /api/guilds/:guildId/modules/:slug/settings', () => {
@@ -200,6 +290,26 @@ describe('Guild Settings Routes', () => {
 
             expect(res.status).toBe(200)
             expect(res.body.success).toBe(true)
+        })
+
+        test('returns 403 for a user without manage access to the requested module (IDOR regression, #2243)', async () => {
+            const mockSession = sessionService as jest.Mocked<
+                typeof sessionService
+            >
+            mockSession.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            const res = await request(app)
+                .post(`/api/guilds/${GUILD_ID}/modules/music/settings`)
+                .set('Cookie', ['sessionId=valid_session_id'])
+                .send({ defaultVolume: 75 })
+
+            expect(res.status).toBe(403)
+            expect(mockSetSettings).not.toHaveBeenCalled()
         })
     })
 })

--- a/packages/backend/tests/integration/routes/guildSettings.test.ts
+++ b/packages/backend/tests/integration/routes/guildSettings.test.ts
@@ -239,7 +239,7 @@ describe('Guild Settings Routes', () => {
             expect(res.body.settings).toEqual(settings)
         })
 
-        test('checks access against the requested slug, not a hardcoded module (IDOR regression, #2243)', async () => {
+        test('checks settings access regardless of slug — the handler reads the whole record, not a per-module projection (IDOR regression, #2243)', async () => {
             const mockSession = sessionService as jest.Mocked<
                 typeof sessionService
             >
@@ -256,7 +256,7 @@ describe('Guild Settings Routes', () => {
 
             expect(mockGuildAccessService.hasAccess).toHaveBeenCalledWith(
                 MOCK_GUILD_CONTEXT,
-                'moderation',
+                'settings',
                 'view',
             )
         })

--- a/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.spec.ts
@@ -224,7 +224,7 @@ describe('setupLifecycleHandlers', () => {
         expect(watchdogCheckRecoverMock).not.toHaveBeenCalled()
     })
 
-    it('does NOT call checkAndRecover when disconnect is intentional stop', async () => {
+    it('does NOT save snapshot or call checkAndRecover when disconnect is intentional stop (#2241)', async () => {
         watchdogIsIntentionalStopMock.mockReturnValue(true)
 
         const handlers: Record<string, PlayerEventHandler> = {}
@@ -244,8 +244,58 @@ describe('setupLifecycleHandlers', () => {
 
         await handlers.disconnect(queue)
 
-        expect(saveSnapshotMock).toHaveBeenCalledWith(queue)
+        // Regression: an intentional /stop already deleted the snapshot.
+        // Re-saving it here resurrected it, which the orphan-session monitor
+        // later restored as if it were an accidental disconnect.
+        expect(saveSnapshotMock).not.toHaveBeenCalled()
         expect(watchdogCheckRecoverMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT save snapshot on connectionDestroyed when it is an intentional stop (#2241)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-3b', name: 'Guild 3b' },
+        } as unknown as GuildQueue
+
+        await handlers.connectionDestroyed(queue)
+
+        expect(saveSnapshotMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT save snapshot on emptyChannel when it is an intentional stop (#2241)', async () => {
+        watchdogIsIntentionalStopMock.mockReturnValue(true)
+
+        const handlers: Record<string, PlayerEventHandler> = {}
+        const player = {
+            events: {
+                on: jest.fn((event: string, handler: PlayerEventHandler) => {
+                    handlers[event] = handler
+                }),
+            },
+        }
+
+        setupLifecycleHandlers(player)
+
+        const queue = {
+            guild: { id: 'guild-empty', name: 'Guild Empty' },
+        } as unknown as GuildQueue
+
+        await handlers.emptyChannel(queue)
+
+        expect(saveSnapshotMock).not.toHaveBeenCalled()
+        expect(watchdogClearMock).toHaveBeenCalledWith('guild-empty')
     })
 
     it('replenishes queue on emptyQueue when autoplay is enabled', async () => {

--- a/packages/bot/src/handlers/player/lifecycleHandlers.ts
+++ b/packages/bot/src/handlers/player/lifecycleHandlers.ts
@@ -247,14 +247,21 @@ export const setupLifecycleHandlers = (player: {
         })
 
         await voiceStatus.clearStatus(queue)
-        await musicSessionSnapshotService.saveSnapshot(queue)
-        // Queue was explicitly deleted — never attempt recovery here.
+        // Queue was explicitly deleted — never attempt recovery here. An
+        // intentional /stop already deleted the snapshot; re-saving it here
+        // unconditionally resurrected it, which the orphan-session monitor
+        // later restored as if it were an accidental disconnect (#2241).
+        if (!musicWatchdogService.isIntentionalStop(queue.guild.id)) {
+            await musicSessionSnapshotService.saveSnapshot(queue)
+        }
     })
 
     player.events.on('emptyChannel', async (queue: GuildQueue) => {
         infoLog({ message: `Channel is empty in ${queue.guild.name}` })
         await voiceStatus.clearStatus(queue)
-        await musicSessionSnapshotService.saveSnapshot(queue)
+        if (!musicWatchdogService.isIntentionalStop(queue.guild.id)) {
+            await musicSessionSnapshotService.saveSnapshot(queue)
+        }
         musicWatchdogService.clear(queue.guild.id)
     })
 
@@ -283,8 +290,8 @@ export const setupLifecycleHandlers = (player: {
         })
 
         await voiceStatus.clearStatus(queue)
-        await musicSessionSnapshotService.saveSnapshot(queue)
         if (!musicWatchdogService.isIntentionalStop(queue.guild.id)) {
+            await musicSessionSnapshotService.saveSnapshot(queue)
             await musicWatchdogService.checkAndRecover(queue)
         }
     })


### PR DESCRIPTION
## What

Fixes #2243 (CRITICAL, filed from an `/audit-deep` security pass).

`packages/backend/src/routes/guildSettings.ts` and `packages/backend/src/routes/music/autoplayRoutes.ts` chained only `requireAuth`, never `requireGuildModuleAccess`. Any authenticated dashboard user (any Discord OAuth login, no membership needed) could read or write **any** guild's bot config: prefix, embed color, language, playlist/spotify toggles, cooldown, queue size, default volume, vote-skip threshold, and autoplay genres. Every sibling route file (`management.ts`, `guildAutomation.ts`, `guilds.ts`, `moderation.ts`, `roles.ts`) already used `requireAuth` + `requireGuildModuleAccess(...)`; these two were the outliers.

## Fix

- `guildSettings.ts`: guard `/settings` (GET → `settings:view`, POST → `settings:manage`) and `/modules/:slug/settings` with `requireGuildModuleAccess`.
- `/modules/:slug/settings` is dynamic — `slug` selects which RBAC module's settings are being touched (frontend calls it with `'music'` today). Hardcoding a module there would be wrong, so:
  - `moduleSlugParam`'s `slug` field is now `z.enum(RBAC_MODULES)` instead of a free-form string, rejecting non-module slugs with 400.
  - `requireGuildModuleAccess` now also accepts a `(req) => ModuleKey` resolver in addition to a static `ModuleKey`, so the route can authorize against the requested slug instead of a fixed module.
- `autoplayRoutes.ts`: guard both routes with `requireGuildModuleAccess('music', 'view'|'manage')`.

## Testing

- Added regression tests in `guildSettings.test.ts` and `autoplay.test.ts` asserting 403 when `guildAccessService` denies access, and that the dynamic `/modules/:slug/settings` route calls `hasAccess` with the requested slug (not a hardcoded module).
- Full backend suite: `npx jest --config packages/backend/jest.config.cjs` → 1401/1401 passing.
- `npm run type:check --workspace=packages/backend` clean.

## Test plan

- [ ] As a non-admin user with no RBAC grant on a guild, confirm `GET/POST /api/guilds/:id/settings` and `/autoplay/genres` now return 403 instead of the guild's real data.
- [ ] As an admin/owner, confirm the dashboard settings and autoplay-genre pickers still load and save normally (unaffected — admins get automatic manage access).

## Follow-up (not in this PR)

While investigating this, found the same missing-authorization pattern across `packages/backend/src/routes/music/{playbackRoutes,queueRoutes,stateRoutes}.ts` (play/pause/skip/volume/seek/queue-move/queue-remove/queue-clear/import/state/stream — 12 more endpoints, same `requireAuth`-only gap). Flagged separately since it's a larger blast radius and changes live playback-control behavior for any user without an explicit `music` RBAC grant; pending confirmation before applying the same fix there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the IDOR where any authenticated dashboard user could read or write any guild's bot config, and stops the bot from resurrecting autoplay sessions after an explicit `/stop`.

**Backend access control**
- `guildSettings.ts` and `autoplayRoutes.ts` now enforce `requireGuildModuleAccess` with view/manage modes; previously they only required any authenticated login, so any dashboard user could read/write any guild's settings regardless of membership.
- `/modules/:slug/settings` authorizes against `'settings'` access rather than the requested slug's module, since the handler exposes the whole settings record.
- The `slug` param now validates against `RBAC_MODULES`; unknown slugs return 400.

**Bot snapshot fix**
- The `disconnect`, `connectionDestroyed`, and `emptyChannel` handlers re-saved session snapshots after an intentional `/stop`, undoing the snapshot deletion and letting the orphan-session monitor restore playback.
- Those handlers now skip saving when `isIntentionalStop` is true, so a stopped session won't resume.

<sup>Written for commit 36601d8c879f6fc4be557e278a069b8c79b9b917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

