### PR TITLE
fix(bot): give each repeat-mode track play its own start time

### DIFF
--- a/packages/bot/src/handlers/player/autoplayOutcomeTracking.ts
+++ b/packages/bot/src/handlers/player/autoplayOutcomeTracking.ts
@@ -26,24 +26,39 @@ export const OUTCOME_ACCEPT_PLAY_RATIO = 0.3
 // unreachable when its track does. It also cannot collide, which a key built
 // from a timestamp can when two plays start inside the same millisecond.
 //
-// KNOWN GAP (#2334): repeat modes re-dispatch the SAME instance from history,
-// so a repeat replay reuses this key. Sequential repeats are fine (finish
-// consumes the entry before play N+1 starts), but interleaved repeat modes can
-// still let finish(N) read start(N+1)'s timestamp.
+// #2334: repeat modes re-dispatch the SAME Track instance from history, so a
+// repeat replay reuses this key. A single stored value per track can't tell
+// two overlapping plays of that instance apart: if the next repeat's start
+// fires before the previous play's finish is read, the second start
+// overwrites the first and that finish reads the wrong timestamp. Each track
+// instead gets a small FIFO queue of start times, one per in-flight play,
+// since plays of a given track can only start in the order they are dispatched.
+// getTrackPlayStart peeks the oldest entry; clearTrackPlayStart removes it —
+// together the read-and-clear pairing at each finish/skip site still consumes
+// exactly one play's start time, now without the two plays being able to
+// collide.
 // Not exported directly: it is reassigned by the test reset below, and an
 // exported binding captured by an importer would go on pointing at the old map.
-let trackPlayStartTime = new WeakMap<Track, number>()
+let trackPlayStartTimes = new WeakMap<Track, number[]>()
 
 export function setTrackPlayStart(track: Track, startedAt: number): void {
-    trackPlayStartTime.set(track, startedAt)
+    const queue = trackPlayStartTimes.get(track)
+    if (queue) {
+        queue.push(startedAt)
+    } else {
+        trackPlayStartTimes.set(track, [startedAt])
+    }
 }
 
 export function getTrackPlayStart(track: Track): number | undefined {
-    return trackPlayStartTime.get(track)
+    return trackPlayStartTimes.get(track)?.[0]
 }
 
 export function clearTrackPlayStart(track: Track): void {
-    trackPlayStartTime.delete(track)
+    const queue = trackPlayStartTimes.get(track)
+    if (!queue) return
+    queue.shift()
+    if (queue.length === 0) trackPlayStartTimes.delete(track)
 }
 
 function classifyOutcome(
@@ -69,7 +84,7 @@ export function __resetTrackHandlerCachesForTests(): void {
     guildRecentSkipCounts.clear()
     // A WeakMap has no clear(), so drop the whole map. Tests rely on this to
     // simulate a start time being lost before its finish event arrives.
-    trackPlayStartTime = new WeakMap<Track, number>()
+    trackPlayStartTimes = new WeakMap<Track, number[]>()
 }
 
 export function getTrackRequesterId(track: Track): string | undefined {

--- a/packages/bot/src/handlers/player/trackEventHandlers.spec.ts
+++ b/packages/bot/src/handlers/player/trackEventHandlers.spec.ts
@@ -805,4 +805,51 @@ describe('trackHandlers autoplay replenishment', () => {
             )
         })
     })
