### PR TITLE
test(bot): add moderation and playerError coverage

### DIFF
--- a/packages/bot/src/functions/moderation/batch/bulkRemoveRoleExecutor.spec.ts
+++ b/packages/bot/src/functions/moderation/batch/bulkRemoveRoleExecutor.spec.ts
@@ -215,4 +215,87 @@ describe('BulkRemoveRoleExecutor', () => {
 
         expect(result).toMatchObject({ paused: true })
     })
+
+    test('resumes from cursor when prior run did not process all members', async () => {
+        const removeFirst = jest.fn()
+        const removeSecond = jest.fn().mockResolvedValue(undefined)
+        getClientMock.mockReturnValue(
+            makeClient([
+                member('100', { remove: removeFirst }),
+                member('200', { remove: removeSecond }),
+            ]),
+        )
+
+        batchJobServiceMock.getById.mockResolvedValue({
+            nextCursor: '100',
+            status: 'in_progress',
+        })
+
+        const result = await new BulkRemoveRoleExecutor().execute(
+            JOB({ totalItems: 2 }),
+            jest.fn() as any,
+        )
+
+        expect(removeFirst).not.toHaveBeenCalled()
+        expect(removeSecond).toHaveBeenCalledWith('r1', 'cleanup')
+        expect(result).toMatchObject({ removed: 1, skipped: 0, failed: 0 })
+    })
+
+    test('throws when ManageRoles permission is missing', async () => {
+        getClientMock.mockReturnValue({
+            guilds: {
+                fetch: jest.fn().mockResolvedValue({
+                    members: {
+                        me: { permissions: { has: () => false } },
+                        fetch: jest.fn().mockResolvedValue(undefined),
+                    },
+                    roles: {
+                        fetch: jest
+                            .fn()
+                            .mockResolvedValue({ members: new Collection() }),
+                    },
+                }),
+            },
+        } as never)
+
+        await expect(
+            new BulkRemoveRoleExecutor().execute(JOB(), jest.fn() as any),
+        ).rejects.toThrow('Bot missing Manage Roles permission')
+    })
+
+    test('throws when guild cannot be fetched', async () => {
+        getClientMock.mockReturnValue({
+            guilds: {
+                fetch: jest
+                    .fn()
+                    .mockRejectedValue(new Error('Guild not found: g1')),
+            },
+        } as never)
+
+        await expect(
+            new BulkRemoveRoleExecutor().execute(JOB(), jest.fn() as any),
+        ).rejects.toThrow('Guild not found')
+    })
+
+    test('throws when role cannot be fetched', async () => {
+        getClientMock.mockReturnValue({
+            guilds: {
+                fetch: jest.fn().mockResolvedValue({
+                    members: {
+                        me: { permissions: { has: () => true } },
+                        fetch: jest.fn().mockResolvedValue(undefined),
+                    },
+                    roles: {
+                        fetch: jest
+                            .fn()
+                            .mockRejectedValue(new Error('Role not found: r1')),
+                    },
+                }),
+            },
+        } as never)
+
+        await expect(
+            new BulkRemoveRoleExecutor().execute(JOB(), jest.fn() as any),
+        ).rejects.toThrow('Role not found')
+    })
 })

--- a/packages/bot/src/functions/moderation/batch/bulkRemoveRoleExecutor.spec.ts
+++ b/packages/bot/src/functions/moderation/batch/bulkRemoveRoleExecutor.spec.ts
@@ -268,7 +268,7 @@ describe('BulkRemoveRoleExecutor', () => {
             guilds: {
                 fetch: jest
                     .fn()
-                    .mockRejectedValue(new Error('Guild not found: g1')),
+                    .mockRejectedValue(new Error('network timeout')),
             },
         } as never)
 
@@ -288,7 +288,7 @@ describe('BulkRemoveRoleExecutor', () => {
                     roles: {
                         fetch: jest
                             .fn()
-                            .mockRejectedValue(new Error('Role not found: r1')),
+                            .mockRejectedValue(new Error('network timeout')),
                     },
                 }),
             },

--- a/packages/bot/src/functions/moderation/commands/bulkRemoveRole.spec.ts
+++ b/packages/bot/src/functions/moderation/commands/bulkRemoveRole.spec.ts
@@ -288,4 +288,36 @@ describe('bulkRemoveRole command', () => {
         )
         expect(errorLogMock).toHaveBeenCalled()
     })
