### PR TITLE
fix(frontend): raise Changelog test timeout to fix CI flake

### DIFF
--- a/packages/frontend/src/pages/Changelog.test.tsx
+++ b/packages/frontend/src/pages/Changelog.test.tsx
@@ -16,7 +16,10 @@ function renderPage() {
     )
 }
 
-describe('Changelog', () => {
+// CHANGELOG.md is append-only and keeps growing, so rendering + querying it
+// in full gets slower over time; the default 5000ms timeout has started
+// flaking in CI under load (observed ~9.9s for the full suite).
+describe('Changelog', { timeout: 20000 }, () => {
     test('renders page title', () => {
         renderPage()
         expect(


### PR DESCRIPTION
## Summary
- `Changelog.test.tsx` was timing out intermittently in CI (default 5000ms) as `CHANGELOG.md` keeps growing, blocking unrelated PRs' "Test — frontend" / "Quality Gates" checks
- Raised the describe block's timeout to 20000ms; test-only change, no production code touched

Fixes #2279

## Test plan
- [x] `npm run test --workspace=packages/frontend -- src/pages/Changelog.test.tsx` passes locally
- [x] Full frontend suite passes (91 files / 1051 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the Changelog test timeout from 5000ms to 20000ms. `CHANGELOG.md` is append-only and keeps growing, so the test started intermittently exceeding the default timeout under CI load, blocking unrelated PRs. This is a test-only change and closes #2279.

<sup>Written for commit 0f284c47ba0ea3883186937db6de8160c1e5d077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

