### PR TITLE
fix(bot): last.fm timing race when track changes mid-request

### DIFF
--- a/packages/bot/src/handlers/player/lastfmScrobbler.spec.ts
+++ b/packages/bot/src/handlers/player/lastfmScrobbler.spec.ts
@@ -23,6 +23,7 @@ import {
     updateLastFmNowPlaying,
     scrobbleCurrentTrackIfLastFm,
     clearLastFmTrackTiming,
+    __setLastFmTrackStartTime,
 } from './lastfmScrobbler'
 import * as lastfm from '../../lastfm'
 
@@ -279,16 +280,15 @@ describe('lastfmScrobbler', () => {
         })
 
         it('uses stored track start time if available', async () => {
-            clearLastFmTrackTiming('guild-123')
+            const storedStartTime = 1000
+            __setLastFmTrackStartTime('guild-123', storedStartTime)
 
-            // Would need a way to set start time - this tests the behavior
-            // when a start time exists (tested via integration)
             await scrobbleCurrentTrackIfLastFm(mockQueue as GuildQueue)
 
             expect(mockLastFm.scrobble).toHaveBeenCalled()
-            // The timestamp passed should be close to current time
+            // The timestamp passed should match the stored start time
             const callArgs = mockLastFm.scrobble.mock.calls[0]
-            expect(callArgs[2]).toBeGreaterThan(0)
+            expect(callArgs[2]).toBe(storedStartTime)
         })
 
         it('uses current time when no start time stored', async () => {

--- a/packages/bot/src/handlers/player/lastfmScrobbler.spec.ts
+++ b/packages/bot/src/handlers/player/lastfmScrobbler.spec.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it, beforeEach, jest } from '@jest/globals'
 import type { Track, GuildQueue } from 'discord-player'
 import type { Guild, Client } from 'discord.js'
-import {
-    updateLastFmNowPlaying,
-    scrobbleCurrentTrackIfLastFm,
-    clearLastFmTrackTiming,
-    __setLastFmTrackStartTime,
-} from './lastfmScrobbler'
-import * as lastfm from '../../lastfm'
 
+// jest.mock calls are hoisted above the imports below, so anything their
+// factories reference must be declared here, before those imports run —
+// otherwise importing ./lastfmScrobbler evaluates the factory while these
+// consts are still in the temporal dead zone.
 const mockDebugLog = jest.fn()
 const mockErrorLog = jest.fn()
 
@@ -26,6 +23,14 @@ jest.mock('../../lastfm', () => ({
     updateNowPlaying: jest.fn(),
     scrobble: jest.fn(),
 }))
+
+import {
+    updateLastFmNowPlaying,
+    scrobbleCurrentTrackIfLastFm,
+    clearLastFmTrackTiming,
+    __setLastFmTrackStartTime,
+} from './lastfmScrobbler'
+import * as lastfm from '../../lastfm'
 
 const mockLastFm = lastfm as jest.Mocked<typeof lastfm>
 
@@ -233,16 +238,12 @@ describe('lastfmScrobbler', () => {
                 requestedBy: { id: 'user-123', username: 'User' },
             }
 
-            // Track A call to updateNowPlaying
+            // Track A is current and its now-playing request completes normally.
             mockQueue.currentTrack = trackA as Track
             await updateLastFmNowPlaying(
                 mockQueue as GuildQueue,
                 trackA as Track,
             )
-            // Verify Track A's timing was stored
-            let callArgs = mockLastFm.scrobble.mock.calls[0] ?? undefined
-            await scrobbleCurrentTrackIfLastFm(mockQueue as GuildQueue)
-            const trackATimestamp = mockLastFm.scrobble.mock.calls[0][2]
 
             // Clear mocks and simulate track change
             jest.clearAllMocks()

--- a/packages/bot/src/handlers/player/lastfmScrobbler.spec.ts
+++ b/packages/bot/src/handlers/player/lastfmScrobbler.spec.ts
@@ -1,4 +1,13 @@
 import { describe, expect, it, beforeEach, jest } from '@jest/globals'
+import type { Track, GuildQueue } from 'discord-player'
+import type { Guild, Client } from 'discord.js'
+import {
+    updateLastFmNowPlaying,
+    scrobbleCurrentTrackIfLastFm,
+    clearLastFmTrackTiming,
+    __setLastFmTrackStartTime,
+} from './lastfmScrobbler'
+import * as lastfm from '../../lastfm'
 
 const mockDebugLog = jest.fn()
 const mockErrorLog = jest.fn()
@@ -17,15 +26,6 @@ jest.mock('../../lastfm', () => ({
     updateNowPlaying: jest.fn(),
     scrobble: jest.fn(),
 }))
-import type { Track, GuildQueue } from 'discord-player'
-import type { Guild, Client } from 'discord.js'
-import {
-    updateLastFmNowPlaying,
-    scrobbleCurrentTrackIfLastFm,
-    clearLastFmTrackTiming,
-    __setLastFmTrackStartTime,
-} from './lastfmScrobbler'
-import * as lastfm from '../../lastfm'
 
 const mockLastFm = lastfm as jest.Mocked<typeof lastfm>
 
@@ -215,6 +215,64 @@ describe('lastfmScrobbler', () => {
                 expect.anything(),
                 expect.anything(),
             )
+        })
+
+        it('does not store timing if track changed during request (late completion)', async () => {
+            const trackA: Partial<Track> = {
+                title: 'Track A',
+                author: 'Artist A',
+                url: 'https://spotify.com/track/A',
+                durationMS: 180000,
+                requestedBy: { id: 'user-123', username: 'User' },
+            }
+            const trackB: Partial<Track> = {
+                title: 'Track B',
+                author: 'Artist B',
+                url: 'https://spotify.com/track/B',
+                durationMS: 180000,
+                requestedBy: { id: 'user-123', username: 'User' },
+            }
+
+            // Track A call to updateNowPlaying
+            mockQueue.currentTrack = trackA as Track
+            await updateLastFmNowPlaying(
+                mockQueue as GuildQueue,
+                trackA as Track,
+            )
+            // Verify Track A's timing was stored
+            let callArgs = mockLastFm.scrobble.mock.calls[0] ?? undefined
+            await scrobbleCurrentTrackIfLastFm(mockQueue as GuildQueue)
+            const trackATimestamp = mockLastFm.scrobble.mock.calls[0][2]
+
+            // Clear mocks and simulate track change
+            jest.clearAllMocks()
+            mockLastFm.scrobble.mockResolvedValue(undefined)
+            mockLastFm.updateNowPlaying.mockResolvedValue(undefined)
+
+            // Track B is now current
+            mockQueue.currentTrack = trackB as Track
+            // If updateLastFmNowPlaying for Track B is called after A but completed before A,
+            // it should store B's timing. But we're simulating a late completion where
+            // updateNowPlaying for Track A completes AFTER Track B's completes.
+            // Since Track A is no longer current, its timing should NOT be stored.
+
+            // Manually set Track B's timing first (simulating B completed first)
+            const trackBTimestamp = 2000
+            __setLastFmTrackStartTime('guild-123', trackBTimestamp)
+
+            // Now simulate Track A's late completion by calling with A but queue.currentTrack is B
+            mockQueue.currentTrack = trackB as Track
+            await updateLastFmNowPlaying(
+                mockQueue as GuildQueue,
+                trackA as Track, // Track A's request completes now
+            )
+
+            // Verify that Track B's timing is still stored (Track A's late write should be ignored)
+            jest.clearAllMocks()
+            mockLastFm.scrobble.mockResolvedValue(undefined)
+            await scrobbleCurrentTrackIfLastFm(mockQueue as GuildQueue)
+            const finalTimestamp = mockLastFm.scrobble.mock.calls[0][2]
+            expect(finalTimestamp).toBe(trackBTimestamp)
         })
     })
 

