### PR TITLE
fix(bot): log non-404 message.delete failures in automod handlers

### DIFF
--- a/packages/bot/src/handlers/message/__tests__/messageDeleteSafely.test.ts
+++ b/packages/bot/src/handlers/message/__tests__/messageDeleteSafely.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
+import type { Message } from 'discord.js'
+
+const warnLogMock = jest.fn()
+jest.mock('@lucky/shared/utils', () => ({
+    warnLog: (...args: unknown[]) => warnLogMock(...args),
+}))
+
+import { deleteMessageSafely } from '../messageDeleteSafely'
+
+function createMessage(deleteImpl: () => Promise<unknown>) {
+    return {
+        channelId: 'channel1',
+        delete: jest.fn(deleteImpl),
+    } as unknown as Message
+}
+
+describe('deleteMessageSafely', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('deletes the message without logging on success', async () => {
+        const message = createMessage(() => Promise.resolve(undefined))
+
+        await deleteMessageSafely(message)
+
+        expect(message.delete).toHaveBeenCalled()
+        expect(warnLogMock).not.toHaveBeenCalled()
+    })
+
+    it('silently ignores an Unknown Message (10008) error', async () => {
+        const message = createMessage(() =>
+            Promise.reject({ code: 10008, message: 'Unknown Message' }),
+        )
+
+        await deleteMessageSafely(message)
+
+        expect(warnLogMock).not.toHaveBeenCalled()
+    })
+
+    it('logs any other error, e.g. missing permissions (50013)', async () => {
+        const error = { code: 50013, message: 'Missing Permissions' }
+        const message = createMessage(() => Promise.reject(error))
+
+        await deleteMessageSafely(message)
+
+        expect(warnLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Failed to delete message',
+                error,
+                data: { channelId: 'channel1' },
+            }),
+        )
+    })
+})

--- a/packages/bot/src/handlers/message/__tests__/spamHandler.test.ts
+++ b/packages/bot/src/handlers/message/__tests__/spamHandler.test.ts
@@ -12,6 +12,7 @@ jest.mock('@lucky/shared/services', () => ({
 
 jest.mock('@lucky/shared/utils', () => ({
     errorLog: jest.fn(),
+    warnLog: jest.fn(),
 }))
 
 import { autoModService } from '@lucky/shared/services'

--- a/packages/bot/src/handlers/message/autoModHandler.ts
+++ b/packages/bot/src/handlers/message/autoModHandler.ts
@@ -3,6 +3,7 @@ import { PermissionFlagsBits } from 'discord.js'
 import { autoModService } from '@lucky/shared/services'
 import { errorLog, warnLog } from '@lucky/shared/utils'
 import { assertDefined } from '@lucky/shared/utils/guards'
+import { deleteMessageSafely } from './messageDeleteSafely'
 import type {
     MessageContext,
     MessageHandler,
@@ -137,7 +138,7 @@ export const autoModHandler: MessageHandler = {
                 })
                 // Don't delete the message, but continue processing actions
             } else {
-                await message.delete().catch(() => {})
+                await deleteMessageSafely(message)
             }
 
             return { stop: true }

--- a/packages/bot/src/handlers/message/messageDeleteSafely.ts
+++ b/packages/bot/src/handlers/message/messageDeleteSafely.ts
@@ -1,0 +1,22 @@
+import type { Message } from 'discord.js'
+import { warnLog } from '@lucky/shared/utils'
+
+/** discord.js DiscordAPIError code for "Unknown Message" — already deleted or aged out. */
+const UNKNOWN_MESSAGE_CODE = 10008
+
+/**
+ * Deletes a message, swallowing the expected "already gone" race (someone
+ * else deleted it, or it aged out) but logging anything else — most notably
+ * a missing-permissions failure, which would otherwise leave automod
+ * silently doing nothing while reporting success.
+ */
+export async function deleteMessageSafely(message: Message): Promise<void> {
+    await message.delete().catch((error: { code?: number }) => {
+        if (error?.code === UNKNOWN_MESSAGE_CODE) return
+        warnLog({
+            message: 'Failed to delete message',
+            error,
+            data: { channelId: message.channelId },
+        })
+    })
+}

--- a/packages/bot/src/handlers/message/spamHandler.ts
+++ b/packages/bot/src/handlers/message/spamHandler.ts
@@ -1,6 +1,7 @@
 import type { Message } from 'discord.js'
 import { autoModService } from '@lucky/shared/services'
 import { errorLog } from '@lucky/shared/utils'
+import { deleteMessageSafely } from './messageDeleteSafely'
 import type {
     MessageContext,
     MessageHandler,
@@ -38,7 +39,7 @@ export const spamHandler: MessageHandler = {
                 return { stop: false }
             }
 
-            await message.delete().catch(() => {})
+            await deleteMessageSafely(message)
             return { stop: true }
         } catch (error) {
             errorLog({


### PR DESCRIPTION
## Summary
- `spamHandler.ts` and `autoModHandler.ts` both swallowed every `message.delete()` failure with an empty catch, including a missing-permissions (50013) error — automod would detect a violation, fail to delete it, and report success by staying silent
- Added a shared `deleteMessageSafely()` helper (`packages/bot/src/handlers/message/messageDeleteSafely.ts`): ignores the expected 10008 "Unknown Message" race (already deleted / aged out), warn-logs anything else with the channel id
- Chose a shared helper over duplicating the catch block since both call sites want identical behavior (per the issue's own suggestion)

Fixes #1919

## Test plan
- [x] New `messageDeleteSafely.test.ts` (3 tests, mutation-verified: flipping the 10008 check flips both assertions)
- [x] Existing `spamHandler.test.ts` / `autoModHandler.test.ts` pass unmodified (mock additions only)
- [x] `tsc --noEmit` clean
- [x] Full bot suite: 251/252 suites, 3284/3285 tests (1 pre-existing unrelated skip)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes automod handlers so failed message deletions are no longer silently swallowed — a missing-permissions error previously went unnoticed while automod reported success. Now `spamHandler` and `autoModHandler` use a shared `deleteMessageSafely()` helper that ignores the expected 10008 "Unknown Message" race and warn-logs any other error with the channel id. Resolves #1919.

- Adds `packages/bot/src/handlers/message/messageDeleteSafely.ts` with the new helper and unit tests.
- Replaces the empty `.catch(() => {})` in both handlers.
- Existing handler tests pass with only a mock addition for `warnLog`.

<sup>Written for commit 1266dfa97d22fd19eb6f2d2dda6457e9aad71578. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

