### PR TITLE
fix(backend): force jest to run in-band to kill the socket-hang-up flake

### DIFF
--- a/packages/backend/jest.config.cjs
+++ b/packages/backend/jest.config.cjs
@@ -38,11 +38,15 @@ module.exports = {
   resolver: '<rootDir>/jest-resolver.cjs',
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   testTimeout: 30000,
-  // ponytail: conservative maxWorkers to reduce concurrent database connections during
-  // parallel test execution. ECONNRESET failures observed during full suite runs suggest
-  // connection pool pressure under high parallelism. Reduced from '50%' to '25%' as baseline;
-  // further reduction to specific number (2-4) if flakiness persists.
-  maxWorkers: '25%',
+  // #2041/#2120: integration tests spin up real supertest listening servers: under
+  // parallel workers this causes intermittent "socket hang up" / connection-reset
+  // failures (ephemeral-port/socket contention), a different test failing each run.
+  // NOT database connection-pool pressure - the prior "25%" mitigation's rationale
+  // was wrong: Prisma is fully mocked in this suite (moduleNameMapper below), so
+  // there is no real DB connection to contend over. Forcing maxWorkers to 1
+  // eliminated the flake across repeated local repro runs with negligible runtime
+  // cost on this suite's size (~85s either way).
+  maxWorkers: 1,
   moduleNameMapper: {
     '^@lucky/shared$': '<rootDir>/../shared/src/index',
     '^@lucky/shared/services$': '<rootDir>/../shared/src/services/index',


### PR DESCRIPTION
## Summary

Refs #2041, #2120.

Both issues track the same recurring flake: a different backend integration test fails each full-suite run (socket hang up, ECONNRESET, malformed HTTP framing), always passing 100% in isolation. #2041's own investigation root-caused it to ephemeral port/socket contention: integration tests each spin up a real `supertest` listening server, and running many of them concurrently across parallel Jest workers causes intermittent connection failures. #2120 (a `twitch.test.ts` instance of the same symptom) independently converged on the same conclusion.

The existing `maxWorkers: '25%'` mitigation (#1751, 2026-07-10) had the wrong rationale. Its comment blames "connection pool pressure" from concurrent database connections, but `packages/backend/jest.config.cjs`'s `moduleNameMapper` fully mocks `generated/prisma/client` (`tests/__mocks__/prismaClient.ts`, zero shared state) - there is no real DB connection in this suite to contend over.

Set `maxWorkers: 1` and replaced the stale comment with the correct root cause.

## Test plan

- [x] 3 consecutive full `npx jest` runs at the previous `'25%'` setting: 1 failure (reproducing the documented flake), 2 clean
- [x] 3 consecutive full `npx jest --maxWorkers=1` runs: 3/3 clean, 1410/1410 tests
- [x] Runtime cost: negligible (~87s at maxWorkers=1 vs ~82s at '25%' on this suite's current size)
- [x] `tsc --noEmit` clean across bot/backend/frontend/shared

## Follow-up

Leaving #2041 and #2120 open post-merge rather than auto-closing - a probabilistic flake needs a run or two of real CI (not just local reproduction) before calling it fully resolved. Will close both once CI shows sustained green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the backend integration flake from #2041 and #2120 by setting `maxWorkers: 1` in `packages/backend/jest.config.cjs`, so a different test no longer fails each full-suite run with socket hang-ups and connection resets.

- Parallel workers each spun up a real `supertest` listening server, causing ephemeral port/socket contention.
- The previous `'25%'` setting blamed database connection pressure, but `generated/prisma/client` is fully mocked in this suite, so that rationale was wrong.
- Runtime impact is negligible: ~87s at `maxWorkers: 1` vs ~82s at `'25%'` on the current suite.

<sup>Written for commit 1c8bbdd68ddceb98b44993142f7f69f6fcc2e11a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