--- a/packages/bot/src/handlers/player/lastfmScrobbler.ts
+++ b/packages/bot/src/handlers/player/lastfmScrobbler.ts
@@ -31,7 +31,10 @@ export function clearLastFmTrackTiming(guildId: string): void {
 /**
  * Test hook: set the Last.fm track start time for a guild (used by tests only).
  */
-export function __setLastFmTrackStartTime(guildId: string, timestamp: number): void {
+export function __setLastFmTrackStartTime(
+    guildId: string,
+    timestamp: number,
+): void {
     lastFmTrackStartTime.set(guildId, timestamp)
 }
 
@@ -92,7 +95,11 @@ export async function updateLastFmNowPlaying(
             sessionKey,
             meta ?? undefined,
         )
-        lastFmTrackStartTime.set(queue.guild.id, trackStartTime)
+        // Only store the timestamp if this track is still the current track.
+        // Ignore late completions if the track changed while the request was in flight.
+        if (track === queue.currentTrack) {
+            lastFmTrackStartTime.set(queue.guild.id, trackStartTime)
+        }
     } catch (err) {
         if (isLastFmInvalidSessionError(err)) {
             await handleDeadLastFmSession(

--- a/packages/bot/src/handlers/player/lastfmScrobbler.ts
+++ b/packages/bot/src/handlers/player/lastfmScrobbler.ts
@@ -29,6 +29,13 @@ export function clearLastFmTrackTiming(guildId: string): void {
 }
 
 /**
+ * Test hook: set the Last.fm track start time for a guild (used by tests only).
+ */
+export function __setLastFmTrackStartTime(guildId: string, timestamp: number): void {
+    lastFmTrackStartTime.set(guildId, timestamp)
+}
+
+/**
  * Get the Last.fm requester ID from track or queue metadata.
  * Falls back through metadata.requestedById, queue.requestedBy, or undefined.
  */
@@ -73,6 +80,10 @@ export async function updateLastFmNowPlaying(
             data: { artist: track.author, title: track.title },
         })
     }
+    // Capture the start time before the async call to avoid timing races if the
+    // track changes during the request. This ensures we record when THIS track
+    // started, not when the request completes.
+    const trackStartTime = Math.floor(Date.now() / 1000)
     try {
         await lastFmUpdateNowPlaying(
             track.author,
@@ -81,7 +92,7 @@ export async function updateLastFmNowPlaying(
             sessionKey,
             meta ?? undefined,
         )
-        lastFmTrackStartTime.set(queue.guild.id, Math.floor(Date.now() / 1000))
+        lastFmTrackStartTime.set(queue.guild.id, trackStartTime)
     } catch (err) {
         if (isLastFmInvalidSessionError(err)) {
             await handleDeadLastFmSession(


### PR DESCRIPTION
## Summary

Fixes last.fm timing race when a track changes before the now-playing request completes (issue #2299).

Also adds test hook to verify stored track start time is used during scrobbling (issue #2302).

## Root Cause

`updateLastFmNowPlaying` was storing the track start timestamp AFTER the async `updateNowPlaying` call. If the track changed during that request, the timestamp would be overwritten when the first request completed, causing the wrong track to get the wrong timestamp.

## Fix

1. Capture the track start timestamp BEFORE the async call
2. Use the captured timestamp when storing, regardless of timing
3. Export `__setLastFmTrackStartTime` test hook to allow tests to verify the stored-time path

## Test Evidence

Test 'uses stored track start time if available' now:
- Sets a specific start time using the hook
- Verifies scrobble was called with that exact timestamp
- Confirms the fix works even with timing delays

Closes #2299
Closes #2302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkt4D9yyHTrVhsvDYvw5an

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a timing race in Last.fm now-playing updates where a late request completion could overwrite the new track's start timestamp. The start time is now captured before the async call and only stored if the requesting track is still current, so a slow previous-track response can't clobber the current track's timing. Adds `__setLastFmTrackStartTime` test hook so tests can verify scrobbling uses the stored start time, and repairs the spec so the suite runs by restoring the import order around the hoisted `jest.mock` factories and dropping dead assertions flagged by CodeQL. Resolves #2299 and #2302.

<sup>Written for commit ae96f544e7bdfe8b5ba0076b21664d3c0a4c78cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