+
+    // #2334: discord-player re-dispatches the SAME Track instance under repeat
+    // modes (verified in discord-player's dist — history.push(track) at :5904,
+    // then that identical object comes back out at :5914/:5922). A per-instance
+    // WeakMap<Track, number> only holds one value, so if the next repeat's
+    // playerStart fires (and overwrites the entry) before the previous play's
+    // playerFinish reads it, that finish gets the wrong play's start time.
+    describe('repeat-mode same-instance start time collision (#2334)', () => {
+        it('gives each play of the SAME Track instance its own start time when the next start fires before the previous finish', async () => {
+            jest.useFakeTimers()
+            const handlers = setupHandlers()
+            const queue = createQueue(QueueRepeatMode.AUTOPLAY)
+            // One Track object played twice — discord-player's repeat dispatch
+            // reuses the identical instance, not a copy.
+            const track = {
+                ...createAutoplayTrack('listener-1'),
+                id: 'repeat-collide',
+                durationMS: 100000,
+            } as unknown as Track
+
+            await handlers.playerStart(queue, track) // play N starts at t=0
+            jest.advanceTimersByTime(90000)
+            // repeat re-dispatches the SAME instance for play N+1 before play
+            // N's playerFinish has been emitted
+            await handlers.playerStart(queue, track) // play N+1 starts at t=90000
+            jest.advanceTimersByTime(5000)
+            await handlers.playerFinish(queue, track) // finish for play N (t=95000)
+            jest.advanceTimersByTime(5000)
+            await handlers.playerFinish(queue, track) // finish for play N+1 (t=100000)
+
+            // Play N: started at 0, finished at 95000 -> 95% played -> accepted.
+            expect(recordRecommendationOutcomeMock).toHaveBeenNthCalledWith(1, {
+                guildId: 'guild-1',
+                trackId: 'repeat-collide',
+                outcome: 'accepted',
+            })
+            // Play N+1: started at 90000, finished at 100000 -> 10% played ->
+            // rejected. A collided start time would either misclassify this as
+            // accepted (using play N's 0) or drop it entirely (already
+            // consumed by play N's finish).
+            expect(recordRecommendationOutcomeMock).toHaveBeenNthCalledWith(2, {
+                guildId: 'guild-1',
+                trackId: 'repeat-collide',
+                outcome: 'rejected',
+            })
+        })
+    })
 })


### PR DESCRIPTION
## Summary
- discord-player re-dispatches the SAME Track instance under repeat modes (`history.push(track)` at dist:5904, then the identical object comes back out at dist:5914/5922). The start-time store was a `WeakMap<Track, number>`, so if the next repeat's `playerStart` fired before the previous play's `playerFinish` read the entry, the second start silently overwrote the first, corrupting that finish's `playedRatio` and accept/reject classification.
- Fixes #2334, a narrower follow-up to #2298 / PR #2322 (open, this branch is based on it).
- `setTrackPlayStart` / `getTrackPlayStart` / `clearTrackPlayStart` now keep a small FIFO queue of start times per Track instance instead of a single value, so each finish/skip event still does a read-and-clear of exactly its own play's start time, even when two plays of the same instance overlap.
- No composite key, LRU, TTL, or cache abstraction added — same WeakMap, values are now arrays.

## Test plan
- [x] Added a spec in `trackEventHandlers.spec.ts` that replays the SAME Track object across two overlapping plays and proves each `playerFinish` gets its own start time. Confirmed it fails against the pre-fix implementation (first finish misclassified as `rejected` instead of `accepted`, second finish dropped entirely) before applying the fix.
- [x] `cd packages/bot && npx jest src/handlers/player/autoplayOutcomeTracking src/handlers/player/trackEventHandlers` — 30/30 passing
- [x] `npm run lint` in packages/bot — 0 errors, only pre-existing unrelated warnings
- [x] `npx tsc --noEmit` in packages/bot — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkt4D9yyHTrVhsvDYvw5an

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2334: repeat-mode plays that re-dispatch the same `Track` instance now each get their own start time, so overlapping plays no longer corrupt `playedRatio` and accept/reject classification.

**Bug Fixes**
- Start times are now stored as a small FIFO queue per track instead of a single value.
- Each finish/skip event still reads and clears exactly its own play's start time, even when two plays of the same instance overlap.

<sup>Written for commit 3cdf836e83d6000269bdcf437bb48e865753cc38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

