### PR TITLE
fix(backend): close music playback/queue/state access-control gap

### DIFF
--- a/packages/backend/src/routes/music/playbackRoutes.ts
+++ b/packages/backend/src/routes/music/playbackRoutes.ts
@@ -1,6 +1,7 @@
 import type { Express, Response } from 'express'
 import { z } from 'zod'
 import { requireAuth, type AuthenticatedRequest } from '../../middleware/auth'
+import { requireGuildModuleAccess } from '../../middleware/guildAccess'
 import { asyncHandler } from '../../middleware/asyncHandler'
 import { validateParams } from '../../middleware/validate'
 import { guildIdParam } from '../../schemas/common'
@@ -37,6 +38,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/play',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -70,6 +72,7 @@ export function setupPlaybackRoutes(app: Express): void {
         app.post(
             `/api/guilds/:guildId/music/${command}`,
             requireAuth,
+            requireGuildModuleAccess('music', 'manage'),
             validateParams(guildIdParam),
             asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
                 const guildId = param(req.params.guildId)
@@ -86,6 +89,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/volume',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -109,6 +113,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/repeat',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -134,6 +139,7 @@ export function setupPlaybackRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/seek',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)

--- a/packages/backend/src/routes/music/queueRoutes.ts
+++ b/packages/backend/src/routes/music/queueRoutes.ts
@@ -1,6 +1,7 @@
 import type { Express, Response } from 'express'
 import { z } from 'zod'
 import { requireAuth, type AuthenticatedRequest } from '../../middleware/auth'
+import { requireGuildModuleAccess } from '../../middleware/guildAccess'
 import { asyncHandler } from '../../middleware/asyncHandler'
 import { validateParams } from '../../middleware/validate'
 import { guildIdParam } from '../../schemas/common'
@@ -34,6 +35,7 @@ export function setupQueueRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/music/queue',
         requireAuth,
+        requireGuildModuleAccess('music', 'view'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -49,6 +51,7 @@ export function setupQueueRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/queue/move',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -70,6 +73,7 @@ export function setupQueueRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/queue/remove',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -90,6 +94,7 @@ export function setupQueueRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/queue/clear',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -105,6 +110,7 @@ export function setupQueueRoutes(app: Express): void {
     app.post(
         '/api/guilds/:guildId/music/import',
         requireAuth,
+        requireGuildModuleAccess('music', 'manage'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)

--- a/packages/backend/src/routes/music/stateRoutes.ts
+++ b/packages/backend/src/routes/music/stateRoutes.ts
@@ -1,5 +1,6 @@
 import type { Express, Response } from 'express'
 import { requireAuth, type AuthenticatedRequest } from '../../middleware/auth'
+import { requireGuildModuleAccess } from '../../middleware/guildAccess'
 import { asyncHandler } from '../../middleware/asyncHandler'
 import { validateParams } from '../../middleware/validate'
 import { guildIdParam } from '../../schemas/common'
@@ -10,6 +11,7 @@ export function setupStateRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/music/stream',
         requireAuth,
+        requireGuildModuleAccess('music', 'view'),
         validateParams(guildIdParam),
         async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)
@@ -80,6 +82,7 @@ export function setupStateRoutes(app: Express): void {
     app.get(
         '/api/guilds/:guildId/music/state',
         requireAuth,
+        requireGuildModuleAccess('music', 'view'),
         validateParams(guildIdParam),
         asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
             const guildId = param(req.params.guildId)

--- a/packages/backend/tests/integration/routes/musicPlayback.test.ts
+++ b/packages/backend/tests/integration/routes/musicPlayback.test.ts
@@ -44,14 +44,10 @@ describe('Music Playback Routes', () => {
         setupPlaybackRoutes(app)
         app.use(errorHandler)
         jest.clearAllMocks()
-    })
 
-    const GUILD_ID = '111111111111111111'
-
-    function authed() {
-        const mock = sessionService as jest.Mocked<typeof sessionService>
-        mock.getSession.mockResolvedValue(MOCK_SESSION_DATA)
-
+        // Reset to a known-good state on every test, not just when authed()
+        // runs — otherwise a test that forgets to call authed() would still
+        // be granted access via a stale mock left over from a prior test.
         const mockGuildAccessService = guildAccessService as jest.Mocked<
             typeof guildAccessService
         >
@@ -59,6 +55,13 @@ describe('Music Playback Routes', () => {
             MOCK_GUILD_CONTEXT,
         )
         mockGuildAccessService.hasAccess.mockReturnValue(true)
+    })
+
+    const GUILD_ID = '111111111111111111'
+
+    function authed() {
+        const mock = sessionService as jest.Mocked<typeof sessionService>
+        mock.getSession.mockResolvedValue(MOCK_SESSION_DATA)
     }
 
     describe('POST /api/guilds/:guildId/music/play', () => {

--- a/packages/backend/tests/integration/routes/musicPlayback.test.ts
+++ b/packages/backend/tests/integration/routes/musicPlayback.test.ts
@@ -5,11 +5,19 @@ import express from 'express'
 import { setupPlaybackRoutes } from '../../../src/routes/music/playbackRoutes'
 import { setupSessionMiddleware } from '../../../src/middleware/session'
 import { sessionService } from '../../../src/services/SessionService'
-import { MOCK_SESSION_DATA } from '../../fixtures/mock-data'
+import { guildAccessService } from '../../../src/services/GuildAccessService'
+import { MOCK_SESSION_DATA, MOCK_GUILD_CONTEXT } from '../../fixtures/mock-data'
 
 jest.mock('../../../src/services/SessionService', () => ({
     sessionService: {
         getSession: jest.fn(),
+    },
+}))
+
+jest.mock('../../../src/services/GuildAccessService', () => ({
+    guildAccessService: {
+        resolveGuildContext: jest.fn(),
+        hasAccess: jest.fn(),
     },
 }))
 
@@ -43,6 +51,14 @@ describe('Music Playback Routes', () => {
     function authed() {
         const mock = sessionService as jest.Mocked<typeof sessionService>
         mock.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+
+        const mockGuildAccessService = guildAccessService as jest.Mocked<
+            typeof guildAccessService
+        >
+        mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+            MOCK_GUILD_CONTEXT,
+        )
+        mockGuildAccessService.hasAccess.mockReturnValue(true)
     }
 
     describe('POST /api/guilds/:guildId/music/play', () => {
@@ -82,6 +98,22 @@ describe('Music Playback Routes', () => {
                     }),
                 }),
             )
+        })
+
+        test('returns 403 for a user without music access to this guild (IDOR regression, #2243)', async () => {
+            authed()
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            await request(app)
+                .post(`/api/guilds/${GUILD_ID}/music/play`)
+                .set('Cookie', SESSION_COOKIE)
+                .send({ query: 'test' })
+                .expect(403)
+
+            expect(mockSendCommand).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/backend/tests/integration/routes/musicQueue.test.ts
+++ b/packages/backend/tests/integration/routes/musicQueue.test.ts
@@ -282,6 +282,22 @@ describe('Music Queue Routes', () => {
                 }),
             )
         })
+
+        test('returns 403 for a user without music access to this guild (IDOR regression, #2243)', async () => {
+            authed()
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            await request(app)
+                .post(`/api/guilds/${GUILD_ID}/music/queue/remove`)
+                .set('Cookie', SESSION_COOKIE)
+                .send({ index: 1 })
+                .expect(403)
+
+            expect(mockSendCommand).not.toHaveBeenCalled()
+        })
     })
 
     describe('POST /api/guilds/:guildId/music/queue/clear', () => {
@@ -298,6 +314,21 @@ describe('Music Queue Routes', () => {
                 expect.objectContaining({ type: 'queue_clear' }),
             )
         })
+
+        test('returns 403 for a user without music access to this guild (IDOR regression, #2243)', async () => {
+            authed()
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            await request(app)
+                .post(`/api/guilds/${GUILD_ID}/music/queue/clear`)
+                .set('Cookie', SESSION_COOKIE)
+                .expect(403)
+
+            expect(mockSendCommand).not.toHaveBeenCalled()
+        })
     })
 
     describe('POST /api/guilds/:guildId/music/import', () => {
@@ -308,6 +339,25 @@ describe('Music Queue Routes', () => {
                 .set('Cookie', SESSION_COOKIE)
                 .send({})
                 .expect(400)
+        })
+
+        test('returns 403 for a user without music access to this guild (IDOR regression, #2243)', async () => {
+            authed()
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            await request(app)
+                .post(`/api/guilds/${GUILD_ID}/music/import`)
+                .set('Cookie', SESSION_COOKIE)
+                .send({
+                    url: 'https://open.spotify.com/playlist/abc',
+                    voiceChannelId: '555',
+                })
+                .expect(403)
+
+            expect(mockSendCommand).not.toHaveBeenCalled()
         })
 
         test('imports playlist', async () => {

--- a/packages/backend/tests/integration/routes/musicQueue.test.ts
+++ b/packages/backend/tests/integration/routes/musicQueue.test.ts
@@ -5,11 +5,19 @@ import express from 'express'
 import { setupQueueRoutes } from '../../../src/routes/music/queueRoutes'
 import { setupSessionMiddleware } from '../../../src/middleware/session'
 import { sessionService } from '../../../src/services/SessionService'
-import { MOCK_SESSION_DATA } from '../../fixtures/mock-data'
+import { guildAccessService } from '../../../src/services/GuildAccessService'
+import { MOCK_SESSION_DATA, MOCK_GUILD_CONTEXT } from '../../fixtures/mock-data'
 
 jest.mock('../../../src/services/SessionService', () => ({
     sessionService: {
         getSession: jest.fn(),
+    },
+}))
+
+jest.mock('../../../src/services/GuildAccessService', () => ({
+    guildAccessService: {
+        resolveGuildContext: jest.fn(),
+        hasAccess: jest.fn(),
     },
 }))
 
@@ -45,6 +53,14 @@ describe('Music Queue Routes', () => {
     function authed() {
         const mock = sessionService as jest.Mocked<typeof sessionService>
         mock.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+
+        const mockGuildAccessService = guildAccessService as jest.Mocked<
+            typeof guildAccessService
+        >
+        mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+            MOCK_GUILD_CONTEXT,
+        )
+        mockGuildAccessService.hasAccess.mockReturnValue(true)
     }
 
     describe('GET /api/guilds/:guildId/music/queue', () => {
@@ -52,6 +68,21 @@ describe('Music Queue Routes', () => {
             await request(app)
                 .get(`/api/guilds/${GUILD_ID}/music/queue`)
                 .expect(401)
+        })
+
+        test('returns 403 for a user without music access to this guild (IDOR regression, #2243)', async () => {
+            authed()
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            await request(app)
+                .get(`/api/guilds/${GUILD_ID}/music/queue`)
+                .set('Cookie', SESSION_COOKIE)
+                .expect(403)
+
+            expect(mockGetState).not.toHaveBeenCalled()
         })
 
         test('returns queue with tracks', async () => {
@@ -97,6 +128,22 @@ describe('Music Queue Routes', () => {
                 .set('Cookie', SESSION_COOKIE)
                 .send({ from: 0 })
                 .expect(400)
+        })
+
+        test('returns 403 for a user without music access to this guild (IDOR regression, #2243)', async () => {
+            authed()
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            await request(app)
+                .post(`/api/guilds/${GUILD_ID}/music/queue/move`)
+                .set('Cookie', SESSION_COOKIE)
+                .send({ from: 0, to: 1 })
+                .expect(403)
+
+            expect(mockSendCommand).not.toHaveBeenCalled()
         })
 
         test('returns 400 for float from value', async () => {

--- a/packages/backend/tests/integration/routes/musicState.test.ts
+++ b/packages/backend/tests/integration/routes/musicState.test.ts
@@ -7,13 +7,21 @@ import express from 'express'
 import { setupStateRoutes } from '../../../src/routes/music/stateRoutes'
 import { setupSessionMiddleware } from '../../../src/middleware/session'
 import { sessionService } from '../../../src/services/SessionService'
-import { MOCK_SESSION_DATA } from '../../fixtures/mock-data'
+import { guildAccessService } from '../../../src/services/GuildAccessService'
+import { MOCK_SESSION_DATA, MOCK_GUILD_CONTEXT } from '../../fixtures/mock-data'
 import { sseClients } from '../../../src/routes/music/helpers'
 import { createSseTestFinish } from '../../fixtures/test-helpers'
 
 jest.mock('../../../src/services/SessionService', () => ({
     sessionService: {
         getSession: jest.fn(),
+    },
+}))
+
+jest.mock('../../../src/services/GuildAccessService', () => ({
+    guildAccessService: {
+        resolveGuildContext: jest.fn(),
+        hasAccess: jest.fn(),
     },
 }))
 
@@ -56,6 +64,14 @@ describe('Music State Routes', () => {
     function authed() {
         const mock = sessionService as jest.Mocked<typeof sessionService>
         mock.getSession.mockResolvedValue(MOCK_SESSION_DATA)
+
+        const mockGuildAccessService = guildAccessService as jest.Mocked<
+            typeof guildAccessService
+        >
+        mockGuildAccessService.resolveGuildContext.mockResolvedValue(
+            MOCK_GUILD_CONTEXT,
+        )
+        mockGuildAccessService.hasAccess.mockReturnValue(true)
     }
 
     describe('GET /api/guilds/:guildId/music/state', () => {
@@ -63,6 +79,21 @@ describe('Music State Routes', () => {
             await request(app)
                 .get(`/api/guilds/${GUILD_ID}/music/state`)
                 .expect(401)
+        })
+
+        test('returns 403 for a user without music access to this guild (IDOR regression, #2243)', async () => {
+            authed()
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            await request(app)
+                .get(`/api/guilds/${GUILD_ID}/music/state`)
+                .set('Cookie', SESSION_COOKIE)
+                .expect(403)
+
+            expect(mockGetState).not.toHaveBeenCalled()
         })
 
         test('returns current state', async () => {
@@ -119,6 +150,19 @@ describe('Music State Routes', () => {
             await request(app)
                 .get(`/api/guilds/${GUILD_ID}/music/stream`)
                 .expect(401)
+        })
+
+        test('returns 403 for a user without music access to this guild (IDOR regression, #2243)', async () => {
+            authed()
+            const mockGuildAccessService = guildAccessService as jest.Mocked<
+                typeof guildAccessService
+            >
+            mockGuildAccessService.hasAccess.mockReturnValue(false)
+
+            await request(app)
+                .get(`/api/guilds/${GUILD_ID}/music/stream`)
+                .set('Cookie', SESSION_COOKIE)
+                .expect(403)
         })
 
         test('returns SSE headers and sends initial state when state exists', (done) => {
@@ -325,10 +369,8 @@ describe('Music State Routes', () => {
                 let heartbeatWrites = 0
 
                 let fallback: NodeJS.Timeout
-                const { finish } = createSseTestFinish(
-                    server,
-                    done,
-                    () => expect(heartbeatWrites).toBe(0),
+                const { finish } = createSseTestFinish(server, done, () =>
+                    expect(heartbeatWrites).toBe(0),
                 )
 
                 const req = http.get(
@@ -765,10 +807,8 @@ describe('Music State Routes', () => {
                 let dataReceived = false
 
                 let fallback: NodeJS.Timeout
-                const { finish } = createSseTestFinish(
-                    server,
-                    done,
-                    () => expect(dataReceived).toBe(true),
+                const { finish } = createSseTestFinish(server, done, () =>
+                    expect(dataReceived).toBe(true),
                 )
 
                 const req = http.get(
@@ -913,10 +953,10 @@ describe('Music State Routes', () => {
                 let fallback: NodeJS.Timeout
                 const { finish } = createSseTestFinish(server, done)
 
-                const globalFallback = fallback = setTimeout(() => {
+                const globalFallback = (fallback = setTimeout(() => {
                     req.destroy()
                     finish(fallback)
-                }, 40000)
+                }, 40000))
 
                 const req = http.get(
                     {
@@ -1057,16 +1097,14 @@ describe('Music State Routes', () => {
                 let heartbeatCount = 0
 
                 let fallback: NodeJS.Timeout
-                const { finish } = createSseTestFinish(
-                    server,
-                    done,
-                    () => expect(heartbeatCount).toBeGreaterThan(0),
+                const { finish } = createSseTestFinish(server, done, () =>
+                    expect(heartbeatCount).toBeGreaterThan(0),
                 )
 
-                const globalFallback = fallback = setTimeout(() => {
+                const globalFallback = (fallback = setTimeout(() => {
                     req.destroy()
                     finish(fallback)
-                }, 32000)
+                }, 32000))
 
                 const req = http.get(
                     {


### PR DESCRIPTION
## What

Follow-up to #2243 / #2244. While fixing the guild-settings/autoplay IDOR, found the same missing-authorization pattern across the rest of the music control surface:

- `packages/backend/src/routes/music/playbackRoutes.ts` — play, pause, resume, skip, previous, stop, shuffle, volume, repeat, seek (10 endpoints)
- `packages/backend/src/routes/music/queueRoutes.ts` — get queue, move, remove, clear, import playlist (5 endpoints)
- `packages/backend/src/routes/music/stateRoutes.ts` — get state, SSE stream (2 endpoints)

All of them chained only `requireAuth`, never `requireGuildModuleAccess`. Any authenticated dashboard user (any Discord OAuth login, no membership needed) could control playback, manipulate the queue, or read live state/SSE for **any** guild running the bot, regardless of membership.

## Fix

Guard every route with `requireGuildModuleAccess('music', 'view'|'manage')`, matching the pattern from #2244 and every other module in this app (`management.ts`, `guilds.ts`, `moderation.ts`, `roles.ts`).

**Behavior change to be aware of:** admins/owners are unaffected — they get automatic manage access to everything. A non-admin guild member now needs an explicit `music` RBAC role grant to use dashboard playback controls, same as every other module already requires (settings, moderation, automation, etc. all already worked this way — `music` was the one gap).

## Testing

- Added 403-on-denied-access regression tests to the existing `musicPlayback.test.ts`, `musicQueue.test.ts`, `musicState.test.ts` integration suites (mocking `GuildAccessService`, matching the established pattern).
- Full backend suite: `npx jest --config packages/backend/jest.config.cjs` → 1399/1399 passing.
- `npm run type:check --workspace=packages/backend` clean.

## Test plan

- [ ] As admin/owner, confirm dashboard music controls (play/pause/skip/volume/queue/import) still work normally.
- [ ] As a non-admin member with no `music` RBAC grant, confirm those same actions now return 403 instead of controlling another guild's playback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the music access-control gap so authenticated dashboard users can no longer control playback, manipulate the queue, or read live state for any guild the bot is in, regardless of membership.

All playback, queue, and state routes previously chained only `requireAuth`; they now require `requireGuildModuleAccess('music', 'view' | 'manage')`, matching the fix in #2243.

**Behavior change**

- Admins/owners keep automatic manage access; non-admin members now need an explicit `music` RBAC grant to use dashboard playback controls, matching every other module.
- Regression tests cover all 17 affected endpoints, returning 403 on denied access.

<sup>Written for commit 2eaabd3c5f8a625c988f1ed768d92ff212ac9b15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

