### PR TITLE
refactor(bot): decompose queue replenishment into 8 focused seams

### DIFF
--- a/packages/bot/src/services/musicRecommendation/autoplay/replenisher.seams.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/replenisher.seams.spec.ts
@@ -1,0 +1,953 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
+import type { Track, GuildQueue } from 'discord-player'
+import { User } from 'discord.js'
+
+jest.mock('lru-cache', () => ({
+    LRUCache: jest.fn(function () {
+        this.get = jest.fn().mockReturnValue(null)
+        this.set = jest.fn()
+        this.delete = jest.fn()
+        this.clear = jest.fn()
+    }),
+}))
+
+jest.mock('@lucky/shared/utils', () => ({
+    debugLog: jest.fn(),
+    errorLog: jest.fn(),
+    warnLog: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/services/recommendationTelemetryReadService', () => ({
+    getAutoplaySkipRateForGuild: jest.fn(),
+}))
+
+jest.mock('@lucky/shared/services', () => ({
+    trackHistoryService: {
+        getTrackHistory: jest.fn(),
+        getReplayFrequentTracks: jest.fn(),
+    },
+    guildSettingsService: {
+        getGuildSettings: jest.fn(),
+    },
+    spotifyLinkService: {
+        getValidAccessToken: jest.fn(),
+    },
+    premiumService: {
+        isPremium: jest.fn(),
+    },
+}))
+
+jest.mock('../../../services/musicRecommendation/feedbackService', () => ({
+    recommendationFeedbackService: {
+        getLikedTrackWeights: jest.fn(),
+        getDislikedTrackWeights: jest.fn(),
+        getImplicitDislikeKeys: jest.fn(),
+        getImplicitLikeKeys: jest.fn(),
+        getPreferredArtistKeys: jest.fn(),
+        getBlockedArtistKeys: jest.fn(),
+        getGuildImplicitDislikeKeys: jest.fn(),
+    },
+}))
+
+jest.mock(
+    '../../../services/musicRecommendation/recommendationTelemetry',
+    () => ({
+        recordRecommendationOutcome: jest.fn().mockResolvedValue(undefined),
+    }),
+)
+
+jest.mock('./sessionMood', () => ({
+    detectSessionMood: jest.fn(),
+}))
+
+jest.mock('./candidateCollector', () => ({
+    collectRecommendationCandidates: jest.fn(),
+}))
+
+jest.mock('./diversitySelector', () => ({
+    buildExcludedUrls: jest.fn(),
+    buildExcludedKeys: jest.fn(),
+    selectDiverseCandidates: jest.fn(),
+    addSelectedTracks: jest.fn(),
+    purgeDuplicatesOfCurrentTrack: jest.fn(),
+}))
+
+jest.mock('../candidateFallback', () => ({
+    collectBroadFallbackCandidates: jest.fn(),
+    collectGenreCandidates: jest.fn(),
+    interleaveByArtist: jest.fn(),
+}))
+
+jest.mock('./vcWeights', () => ({
+    buildVcContributionWeights: jest.fn(),
+}))
+
+jest.mock('./artistTagCache', () => ({
+    createArtistTagFetcher: jest.fn(),
+    hasGenreTag: jest.fn(),
+}))
+
+jest.mock('./lastFmSeeder', () => ({
+    collectLastFmCandidates: jest.fn(),
+}))
+
+jest.mock('./seedSimilarityCollector', () => ({
+    collectSeedSimilarCandidates: jest.fn(),
+}))
+
+jest.mock('./skipCircuitBreaker', () => ({
+    evaluateSkipRateBreaker: jest.fn(),
+}))
+
+jest.mock('../../../spotify/spotifyApi', () => ({
+    getArtistPopularity: jest.fn(),
+    getArtistGenres: jest.fn(),
+}))
+
+jest.mock('./candidateScorer', () => ({
+    getGenreFamilies: jest.fn(),
+}))
+
+jest.mock('./recommendationBasis', () => ({
+    serializeBasis: jest.fn(),
+}))
+
+jest.mock('./candidateContracts', () => ({
+    getRejectionCounts: jest.fn(),
+}))
+
+import {
+    evaluateGatingChecks,
+    extractSeedAndSessionMood,
+    fetchFeedbackAndHistoryData,
+    buildExclusionAndDerivedSignals,
+    buildGenreTagContext,
+    collectAllCandidates,
+    selectAndRerankCandidates,
+    enqueueAndFinalize,
+} from './replenisher'
+
+function createTrack(overrides: Partial<Track> = {}): Track {
+    return {
+        title: 'Test Song',
+        author: 'Test Artist',
+        durationMS: 3 * 60 * 1000,
+        url: 'https://open.spotify.com/track/testid',
+        id: 'testid',
+        source: 'spotify',
+        requestedBy: null,
+        ...overrides,
+    } as Track
+}
+
+function createTracksMap(
+    entries: [string, Track][] = [],
+): Map<string, Track> & { toArray: () => Track[] } {
+    const map = new Map<string, Track>(entries) as Map<string, Track> & {
+        toArray: () => Track[]
+    }
+    map.toArray = () => [...map.values()]
+    return map
+}
+
+function createGuildQueue(overrides: Partial<GuildQueue> = {}): GuildQueue {
+    return {
+        guild: { id: 'guildid' },
+        tracks: createTracksMap(),
+        currentTrack: createTrack(),
+        metadata: {},
+        history: { tracks: { toArray: () => [] } },
+        ...overrides,
+    } as GuildQueue
+}
+
+function createUser(overrides: Partial<User> = {}): User {
+    return {
+        id: 'userid',
+        bot: false,
+        system: false,
+        username: 'testuser',
+        ...overrides,
+    } as User
+}
+
+describe('replenisher seam functions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        const {
+            recommendationFeedbackService,
+        } = require('../../../services/musicRecommendation/feedbackService')
+        recommendationFeedbackService.getLikedTrackWeights.mockResolvedValue(
+            new Map(),
+        )
+        recommendationFeedbackService.getDislikedTrackWeights.mockResolvedValue(
+            new Map(),
+        )
+        recommendationFeedbackService.getImplicitDislikeKeys.mockResolvedValue(
+            new Set(),
+        )
+        recommendationFeedbackService.getImplicitLikeKeys.mockResolvedValue(
+            new Set(),
+        )
+        recommendationFeedbackService.getPreferredArtistKeys.mockResolvedValue(
+            new Set(),
+        )
+        recommendationFeedbackService.getBlockedArtistKeys.mockResolvedValue(
+            new Set(),
+        )
+        recommendationFeedbackService.getGuildImplicitDislikeKeys.mockReturnValue(
+            new Set(),
+        )
+
+        const {
+            trackHistoryService,
+            guildSettingsService,
+            spotifyLinkService,
+            premiumService,
+        } = require('@lucky/shared/services')
+        trackHistoryService.getTrackHistory.mockResolvedValue([])
+        trackHistoryService.getReplayFrequentTracks.mockResolvedValue({
+            trackIds: new Set(),
+            artists: new Set(),
+        })
+        guildSettingsService.getGuildSettings.mockResolvedValue(null)
+        spotifyLinkService.getValidAccessToken.mockResolvedValue(null)
+        premiumService.isPremium.mockResolvedValue(false)
+
+        const { detectSessionMood } = require('./sessionMood')
+        detectSessionMood.mockReturnValue({
+            deepDiveArtist: null,
+            preferLong: false,
+            preferShort: false,
+            restless: false,
+            dominantLocale: null,
+        })
+
+        const {
+            buildExcludedUrls,
+            buildExcludedKeys,
+            selectDiverseCandidates,
+            addSelectedTracks,
+            purgeDuplicatesOfCurrentTrack,
+        } = require('./diversitySelector')
+        buildExcludedUrls.mockReturnValue(new Set())
+        buildExcludedKeys.mockReturnValue(new Set())
+        selectDiverseCandidates.mockReturnValue([])
+        addSelectedTracks.mockResolvedValue(undefined)
+        purgeDuplicatesOfCurrentTrack.mockReturnValue([])
+
+        const {
+            collectBroadFallbackCandidates,
+            collectGenreCandidates,
+            interleaveByArtist,
+        } = require('../candidateFallback')
+        collectBroadFallbackCandidates.mockResolvedValue(undefined)
+        collectGenreCandidates.mockResolvedValue(undefined)
+        interleaveByArtist.mockImplementation((tracks: any[]) => tracks)
+
+        const { buildVcContributionWeights } = require('./vcWeights')
+        buildVcContributionWeights.mockReturnValue(new Map())
+
+        const {
+            createArtistTagFetcher,
+            hasGenreTag,
+        } = require('./artistTagCache')
+        createArtistTagFetcher.mockReturnValue(jest.fn().mockResolvedValue([]))
+        hasGenreTag.mockReturnValue(false)
+
+        const { evaluateSkipRateBreaker } = require('./skipCircuitBreaker')
+        evaluateSkipRateBreaker.mockResolvedValue(true)
+
+        const { getArtistPopularity } = require('../../../spotify/spotifyApi')
+        getArtistPopularity.mockResolvedValue(50)
+
+        const { getGenreFamilies } = require('./candidateScorer')
+        getGenreFamilies.mockReturnValue(new Set())
+
+        const { getRejectionCounts } = require('./candidateContracts')
+        getRejectionCounts.mockReturnValue({})
+    })
+
+    describe('evaluateGatingChecks', () => {
+        it('returns null when currentTrack is absent', async () => {
+            const queue = createGuildQueue({ currentTrack: undefined })
+            const result = await evaluateGatingChecks(queue)
+            expect(result).toBeNull()
+        })
+
+        it('uses finishedTrack when currentTrack is null', async () => {
+            const queue = createGuildQueue({ currentTrack: null })
+            const finished = createTrack({ title: 'Finished Song' })
+            const result = await evaluateGatingChecks(queue, finished)
+            expect(result?.currentTrack.title).toBe('Finished Song')
+        })
+
+        it('returns null when missingTracks <= 0', async () => {
+            const track = createTrack()
+            const autoplayTrack = createTrack({ id: 'autoplayid' })
+            autoplayTrack.metadata = { isAutoplay: true }
+            const queue = createGuildQueue({
+                currentTrack: track,
+                tracks: createTracksMap([
+                    ['auto1', autoplayTrack],
+                    ['auto2', autoplayTrack],
+                ]),
+            })
+            const { premiumService } = require('@lucky/shared/services')
+            premiumService.isPremium.mockResolvedValue(false)
+
+            const result = await evaluateGatingChecks(queue)
+            expect(result).toBeNull()
+        })
+
+        it('calls evaluateSkipRateBreaker and returns null if false', async () => {
+            const queue = createGuildQueue()
+            const { evaluateSkipRateBreaker } = require('./skipCircuitBreaker')
+            evaluateSkipRateBreaker.mockResolvedValue(false)
+
+            const result = await evaluateGatingChecks(queue)
+            expect(result).toBeNull()
+            expect(evaluateSkipRateBreaker).toHaveBeenCalledWith(queue)
+        })
+
+        it('returns {currentTrack, missingTracks} when gating passes', async () => {
+            const queue = createGuildQueue()
+            const { premiumService } = require('@lucky/shared/services')
+            premiumService.isPremium.mockResolvedValue(false)
+
+            const result = await evaluateGatingChecks(queue)
+            expect(result).toEqual({
+                currentTrack: queue.currentTrack,
+                missingTracks: 2,
+            })
+        })
+    })
+
+    describe('extractSeedAndSessionMood', () => {
+        it('extracts history tracks and creates seed tracks', async () => {
+            const queue = createGuildQueue()
+            const currentTrack = createTrack()
+
+            const result = await extractSeedAndSessionMood(queue, currentTrack)
+            expect(result.seedTracks[0]).toBe(currentTrack)
+            expect(result.historyTracks).toEqual([])
+        })
+
+        it('caches session mood when history length stable', async () => {
+            const { detectSessionMood } = require('./sessionMood')
+            detectSessionMood.mockClear()
+
+            const queue = createGuildQueue()
+            const currentTrack = createTrack()
+            const result1 = await extractSeedAndSessionMood(queue, currentTrack)
+
+            // Call again - should use cached mood
+            const result2 = await extractSeedAndSessionMood(queue, currentTrack)
+
+            // detectSessionMood called only once if history length unchanged
+            expect(detectSessionMood.mock.calls.length).toBeLessThanOrEqual(2)
+            expect(result1.sessionMood).toEqual(result2.sessionMood)
+        })
+
+        it('recomputes mood when history changes by 3+ tracks', async () => {
+            const queue = createGuildQueue()
+            const currentTrack = createTrack()
+            await extractSeedAndSessionMood(queue, currentTrack)
+
+            const moodDetector = require('./sessionMood')
+            moodDetector.detectSessionMood.mockClear()
+
+            // Simulate new history with 3+ new tracks
+            const newQueue = createGuildQueue({
+                history: {
+                    tracks: {
+                        toArray: () => [
+                            createTrack(),
+                            createTrack(),
+                            createTrack(),
+                        ],
+                    },
+                },
+            })
+            await extractSeedAndSessionMood(newQueue, currentTrack)
+            expect(moodDetector.detectSessionMood).toHaveBeenCalled()
+        })
+    })
+
+    describe('fetchFeedbackAndHistoryData', () => {
+        it('fetches all feedback and history data in parallel', async () => {
+            const queue = createGuildQueue()
+            const requestedBy = createUser()
+
+            const result = await fetchFeedbackAndHistoryData(
+                queue,
+                requestedBy,
+                [],
+                [requestedBy.id],
+                [],
+            )
+
+            const {
+                recommendationFeedbackService,
+            } = require('../../../services/musicRecommendation/feedbackService')
+            expect(
+                recommendationFeedbackService.getLikedTrackWeights,
+            ).toHaveBeenCalled()
+            expect(
+                recommendationFeedbackService.getDislikedTrackWeights,
+            ).toHaveBeenCalled()
+            expect(result.likedWeights).toBeInstanceOf(Map)
+        })
+
+        it('merges guild and user implicit dislike keys', async () => {
+            const queue = createGuildQueue()
+            const requestedBy = createUser()
+
+            const {
+                recommendationFeedbackService,
+            } = require('../../../services/musicRecommendation/feedbackService')
+            const userKeys = new Set(['user-key-1'])
+            const guildKeys = new Set(['guild-key-1'])
+
+            recommendationFeedbackService.getImplicitDislikeKeys.mockResolvedValue(
+                userKeys,
+            )
+            recommendationFeedbackService.getGuildImplicitDislikeKeys.mockReturnValue(
+                guildKeys,
+            )
+
+            const result = await fetchFeedbackAndHistoryData(
+                queue,
+                requestedBy,
+                [],
+                [requestedBy.id],
+                [],
+            )
+
+            expect(result.mergedImplicitDislikeKeys).toContain('user-key-1')
+            expect(result.mergedImplicitDislikeKeys).toContain('guild-key-1')
+        })
+
+        it('logs warning when persistent history empty', async () => {
+            const queue = createGuildQueue()
+            const { warnLog } = require('@lucky/shared/utils')
+
+            const { trackHistoryService } = require('@lucky/shared/services')
+            trackHistoryService.getTrackHistory.mockResolvedValue([])
+
+            await fetchFeedbackAndHistoryData(queue, null, [], [], [])
+
+            expect(warnLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'persistent history empty',
+                    ),
+                }),
+            )
+        })
+
+        it('degrades gracefully when getReplayFrequentTracks rejects', async () => {
+            const queue = createGuildQueue()
+            const requestedBy = createUser()
+
+            const { trackHistoryService } = require('@lucky/shared/services')
+            trackHistoryService.getReplayFrequentTracks.mockRejectedValue(
+                new Error('redis connection refused'),
+            )
+
+            const result = await fetchFeedbackAndHistoryData(
+                queue,
+                requestedBy,
+                [],
+                [requestedBy.id],
+                [],
+            )
+
+            expect(result.replayFrequency).toEqual({
+                trackIds: new Set(),
+                artists: new Set(),
+            })
+            expect(result.likedWeights).toBeInstanceOf(Map)
+        })
+    })
+
+    describe('buildExclusionAndDerivedSignals', () => {
+        it('calls buildExcludedUrls and buildExcludedKeys', async () => {
+            const queue = createGuildQueue()
+            const currentTrack = createTrack()
+
+            const {
+                buildExcludedUrls,
+                buildExcludedKeys,
+            } = require('./diversitySelector')
+
+            const result = buildExclusionAndDerivedSignals(
+                queue,
+                currentTrack,
+                [],
+                [],
+                [],
+            )
+
+            expect(buildExcludedUrls).toHaveBeenCalled()
+            expect(buildExcludedKeys).toHaveBeenCalled()
+            expect(result.excludedUrls).toBeInstanceOf(Set)
+            expect(result.excludedKeys).toBeInstanceOf(Set)
+        })
+
+        it('builds recent artists from current track and history', () => {
+            const currentTrack = createTrack({ author: 'Current Artist' })
+            const historyTrack = createTrack({ author: 'History Artist' })
+
+            const result = buildExclusionAndDerivedSignals(
+                createGuildQueue(),
+                currentTrack,
+                [],
+                [historyTrack],
+                [],
+            )
+
+            expect(result.recentArtists.has('current artist')).toBe(true)
+            expect(result.recentArtists.has('history artist')).toBe(true)
+        })
+
+        it('builds artist frequency from persistent history', () => {
+            const history = [
+                { author: 'Frequent Artist', isAutoplay: false },
+                { author: 'Frequent Artist', isAutoplay: false },
+                { author: 'Rare Artist', isAutoplay: false },
+            ]
+
+            const result = buildExclusionAndDerivedSignals(
+                createGuildQueue(),
+                createTrack(),
+                [],
+                [],
+                history,
+            )
+
+            expect(result.artistFrequency.size).toBeGreaterThan(0)
+        })
+
+        it('logs exclusion set details', () => {
+            const { debugLog } = require('@lucky/shared/utils')
+            debugLog.mockClear()
+
+            buildExclusionAndDerivedSignals(
+                createGuildQueue(),
+                createTrack(),
+                [],
+                [],
+                [],
+            )
+
+            expect(debugLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining('exclusion sets built'),
+                }),
+            )
+        })
+    })
+
+    describe('buildGenreTagContext', () => {
+        it('fetches artist tags for current track', async () => {
+            const queue = createGuildQueue()
+            const currentTrack = createTrack()
+            const requestedBy = createUser()
+
+            const { createArtistTagFetcher } = require('./artistTagCache')
+            const mockFetcher = jest.fn().mockResolvedValue(['tag1', 'tag2'])
+            createArtistTagFetcher.mockReturnValue(mockFetcher)
+
+            const result = await buildGenreTagContext(
+                queue,
+                currentTrack,
+                [],
+                null,
+                requestedBy,
+            )
+
+            expect(mockFetcher).toHaveBeenCalledWith(currentTrack.author)
+            expect(result.currentTrackTags.length).toBeGreaterThanOrEqual(0)
+        })
+
+        it('detects sertanejo seed with hasGenreTag true', async () => {
+            const {
+                createArtistTagFetcher,
+                hasGenreTag,
+            } = require('./artistTagCache')
+            const mockFetcher = jest
+                .fn()
+                .mockResolvedValue(['sertanejo', 'forró'])
+            createArtistTagFetcher.mockReturnValue(mockFetcher)
+            hasGenreTag.mockReturnValue(true)
+
+            const result = await buildGenreTagContext(
+                createGuildQueue(),
+                createTrack(),
+                [],
+                null,
+                createUser(),
+            )
+
+            expect(result.blockSertanejo).toBe(false)
+        })
+
+        it('sets seedIsSertanejo false when currentTrackTags empty', async () => {
+            const { createArtistTagFetcher } = require('./artistTagCache')
+            const mockFetcher = jest.fn().mockResolvedValue([])
+            createArtistTagFetcher.mockReturnValue(mockFetcher)
+
+            const result = await buildGenreTagContext(
+                createGuildQueue(),
+                createTrack(),
+                [],
+                null,
+                createUser(),
+            )
+
+            expect(result.blockSertanejo).toBe(true)
+        })
+
+        it('respects blockSertanejo guild setting', async () => {
+            const guildSettings = { blockSertanejo: false }
+            const result = await buildGenreTagContext(
+                createGuildQueue(),
+                createTrack(),
+                [],
+                guildSettings,
+                createUser(),
+            )
+
+            expect(result.blockSertanejo).toBe(false)
+        })
+
+        it('logs genre context details', async () => {
+            const { debugLog } = require('@lucky/shared/utils')
+            debugLog.mockClear()
+
+            await buildGenreTagContext(
+                createGuildQueue(),
+                createTrack(),
+                [],
+                null,
+                createUser(),
+            )
+
+            expect(debugLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining('genre context built'),
+                }),
+            )
+        })
+    })
+
+    describe('collectAllCandidates', () => {
+        it('collects from all five sources', async () => {
+            const {
+                collectRecommendationCandidates,
+            } = require('./candidateCollector')
+            const {
+                collectBroadFallbackCandidates,
+            } = require('../candidateFallback')
+            const {
+                collectSeedSimilarCandidates,
+            } = require('./seedSimilarityCollector')
+            const { collectLastFmCandidates } = require('./lastFmSeeder')
+
+            const candidates = new Map()
+            collectRecommendationCandidates.mockResolvedValue(candidates)
+
+            const autoplayContext = {
+                queue: createGuildQueue(),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                autoplayMode: 'similar' as const,
+                artistFrequency: new Map(),
+                excludedUrls: new Set(),
+                excludedKeys: new Set(),
+                preferredArtistKeys: new Set(),
+                blockedArtistKeys: new Set(),
+                implicitDislikeKeys: new Set(),
+                implicitLikeKeys: new Set(),
+                dislikedWeights: new Map(),
+                likedWeights: new Map(),
+                sessionMood: {
+                    deepDiveArtist: null,
+                    preferLong: false,
+                    preferShort: false,
+                    restless: false,
+                    dominantLocale: null,
+                },
+                genreContext: {
+                    getArtistTags: jest.fn().mockResolvedValue([]),
+                    currentTrackTags: [],
+                    sessionGenreFamilies: new Set(),
+                },
+                replayFrequentTrackIds: new Set(),
+                replayFrequentArtists: new Set(),
+                recentArtistIndices: new Map(),
+            }
+
+            const result = await collectAllCandidates(
+                autoplayContext,
+                [createTrack()],
+                createUser(),
+                'guildid',
+                false,
+                null,
+                new Map(),
+                new Map(),
+                new Set(),
+                new Set(),
+                [],
+                new Set(),
+                new Map(),
+            )
+
+            expect(collectRecommendationCandidates).toHaveBeenCalled()
+            expect(result.sourcesCounts).toHaveProperty('recommendation')
+        })
+
+        it('skips seedSimilar when requestedBy is null', async () => {
+            const {
+                collectSeedSimilarCandidates,
+            } = require('./seedSimilarityCollector')
+
+            const autoplayContext = {
+                queue: createGuildQueue(),
+                currentTrack: createTrack(),
+                recentArtists: new Set(),
+                autoplayMode: 'similar' as const,
+                artistFrequency: new Map(),
+                excludedUrls: new Set(),
+                excludedKeys: new Set(),
+                preferredArtistKeys: new Set(),
+                blockedArtistKeys: new Set(),
+                implicitDislikeKeys: new Set(),
+                implicitLikeKeys: new Set(),
+                dislikedWeights: new Map(),
+                likedWeights: new Map(),
+                sessionMood: {
+                    deepDiveArtist: null,
+                    preferLong: false,
+                    preferShort: false,
+                    restless: false,
+                    dominantLocale: null,
+                },
+                genreContext: {
+                    getArtistTags: jest.fn().mockResolvedValue([]),
+                    currentTrackTags: [],
+                    sessionGenreFamilies: new Set(),
+                },
+                replayFrequentTrackIds: new Set(),
+                replayFrequentArtists: new Set(),
+                recentArtistIndices: new Map(),
+            }
+
+            const {
+                collectRecommendationCandidates,
+            } = require('./candidateCollector')
+            collectRecommendationCandidates.mockResolvedValue(new Map())
+
+            const result = await collectAllCandidates(
+                autoplayContext,
+                [createTrack()],
+                null,
+                'guildid',
+                false,
+                null,
+                new Map(),
+                new Map(),
+                new Set(),
+                new Set(),
+                [],
+                new Set(),
+                new Map(),
+            )
+
+            expect(result.sourcesCounts.seedSimilar).toEqual({ skipped: true })
+            expect(collectSeedSimilarCandidates).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('selectAndRerankCandidates', () => {
+        it('calls selectDiverseCandidates with correct parameters', async () => {
+            const { selectDiverseCandidates } = require('./diversitySelector')
+            selectDiverseCandidates.mockReturnValue([])
+
+            const candidates = new Map()
+            const mood = {
+                deepDiveArtist: null,
+                preferLong: false,
+                preferShort: false,
+                restless: false,
+                dominantLocale: null,
+            }
+
+            await selectAndRerankCandidates(
+                candidates,
+                2,
+                mood,
+                createTrack(),
+                'similar',
+                null,
+            )
+
+            expect(selectDiverseCandidates).toHaveBeenCalledWith(
+                candidates,
+                2,
+                expect.any(Number),
+                expect.any(Number),
+                expect.any(String),
+            )
+        })
+
+        it('relaxes max-per-artist when deep-diving', async () => {
+            const { selectDiverseCandidates } = require('./diversitySelector')
+            const { interleaveByArtist } = require('../candidateFallback')
+            selectDiverseCandidates.mockReturnValue([])
+            interleaveByArtist.mockImplementation((tracks: any[]) => tracks)
+
+            const currentTrack = createTrack({ author: 'Deep Dive Artist' })
+            const mood = {
+                deepDiveArtist: 'deep dive artist',
+                preferLong: false,
+                preferShort: false,
+                restless: false,
+                dominantLocale: null,
+            }
+
+            await selectAndRerankCandidates(
+                new Map(),
+                2,
+                mood,
+                currentTrack,
+                'similar',
+                null,
+            )
+
+            const callArgs = selectDiverseCandidates.mock.calls[0]
+            expect(callArgs[2]).toBe(5)
+        })
+    })
+
+    describe('enqueueAndFinalize', () => {
+        it('logs and returns early when enriched is empty', async () => {
+            const { warnLog, debugLog } = require('@lucky/shared/utils')
+            warnLog.mockClear()
+
+            const queue = createGuildQueue()
+            const autoplayContext = {
+                queue,
+                currentTrack: createTrack(),
+                excludedUrls: new Set(),
+                excludedKeys: new Set(),
+                autoplayMode: 'similar' as const,
+            } as any
+            await enqueueAndFinalize(
+                autoplayContext,
+                [],
+                new Map(),
+                null,
+                {
+                    recommendation: 0,
+                    seedSimilar: 0,
+                    lastfm: 0,
+                    genre: 0,
+                    fallback: 0,
+                },
+                Date.now(),
+            )
+
+            expect(warnLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining('no candidates selected'),
+                }),
+            )
+        })
+
+        it('calls addSelectedTracks when enriched has items', async () => {
+            const { addSelectedTracks } = require('./diversitySelector')
+            addSelectedTracks.mockResolvedValue(undefined)
+
+            const track = createTrack()
+            const enriched = [
+                {
+                    track,
+                    score: 0.8,
+                    basis: { sources: ['recommendation'] },
+                } as any,
+            ]
+
+            const queue = createGuildQueue()
+            const autoplayContext = {
+                queue,
+                currentTrack: createTrack(),
+                excludedUrls: new Set(),
+                excludedKeys: new Set(),
+                autoplayMode: 'similar' as const,
+            } as any
+            await enqueueAndFinalize(
+                autoplayContext,
+                enriched,
+                new Map(),
+                createUser(),
+                {
+                    recommendation: 1,
+                    seedSimilar: 0,
+                    lastfm: 0,
+                    genre: 0,
+                    fallback: 0,
+                },
+                Date.now(),
+            )
+
+            expect(addSelectedTracks).toHaveBeenCalled()
+        })
+
+        it('logs completion when tracks are enqueued', async () => {
+            const { debugLog } = require('@lucky/shared/utils')
+            debugLog.mockClear()
+
+            const track = createTrack()
+            const enriched = [
+                {
+                    track,
+                    score: 0.8,
+                    basis: { sources: ['recommendation'] },
+                } as any,
+            ]
+
+            const queue = createGuildQueue()
+            const autoplayContext = {
+                queue,
+                currentTrack: createTrack(),
+                excludedUrls: new Set(),
+                excludedKeys: new Set(),
+                autoplayMode: 'similar' as const,
+            } as any
+            await enqueueAndFinalize(
+                autoplayContext,
+                enriched,
+                new Map(),
+                null,
+                {
+                    recommendation: 1,
+                    seedSimilar: 0,
+                    lastfm: 0,
+                    genre: 0,
+                    fallback: 0,
+                },
+                Date.now(),
+            )
+
+            expect(debugLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining('Autoplay pass complete'),
+                }),
+            )
+        })
+    })
+})

