### PR TITLE
test(bot): add timeout and metadata tests for stream recovery

### DIFF
--- a/packages/bot/src/handlers/player/streamFallbackState.spec.ts
+++ b/packages/bot/src/handlers/player/streamFallbackState.spec.ts
@@ -1,4 +1,8 @@
-import { getStreamBridgeFallbackLabel, STREAM_BRIDGE_FALLBACK_METADATA_KEY } from './streamFallbackState'
+import {
+    getStreamBridgeFallbackLabel,
+    stampFallbackStage,
+    STREAM_BRIDGE_FALLBACK_METADATA_KEY,
+} from './streamFallbackState'
 
 describe('getStreamBridgeFallbackLabel', () => {
     it('returns undefined for a track without bridge metadata', () => {
@@ -41,5 +45,79 @@ describe('getStreamBridgeFallbackLabel', () => {
                 },
             }),
         ).toBe('SoundCloud simplified-title search')
+    })
+})
+
+describe('stampFallbackStage', () => {
+    it('stamps the fallback stage on a track with no existing metadata', () => {
+        let metadata: unknown = undefined
+        const track = {
+            title: 'Test Track',
+            author: 'Test Artist',
+            duration: '3:30',
+            url: 'https://example.com/track',
+            get metadata() {
+                return metadata
+            },
+            setMetadata(m: unknown) {
+                metadata = m
+            },
+        }
+
+        stampFallbackStage(track, 'soundcloud-full')
+
+        expect(metadata).toEqual({
+            [STREAM_BRIDGE_FALLBACK_METADATA_KEY]: 'soundcloud-full',
+        })
+    })
+
+    it('preserves existing metadata when stamping the fallback stage', () => {
+        let metadata: unknown = { isAutoplay: true, customData: 'preserved' }
+        const track = {
+            title: 'Test Track',
+            author: 'Test Artist',
+            duration: '3:30',
+            url: 'https://example.com/track',
+            get metadata() {
+                return metadata
+            },
+            setMetadata(m: unknown) {
+                metadata = m
+            },
+        }
+
+        stampFallbackStage(track, 'soundcloud-title')
+
+        expect(metadata).toEqual({
+            isAutoplay: true,
+            customData: 'preserved',
+            [STREAM_BRIDGE_FALLBACK_METADATA_KEY]: 'soundcloud-title',
+        })
+    })
+
+    it('overwrites existing fallback stage key when re-stamping', () => {
+        let metadata: unknown = {
+            isAutoplay: true,
+            [STREAM_BRIDGE_FALLBACK_METADATA_KEY]: 'soundcloud-full',
+        }
+        const track = {
+            title: 'Test Track',
+            author: 'Test Artist',
+            duration: '3:30',
+            url: 'https://example.com/track',
+            get metadata() {
+                return metadata
+            },
+            setMetadata(m: unknown) {
+                metadata = m
+            },
+        }
+
+        stampFallbackStage(track, 'soundcloud-core')
+
+        expect(metadata).toEqual({
+            isAutoplay: true,
+            [STREAM_BRIDGE_FALLBACK_METADATA_KEY]: 'soundcloud-core',
+        })
     })
 })

--- a/packages/bot/src/handlers/player/streamRecovery.spec.ts
+++ b/packages/bot/src/handlers/player/streamRecovery.spec.ts
@@ -261,6 +261,44 @@ describe('streamRecovery', () => {
             expect(queue.node.skip).toHaveBeenCalled()
         })
 
+        it('times out after 10s when YouTube search does not resolve', async () => {
+            jest.useFakeTimers()
+            try {
+                const searchPromise = new Promise((resolve) => {
+                    setTimeout(() => resolve({ tracks: [] }), 20_000)
+                })
+                const queue = {
+                    guild: { id: 'guild-1', name: 'Guild 1' },
+                    metadata: { requestedBy: { id: 'user-1' } },
+                    currentTrack: {
+                        url: 'https://example.com/current',
+                        title: 'Hangs Song',
+                        requestedBy: { id: 'user-1' },
+                    },
+                    player: { search: jest.fn(() => searchPromise) },
+                    insertTrack: jest.fn(),
+                    node: { skip: jest.fn() },
+                }
+
+                const promise = recoverFromStreamExtractionError(
+                    queue as any,
+                    queue.currentTrack as any,
+                )
+
+                jest.advanceTimersByTime(10_000)
+                await promise
+
+                expect(queue.insertTrack).not.toHaveBeenCalled()
+                expect(notifyChannelStreamFailedMock).toHaveBeenCalledWith(
+                    queue,
+                    'Hangs Song',
+                )
+                expect(queue.node.skip).toHaveBeenCalled()
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
         it('skips without reinserting when all alternatives have same URL', async () => {
             const queue = {
                 guild: { id: 'guild-1', name: 'Guild 1' },


### PR DESCRIPTION
## Summary
- Add timeout test for `recoverFromStreamExtractionError` that verifies the 10s Promise.race guard skips the track when YouTube search hangs
- Add unit tests for `stampFallbackStage` that verify it preserves existing track metadata while merging in the fallback stage key

## Test assertions
**#2303 (timeout test):** Verifies that when `queue.player.search()` does not resolve within 10s, the timeout promise wins the race, returns null to the recovery handler, and skips the track without reinserting.

**#2300 (stampFallbackStage tests):**
- Empty metadata → stamps only the stage key
- Existing metadata (e.g. `{isAutoplay: true}`) → merges both, preserving existing fields
- Re-stamping with a different stage → overwrites the old stage key, preserves other fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkt4D9yyHTrVhsvDYvw5an

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests for stream recovery: a 10s timeout guard for `recoverFromStreamExtractionError` and metadata preservation checks for `stampFallbackStage`.

**Test coverage**
- The timeout test uses fake timers to verify a hanging YouTube search skips the track without reinserting it.
- `stampFallbackStage` tests cover empty metadata, existing metadata, and re-stamping with a different stage.
- These tests cover the requirements from #2303 and #2300.

<sup>Written for commit 8429ade672b8cc9411ecb3fd76ae0b1293286572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

