### PR TITLE
chore(lint): promote unused-vars rule to error for bot and shared

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -174,4 +174,36 @@ export default [
             "no-case-declarations": "warn",
         },
     },
+    {
+        // Same unused-vars guard for backend and frontend when eslint runs from
+        // the repo root, which is how lint-staged invokes it (#2345). The block
+        // above covers bot and shared but is a ratchet that also downgrades
+        // type-safety, complexity and import rules, so widening its glob would
+        // weaken these two packages instead of guarding them. This adds only
+        // the one rule. Their per-package configs already set it to error; that
+        // block's `src/**/*.ts` glob just does not match from the root.
+        basePath: __dirname,
+        files: ["packages/{backend,frontend}/src/**/*.{ts,tsx}"],
+        languageOptions: {
+            parser: parserTs,
+            parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+        },
+        plugins: { "@typescript-eslint": pluginTs },
+        rules: {
+            "no-unused-vars": "off",
+            // Off for the same reason the block above turns it off: the base
+            // rule does not know TS types or DOM globals, so it reports every
+            // one of them as undefined. tsc already covers this.
+            "no-undef": "off",
+            "@typescript-eslint/no-unused-vars": [
+                "error",
+                {
+                    argsIgnorePattern: "^_",
+                    varsIgnorePattern: "^_",
+                    caughtErrorsIgnorePattern: "^_",
+                    ignoreRestSiblings: true,
+                },
+            ],
+        },
+    },
 ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -145,8 +145,12 @@ export default [
             // (line ~52): without these options the root-cwd lint flags
             // intentionally-unused _-prefixed params/vars/caught-errors that
             // the per-package lint already excuses (#1378).
+            // Promoted to error (#2345): unused imports/vars were only
+            // warnings here, so they passed the local gate (lint-staged,
+            // npm run lint, tsc --noEmit) and were caught later by CodeQL
+            // at review time instead of on save.
             "@typescript-eslint/no-unused-vars": [
-                "warn",
+                "error",
                 {
                     argsIgnorePattern: "^_",
                     varsIgnorePattern: "^_",

--- a/packages/bot/src/functions/moderation/commands/bulkMoveMessages.ts
+++ b/packages/bot/src/functions/moderation/commands/bulkMoveMessages.ts
@@ -1,7 +1,6 @@
 import {
     SlashCommandBuilder,
     PermissionFlagsBits,
-    type ChatInputCommandInteraction,
     type GuildTextBasedChannel,
     type Collection,
     type Message,
@@ -110,11 +109,7 @@ export default new Command({
             true,
         )
         const scopeType = interaction.options.getString('scope', true) as
-            | 'all'
-            | 'count'
-            | 'user'
-            | 'date_range'
-            | 'contains'
+            'all' | 'count' | 'user' | 'date_range' | 'contains'
         const dryRun = interaction.options.getBoolean('dry_run') ?? false
 
         // Type-guard the channels

--- a/packages/bot/src/services/musicRecommendation/autoplay/candidateScorer.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/candidateScorer.ts
@@ -1,11 +1,9 @@
 import type { Track } from 'discord-player'
-import { spotifyLinkService } from '@lucky/shared/services'
 import type { SessionMood } from './sessionMood'
 import type { RecommendationSignal } from './recommendationBasis.js'
 import { cleanAuthor } from '../../../utils/music/searchQueryCleaner'
 import { detectSpanishMarkers } from '../../../utils/music/languageHeuristics'
 import { normalizeText, normalizeTrackKey } from './scoringUtils'
-import type { ScoredTrack } from './diversitySelector'
 
 const SCORE_SAME_ARTIST = 0.3
 const SCORE_POPULAR_ARTIST = 0.2
@@ -26,9 +24,6 @@ const SCORE_GENRE_TAG_MAX = 0.2
 const SCORE_GENRE_TAG_PER_MATCH = 0.05
 const SCORE_LIKED_ARTIST_WEIGHT = 0.2
 const SCORE_LIKED_ARTIST_TEMPO = 0.1
-const SCORE_TEMPO_PENALTY_LARGE = -0.15
-const SCORE_TEMPO_PENALTY_SMALL = -0.07
-const TEMPO_DELTA_SMALL = 25
 const DURATION_RATIO_TIGHT_LOW = 0.8
 const DURATION_RATIO_TIGHT_HIGH = 1.2
 const DURATION_RATIO_LOOSE_LOW = 0.7

--- a/packages/bot/src/services/musicRecommendation/autoplay/spotifyRecommender.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/spotifyRecommender.ts
@@ -1,33 +1,13 @@
 import { QueryType, type Track, type GuildQueue } from 'discord-player'
 import type { User } from 'discord.js'
 import { debugLog, warnLog } from '@lucky/shared/utils'
-import { logAndSwallow } from '@lucky/shared/utils/error'
-import { spotifyLinkService } from '@lucky/shared/services'
-import {
-    searchSpotifyTrack,
-    getArtistGenres,
-} from '../../../spotify/spotifyApi'
-import { getUserSpotifySeeds } from '../../../spotify/spotifyUserSeeds'
 import {
     cleanTitle,
     cleanAuthor,
     extractSongCore,
     cleanSearchQuery,
 } from '../../../utils/music/searchQueryCleaner'
-import type { AutoplayContext } from './autoplayContext'
-import {
-    normalizeTrackKey,
-    normalizeText,
-    extractSpotifyTrackId,
-} from './scoringUtils'
-import {
-    shouldIncludeCandidate,
-    upsertScoredCandidate,
-} from './candidateContracts'
-import { calculateRecommendationScore } from './candidateScorer'
-import { createArtistTagFetcher } from './artistTagCache'
-import type { ScoredTrack } from './diversitySelector'
-import type { AutoplayAuditCollector } from './autoplayAudit'
+import { normalizeText } from './scoringUtils'
 
 const MAX_AUTOPLAY_DURATION_MS = 7 * 60 * 1000
 const SEARCH_RESULTS_LIMIT = 8

--- a/packages/bot/src/services/musicRecommendation/candidateFallback.ts
+++ b/packages/bot/src/services/musicRecommendation/candidateFallback.ts
@@ -2,7 +2,6 @@ import { QueryType, type Track, type GuildQueue } from 'discord-player'
 import type { User } from 'discord.js'
 import { logAndSwallow } from '@lucky/shared/utils/error'
 import { assertDefined } from '@lucky/shared/utils/guards'
-import { spotifyLinkService } from '@lucky/shared/services'
 import type { AutoplayContext } from './autoplay/autoplayContext'
 import { getTagTopTracks } from '../../lastfm'
 import {
@@ -22,10 +21,7 @@ import {
     cleanSearchQuery,
     cleanAuthor,
 } from '../../utils/music/searchQueryCleaner'
-import {
-    normalizeTrackKey,
-    calculateGenreFamilyPenalty,
-} from '../../utils/music/trackNormalization'
+import { normalizeTrackKey } from '../../utils/music/trackNormalization'
 
 const AUTOPLAY_BUFFER_SIZE = 8
 const SEARCH_RESULTS_LIMIT = 8

--- a/packages/frontend/src/pages/ReactionRoles.tsx
+++ b/packages/frontend/src/pages/ReactionRoles.tsx
@@ -525,7 +525,7 @@ function MessageForm({
             }
             resetForm()
             onSuccess()
-        } catch (err) {
+        } catch (_err) {
             const msg =
                 mode === 'create'
                     ? t('reactionRoles.createFailedError')

--- a/packages/shared/src/services/ReactionRolesService/index.ts
+++ b/packages/shared/src/services/ReactionRolesService/index.ts
@@ -887,7 +887,7 @@ export class ReactionRolesService {
             }
 
             return { status: 'ok' as const, mapping: createdMapping }
-        } catch (discordError) {
+        } catch (_discordError) {
             return {
                 status: 'partial_success' as const,
                 mapping: createdMapping,


### PR DESCRIPTION
## Summary

- `@typescript-eslint/no-unused-vars` was only a **warning** in the `packages/{bot,shared}` ratchet block in `eslint.config.js`, so unused imports/vars passed the local gate (lint-staged, `npm run lint`, `tsc --noEmit`) and were only caught by CodeQL after push, blocking merge via a review thread instead of failing on save.
- Promoted the rule to `error` in that block.
- Deleted the pre-existing unused imports/vars it now surfaces (5 files, all mechanical deletions - dead imports and one unused caught-error rename to `_discordError` per the repo's `^_` ignore convention).
- Proved the rule fires: added a scratch `.ts` file under `packages/shared/src` with one unused import, ran `npx eslint <file> -c eslint.config.js`, confirmed it failed with `error 'readFileSync' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars` (exit 1), then removed the scratch file.

Scope note: dropped the originally-planned companion fix for #2346 (missing `AbortSignal.timeout` in `searchSpotifyArtists`) from this PR - that's being resolved as a side effect of a duplication fix on PR #2343 touching the same file, to avoid a collision. This PR closes only #2345.

## Test plan

- [x] `npm run lint` (root) - 0 errors, 25 warnings (no `no-unused-vars` left)
- [x] `npm run lint` in `packages/shared` - 0 errors
- [x] `npm run lint` in `packages/bot` - 0 errors
- [x] `npx tsc --noEmit -p packages/shared/tsconfig.json` - clean
- [x] `npx tsc --noEmit -p packages/bot/tsconfig.json` - clean
- [x] `npx jest spotifyRecommender candidateScorer candidateFallback bulkMoveMessages` in `packages/bot` - 4 suites, 76 tests passed
- [x] `npx jest ReactionRolesService` in `packages/shared` - 1 suite, 99 tests passed
- [x] `npm run build` (root) - succeeded
- [x] Proved the rule fires on a scratch unused import (see Summary)

Closes #2345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkt4D9yyHTrVhsvDYvw5an

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `@typescript-eslint/no-unused-vars` to error for `packages/{bot,shared}` and adds the same guard for `packages/{backend,frontend}`, so unused imports fail on save instead of being caught by CodeQL at review time. Deletes the unused imports and vars this surfaces, renames unused caught-errors to `_err`/`_discordError`, and closes #2345; the #2346 fix is deferred to avoid a collision with a duplication fix on the same file.

The backend/frontend guard is a separate eslint block because the bot/shared ratchet also downgrades other rules, so widening its glob would weaken those packages.

<sup>Written for commit bffbdf4bae0455fb6e4b315ac3c3a7f853b8612b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