+
+    test('excludes bot members from count and job creation', async () => {
+        const role = createMockRole('role-789')
+        role.members.set('human-1', { user: { bot: false } } as any)
+        role.members.set('bot-member', { user: { bot: true } } as any)
+        role.members.set('human-2', { user: { bot: false } } as any)
+        const interaction = createInteraction({
+            role,
+            reason: 'cleanup',
+        })
+
+        await bulkRemoveRoleCommand.execute({ interaction })
+
+        expect(batchJobServiceMock.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                jobType: 'bulk_remove_role',
+                totalItems: 2,
+                options: expect.objectContaining({
+                    roleId: 'role-789',
+                    reason: 'cleanup',
+                }),
+            }),
+        )
+
+        expect(enqueueBatchJobMock).toHaveBeenCalledWith('job-123')
+
+        expect(interaction.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining('Bulk role removal queued'),
+            }),
+        )
+    })
 })

--- a/packages/bot/src/handlers/player/errorEventHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/errorEventHandlers.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
-import { setupErrorHandlers } from './errorEventHandlers'
+import { setupErrorHandlers, handlePlayerError } from './errorEventHandlers'
 
 const debugLogMock = jest.fn()
 const errorLogMock = jest.fn()
@@ -357,7 +357,7 @@ describe('errorEventHandlers', () => {
         )
     })
 
-    it('invokes playerError handler and logs/captures on stream extraction error', async () => {
+    it('logs and captures on a stream extraction error', async () => {
         const queueHandlers: Record<
             string,
             QueueErrorHandler | PlayerErrorHandler | DebugHandler
@@ -390,7 +390,12 @@ describe('errorEventHandlers', () => {
             node: { skip: jest.fn() },
         }
 
-        await (queueHandlers.playerError as PlayerErrorHandler)(
+        // Call the exported async function, not the registered listener: the
+        // listener is `(queue, error) => { void handlePlayerErrorSafely(...) }`
+        // and returns void, so awaiting it settles nothing. Assertions would
+        // then only pass while these calls happen to run before the first
+        // internal await.
+        await handlePlayerError(
             queue as any,
             new Error('Could not extract stream'),
         )

--- a/packages/bot/src/handlers/player/errorEventHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/errorEventHandlers.spec.ts
@@ -356,4 +356,57 @@ describe('errorEventHandlers', () => {
             }),
         )
     })
+
+    it('invokes playerError handler and logs/captures on stream extraction error', async () => {
+        const queueHandlers: Record<
+            string,
+            QueueErrorHandler | PlayerErrorHandler | DebugHandler
+        > = {}
+        const player = {
+            events: {
+                on: jest.fn(
+                    (
+                        event: string,
+                        handler:
+                            | QueueErrorHandler
+                            | PlayerErrorHandler
+                            | DebugHandler,
+                    ) => {
+                        queueHandlers[event] = handler
+                    },
+                ),
+            },
+            on: jest.fn(),
+        }
+
+        setupErrorHandlers(player as any)
+
+        const queue = {
+            guild: { id: 'guild-1', name: 'Guild 1' },
+            currentTrack: {
+                url: 'https://youtube.com/watch?v=123',
+                title: 'Test Track',
+            },
+            node: { skip: jest.fn() },
+        }
+
+        await (queueHandlers.playerError as PlayerErrorHandler)(
+            queue as any,
+            new Error('Could not extract stream'),
+        )
+
+        expect(captureExceptionMock).toHaveBeenCalledWith(
+            expect.any(Error),
+            expect.objectContaining({
+                context: 'player-error',
+                guildId: 'guild-1',
+            }),
+        )
+
+        expect(debugLogMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('stream extraction error'),
+            }),
+        )
+    })
 })


### PR DESCRIPTION
## Summary

Closes #2297, #2296

### #2297 - playerError event coverage
Test playerError handler with 'Could not extract stream' error; assert logging and exception capture.

### #2296 Gap 1 - cursor-resume path
Test cursor='100' filtering (only member '200' processed). Add permission, guild, role-not-found error tests.

### #2296 Gap 2 - bot-member filtering  
Test with 2 human + 1 bot member; assert job counts only humans (totalItems=2).

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkt4D9yyHTrVhsvDYvw5an

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds test coverage for the playerError handler, cursor-resume in bulk role removal, and bot-member filtering. Covers stream extraction error logging and exception capture, cursor-based filtering when a previous run didn't finish, and bot-member exclusion from job counts. Also hardens two tests that could pass falsely: error mocks now reject with 'network timeout' so the 'Guild not found'/'Role not found' assertions exercise the executor's error wrapping, and the player-error test now awaits the exported handlePlayerError promise. No production code changes. Closes #2297 and #2296.

<sup>Written for commit 5615fab08340801e25447e13f8ad6b17f9ccd826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