--- a/packages/bot/src/services/musicRecommendation/autoplay/replenisher.seams.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/replenisher.seams.spec.ts
@@ -554,33 +554,22 @@ describe('replenisher seam functions', () => {
         it('fetches artist tags for current track', async () => {
             const queue = createGuildQueue()
             const currentTrack = createTrack()
-            const requestedBy = createUser()
-
-            const { createArtistTagFetcher } = require('./artistTagCache')
-            const mockFetcher = jest.fn().mockResolvedValue(['tag1', 'tag2'])
-            createArtistTagFetcher.mockReturnValue(mockFetcher)
+            const fetcher = jest.fn().mockResolvedValue(['tag1', 'tag2'])
 
             const result = await buildGenreTagContext(
                 queue,
                 currentTrack,
                 [],
                 null,
-                requestedBy,
+                fetcher,
             )
 
-            expect(mockFetcher).toHaveBeenCalledWith(currentTrack.author)
+            expect(fetcher).toHaveBeenCalledWith(currentTrack.author)
             expect(result.currentTrackTags.length).toBeGreaterThanOrEqual(0)
         })
 
         it('detects sertanejo seed with hasGenreTag true', async () => {
-            const {
-                createArtistTagFetcher,
-                hasGenreTag,
-            } = require('./artistTagCache')
-            const mockFetcher = jest
-                .fn()
-                .mockResolvedValue(['sertanejo', 'forró'])
-            createArtistTagFetcher.mockReturnValue(mockFetcher)
+            const { hasGenreTag } = require('./artistTagCache')
             hasGenreTag.mockReturnValue(true)
 
             const result = await buildGenreTagContext(
@@ -588,23 +577,19 @@ describe('replenisher seam functions', () => {
                 createTrack(),
                 [],
                 null,
-                createUser(),
+                jest.fn().mockResolvedValue(['sertanejo', 'forró']),
             )
 
             expect(result.blockSertanejo).toBe(false)
         })
 
         it('sets seedIsSertanejo false when currentTrackTags empty', async () => {
-            const { createArtistTagFetcher } = require('./artistTagCache')
-            const mockFetcher = jest.fn().mockResolvedValue([])
-            createArtistTagFetcher.mockReturnValue(mockFetcher)
-
             const result = await buildGenreTagContext(
                 createGuildQueue(),
                 createTrack(),
                 [],
                 null,
-                createUser(),
+                jest.fn().mockResolvedValue([]),
             )
 
             expect(result.blockSertanejo).toBe(true)
@@ -617,10 +602,33 @@ describe('replenisher seam functions', () => {
                 createTrack(),
                 [],
                 guildSettings,
-                createUser(),
+                jest.fn().mockResolvedValue([]),
             )
 
             expect(result.blockSertanejo).toBe(false)
+        })
+
+        it('reuses one fetcher for the seed and the session families', async () => {
+            const fetcher = jest.fn().mockResolvedValue([])
+            const history = [
+                createTrack({ author: 'A' }),
+                createTrack({ author: 'B' }),
+            ]
+
+            await buildGenreTagContext(
+                createGuildQueue(),
+                createTrack({ author: 'Seed' }),
+                history,
+                null,
+                fetcher,
+            )
+
+            // The caller owns the fetcher, so the memo cache inside it survives
+            // across the seed lookup, session-family detection and the
+            // collectors. Building a second one here would reset that cache.
+            const { createArtistTagFetcher } = require('./artistTagCache')
+            expect(createArtistTagFetcher).not.toHaveBeenCalled()
+            expect(fetcher).toHaveBeenCalledWith('Seed')
         })
 
         it('logs genre context details', async () => {
@@ -632,7 +640,7 @@ describe('replenisher seam functions', () => {
                 createTrack(),
                 [],
                 null,
-                createUser(),
+                jest.fn().mockResolvedValue([]),
             )
 
             expect(debugLog).toHaveBeenCalledWith(
@@ -650,6 +658,7 @@ describe('replenisher seam functions', () => {
             } = require('./candidateCollector')
             const {
                 collectBroadFallbackCandidates,
+                collectGenreCandidates,
             } = require('../candidateFallback')
             const {
                 collectSeedSimilarCandidates,
@@ -690,23 +699,23 @@ describe('replenisher seam functions', () => {
                 recentArtistIndices: new Map(),
             }
 
+            // guildSettings must carry autoplayGenres or the genre collector is
+            // skipped, and every collector mock leaves `candidates` empty, which
+            // is what lets the fallback branch (size === 0) run too.
             const result = await collectAllCandidates(
                 autoplayContext,
                 [createTrack()],
                 createUser(),
-                'guildid',
                 false,
-                null,
-                new Map(),
-                new Map(),
-                new Set(),
-                new Set(),
-                [],
-                new Set(),
+                { autoplayGenres: ['rock'] },
                 new Map(),
             )
 
             expect(collectRecommendationCandidates).toHaveBeenCalled()
+            expect(collectSeedSimilarCandidates).toHaveBeenCalled()
+            expect(collectLastFmCandidates).toHaveBeenCalled()
+            expect(collectGenreCandidates).toHaveBeenCalled()
+            expect(collectBroadFallbackCandidates).toHaveBeenCalled()
             expect(result.sourcesCounts).toHaveProperty('recommendation')
         })
 
@@ -755,15 +764,8 @@ describe('replenisher seam functions', () => {
                 autoplayContext,
                 [createTrack()],
                 null,
-                'guildid',
                 false,
                 null,
-                new Map(),
-                new Map(),
-                new Set(),
-                new Set(),
-                [],
-                new Set(),
                 new Map(),
             )
 
@@ -835,7 +837,7 @@ describe('replenisher seam functions', () => {
 
     describe('enqueueAndFinalize', () => {
         it('logs and returns early when enriched is empty', async () => {
-            const { warnLog, debugLog } = require('@lucky/shared/utils')
+            const { warnLog } = require('@lucky/shared/utils')
             warnLog.mockClear()
 
             const queue = createGuildQueue()

--- a/packages/bot/src/services/musicRecommendation/autoplay/replenisher.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/replenisher.ts
@@ -226,13 +226,16 @@ async function _replenishQueue(
             historyTracks,
             persistentHistory,
         )
+        // Built once and shared with the collectors below, as before the
+        // decomposition: the fetcher carries a per-pass memo cache.
+        const getArtistTags = await buildArtistTagFetcher(requestedBy)
         const { currentTrackTags, sessionGenreFamilies, blockSertanejo } =
             await buildGenreTagContext(
                 queue,
                 currentTrack,
                 historyTracks,
                 guildSettings,
-                requestedBy,
+                getArtistTags,
             )
         const autoplayContext: AutoplayContext = {
             queue,
@@ -250,7 +253,7 @@ async function _replenishQueue(
             implicitLikeKeys,
             sessionMood,
             genreContext: {
-                getArtistTags: await buildArtistTagFetcher(requestedBy),
+                getArtistTags,
                 currentTrackTags,
                 sessionGenreFamilies,
             },
@@ -611,15 +614,15 @@ export async function buildGenreTagContext(
     currentTrack: Track,
     historyTracks: Track[],
     guildSettings: { blockSertanejo?: boolean } | null,
-    requestedBy: User | null,
+    // Takes the fetcher rather than building its own: createArtistTagFetcher
+    // memoizes per instance, so a second one would re-run getValidAccessToken
+    // and hand the collectors a cold cache for artists this pass already looked up.
+    getArtistTags: ArtistTagFetcher,
 ): Promise<{
     currentTrackTags: string[]
     sessionGenreFamilies: Set<string>
     blockSertanejo: boolean
 }> {
-    const getArtistTags: ArtistTagFetcher =
-        await buildArtistTagFetcher(requestedBy)
-
     // Parallelize tag fetching for current track + genre family detection
     const [currentTrackTags, sessionGenreFamilies] = await Promise.all([
         getArtistTags(currentTrack.author),

--- a/packages/bot/src/services/musicRecommendation/autoplay/replenisher.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/replenisher.ts
@@ -9,6 +9,7 @@ import {
     guildSettingsService,
     spotifyLinkService,
     premiumService,
+    type TrackHistoryEntry,
 } from '@lucky/shared/services'
 import {
     getArtistPopularity,
@@ -32,6 +33,7 @@ import {
     selectDiverseCandidates,
     addSelectedTracks,
     purgeDuplicatesOfCurrentTrack,
+    type ScoredTrack,
 } from './diversitySelector'
 import { collectLastFmCandidates } from './lastFmSeeder'
 import { collectSeedSimilarCandidates } from './seedSimilarityCollector'
@@ -174,227 +176,64 @@ async function _replenishQueue(
             data: { guildId, queueSize: queue.tracks.size },
         })
 
-        const currentTrack = queue.currentTrack ?? finishedTrack ?? null
-        if (!currentTrack) return
+        const gatingResult = await evaluateGatingChecks(queue, finishedTrack)
+        if (!gatingResult) return
+        const { currentTrack, missingTracks } = gatingResult
 
-        // Record evicted duplicate recommendations as rejected to improve telemetry
-        // coverage. These tracks never get a chance to emit playerStart.
-        const purgedTracks = purgeDuplicatesOfCurrentTrack(queue, currentTrack)
-        await cancelPendingRecommendations(queue, purgedTracks)
-
-        const bufferSize = (await premiumService.isPremium(queue.guild.id))
-            ? AUTOPLAY_BUFFER_SIZE_PREMIUM
-            : AUTOPLAY_BUFFER_SIZE
-        const autoplayInQueue = [...queue.tracks.toArray()].filter(
-            (t) =>
-                (t.metadata as { isAutoplay?: boolean } | undefined)
-                    ?.isAutoplay === true,
-        ).length
-        const missingTracks = bufferSize - autoplayInQueue
-        if (missingTracks <= 0) return
-
-        // Autoplay skip-rate circuit breaker: check if we should pause replenishment
-        const shouldContinue = await evaluateSkipRateBreaker(queue)
-        if (!shouldContinue) return
-
-        const allHistoryTracks = getAllHistoryTracks(queue)
-        const replenishGuildId = queue.guild.id
-        const guildMoodCache = sessionMoodCache.get(replenishGuildId)
-        const sessionMood =
-            guildMoodCache &&
-            Math.abs(allHistoryTracks.length - guildMoodCache.historyLen) < 3
-                ? guildMoodCache.mood
-                : (() => {
-                      const mood = detectSessionMood(
-                          allHistoryTracks,
-                          skipStateProvider?.() ?? 0,
-                      )
-                      sessionMoodCache.set(replenishGuildId, {
-                          mood,
-                          historyLen: allHistoryTracks.length,
-                      })
-                      return mood
-                  })()
-        const historyTracks = allHistoryTracks.slice(0, HISTORY_SEED_LIMIT)
-        const seedTracks = [currentTrack, ...historyTracks].slice(
-            0,
-            HISTORY_SEED_LIMIT + 1,
+        const {
+            allHistoryTracks,
+            sessionMood,
+            historyTracks,
+            seedTracks,
+            requestedBy,
+            vcMemberIds,
+            allMemberIds,
+        } = await extractSeedAndSessionMood(
+            queue,
+            currentTrack,
+            skipStateProvider,
         )
-        const requestedBy = getRequestedBy(queue, currentTrack)
-        const metadata = queue.metadata as QueueMetadata | undefined
-        const vcMemberIds = metadata?.vcMemberIds ?? []
-        const allMemberIds = Array.from(
-            new Set([
-                ...(requestedBy?.id ? [requestedBy.id] : []),
-                ...vcMemberIds,
-            ]),
-        )
-
-        const [
+        const {
             likedWeights,
             dislikedWeights,
             persistentHistory,
             guildSettings,
-            implicitDislikeKeys,
+            implicitDislikeKeys: _implicitDislikeKeys,
             implicitLikeKeys,
-            allPreferredSets,
-            allBlockedSets,
+            mergedImplicitDislikeKeys,
+            preferredArtistKeys,
+            blockedArtistKeys,
+            contributionWeights,
+            autoplayMode,
             replayFrequency,
-        ] = await Promise.all([
-            recommendationFeedbackService.getLikedTrackWeights(
-                queue.guild.id,
-                requestedBy?.id ?? '',
-            ),
-            recommendationFeedbackService.getDislikedTrackWeights(
-                queue.guild.id,
-                requestedBy?.id ?? '',
-            ),
-            trackHistoryService.getTrackHistory(queue.guild.id, 150),
-            guildSettingsService.getGuildSettings(queue.guild.id),
-            recommendationFeedbackService.getImplicitDislikeKeys(
-                requestedBy?.id ?? '',
-            ),
-            recommendationFeedbackService.getImplicitLikeKeys(
-                requestedBy?.id ?? '',
-            ),
-            Promise.all(
-                allMemberIds.map((id) =>
-                    recommendationFeedbackService.getPreferredArtistKeys(
-                        queue.guild.id,
-                        id,
-                    ),
-                ),
-            ),
-            Promise.all(
-                allMemberIds.map((id) =>
-                    recommendationFeedbackService.getBlockedArtistKeys(
-                        queue.guild.id,
-                        id,
-                    ),
-                ),
-            ),
-            // Async wrapper so even a synchronous throw (e.g. method absent on
-            // a partial service double) degrades to the empty no-boost result
-            (async () => {
-                try {
-                    return await trackHistoryService.getReplayFrequentTracks(
-                        queue.guild.id,
-                    )
-                } catch {
-                    return {
-                        trackIds: new Set<string>(),
-                        artists: new Set<string>(),
-                    }
-                }
-            })(),
-        ])
-
-        // Merge guild-scoped implicit dislike keys with user-level keys so skip
-        // signals always reach the scorer, even when requestedBy is undefined.
-        const guildImplicitDislikeKeys =
-            recommendationFeedbackService.getGuildImplicitDislikeKeys(
-                queue.guild.id,
+        } = await fetchFeedbackAndHistoryData(
+            queue,
+            requestedBy,
+            vcMemberIds,
+            allMemberIds,
+            allHistoryTracks,
+        )
+        const {
+            excludedUrls,
+            excludedKeys,
+            recentArtists,
+            recentArtistIndices,
+            artistFrequency,
+        } = buildExclusionAndDerivedSignals(
+            queue,
+            currentTrack,
+            allHistoryTracks,
+            historyTracks,
+            persistentHistory,
+        )
+        const { currentTrackTags, sessionGenreFamilies, blockSertanejo } =
+            await buildGenreTagContext(
+                queue,
+                currentTrack,
+                historyTracks,
+                guildSettings,
+                requestedBy,
             )
-        const mergedImplicitDislikeKeys = new Set([
-            ...implicitDislikeKeys,
-            ...guildImplicitDislikeKeys,
-        ])
-
-        const preferredArtistKeys = new Set(
-            allPreferredSets.flatMap((s) => [...s]),
-        )
-        const blockedArtistKeys = new Set(allBlockedSets.flatMap((s) => [...s]))
-        const contributionWeights =
-            vcMemberIds.length > 1
-                ? buildVcContributionWeights(allHistoryTracks, vcMemberIds)
-                : new Map<string, number>()
-        const autoplayMode = guildSettings?.autoplayMode ?? 'similar'
-        if (persistentHistory.length === 0) {
-            warnLog({
-                message:
-                    'Autoplay: persistent history empty — Redis may be unavailable',
-                data: { guildId: queue.guild.id },
-            })
-        }
-        const excludedUrls = buildExcludedUrls(
-            queue,
-            currentTrack,
-            allHistoryTracks,
-            persistentHistory,
-        )
-        const excludedKeys = buildExcludedKeys(
-            queue,
-            currentTrack,
-            allHistoryTracks,
-            persistentHistory,
-        )
-        debugLog({
-            message: 'Autoplay: exclusion sets built',
-            data: {
-                guildId: queue.guild.id,
-                excludedUrlCount: excludedUrls.size,
-                excludedKeyCount: excludedKeys.size,
-                queueHistoryTracks: allHistoryTracks.length,
-                seedHistoryTracks: historyTracks.length,
-                persistentHistory: persistentHistory.length,
-            },
-        })
-        const recentArtists = buildRecentArtists(currentTrack, historyTracks)
-        // Recency-decay needs the real recent queue, not the 3-track seed sample
-        // (HISTORY_SEED_LIMIT) — otherwise the linear-decay window never fills and
-        // every recent artist gets a near-max penalty. Feed it the fuller history.
-        const recentArtistIndices = buildRecentArtistIndices(
-            currentTrack,
-            allHistoryTracks,
-        )
-        const artistFrequency = buildArtistFrequency(persistentHistory)
-
-        const spotifyToken = requestedBy?.id
-            ? await Promise.resolve(
-                  spotifyLinkService.getValidAccessToken(requestedBy.id),
-              ).catch(() => null)
-            : null
-        const replenishCount = replenishCounters.get(guildId) ?? 0
-
-        // Tag-driven genre context (Phase 2). One artist-tag cache for the
-        // whole pass — every candidate collector reuses it. When Last.fm is not
-        // linked the fetcher falls back to Spotify genre strings so the
-        // cross-locale veto can still reject Spanish gospel tracks whose
-        // title/author carry no Spanish text markers.
-        const getArtistTags: ArtistTagFetcher = createArtistTagFetcher(
-            spotifyToken
-                ? (artist) => getArtistGenres(spotifyToken, artist)
-                : undefined,
-        )
-        // Parallelize tag fetching for current track + genre family detection
-        const [currentTrackTags, sessionGenreFamilies] = await Promise.all([
-            getArtistTags(currentTrack.author),
-            detectSessionGenreFamilies(historyTracks, getArtistTags),
-        ])
-        const seedIsSertanejo =
-            currentTrackTags.length > 0
-                ? hasGenreTag(currentTrackTags, SERTANEJO_TAGS)
-                : false
-        // Block sertanejo candidates unless the seed itself is sertanejo — fail-open
-        // when tags are absent (Last.fm unlinked) to avoid over-filtering.
-        // Allow guild to opt-out via blockSertanejo setting (defaults to true).
-        const blockSertanejo =
-            guildSettings?.blockSertanejo !== false && !seedIsSertanejo
-
-        const candidateGenreContext = {
-            getArtistTags,
-            currentTrackTags,
-            sessionGenreFamilies,
-        }
-        debugLog({
-            message: 'Autoplay: genre context built',
-            data: {
-                guildId,
-                currentTrackTagCount: currentTrackTags.length,
-                sessionGenreFamilies: Array.from(sessionGenreFamilies),
-                blockSertanejo,
-            },
-        })
         const autoplayContext: AutoplayContext = {
             queue,
             excludedUrls,
@@ -410,125 +249,30 @@ async function _replenishQueue(
             implicitDislikeKeys: mergedImplicitDislikeKeys,
             implicitLikeKeys,
             sessionMood,
-            genreContext: candidateGenreContext,
+            genreContext: {
+                getArtistTags: await buildArtistTagFetcher(requestedBy),
+                currentTrackTags,
+                sessionGenreFamilies,
+            },
             replayFrequentTrackIds: replayFrequency?.trackIds ?? new Set(),
             replayFrequentArtists: replayFrequency?.artists ?? new Set(),
             recentArtistIndices,
         }
-        const candidates = await collectRecommendationCandidates(
-            autoplayContext,
-            seedTracks,
-            requestedBy,
-            replenishCount,
-            blockSertanejo,
-        )
-        sourcesCounts.recommendation = candidates.size
-        debugLog({
-            message: 'Autoplay: recommendation candidates',
-            data: { guildId, count: candidates.size, source: 'recommendation' },
-        })
 
-        // Seed-similarity spine: grounds autoplay on the current track's Last.fm
-        // similars regardless of whether the user linked Last.fm. Runs before the
-        // user-linked Last.fm collector so the pool is anchored to the seed even
-        // for unlinked sessions (the common case the drift fix targets).
-        if (requestedBy) {
-            const beforeSeedSimilar = candidates.size
-            await collectSeedSimilarCandidates(
+        const { candidates, sourcesCounts: finalSourcesCounts } =
+            await collectAllCandidates(
                 autoplayContext,
+                seedTracks,
                 requestedBy,
-                candidates,
-            )
-            sourcesCounts.seedSimilar = candidates.size - beforeSeedSimilar
-            debugLog({
-                message: 'Autoplay: seed-similar candidates',
-                data: {
-                    guildId,
-                    added: candidates.size - beforeSeedSimilar,
-                    total: candidates.size,
-                    source: 'seed-similar',
-                },
-            })
-        } else {
-            sourcesCounts.seedSimilar = { skipped: true }
-        }
-
-        if (requestedBy?.id) {
-            const beforeLastFm = candidates.size
-            await collectLastFmCandidates(
-                autoplayContext,
-                requestedBy,
-                candidates,
+                blockSertanejo,
+                guildSettings,
                 contributionWeights,
             )
-            sourcesCounts.lastfm = candidates.size - beforeLastFm
-            debugLog({
-                message: 'Autoplay: last.fm candidates',
-                data: {
-                    guildId,
-                    added: candidates.size - beforeLastFm,
-                    total: candidates.size,
-                    source: 'lastfm',
-                },
-            })
-        } else {
-            sourcesCounts.lastfm = { skipped: true }
-        }
-        if (requestedBy && guildSettings?.autoplayGenres?.length) {
-            const beforeGenre = candidates.size
-            await collectGenreCandidates(
-                queue,
-                guildSettings.autoplayGenres,
-                requestedBy,
-                {
-                    candidates,
-                    recentArtists,
-                    likedTrackKeys: likedWeights,
-                    dislikedTrackKeys: dislikedWeights,
-                    currentTrack,
-                    excludedUrls,
-                    excludedKeys,
-                    preferredArtistKeys,
-                    blockedArtistKeys,
-                    autoplayMode,
-                    artistFrequency,
-                    implicitDislikeKeys: mergedImplicitDislikeKeys,
-                    implicitLikeKeys,
-                    sessionMood,
-                    genreContext: {
-                        currentTrackTags,
-                        sessionGenreFamilies,
-                    },
-                },
-            )
-            sourcesCounts.genre = candidates.size - beforeGenre
-            debugLog({
-                message: 'Autoplay: genre candidates',
-                data: {
-                    guildId,
-                    added: candidates.size - beforeGenre,
-                    total: candidates.size,
-                    genres: guildSettings.autoplayGenres,
-                    source: 'genre',
-                },
-            })
-        } else {
-            sourcesCounts.genre = { skipped: true }
-        }
-        if (candidates.size === 0 && currentTrack) {
-            const beforeFallback = candidates.size
-            await collectBroadFallbackCandidates(autoplayContext, candidates)
-            sourcesCounts.fallback = candidates.size - beforeFallback
-            debugLog({
-                message: 'Autoplay: broad fallback candidates',
-                data: { guildId, count: candidates.size, source: 'fallback' },
-            })
-        }
 
         debugLog({
             message: 'Autoplay: candidate pool ready',
             data: {
-                guildId: queue.guild.id,
+                guildId,
                 candidateCount: candidates.size,
                 missingTracks,
                 autoplayMode,
@@ -536,129 +280,688 @@ async function _replenishQueue(
             },
         })
 
-        const seedArtistKey = currentTrack.author.toLowerCase()
-        // When the user is deep-diving an artist (3+ tracks in last 8), relax
-        // the per-artist cap for that artist so autoplay follows their intent.
-        const deepDiveKey = sessionMood.deepDiveArtist
-        const effectiveMaxPerArtist =
-            deepDiveKey && seedArtistKey.includes(deepDiveKey)
-                ? 5
-                : MAX_TRACKS_PER_ARTIST
-        const selected = interleaveByArtist(
-            selectDiverseCandidates(
-                candidates,
-                missingTracks,
-                effectiveMaxPerArtist,
-                MAX_TRACKS_PER_SOURCE,
-                seedArtistKey,
-            ),
-        )
+        Object.assign(sourcesCounts, finalSourcesCounts)
 
-        const enriched = selected
-
-        if (requestedBy?.id) {
-            const token = await Promise.resolve(
-                spotifyLinkService.getValidAccessToken(requestedBy.id),
-            ).catch(() => null)
-            if (token) {
-                // Re-rank a bounded head of the already-selected (genre-safe,
-                // de-duped) candidates by artist popularity. Post-selection
-                // only: it reorders vetted candidates and never introduces new
-                // ones, so popularity weighting can't reintroduce off-genre
-                // mainstream drift.
-                const rerankHead =
-                    autoplayMode === 'similar' ? POPULARITY_RERANK_HEAD : 3
-                await Promise.all(
-                    enriched.slice(0, rerankHead).map(async (track) => {
-                        const popularity = await getArtistPopularity(
-                            token,
-                            track.track.author,
-                        ).catch(() => null)
-                        if (popularity === null) return
-                        track.score += popularityBoost(autoplayMode, popularity)
-                    }),
-                )
-                enriched.sort((a, b) => b.score - a.score)
-            }
-        }
-
-        if (enriched.length === 0) {
-            // The per-source breakdown has to ride on this warn, not on the
-            // debug below it: production runs LOG_LEVEL=2, so the debug is
-            // suppressed and an empty pool was indistinguishable from "which
-            // of the five collectors came back dry" (#2146).
-            // sources now includes skipped markers and rejected shows
-            // how many candidates were vetoed by scoring or deduplication.
-            warnLog({
-                message: 'Autoplay: no candidates selected — queue may stall',
-                data: {
-                    guildId: queue.guild.id,
-                    candidatePoolSize: candidates.size,
-                    sources: sourcesCounts,
-                    rejected: getRejectionCounts(candidates),
-                    autoplayMode,
-                    // Four of the five collectors are gated on a requester, so
-                    // a zero count means "skipped" rather than "found nothing"
-                    // when this is false. Without it the breakdown is ambiguous.
-                    hasRequester: Boolean(requestedBy),
-                },
-            })
-            replenishCounters.set(guildId, replenishCount + 1)
-            debugLog({
-                message:
-                    'Autoplay replenish exhausted: all candidate sources returned empty',
-                data: {
-                    guildId,
-                    currentTrack: currentTrack?.title,
-                    autoplayMode,
-                },
-            })
-            return
-        }
-
-        debugLog({
-            message: 'Autoplay: tracks selected for queue',
-            data: {
-                guildId: queue.guild.id,
-                tracks: enriched.map((s) => ({
-                    title: s.track.title,
-                    author: s.track.author,
-                    score: s.score.toFixed(3),
-                    reason: serializeBasis(s.basis),
-                    url: s.track.url,
-                })),
-            },
-        })
-
-        await addSelectedTracks(
-            queue,
-            enriched,
-            excludedUrls,
-            excludedKeys,
-            requestedBy?.id,
+        const enriched = await selectAndRerankCandidates(
+            candidates,
+            missingTracks,
+            sessionMood,
+            currentTrack,
             autoplayMode,
+            requestedBy,
         )
 
-        // Increment replenish counter for next call's query variation
-        replenishCounters.set(guildId, replenishCount + 1)
-
-        debugLog({
-            message: 'Autoplay pass complete',
-            data: {
-                guildId,
-                tracksAdded: enriched.length,
-                newQueueSize: queue.tracks.size,
-                // #2147: read the final pool size directly (as the warn path
-                // below already does), not a variable assigned once after the
-                // first of five collectors.
-                candidatePoolSize: candidates.size,
-                durationMs: Date.now() - startTime,
-                sources: sourcesCounts,
-            },
-        })
+        await enqueueAndFinalize(
+            autoplayContext,
+            enriched,
+            candidates,
+            requestedBy,
+            sourcesCounts,
+            startTime,
+        )
     } catch (error) {
         errorLog({ message: 'Error replenishing queue:', error })
     }
+}
+
+/**
+ * Evaluate gating checks: currentTrack presence, purge duplicates, buffer size,
+ * skip-rate circuit breaker. Returns {currentTrack, missingTracks} or null.
+ */
+export async function evaluateGatingChecks(
+    queue: GuildQueue,
+    finishedTrack?: Track,
+): Promise<{ currentTrack: Track; missingTracks: number } | null> {
+    const currentTrack = queue.currentTrack ?? finishedTrack ?? null
+    if (!currentTrack) return null
+
+    // Record evicted duplicate recommendations as rejected to improve telemetry
+    // coverage. These tracks never get a chance to emit playerStart.
+    const purgedTracks = purgeDuplicatesOfCurrentTrack(queue, currentTrack)
+    await cancelPendingRecommendations(queue, purgedTracks)
+
+    const bufferSize = (await premiumService.isPremium(queue.guild.id))
+        ? AUTOPLAY_BUFFER_SIZE_PREMIUM
+        : AUTOPLAY_BUFFER_SIZE
+    const autoplayInQueue = [...queue.tracks.toArray()].filter(
+        (t) =>
+            (t.metadata as { isAutoplay?: boolean } | undefined)?.isAutoplay ===
+            true,
+    ).length
+    const missingTracks = bufferSize - autoplayInQueue
+    if (missingTracks <= 0) return null
+
+    // Autoplay skip-rate circuit breaker: check if we should pause replenishment
+    const shouldContinue = await evaluateSkipRateBreaker(queue)
+    if (!shouldContinue) return null
+
+    return { currentTrack, missingTracks }
+}
+
+/**
+ * Extract seed tracks, session mood, history, and member context.
+ */
+export async function extractSeedAndSessionMood(
+    queue: GuildQueue,
+    currentTrack: Track,
+    skipStateProvider?: SkipStateProvider,
+): Promise<{
+    allHistoryTracks: Track[]
+    sessionMood: import('./sessionMood').SessionMood
+    historyTracks: Track[]
+    seedTracks: Track[]
+    requestedBy: User | null
+    vcMemberIds: string[]
+    allMemberIds: string[]
+}> {
+    const allHistoryTracks = getAllHistoryTracks(queue)
+    const replenishGuildId = queue.guild.id
+    const guildMoodCache = sessionMoodCache.get(replenishGuildId)
+    const sessionMood =
+        guildMoodCache &&
+        Math.abs(allHistoryTracks.length - guildMoodCache.historyLen) < 3
+            ? guildMoodCache.mood
+            : (() => {
+                  const mood = detectSessionMood(
+                      allHistoryTracks,
+                      skipStateProvider?.() ?? 0,
+                  )
+                  sessionMoodCache.set(replenishGuildId, {
+                      mood,
+                      historyLen: allHistoryTracks.length,
+                  })
+                  return mood
+              })()
+    const historyTracks = allHistoryTracks.slice(0, HISTORY_SEED_LIMIT)
+    const seedTracks = [currentTrack, ...historyTracks].slice(
+        0,
+        HISTORY_SEED_LIMIT + 1,
+    )
+    const requestedBy = getRequestedBy(queue, currentTrack)
+    const metadata = queue.metadata as QueueMetadata | undefined
+    const vcMemberIds = metadata?.vcMemberIds ?? []
+    const allMemberIds = Array.from(
+        new Set([...(requestedBy?.id ? [requestedBy.id] : []), ...vcMemberIds]),
+    )
+
+    return {
+        allHistoryTracks,
+        sessionMood,
+        historyTracks,
+        seedTracks,
+        requestedBy,
+        vcMemberIds,
+        allMemberIds,
+    }
+}
+
+/**
+ * Fetch feedback and history data: liked/disliked weights, persistent history,
+ * guild settings, implicit signals, preferred/blocked artists, replay frequency.
+ */
+export async function fetchFeedbackAndHistoryData(
+    queue: GuildQueue,
+    requestedBy: User | null,
+    vcMemberIds: string[],
+    allMemberIds: string[],
+    allHistoryTracks: Track[],
+): Promise<{
+    likedWeights: Map<string, number>
+    dislikedWeights: Map<string, number>
+    persistentHistory: TrackHistoryEntry[]
+    guildSettings: {
+        autoplayMode?: 'similar' | 'discover' | 'popular'
+        blockSertanejo?: boolean
+        autoplayGenres?: string[]
+    } | null
+    implicitDislikeKeys: Set<string>
+    implicitLikeKeys: Set<string>
+    mergedImplicitDislikeKeys: Set<string>
+    preferredArtistKeys: Set<string>
+    blockedArtistKeys: Set<string>
+    contributionWeights: Map<string, number>
+    autoplayMode: 'similar' | 'discover' | 'popular'
+    replayFrequency: { trackIds: Set<string>; artists: Set<string> }
+}> {
+    const [
+        likedWeights,
+        dislikedWeights,
+        persistentHistory,
+        guildSettings,
+        implicitDislikeKeys,
+        implicitLikeKeys,
+        allPreferredSets,
+        allBlockedSets,
+        replayFrequency,
+    ] = await Promise.all([
+        recommendationFeedbackService.getLikedTrackWeights(
+            queue.guild.id,
+            requestedBy?.id ?? '',
+        ),
+        recommendationFeedbackService.getDislikedTrackWeights(
+            queue.guild.id,
+            requestedBy?.id ?? '',
+        ),
+        trackHistoryService.getTrackHistory(queue.guild.id, 150),
+        guildSettingsService.getGuildSettings(queue.guild.id),
+        recommendationFeedbackService.getImplicitDislikeKeys(
+            requestedBy?.id ?? '',
+        ),
+        recommendationFeedbackService.getImplicitLikeKeys(
+            requestedBy?.id ?? '',
+        ),
+        Promise.all(
+            allMemberIds.map((id) =>
+                recommendationFeedbackService.getPreferredArtistKeys(
+                    queue.guild.id,
+                    id,
+                ),
+            ),
+        ),
+        Promise.all(
+            allMemberIds.map((id) =>
+                recommendationFeedbackService.getBlockedArtistKeys(
+                    queue.guild.id,
+                    id,
+                ),
+            ),
+        ),
+        // Async wrapper so even a synchronous throw (e.g. method absent on
+        // a partial service double) degrades to the empty no-boost result
+        (async () => {
+            try {
+                return await trackHistoryService.getReplayFrequentTracks(
+                    queue.guild.id,
+                )
+            } catch {
+                return {
+                    trackIds: new Set<string>(),
+                    artists: new Set<string>(),
+                }
+            }
+        })(),
+    ])
+
+    // Merge guild-scoped implicit dislike keys with user-level keys so skip
+    // signals always reach the scorer, even when requestedBy is undefined.
+    const guildImplicitDislikeKeys =
+        recommendationFeedbackService.getGuildImplicitDislikeKeys(
+            queue.guild.id,
+        )
+    const mergedImplicitDislikeKeys = new Set([
+        ...implicitDislikeKeys,
+        ...guildImplicitDislikeKeys,
+    ])
+
+    const preferredArtistKeys = new Set(allPreferredSets.flatMap((s) => [...s]))
+    const blockedArtistKeys = new Set(allBlockedSets.flatMap((s) => [...s]))
+    const contributionWeights =
+        vcMemberIds.length > 1
+            ? buildVcContributionWeights(allHistoryTracks, vcMemberIds)
+            : new Map<string, number>()
+    const autoplayMode = guildSettings?.autoplayMode ?? 'similar'
+    if (persistentHistory.length === 0) {
+        warnLog({
+            message:
+                'Autoplay: persistent history empty — Redis may be unavailable',
+            data: { guildId: queue.guild.id },
+        })
+    }
+
+    return {
+        likedWeights,
+        dislikedWeights,
+        persistentHistory,
+        guildSettings,
+        implicitDislikeKeys,
+        implicitLikeKeys,
+        mergedImplicitDislikeKeys,
+        preferredArtistKeys,
+        blockedArtistKeys,
+        contributionWeights,
+        autoplayMode,
+        replayFrequency,
+    }
+}
+
+/**
+ * Build exclusion sets and derived signal maps: excludedUrls, excludedKeys,
+ * recentArtists, recentArtistIndices, artistFrequency.
+ */
+export function buildExclusionAndDerivedSignals(
+    queue: GuildQueue,
+    currentTrack: Track,
+    allHistoryTracks: Track[],
+    historyTracks: Track[],
+    persistentHistory: TrackHistoryEntry[],
+): {
+    excludedUrls: Set<string>
+    excludedKeys: Set<string>
+    recentArtists: Set<string>
+    recentArtistIndices: Map<string, number>
+    artistFrequency: Map<string, number>
+} {
+    const excludedUrls = buildExcludedUrls(
+        queue,
+        currentTrack,
+        allHistoryTracks,
+        persistentHistory,
+    )
+    const excludedKeys = buildExcludedKeys(
+        queue,
+        currentTrack,
+        allHistoryTracks,
+        persistentHistory,
+    )
+    debugLog({
+        message: 'Autoplay: exclusion sets built',
+        data: {
+            guildId: queue.guild.id,
+            excludedUrlCount: excludedUrls.size,
+            excludedKeyCount: excludedKeys.size,
+            queueHistoryTracks: allHistoryTracks.length,
+            seedHistoryTracks: historyTracks.length,
+            persistentHistory: persistentHistory.length,
+        },
+    })
+    const recentArtists = buildRecentArtists(currentTrack, historyTracks)
+    // Recency-decay needs the real recent queue, not the 3-track seed sample
+    // (HISTORY_SEED_LIMIT) — otherwise the linear-decay window never fills and
+    // every recent artist gets a near-max penalty. Feed it the fuller history.
+    const recentArtistIndices = buildRecentArtistIndices(
+        currentTrack,
+        allHistoryTracks,
+    )
+    const artistFrequency = buildArtistFrequency(persistentHistory)
+
+    return {
+        excludedUrls,
+        excludedKeys,
+        recentArtists,
+        recentArtistIndices,
+        artistFrequency,
+    }
+}
+
+/**
+ * Helper to build the artist tag fetcher with optional Spotify token.
+ */
+export async function buildArtistTagFetcher(
+    requestedBy: User | null,
+): Promise<ArtistTagFetcher> {
+    const spotifyToken = requestedBy?.id
+        ? await Promise.resolve(
+              spotifyLinkService.getValidAccessToken(requestedBy.id),
+          ).catch(() => null)
+        : null
+
+    return createArtistTagFetcher(
+        spotifyToken
+            ? (artist) => getArtistGenres(spotifyToken, artist)
+            : undefined,
+    )
+}
+
+/**
+ * Build genre/tag context: current track tags, session genre families,
+ * sertanejo detection, and block flag.
+ */
+export async function buildGenreTagContext(
+    queue: GuildQueue,
+    currentTrack: Track,
+    historyTracks: Track[],
+    guildSettings: { blockSertanejo?: boolean } | null,
+    requestedBy: User | null,
+): Promise<{
+    currentTrackTags: string[]
+    sessionGenreFamilies: Set<string>
+    blockSertanejo: boolean
+}> {
+    const getArtistTags: ArtistTagFetcher =
+        await buildArtistTagFetcher(requestedBy)
+
+    // Parallelize tag fetching for current track + genre family detection
+    const [currentTrackTags, sessionGenreFamilies] = await Promise.all([
+        getArtistTags(currentTrack.author),
+        detectSessionGenreFamilies(historyTracks, getArtistTags),
+    ])
+
+    // Preserve this guard exactly — replenisher.spec.ts:93-95 mocks artistTagCache
+    // WITHOUT hasGenreTag and only passes because this guard short-circuits when
+    // currentTrackTags.length === 0
+    const seedIsSertanejo =
+        currentTrackTags.length > 0
+            ? hasGenreTag(currentTrackTags, SERTANEJO_TAGS)
+            : false
+    // Block sertanejo candidates unless the seed itself is sertanejo — fail-open
+    // when tags are absent (Last.fm unlinked) to avoid over-filtering.
+    // Allow guild to opt-out via blockSertanejo setting (defaults to true).
+    const blockSertanejo =
+        guildSettings?.blockSertanejo !== false && !seedIsSertanejo
+
+    const guildId = queue.guild.id
+    debugLog({
+        message: 'Autoplay: genre context built',
+        data: {
+            guildId,
+            currentTrackTagCount: currentTrackTags.length,
+            sessionGenreFamilies: Array.from(sessionGenreFamilies),
+            blockSertanejo,
+        },
+    })
+
+    return {
+        currentTrackTags,
+        sessionGenreFamilies,
+        blockSertanejo,
+    }
+}
+
+/**
+ * Collect all autoplay candidates from five sources: recommendation, seed-similar,
+ * lastfm, genre, and fallback. Returns candidates set and sourcesCounts breakdown.
+ */
+export async function collectAllCandidates(
+    autoplayContext: AutoplayContext,
+    seedTracks: Track[],
+    requestedBy: User | null,
+    blockSertanejo: boolean,
+    guildSettings: { autoplayGenres?: string[] } | null,
+    contributionWeights: Map<string, number>,
+): Promise<{
+    candidates: Map<string, ScoredTrack>
+    sourcesCounts: Record<string, number | { skipped: true }>
+}> {
+    const sourcesCounts: Record<string, number | { skipped: true }> = {
+        recommendation: 0,
+        seedSimilar: 0,
+        lastfm: 0,
+        fallback: 0,
+        genre: 0,
+    }
+
+    const guildId = autoplayContext.queue.guild.id
+    const replenishCount = replenishCounters.get(guildId) ?? 0
+    const candidates = await collectRecommendationCandidates(
+        autoplayContext,
+        seedTracks,
+        requestedBy,
+        replenishCount,
+        blockSertanejo,
+    )
+    sourcesCounts.recommendation = candidates.size
+    debugLog({
+        message: 'Autoplay: recommendation candidates',
+        data: { guildId, count: candidates.size, source: 'recommendation' },
+    })
+
+    // Seed-similarity spine: grounds autoplay on the current track's Last.fm
+    // similars regardless of whether the user linked Last.fm. Runs before the
+    // user-linked Last.fm collector so the pool is anchored to the seed even
+    // for unlinked sessions (the common case the drift fix targets).
+    if (requestedBy) {
+        const beforeSeedSimilar = candidates.size
+        await collectSeedSimilarCandidates(
+            autoplayContext,
+            requestedBy,
+            candidates,
+        )
+        sourcesCounts.seedSimilar = candidates.size - beforeSeedSimilar
+        debugLog({
+            message: 'Autoplay: seed-similar candidates',
+            data: {
+                guildId,
+                added: candidates.size - beforeSeedSimilar,
+                total: candidates.size,
+                source: 'seed-similar',
+            },
+        })
+    } else {
+        sourcesCounts.seedSimilar = { skipped: true }
+    }
+
+    if (requestedBy?.id) {
+        const beforeLastFm = candidates.size
+        await collectLastFmCandidates(
+            autoplayContext,
+            requestedBy,
+            candidates,
+            contributionWeights,
+        )
+        sourcesCounts.lastfm = candidates.size - beforeLastFm
+        debugLog({
+            message: 'Autoplay: last.fm candidates',
+            data: {
+                guildId,
+                added: candidates.size - beforeLastFm,
+                total: candidates.size,
+                source: 'lastfm',
+            },
+        })
+    } else {
+        sourcesCounts.lastfm = { skipped: true }
+    }
+
+    if (requestedBy && guildSettings?.autoplayGenres?.length) {
+        const beforeGenre = candidates.size
+        await collectGenreCandidates(
+            autoplayContext.queue,
+            guildSettings.autoplayGenres,
+            requestedBy,
+            {
+                candidates,
+                recentArtists: autoplayContext.recentArtists,
+                likedTrackKeys: autoplayContext.likedWeights,
+                dislikedTrackKeys: autoplayContext.dislikedWeights,
+                currentTrack: autoplayContext.currentTrack,
+                excludedUrls: autoplayContext.excludedUrls,
+                excludedKeys: autoplayContext.excludedKeys,
+                preferredArtistKeys: autoplayContext.preferredArtistKeys,
+                blockedArtistKeys: autoplayContext.blockedArtistKeys,
+                autoplayMode: autoplayContext.autoplayMode,
+                artistFrequency: autoplayContext.artistFrequency,
+                implicitDislikeKeys: autoplayContext.implicitDislikeKeys,
+                implicitLikeKeys: autoplayContext.implicitLikeKeys,
+                sessionMood: autoplayContext.sessionMood,
+                genreContext: {
+                    currentTrackTags:
+                        autoplayContext.genreContext.currentTrackTags,
+                    sessionGenreFamilies:
+                        autoplayContext.genreContext.sessionGenreFamilies,
+                },
+            },
+        )
+        sourcesCounts.genre = candidates.size - beforeGenre
+        debugLog({
+            message: 'Autoplay: genre candidates',
+            data: {
+                guildId,
+                added: candidates.size - beforeGenre,
+                total: candidates.size,
+                genres: guildSettings.autoplayGenres,
+                source: 'genre',
+            },
+        })
+    } else {
+        sourcesCounts.genre = { skipped: true }
+    }
+
+    if (candidates.size === 0 && autoplayContext.currentTrack) {
+        const beforeFallback = candidates.size
+        await collectBroadFallbackCandidates(autoplayContext, candidates)
+        sourcesCounts.fallback = candidates.size - beforeFallback
+        debugLog({
+            message: 'Autoplay: broad fallback candidates',
+            data: { guildId, count: candidates.size, source: 'fallback' },
+        })
+    }
+
+    return { candidates, sourcesCounts }
+}
+
+/**
+ * Select diverse candidates and apply popularity re-ranking.
+ */
+export async function selectAndRerankCandidates(
+    candidates: Map<string, ScoredTrack>,
+    missingTracks: number,
+    sessionMood: import('./sessionMood').SessionMood,
+    currentTrack: Track,
+    autoplayMode: 'similar' | 'discover' | 'popular',
+    requestedBy: User | null,
+): Promise<
+    {
+        track: Track
+        score: number
+        basis: import('./recommendationBasis').RecommendationBasis
+    }[]
+> {
+    const seedArtistKey = currentTrack.author.toLowerCase()
+    // When the user is deep-diving an artist (3+ tracks in last 8), relax
+    // the per-artist cap for that artist so autoplay follows their intent.
+    const deepDiveKey = sessionMood.deepDiveArtist
+    const effectiveMaxPerArtist =
+        deepDiveKey && seedArtistKey.includes(deepDiveKey)
+            ? 5
+            : MAX_TRACKS_PER_ARTIST
+    const selected = interleaveByArtist(
+        selectDiverseCandidates(
+            candidates,
+            missingTracks,
+            effectiveMaxPerArtist,
+            MAX_TRACKS_PER_SOURCE,
+            seedArtistKey,
+        ),
+    )
+
+    const enriched = selected
+
+    if (requestedBy?.id) {
+        const token = await Promise.resolve(
+            spotifyLinkService.getValidAccessToken(requestedBy.id),
+        ).catch(() => null)
+        if (token) {
+            // Re-rank a bounded head of the already-selected (genre-safe,
+            // de-duped) candidates by artist popularity. Post-selection
+            // only: it reorders vetted candidates and never introduces new
+            // ones, so popularity weighting can't reintroduce off-genre
+            // mainstream drift.
+            const rerankHead =
+                autoplayMode === 'similar' ? POPULARITY_RERANK_HEAD : 3
+            await Promise.all(
+                enriched.slice(0, rerankHead).map(async (track) => {
+                    const popularity = await getArtistPopularity(
+                        token,
+                        track.track.author,
+                    ).catch(() => null)
+                    if (popularity === null) return
+                    track.score += popularityBoost(autoplayMode, popularity)
+                }),
+            )
+            enriched.sort((a, b) => b.score - a.score)
+        }
+    }
+
+    return enriched
+}
+
+/**
+ * Enqueue selected tracks and log finalization, or log empty-result path.
+ */
+export async function enqueueAndFinalize(
+    autoplayContext: AutoplayContext,
+    enriched: {
+        track: Track
+        score: number
+        basis: import('./recommendationBasis').RecommendationBasis
+    }[],
+    candidates: Map<string, ScoredTrack>,
+    requestedBy: User | null,
+    sourcesCounts: Record<string, number | { skipped: true }>,
+    startTime: number,
+): Promise<void> {
+    const queue = autoplayContext.queue
+    const currentTrack = autoplayContext.currentTrack
+    const excludedUrls = autoplayContext.excludedUrls
+    const excludedKeys = autoplayContext.excludedKeys
+    const autoplayMode = autoplayContext.autoplayMode
+    const guildId = queue.guild.id
+    const replenishCount = replenishCounters.get(guildId) ?? 0
+
+    if (enriched.length === 0) {
+        // The per-source breakdown has to ride on this warn, not on the
+        // debug below it: production runs LOG_LEVEL=2, so the debug is
+        // suppressed and an empty pool was indistinguishable from "which
+        // of the five collectors came back dry" (#2146).
+        // sources now includes skipped markers and rejected shows
+        // how many candidates were vetoed by scoring or deduplication.
+        warnLog({
+            message: 'Autoplay: no candidates selected — queue may stall',
+            data: {
+                guildId: queue.guild.id,
+                candidatePoolSize: candidates.size,
+                sources: sourcesCounts,
+                rejected: getRejectionCounts(candidates),
+                autoplayMode,
+                // Four of the five collectors are gated on a requester, so
+                // a zero count means "skipped" rather than "found nothing"
+                // when this is false. Without it the breakdown is ambiguous.
+                hasRequester: Boolean(requestedBy),
+            },
+        })
+        replenishCounters.set(guildId, replenishCount + 1)
+        debugLog({
+            message:
+                'Autoplay replenish exhausted: all candidate sources returned empty',
+            data: {
+                guildId,
+                currentTrack: currentTrack?.title,
+                autoplayMode,
+            },
+        })
+        return
+    }
+
+    debugLog({
+        message: 'Autoplay: tracks selected for queue',
+        data: {
+            guildId: queue.guild.id,
+            tracks: enriched.map((s) => ({
+                title: s.track.title,
+                author: s.track.author,
+                score: s.score.toFixed(3),
+                reason: serializeBasis(s.basis),
+                url: s.track.url,
+            })),
+        },
+    })
+
+    await addSelectedTracks(
+        queue,
+        enriched,
+        excludedUrls,
+        excludedKeys,
+        requestedBy?.id,
+        autoplayMode,
+    )
+
+    // Increment replenish counter for next call's query variation
+    replenishCounters.set(guildId, replenishCount + 1)
+
+    debugLog({
+        message: 'Autoplay pass complete',
+        data: {
+            guildId,
+            tracksAdded: enriched.length,
+            newQueueSize: queue.tracks.size,
+            // #2147: read the final pool size directly (as the warn path
+            // below already does), not a variable assigned once after the
+            // first of five collectors.
+            candidatePoolSize: candidates.size,
+            durationMs: Date.now() - startTime,
+            sources: sourcesCounts,
+        },
+    })
 }
 
 function getRequestedBy(queue: GuildQueue, currentTrack: Track): User | null {


### PR DESCRIPTION
## Summary

Closes #2333. `_replenishQueue` in `packages/bot/src/services/musicRecommendation/autoplay/replenisher.ts` was a 508-line single function (lines ~156-662) mixing lock/gating logic, session-mood caching, feedback/history data fetching, exclusion-set building, genre-tag context, candidate-collection orchestration, selection/reranking, and enqueueing/telemetry, with no separately callable seams.

This is a pure refactor: same log lines, same error paths, same early returns. No behavior change.

## Decomposition

Extracted into 8 named, exported functions in the same file (no sibling module, no DI/class/strategy pattern per the existing `decisions/2026-05-24-candidate-aggregator-deferred.md` ADR, which already deferred an aggregator abstraction on this exact file):

1. `evaluateGatingChecks` - current-track resolution, duplicate purge + pending-recommendation cancellation, buffer-size/missingTracks calc, skip-rate circuit breaker
2. `extractSeedAndSessionMood` - history tracks, cached session mood, seed tracks, requester/VC member ids
3. `fetchFeedbackAndHistoryData` - liked/disliked weights, persistent history, guild settings, implicit like/dislike signals, preferred/blocked artists, replay frequency
4. `buildExclusionAndDerivedSignals` - excluded urls/keys, recent artists, recent-artist indices, artist frequency
5. `buildGenreTagContext` - artist tag fetching, sertanejo detection, session genre families
6. `collectAllCandidates` - the five-source candidate pool (recommendation, seed-similar, last.fm, genre, fallback) with sourcesCounts bookkeeping
7. `selectAndRerankCandidates` - diversity selection + popularity re-rank
8. `enqueueAndFinalize` - queue mutation and telemetry logging (empty-result and success paths)

`_replenishQueue` is now a thin orchestrator. Module-level state (`replenishLocks`, `replenishCounters`, `sessionMoodCache`) stays untouched in the file; `clearSessionMoodCache` (consumed by `stop.ts`, `skip.ts`, `previous.ts`, `postPlayBackgroundOps.ts`) is unchanged.

## Tests

Added `replenisher.seams.spec.ts` with unit tests for each new seam. Notable additions:
- Coverage for the previously-untested `seedIsSertanejo === true` branch.
- A regression test for a `replayFrequency` optional-chaining bug caught during review (see below), asserting `fetchFeedbackAndHistoryData` degrades to empty Sets rather than throwing when `getReplayFrequentTracks` rejects.

Spot-checked 3 of the new tests by deliberately breaking the behavior they cover, confirming a real failure, then restoring:
- `evaluateGatingChecks` null check: `expect(received).not.toBeNull()` / `Received: null`
- `buildArtistFrequency` logic inversion: `expect(received).toBe(expected)` / `Expected: 0, Received: 2`
- `selectAndRerankCandidates` deep-dive relaxation: `expect(received).toBe(expected)` / `Expected: 1, Received: 5`

### Test counts (full bot suite, `cd packages/bot && npx jest`)

- Before: 272 of 273 suites passed (1 skipped), 3548 of 3549 tests passed (1 skipped)
- After: 273 of 274 suites passed (1 skipped), 3585 of 3586 tests passed (1 skipped)

The one new suite is `replenisher.seams.spec.ts`; all other suite/test counts match, no regressions.

A first pass of this extraction broke 18 tests across `queueManipulation.{priority,autoplay,dedup}.spec.ts` (integration-style tests that exercise `replenishQueue` indirectly) due to a dropped `?.` optional-chaining guard on `replayFrequency` when assembling `AutoplayContext`. Confirmed via A/B testing against the pre-refactor file, fixed, and covered with the regression test above.

## Follow-up filed, not fixed here

#2349: `replenisher.spec.ts:87-91` mocks the wrong module path for `buildVcContributionWeights` (mocks `../../../services/musicManagement/queueManipulation`, but the real import is `./vcWeights`), so the real implementation runs in tests instead of the mock. Pre-existing, unrelated to this refactor's scope, reproduces on clean main.

## Verification

- `cd packages/bot && npx jest`: 273/274 suites (1 skipped), 3585/3586 tests (1 skipped) - see counts above
- `npm run lint` in packages/bot: clean
- `npx tsc --noEmit` in packages/bot: clean
- `npx madge --circular --extensions ts packages/bot/src`: no circular dependencies
- `npm run build` at repo root: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `_replenishQueue` from one 508-line function into eight exported seam functions in `replenisher.ts`, preserving log lines, error paths, and early returns. No behavior change. Closes #2333.

**What changed**
- Extracts gating, seed/mood extraction, feedback/history fetching, exclusion signals, genre context, candidate collection, selection/reranking, and enqueueing/telemetry into individually testable functions.
- `buildGenreTagContext` now takes the shared artist-tag fetcher as a parameter so one fetcher is built per pass and its memo cache is shared with the collectors.
- Keeps module-level state and `clearSessionMoodCache` untouched.
- Leaves the old `_replenishQueue` as a thin orchestrator over the new seams.

**Tests**
- Adds `replenisher.seams.spec.ts` with unit tests for every seam, including the previously untested `seedIsSertanejo === true` branch.
- Includes a regression test asserting `fetchFeedbackAndHistoryData` falls back to empty Sets when `getReplayFrequentTracks` rejects.
- Corrects `collectAllCandidates` call sites in the spec to match its 6-parameter signature so the all-five-sources test actually exercises the genre collector.
- Full bot suite passes with only the new spec added.

<sup>Written for commit 289a2056c6b56042f331766af91c769db32f10bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

