### PR TITLE
test(backend): cover the SSRF snowflake guard in getGuildEmojis

### DIFF
--- a/packages/backend/tests/unit/services/GuildService.emojis.test.ts
+++ b/packages/backend/tests/unit/services/GuildService.emojis.test.ts
@@ -159,6 +159,17 @@ describe('GuildService - getGuildEmojis', () => {
         ).rejects.toThrow('Network error')
     })
 
+    test('should reject a non-snowflake guildId before hitting the Discord API (SSRF guard)', async () => {
+        process.env.DISCORD_TOKEN = 'test-bot-token'
+        setBotClient(null)
+        global.fetch = jest.fn() as unknown as typeof fetch
+
+        await expect(
+            guildService.getGuildEmojis('../../etc/passwd'),
+        ).rejects.toThrow('Invalid Discord guild id')
+        expect(global.fetch).not.toHaveBeenCalled()
+    })
+
     test('should return empty array when no bot client and no token', async () => {
         setBotClient(null)
         // no token set


### PR DESCRIPTION
## Summary
- `GuildService.getGuildEmojis` rejects any non-snowflake guildId before it reaches the Discord API request URL (SSRF / path-traversal guard), but had no test asserting the guard actually rejects — found via mutation testing during earlier work on #1975
- Added a test that passes a path-traversal-shaped string and asserts it throws `Invalid Discord guild id` without calling `fetch`

Fixes #2269

## Test plan
- [x] Mutation-verified: neutralizing the guard's condition makes the new test fail
- [x] Full backend suite: 87/87 suites, 1411/1411 tests
- [x] `tsc --noEmit` clean

Note: full-suite run hit 2 unrelated failures in `snowflakeValidation.test.ts` on one pass; reran twice (isolated + full) and both came back clean. This matches the already-tracked flake in #2041 (commented there with the occurrence), not a new issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test covering the SSRF guard in `GuildService.getGuildEmojis` so non-snowflake guild IDs are verified to be rejected before they reach the Discord API. Fixes #2269.

**Testing**
- Passes a path-traversal-shaped string and asserts it throws `Invalid Discord guild id` without calling `fetch`.
- Neutralizing the guard's condition makes the new test fail; the full backend suite passes (87/87 suites, 1411/1411 tests).

<sup>Written for commit 301e4b9ad2c0adff2490fe1f218c0b341072d348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

