### PR TITLE
fix(bot): move artist discography helper out of commands scan path

### DIFF
--- a/packages/bot/src/functions/music/commands/artist.ts
+++ b/packages/bot/src/functions/music/commands/artist.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../utils/general/embeds'
 import { interactionReply } from '../../../utils/general/interactionReply'
 import { errorLog, warnLog } from '@lucky/shared/utils'
-import { handleArtistDiscography } from './artistDiscography'
+import { handleArtistDiscography } from './artist/artistDiscography'
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
 import { assertDefined } from '@lucky/shared/utils/guards'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'

--- a/packages/bot/src/functions/music/commands/artist/artistDiscography.spec.ts
+++ b/packages/bot/src/functions/music/commands/artist/artistDiscography.spec.ts
@@ -7,11 +7,11 @@ jest.mock('discord-player', () => ({
     },
 }))
 
-jest.mock('../../../utils/general/interactionReply', () => ({
+jest.mock('../../../../utils/general/interactionReply', () => ({
     interactionReply: jest.fn(),
 }))
 
-jest.mock('../../../utils/general/embeds', () => ({
+jest.mock('../../../../utils/general/embeds', () => ({
     createErrorEmbed: jest.fn((title: string, desc?: string) => ({
         title,
         description: desc,
@@ -22,11 +22,11 @@ jest.mock('../../../utils/general/embeds', () => ({
     })),
 }))
 
-jest.mock('../../../services/musicManagement/queueResolver', () => ({
+jest.mock('../../../../services/musicManagement/queueResolver', () => ({
     resolveGuildQueue: jest.fn(),
 }))
 
-jest.mock('../../../services/musicManagement/queueManipulation', () => ({
+jest.mock('../../../../services/musicManagement/queueManipulation', () => ({
     moveUserTrackToPriority: jest.fn(),
 }))
 
@@ -56,14 +56,14 @@ jest.mock('@lucky/shared/utils', () => ({
         getSpotifyArtistAlbumsMock(...args),
 }))
 
-jest.mock('./play/queryUtils', () => ({
+jest.mock('../play/queryUtils', () => ({
     isUnknownInteractionError: jest.fn(() => false),
 }))
 
 import { handleArtistDiscography } from './artistDiscography'
-import { interactionReply } from '../../../utils/general/interactionReply'
-import { resolveGuildQueue } from '../../../services/musicManagement/queueResolver'
-import { moveUserTrackToPriority } from '../../../services/musicManagement/queueManipulation'
+import { interactionReply } from '../../../../utils/general/interactionReply'
+import { resolveGuildQueue } from '../../../../services/musicManagement/queueResolver'
+import { moveUserTrackToPriority } from '../../../../services/musicManagement/queueManipulation'
 
 const createTrack = (title: string, author: string) => ({
     title,

--- a/packages/bot/src/functions/music/commands/artist/artistDiscography.ts
+++ b/packages/bot/src/functions/music/commands/artist/artistDiscography.ts
@@ -1,13 +1,13 @@
 import { QueryType } from 'discord-player'
 import type { VoiceBasedChannel, ChatInputCommandInteraction } from 'discord.js'
-import type { CustomClient } from '../../../types/CustomClient'
-import { resolveGuildQueue } from '../../../services/musicManagement/queueResolver'
-import { moveUserTrackToPriority } from '../../../services/musicManagement/queueManipulation'
+import type { CustomClient } from '../../../../types/CustomClient'
+import { resolveGuildQueue } from '../../../../services/musicManagement/queueResolver'
+import { moveUserTrackToPriority } from '../../../../services/musicManagement/queueManipulation'
 import {
     createErrorEmbed,
     createSuccessEmbed,
-} from '../../../utils/general/embeds'
-import { interactionReply } from '../../../utils/general/interactionReply'
+} from '../../../../utils/general/embeds'
+import { interactionReply } from '../../../../utils/general/interactionReply'
 import {
     errorLog,
     warnLog,
@@ -18,7 +18,7 @@ import {
 } from '@lucky/shared/utils'
 import { createUserFriendlyError } from '@lucky/shared/utils/general/errorSanitizer'
 import { ENVIRONMENT_CONFIG } from '@lucky/shared/config'
-import { isUnknownInteractionError } from './play/queryUtils'
+import { isUnknownInteractionError } from '../play/queryUtils'
 
 const MAX_DISCOGRAPHY_ALBUMS = 25
 // A prolific artist's catalog can run into the hundreds of tracks once


### PR DESCRIPTION
## Why

User reported the /artist command threw an odd error; checking `lucky-bot` container logs found this at every boot:

```
[ERROR] Command in artistDiscography.js is not a valid Command instance
```

## Root cause

`getCommandsFromDirectory.ts` flat-scans every `.ts`/`.js` file directly under a `commands/` folder and tries to load each as a Command (`default`/`command` export shaped `{data, execute}`). `artistDiscography.ts` (added in #2305) only exports a named handler function consumed by `artist.ts` — it's a helper, not its own slash command — so it fails validation and logs an error on every startup. It did not break `/artist` itself (that command loads fine from `artist.ts`), but it's log noise masking real errors and is architecturally wrong.

## Fix

Moved the helper into `commands/artist/` — same basename as `artist.ts`, so the loader's `flatBaseNames` check skips the directory entirely (same pattern already used by `autoplay/` next to `autoplay.ts`, and `play/`). Updated the one import site (`artist.ts`) and relative import depths in the moved files.

## Test plan
- [x] `tsc --noEmit` clean across bot/shared
- [x] `artist.spec.ts` + `artist/artistDiscography.spec.ts`: 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkt4D9yyHTrVhsvDYvw5an

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the artist discography helper from being scanned as a slash command, eliminating a false error logged at every boot. The command loader flat-scans `commands/` and expects each file to export a `{data, execute}` command, but the helper only exports a named handler used by `artist.ts`. The helper now lives in `commands/artist/`, a directory the loader skips because its basename matches `artist.ts`.

<sup>Written for commit 8778730ac6d44a5c6f5d2c82ea8d18b192671121. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

