### PR TITLE
test(bot): mock the vc contribution weights helper at its real path

### DIFF
--- a/packages/bot/src/services/musicRecommendation/autoplay/replenisher.spec.ts
+++ b/packages/bot/src/services/musicRecommendation/autoplay/replenisher.spec.ts
@@ -84,9 +84,11 @@ jest.mock('../candidateFallback', () => ({
     interleaveByArtist: jest.fn(),
 }))
 
-jest.mock('../../../services/musicManagement/queueManipulation', () => ({
-    enrichWithAudioFeatures: jest.fn(),
-    getTrackAudioFeatures: jest.fn(),
+// './vcWeights' is where replenisher.ts imports buildVcContributionWeights from.
+// This used to mock '../../../services/musicManagement/queueManipulation', a
+// barrel that re-exports none of these names and that replenisher.ts never
+// imports, so the real implementation ran throughout (#2349).
+jest.mock('./vcWeights', () => ({
     buildVcContributionWeights: jest.fn(),
 }))
 
@@ -200,15 +202,7 @@ describe('replenishQueue', () => {
         collectGenreCandidates.mockResolvedValue(undefined)
         iba.mockImplementation((tracks: any[]) => tracks)
 
-        const {
-            enrichWithAudioFeatures,
-            getTrackAudioFeatures,
-            buildVcContributionWeights,
-        } = require('../../../services/musicManagement/queueManipulation')
-        enrichWithAudioFeatures.mockImplementation((tracks: any[]) =>
-            Promise.resolve(tracks),
-        )
-        getTrackAudioFeatures.mockResolvedValue(null)
+        const { buildVcContributionWeights } = require('./vcWeights')
         buildVcContributionWeights.mockReturnValue(new Map())
 
         const { createArtistTagFetcher } = require('./artistTagCache')
@@ -388,6 +382,35 @@ describe('replenishQueue', () => {
         ).toHaveBeenCalledWith('guildid')
     })
 
+    it('weights contributions when more than one member is in the VC', async () => {
+        // The only test that reaches buildVcContributionWeights: the call is
+        // guarded by `vcMemberIds.length > 1`, and every other fixture leaves
+        // metadata empty. Without this the mock is never invoked, so a wrong
+        // mock path silently runs the real implementation unnoticed (#2349).
+        const queue = createGuildQueue({
+            metadata: { vcMemberIds: ['member1', 'member2'] },
+        } as Partial<GuildQueue>)
+        const { buildVcContributionWeights } = require('./vcWeights')
+
+        await replenishQueue(queue)
+
+        expect(buildVcContributionWeights).toHaveBeenCalledWith(
+            expect.any(Array),
+            ['member1', 'member2'],
+        )
+    })
+
+    it('skips contribution weighting when the VC has one member or none', async () => {
+        const queue = createGuildQueue({
+            metadata: { vcMemberIds: ['member1'] },
+        } as Partial<GuildQueue>)
+        const { buildVcContributionWeights } = require('./vcWeights')
+
+        await replenishQueue(queue)
+
+        expect(buildVcContributionWeights).not.toHaveBeenCalled()
+    })
+
     it('should handle errors gracefully without throwing', async () => {
         const queue = createGuildQueue()
         const {
@@ -439,9 +462,6 @@ describe('replenishQueue', () => {
             collectRecommendationCandidates,
         } = require('./candidateCollector')
         const { interleaveByArtist } = require('../candidateFallback')
-        const {
-            enrichWithAudioFeatures,
-        } = require('../../../services/musicManagement/queueManipulation')
         const { guildSettingsService } = require('@lucky/shared/services')
         const { collectGenreCandidates } = require('../candidateFallback')
 
@@ -459,7 +479,6 @@ describe('replenishQueue', () => {
         ]
         selectDiverseCandidates.mockReturnValue(mockScoredTracks)
         interleaveByArtist.mockReturnValue(mockScoredTracks)
-        enrichWithAudioFeatures.mockResolvedValue(mockScoredTracks)
         guildSettingsService.getGuildSettings.mockResolvedValue({
             autoplayGenres: ['rock', 'pop'],
         })


### PR DESCRIPTION
Closes #2349.

## The defect

`replenisher.spec.ts` mocked `../../../services/musicManagement/queueManipulation` to supply `buildVcContributionWeights`, but `replenisher.ts:48` imports it from `./vcWeights`. The mock never intercepted anything, so the real implementation ran.

`queueManipulation.ts` turns out to be a barrel that re-exports none of the three names the mock declared, and nothing in the replenisher dependency graph imports it at all, so the entire block was inert. Two of its three names, `enrichWithAudioFeatures` and `getTrackAudioFeatures`, do not exist anywhere in `packages/bot`; their `mockImplementation` / `mockResolvedValue` calls were configuring phantom `jest.fn()`s nothing ever read. Dropped rather than repointed.

## Why it was invisible

No test outcome changes from this fix on its own. The call site is guarded:

```ts
const contributionWeights =
    vcMemberIds.length > 1
        ? buildVcContributionWeights(allHistoryTracks, vcMemberIds)
        : new Map<string, number>()
```

`vcMemberIds` comes from `queue.metadata.vcMemberIds`, and every existing fixture leaves `metadata` empty, so the function was never reached. Making the mock throw changed nothing. That is exactly why the wrong path survived unnoticed.

## Making the mock load-bearing

Repointing alone would leave the mock still unexercised, so this adds the two tests that actually reach the guard: one asserting the call for a two-member VC, one asserting it is skipped for a single member.

Verified they are not vacuous. Restoring the old mock path fails the first test for the right reason:

```
● replenishQueue › weights contributions when more than one member is in the VC
  Expected: Any<Array>, ["member1", "member2"]
  Number of calls: 0
```

## Verification

- `packages/bot` full suite: 273 suites passed, 3588 tests passed, 1 skipped (was 3586; +2 from this PR)
- `npx tsc --noEmit`: clean, after `npm run db:generate && npm run build:shared`
- eslint and prettier via lint-staged: clean

Note that `tsc` could not have caught the original defect: `packages/bot/tsconfig.json` excludes `**/*.spec.ts` and ts-jest runs with `diagnostics: false`. Filed separately as #2351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `replenisher.spec.ts` mock for `buildVcContributionWeights` to point at its real module path, and adds tests that actually exercise the guarded call. Closes #2349.

- Previously mocked a barrel that re-exports none of the declared names, so the real implementation ran.
- Removed mocks for `enrichWithAudioFeatures` and `getTrackAudioFeatures`, which don't exist in `packages/bot`.
- Adds tests for two-member and single-member VC scenarios so the mock is now load-bearing.

<sup>Written for commit 6b728299050fd8bd7893577c2ac04a035a5f6486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LucasSantana-Dev/Lucky/pull/2352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

